### PR TITLE
feat(api): add medicine verification POST endpoint to close #11

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,8 @@
     "express": "^5.0.0",
     "helmet": "^8.1.0",
     "morgan": "^1.10.0",
-    "redis": "^5.12.1"
+    "redis": "^5.12.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
+import verifyRouter from './routes/verify';
 
 // Load environment variables
 dotenv.config();
@@ -16,7 +17,10 @@ app.use(cors());
 app.use(express.json());
 app.use(morgan('dev'));
 
-// --- ADDED ROUTES ---
+// --- ROUTES ---
+
+// Medicine Verification Endpoint
+app.use('/api/verify', verifyRouter);
 
 // 1. Root Route (This fixes the "Cannot GET /" error)
 app.get('/', (req: Request, res: Response) => {

--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -1,0 +1,88 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+
+const router = Router();
+
+/**
+ * Mock medicine database keyed by batch number.
+ * TODO: Replace with real Supabase DB lookup in Phase 1 (see db/schema.sql — medicines table).
+ */
+const MOCK_MEDICINES: Record<
+  string,
+  { name: string; expiry: string; manufacturer: string }
+> = {
+  'BATCH-CIPLA-001': {
+    name: 'Azithromycin 500mg',
+    expiry: '2026-12-31',
+    manufacturer: 'Cipla Ltd.',
+  },
+  'BATCH-SUN-002': {
+    name: 'Paracetamol 650mg',
+    expiry: '2027-03-15',
+    manufacturer: 'Sun Pharmaceuticals',
+  },
+  'BATCH-DR-003': {
+    name: 'Metformin 500mg',
+    expiry: '2026-08-20',
+    manufacturer: "Dr. Reddy's Laboratories",
+  },
+  'BATCH-AMAN-004': {
+    name: 'Amoxicillin 250mg',
+    expiry: '2025-11-30',
+    manufacturer: 'Mankind Pharma',
+  },
+};
+
+/**
+ * Zod schema for the POST /verify request body.
+ * batchNumber must be a non-empty string with at least 3 characters.
+ */
+const verifySchema = z.object({
+  batchNumber: z
+    .string({ message: 'batchNumber is required and must be a string' })
+    .min(3, 'batchNumber must be at least 3 characters long'),
+});
+
+/**
+ * POST /api/verify
+ *
+ * Verifies if a medicine batch number is authentic.
+ *
+ * @body  { batchNumber: string }
+ * @returns 200  { verified: true,  medicine: { name, expiry, manufacturer } }
+ * @returns 404  { verified: false, message: "Medicine not found" }
+ * @returns 400  { error: string, details: ZodIssue[] }
+ */
+router.post('/', (req: Request, res: Response) => {
+  // --- Input validation ---
+  const parsed = verifySchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    res.status(400).json({
+      error: 'Invalid request body',
+      details: parsed.error.issues,
+    });
+    return;
+  }
+
+  const { batchNumber } = parsed.data;
+
+  // --- Mock DB lookup ---
+  const medicine = MOCK_MEDICINES[batchNumber.toUpperCase()] ?? MOCK_MEDICINES[batchNumber];
+
+  if (!medicine) {
+    res.status(404).json({
+      verified: false,
+      message: 'Medicine not found',
+    });
+    return;
+  }
+
+  // --- Success ---
+  res.status(200).json({
+    verified: true,
+    medicine,
+  });
+});
+
+export default router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
         "express": "^5.0.0",
         "helmet": "^8.1.0",
         "morgan": "^1.10.0",
-        "redis": "^5.12.1"
+        "redis": "^5.12.1",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -9077,7 +9078,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -9094,17 +9094,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     }
   }


### PR DESCRIPTION
## feat(api): add medicine verification POST endpoint

Closes #11

### What this PR does
- Creates `POST /api/verify` route at `apps/api/src/routes/verify.ts`
- Validates `batchNumber` input using Zod (min 3 chars)
- Returns `200` with medicine details on valid batch number
- Returns `404` for unknown batch numbers
- Returns `400` for invalid/missing input
- Registers the router in `index.ts` under `/api/verify`
- Uses mock data (real Supabase DB lookup coming in Phase 1)

### Test it locally
POST http://localhost:4000/api/verify
Body: { "batchNumber": "BATCH-CIPLA-001" }

### Checklist
- [x] TypeScript — no `any` types
- [x] Zod input validation
- [x] Appropriate HTTP status codes (200, 400, 404)
- [x] Rebased on latest upstream/main
- [x] AI assistance used and disclosed (Antigravity)
