### PR TITLE
feat(ui): implement PageHeader component and refactor headers in map,…

### DIFF
--- a/apps/web/app/components/PageHeader.tsx
+++ b/apps/web/app/components/PageHeader.tsx
@@ -1,0 +1,64 @@
+import { ArrowLeft, Globe, Zap } from "lucide-react";
+import Link from "next/link";
+
+interface PageHeaderProps {
+  title?: string;
+  subtitle?: string;
+  backHref: string;
+  variant?: "dark" | "light";
+  showLanguage?: boolean;
+  languageName?: string;
+  children?: React.ReactNode;
+}
+
+export const PageHeader = ({ 
+  title, 
+  subtitle, 
+  backHref, 
+  variant = "dark", 
+  showLanguage = false,
+  languageName,
+  children 
+}: PageHeaderProps) => {
+  
+  const isDark = variant === "dark";
+  
+  return (
+    <header className={`${isDark ? "absolute top-0 left-0 right-0 bg-gradient-to-b from-black/70 to-transparent text-white" : "relative bg-white border-b border-slate-100 shadow-sm text-slate-900"} z-20 p-4 flex flex-col gap-4`}>
+      <div className="flex items-center justify-between">
+        <Link 
+          href={backHref} 
+          className={`w-10 h-10 rounded-full flex items-center justify-center transition-colors ${
+            isDark ? "bg-white/10 backdrop-blur-md hover:bg-white/20" : "bg-slate-100 hover:bg-slate-200"
+          }`}
+        >
+          <ArrowLeft size={24} className={isDark ? "text-white" : "text-slate-600"} />
+        </Link>
+
+        {children ? (
+          <div className="flex-1 px-4">{children}</div>
+        ) : (
+          <div className="flex flex-col items-center text-center">
+            <span className={`text-xs font-bold uppercase tracking-widest ${isDark ? "text-emerald-400" : "text-emerald-600"}`}>
+              {title}
+            </span>
+            <span className="text-sm font-medium">{subtitle}</span>
+          </div>
+        )}
+
+        <div className="flex items-center justify-end w-10">
+          {showLanguage ? (
+            <div className="flex items-center gap-2 px-4 py-1.5 bg-white rounded-full border border-slate-200 shadow-sm whitespace-nowrap">
+              <Globe size={16} className="text-emerald-600" />
+              <span className="text-sm font-bold text-slate-700">{languageName || "English"}</span>
+            </div>
+          ) : isDark ? (
+            <button className="w-10 h-10 rounded-full bg-white/10 backdrop-blur-md flex items-center justify-center hover:bg-white/20 transition-colors">
+              <Zap size={20} className="text-amber-400" />
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/apps/web/app/components/PageHeader.tsx
+++ b/apps/web/app/components/PageHeader.tsx
@@ -25,10 +25,10 @@ export const PageHeader = ({
   
   return (
     <header className={`${isDark ? "absolute top-0 left-0 right-0 bg-gradient-to-b from-black/70 to-transparent text-white" : "relative bg-white border-b border-slate-100 shadow-sm text-slate-900"} z-20 p-4 flex flex-col gap-4`}>
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <Link 
           href={backHref} 
-          className={`w-10 h-10 rounded-full flex items-center justify-center transition-colors ${
+          className={`w-10 h-10 shrink-0 rounded-full flex items-center justify-center transition-colors ${
             isDark ? "bg-white/10 backdrop-blur-md hover:bg-white/20" : "bg-slate-100 hover:bg-slate-200"
           }`}
         >
@@ -36,27 +36,36 @@ export const PageHeader = ({
         </Link>
 
         {children ? (
-          <div className="flex-1 px-4">{children}</div>
+          <div className="flex-1 min-w-0">{children}</div>
         ) : (
-          <div className="flex flex-col items-center text-center">
-            <span className={`text-xs font-bold uppercase tracking-widest ${isDark ? "text-emerald-400" : "text-emerald-600"}`}>
+          <div className="flex-1 flex flex-col items-center text-center min-w-0 px-2">
+            <span className={`text-[10px] sm:text-xs font-bold uppercase tracking-widest truncate w-full ${isDark ? "text-emerald-400" : "text-emerald-600"}`}>
               {title}
             </span>
-            <span className="text-sm font-medium">{subtitle}</span>
+            <span className="text-xs sm:text-sm font-medium truncate w-full">
+              {subtitle}
+            </span>
           </div>
         )}
 
-        <div className="flex items-center justify-end w-10">
+        <div className="flex items-center justify-end shrink-0">
           {showLanguage ? (
-            <div className="flex items-center gap-2 px-4 py-1.5 bg-white rounded-full border border-slate-200 shadow-sm whitespace-nowrap">
-              <Globe size={16} className="text-emerald-600" />
-              <span className="text-sm font-bold text-slate-700">{languageName || "English"}</span>
+            <div className="flex items-center gap-1.5 px-3 py-1.5 bg-white rounded-full border border-slate-200 shadow-sm">
+              <Globe size={14} className="text-emerald-600" />
+              <span className="text-xs font-bold text-slate-700 sm:inline hidden">
+                {languageName || "English"}
+              </span>
+              <span className="text-xs font-bold text-slate-700 sm:hidden">
+                {languageName ? languageName.substring(0, 2).toUpperCase() : "EN"}
+              </span>
             </div>
           ) : isDark ? (
             <button className="w-10 h-10 rounded-full bg-white/10 backdrop-blur-md flex items-center justify-center hover:bg-white/20 transition-colors">
               <Zap size={20} className="text-amber-400" />
             </button>
-          ) : null}
+          ) : (
+            <div className="w-10" />
+          )}
         </div>
       </div>
     </header>

--- a/apps/web/app/map/page.tsx
+++ b/apps/web/app/map/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { MapPin, Search, Navigation, Filter, Star, Phone, ChevronLeft, Globe, Map as MapIcon, Layers } from "lucide-react";
+import { MapPin, Search, Navigation, Filter, Star, Phone, Globe, Map as MapIcon, Layers } from "lucide-react";
 import Link from "next/link";
+import { PageHeader } from "../components/PageHeader";
 
 export default function PharmacyMapPage() {
   const [activeFilter, setActiveFilter] = useState("all");
@@ -16,22 +17,18 @@ export default function PharmacyMapPage() {
   return (
     <div className="h-screen bg-slate-50 font-sans flex flex-col overflow-hidden">
       
-      {/* Search Header */}
-      <div className="bg-white p-4 pb-6 shadow-sm z-20 border-b border-slate-100">
-        <div className="flex items-center gap-4 mb-4">
-          <Link href="/" className="w-10 h-10 rounded-full bg-slate-100 flex items-center justify-center hover:bg-slate-200 transition-colors">
-            <ChevronLeft size={24} className="text-slate-600" />
-          </Link>
-          <div className="flex-1 bg-slate-100 rounded-2xl flex items-center px-4 py-2 border border-slate-200 focus-within:bg-white focus-within:border-emerald-500 transition-all">
-            <Search size={18} className="text-slate-400" />
-            <input 
-                type="text" 
-                placeholder="Search verified pharmacies..." 
-                className="bg-transparent border-none outline-none px-3 py-1.5 w-full text-sm font-medium text-slate-700"
-            />
-          </div>
+      <PageHeader backHref="/" variant="light">
+        <div className="flex-1 bg-slate-100 rounded-2xl flex items-center px-4 py-2 border border-slate-200 focus-within:bg-white focus-within:border-emerald-500 transition-all">
+          <Search size={18} className="text-slate-400" />
+          <input 
+              type="text" 
+              placeholder="Search verified pharmacies..." 
+              className="bg-transparent border-none outline-none px-3 py-1.5 w-full text-sm font-medium text-slate-700"
+          />
         </div>
+      </PageHeader>
 
+      <div className="bg-white p-4 pt-0 pb-6 shadow-sm z-20 border-b border-slate-100">
         <div className="flex gap-2 overflow-x-auto pb-1 no-scrollbar">
             <button 
               onClick={() => setActiveFilter("all")}

--- a/apps/web/app/scan/page.tsx
+++ b/apps/web/app/scan/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Camera, X, Zap, ShieldCheck, Info, AlertCircle, Layers, Image } from "lucide-react";
+import { Camera, ShieldCheck, Info, AlertCircle, Layers } from "lucide-react";
 import Link from "next/link";
+import { PageHeader } from "../components/PageHeader";
 
 export default function ScanPage() {
   const [scanning, setScanning] = useState(true);
@@ -43,21 +44,13 @@ export default function ScanPage() {
         onChange={handleFileUpload}
       />
 
-      {/* Header Overly */}
-      <div className="absolute top-0 left-0 right-0 z-20 p-6 flex items-center justify-between bg-linear-to-b from-black/70 to-transparent">
-        <Link href="/" className="w-10 h-10 rounded-full bg-white/10 backdrop-blur-md flex items-center justify-center hover:bg-white/20 transition-colors">
-          <X size={24} />
-        </Link>
-        <div className="flex flex-col items-center text-center">
-          <span className="text-xs font-bold uppercase tracking-widest text-emerald-400">
-            {uploadedImage ? "Analyzing Upload" : "Scanner Mode"}
-          </span>
-          <span className="text-sm font-medium">Position the Barcode</span>
-        </div>
-        <button className="w-10 h-10 rounded-full bg-white/10 backdrop-blur-md flex items-center justify-center hover:bg-white/20 transition-colors">
-          <Zap size={20} className="text-amber-400" />
-        </button>
-      </div>
+      {/* Header component */}
+      <PageHeader 
+        title="Scanner Mode" 
+        subtitle="Position the Barcode" 
+        backHref="/" 
+        variant="dark" 
+      />
 
       {/* Viewfinder Area */}
       <div className="flex-1 relative flex items-center justify-center overflow-hidden">

--- a/apps/web/app/voice/page.tsx
+++ b/apps/web/app/voice/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { Mic, X, Globe, MessageSquare, Volume2, Sparkles, ChevronLeft, Send } from "lucide-react";
 import Link from "next/link";
+import { PageHeader } from "../components/PageHeader";
 
 export default function VoiceTriagePage() {
   const [isListening, setIsListening] = useState(false);
@@ -29,16 +30,13 @@ export default function VoiceTriagePage() {
       <div className="absolute bottom-0 left-0 w-80 h-80 bg-blue-100/40 rounded-full blur-3xl -ml-20 -mb-20"></div>
 
       {/* Header */}
-      <header className="relative z-10 p-6 flex items-center justify-between">
-        <Link href="/" className="w-10 h-10 rounded-full bg-white shadow-sm border border-slate-200 flex items-center justify-center hover:bg-slate-50 transition-colors">
-          <ChevronLeft size={24} className="text-slate-600" />
-        </Link>
-        <div className="flex items-center gap-2 px-4 py-1.5 bg-white rounded-full border border-slate-200 shadow-sm">
-          <Globe size={16} className="text-emerald-600" />
-          <span className="text-sm font-bold text-slate-700">{language}</span>
-        </div>
-        <div className="w-10 h-10"></div> {/* Spacer */}
-      </header>
+      <PageHeader 
+        title="Voice Search" 
+        subtitle="Speak medicine name" 
+        backHref="/" 
+        variant="light"
+        showLanguage={true}
+      />
 
       {/* Main Content Area */}
       <main className="flex-1 relative z-10 flex flex-col items-center justify-center px-6">


### PR DESCRIPTION
This pull request introduces a new reusable `PageHeader` component and refactors the headers in the `scan`, `map`, and `voice` pages to use this component. The main goals are to improve code consistency, reduce duplication, and enhance maintainability by centralizing header logic and styles.

**Component extraction and usage:**

* Added a new `PageHeader` component in `apps/web/app/components/PageHeader.tsx`, supporting customizable titles, subtitles, back navigation, themes (dark/light), optional language display, and slot for custom children.

**Refactoring of page headers:**

* Updated `apps/web/app/scan/page.tsx` to replace the custom header markup with the new `PageHeader` component, simplifying the code and ensuring consistent styling. [[1]](diffhunk://#diff-521bc1f1c3f7afcce6ca6b26703ff9b04c422e911104d0b2a2b16034fec261e9L4-R6) [[2]](diffhunk://#diff-521bc1f1c3f7afcce6ca6b26703ff9b04c422e911104d0b2a2b16034fec261e9L46-R53)
* Updated `apps/web/app/map/page.tsx` to use `PageHeader` for the search header, removing inline header code and passing the search input as a child to the component. [[1]](diffhunk://#diff-8b143d7f80a557ffad80cd337abb625275c623b62a4ba1996fd7b074836efd3fL4-R6) [[2]](diffhunk://#diff-8b143d7f80a557ffad80cd337abb625275c623b62a4ba1996fd7b074836efd3fL19-R20) [[3]](diffhunk://#diff-8b143d7f80a557ffad80cd337abb625275c623b62a4ba1996fd7b074836efd3fL33-R31)
* Updated `apps/web/app/voice/page.tsx` to use `PageHeader` with language selection, replacing the previous header implementation. [[1]](diffhunk://#diff-0c069bae518dac206ffc60e9bb13a7491094577ee14f8a1e3f231cdbb939ecb2R6) [[2]](diffhunk://#diff-0c069bae518dac206ffc60e9bb13a7491094577ee14f8a1e3f231cdbb939ecb2L32-R39)… scan, and voice pages