### PR TITLE
#28 Add copy button for batch number on result card

### DIFF
--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Camera, ShieldCheck, Info, AlertCircle, Layers } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { Camera, ShieldCheck, Info, AlertCircle, Layers, Copy, Check } from "lucide-react";
 import { Link } from "@/i18n/routing";
 import { PageHeader } from "../components/PageHeader";
 
@@ -9,6 +9,25 @@ export default function ScanPage() {
   const [scanning, setScanning] = useState(true);
   const [result, setResult] = useState<null | "valid" | "invalid">(null);
   const [uploadedImage, setUploadedImage] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyBatch = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText("AUG625D");
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for older browsers
+      const textArea = document.createElement("textarea");
+      textArea.value = "AUG625D";
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textArea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, []);
 
   useEffect(() => {
     if (scanning) {
@@ -103,9 +122,22 @@ export default function ScanPage() {
                   </div>
 
                   <div className="w-full grid grid-cols-2 gap-3 pt-2">
-                    <div className="bg-slate-50 p-3 rounded-2xl border border-slate-100">
+                    <div className="bg-slate-50 p-3 rounded-2xl border border-slate-100 relative">
                        <span className="block text-[10px] uppercase font-bold text-slate-400 tracking-wider">Batch No.</span>
-                       <span className="font-bold text-slate-700">AUG625D</span>
+                       <div className="flex items-center justify-between gap-1">
+                         <span className="font-bold text-slate-700">AUG625D</span>
+                         <button
+                           onClick={handleCopyBatch}
+                           aria-label="Copy batch number"
+                           className={`p-1 rounded-lg transition-all duration-200 shrink-0 ${
+                             copied
+                               ? "bg-emerald-100 text-emerald-600"
+                               : "bg-slate-200/60 text-slate-400 hover:bg-slate-200 hover:text-slate-600"
+                           }`}
+                         >
+                           {copied ? <Check size={14} strokeWidth={3} /> : <Copy size={14} />}
+                         </button>
+                       </div>
                     </div>
                     <div className="bg-slate-50 p-3 rounded-2xl border border-slate-100">
                        <span className="block text-[10px] uppercase font-bold text-slate-400 tracking-wider">Expiry</span>


### PR DESCRIPTION
hey, this fixes #28 #gssoc
added a small copy button next to the batch number on the verified result card. when you click it, the batch number gets copied to clipboard and the icon switches to a green checkmark for about 2 seconds so the user knows it worked, then it goes back to the copy icon.
used the Copy and Check icons from lucide-react which is already in the project so no new dependencies. used navigator.clipboard.writeText() for copying. also added a fallback for older browsers just in case.
tested on both mobile and desktop, works fine. only changed one file - apps/web/app/scan/page.tsx