### PR TITLE
add root route and health check to API. health check routes to API

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -16,7 +16,14 @@ app.use(cors());
 app.use(express.json());
 app.use(morgan('dev'));
 
-// Basic Health Check Route
+// --- ADDED ROUTES ---
+
+// 1. Root Route (This fixes the "Cannot GET /" error)
+app.get('/', (req: Request, res: Response) => {
+  res.send('SahiDawa-India API is running successfully!');
+});
+
+// 2. Health Check Route
 app.get('/health', (req: Request, res: Response) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });


### PR DESCRIPTION
This PR adds a default route to the root path to prevent the 'Cannot GET /' error and includes a health check endpoint.
