### PR TITLE
fix: replace invalid pb-safe class with valid tailwind safe area inset

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -267,7 +267,7 @@ export default function SahiDawaHome() {
       <div className="h-16 md:hidden"></div>
 
       {/* Mobile Bottom Navigation (Visible only on small screens) */}
-      <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white/90 backdrop-blur-md border-t border-slate-200/60 flex justify-around px-2 py-3 items-center z-50 pb-safe">
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white/90 backdrop-blur-md border-t border-slate-200/60 flex justify-around px-2 py-3 items-center z-50 pb-[env(safe-area-inset-bottom)]">
         <button className="flex flex-col items-center gap-1.5 w-16 group">
           <div className="text-emerald-600 group-hover:-translate-y-1 transition-transform">
             <Home size={24} strokeWidth={2.5} />


### PR DESCRIPTION
Fixes #54

Replaced the non-standard `pb-safe` class in the mobile bottom navigation with `pb-[env(safe-area-inset-bottom)]`. This ensures that on iOS devices (like iPhones), the navigation bar respects the home indicator and prevents overlapping content.

Tested locally, no layout regressions.