### PR TITLE
feat(api): add JWT auth middleware for reports

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node dist/index.js",
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "tsc -p tsconfig.test.json && node --test \".tmp/test-dist/**/*.test.js\""
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.105.3",

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -3,11 +3,12 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const supabaseUrl = process.env.SUPABASE_URL || '';
-const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY || '';
+const supabaseUrl = process.env.SUPABASE_URL || 'http://localhost:54321';
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY || 'local-development-key';
 
-if (!supabaseUrl || !supabaseKey) {
-  console.warn('⚠️ Supabase URL or Key is missing. Database connections will fail.');
+if (!process.env.SUPABASE_URL || (!process.env.SUPABASE_SERVICE_ROLE_KEY && !process.env.SUPABASE_ANON_KEY)) {
+  console.warn('Supabase URL or key is missing. Database connections will fail.');
 }
 
 // We use service role key if available for administrative DB tasks on the backend.

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
+import reportsRouter from './routes/reports';
 
 // Load environment variables
 dotenv.config();
@@ -28,7 +29,13 @@ app.get('/health', (req: Request, res: Response) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
+app.use('/reports', reportsRouter);
+
 // Start the server
-app.listen(port, () => {
-  console.log(`[API Server]: SahiDawa API is running at http://localhost:${port}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(port, () => {
+    console.log(`[API Server]: SahiDawa API is running at http://localhost:${port}`);
+  });
+}
+
+export default app;

--- a/apps/api/src/middleware/auth.test.ts
+++ b/apps/api/src/middleware/auth.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { NextFunction, Response } from 'express';
+import { AuthenticatedRequest, createAuthMiddleware, requireRole } from './auth';
+
+const createResponse = () => {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res as Response & { statusCode: number; body: unknown };
+};
+
+const createClient = (user: unknown, error: unknown = null) => ({
+  auth: {
+    getUser: async (token: string) => ({
+      data: { user },
+      error,
+      token,
+    }),
+  },
+});
+
+describe('auth middleware', () => {
+  it('rejects requests without an authorization header', async () => {
+    const req = { headers: {} } as AuthenticatedRequest;
+    const res = createResponse();
+    let nextCalled = false;
+
+    await createAuthMiddleware(createClient(null) as never)(req, res, (() => {
+      nextCalled = true;
+    }) as NextFunction);
+
+    assert.equal(res.statusCode, 401);
+    assert.deepEqual(res.body, { error: 'Authorization bearer token is required' });
+    assert.equal(nextCalled, false);
+  });
+
+  it('rejects malformed bearer tokens', async () => {
+    const req = { headers: { authorization: 'Token abc' } } as AuthenticatedRequest;
+    const res = createResponse();
+
+    await createAuthMiddleware(createClient(null) as never)(req, res, (() => {
+      assert.fail('next should not be called');
+    }) as NextFunction);
+
+    assert.equal(res.statusCode, 401);
+  });
+
+  it('rejects invalid Supabase tokens', async () => {
+    const req = { headers: { authorization: 'Bearer invalid-token' } } as AuthenticatedRequest;
+    const res = createResponse();
+
+    await createAuthMiddleware(createClient(null, new Error('invalid')) as never)(
+      req,
+      res,
+      (() => {
+        assert.fail('next should not be called');
+      }) as NextFunction,
+    );
+
+    assert.equal(res.statusCode, 401);
+    assert.deepEqual(res.body, { error: 'Invalid or expired authentication token' });
+  });
+
+  it('attaches authenticated user details for valid user tokens', async () => {
+    const req = { headers: { authorization: 'Bearer valid-token' } } as AuthenticatedRequest;
+    const res = createResponse();
+    let nextCalled = false;
+
+    await createAuthMiddleware(
+      createClient({
+        id: 'user-1',
+        email: 'user@example.com',
+        app_metadata: {},
+        user_metadata: {},
+      }) as never,
+    )(req, res, (() => {
+      nextCalled = true;
+    }) as NextFunction);
+
+    assert.equal(nextCalled, true);
+    assert.equal(req.user?.id, 'user-1');
+    assert.equal(req.user?.email, 'user@example.com');
+    assert.equal(req.user?.role, 'user');
+  });
+
+  it('allows admin-only handlers for admin users', () => {
+    const req = { user: { role: 'admin' } } as AuthenticatedRequest;
+    const res = createResponse();
+    let nextCalled = false;
+
+    requireRole('admin')(req, res, (() => {
+      nextCalled = true;
+    }) as NextFunction);
+
+    assert.equal(nextCalled, true);
+    assert.equal(res.statusCode, 200);
+  });
+
+  it('rejects user role requests for admin-only handlers', () => {
+    const req = { user: { role: 'user' } } as AuthenticatedRequest;
+    const res = createResponse();
+
+    requireRole('admin')(req, res, (() => {
+      assert.fail('next should not be called');
+    }) as NextFunction);
+
+    assert.equal(res.statusCode, 403);
+    assert.deepEqual(res.body, { error: 'Insufficient permissions' });
+  });
+});

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,0 +1,82 @@
+import { NextFunction, Request, Response } from 'express';
+import { SupabaseClient, User } from '@supabase/supabase-js';
+import { supabase } from '../db/client';
+
+export type AuthRole = 'user' | 'admin';
+
+export interface AuthenticatedUser {
+  id: string;
+  email?: string;
+  role: AuthRole;
+  raw: User;
+}
+
+export interface AuthenticatedRequest extends Request {
+  user?: AuthenticatedUser;
+}
+
+type SupabaseAuthClient = Pick<SupabaseClient, 'auth'>;
+
+const getBearerToken = (authorization?: string): string | null => {
+  if (!authorization) {
+    return null;
+  }
+
+  const [scheme, token] = authorization.split(' ');
+
+  if (scheme !== 'Bearer' || !token) {
+    return null;
+  }
+
+  return token;
+};
+
+const getUserRole = (user: User): AuthRole => {
+  const metadataRole = user.app_metadata?.role || user.user_metadata?.role;
+  return metadataRole === 'admin' ? 'admin' : 'user';
+};
+
+export const createAuthMiddleware =
+  (client: SupabaseAuthClient = supabase) =>
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    const token = getBearerToken(req.headers.authorization);
+
+    if (!token) {
+      res.status(401).json({ error: 'Authorization bearer token is required' });
+      return;
+    }
+
+    const { data, error } = await client.auth.getUser(token);
+
+    if (error || !data.user) {
+      res.status(401).json({ error: 'Invalid or expired authentication token' });
+      return;
+    }
+
+    req.user = {
+      id: data.user.id,
+      email: data.user.email,
+      role: getUserRole(data.user),
+      raw: data.user,
+    };
+
+    next();
+  };
+
+export const requireAuth = createAuthMiddleware();
+
+export const requireRole =
+  (...allowedRoles: AuthRole[]) =>
+  (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    if (!req.user) {
+      res.status(401).json({ error: 'Authentication is required' });
+      return;
+    }
+
+    if (!allowedRoles.includes(req.user.role)) {
+      res.status(403).json({ error: 'Insufficient permissions' });
+      return;
+    }
+
+    next();
+  };

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,0 +1,103 @@
+import { Router, Response } from 'express';
+import { supabase } from '../db/client';
+import { AuthenticatedRequest, requireAuth, requireRole } from '../middleware/auth';
+
+const reportsRouter = Router();
+
+interface CreateReportBody {
+  medicineId?: string;
+  scannedBarcode?: string;
+  reportedBrandName?: string;
+  photoUrl?: string;
+  latitude?: number;
+  longitude?: number;
+  district?: string;
+}
+
+const buildReportLocation = (latitude?: number, longitude?: number) => {
+  if (typeof latitude !== 'number' || typeof longitude !== 'number') {
+    return null;
+  }
+
+  return `POINT(${longitude} ${latitude})`;
+};
+
+reportsRouter.post('/', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const {
+    medicineId,
+    scannedBarcode,
+    reportedBrandName,
+    photoUrl,
+    latitude,
+    longitude,
+    district,
+  } = req.body as CreateReportBody;
+
+  if (!scannedBarcode && !reportedBrandName && !medicineId) {
+    res.status(400).json({
+      error: 'At least one medicine identifier is required',
+    });
+    return;
+  }
+
+  const { data, error } = await supabase
+    .from('counterfeit_reports')
+    .insert({
+      medicine_id: medicineId,
+      scanned_barcode: scannedBarcode,
+      reported_brand_name: reportedBrandName,
+      photo_url: photoUrl,
+      report_location: buildReportLocation(latitude, longitude),
+      district,
+      status: 'pending',
+    })
+    .select()
+    .single();
+
+  if (error) {
+    res.status(500).json({ error: 'Failed to submit counterfeit report' });
+    return;
+  }
+
+  res.status(201).json({ report: data, submittedBy: req.user?.id });
+});
+
+reportsRouter.get('/', requireAuth, requireRole('admin'), async (_req, res: Response) => {
+  const { data, error } = await supabase
+    .from('counterfeit_reports')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    res.status(500).json({ error: 'Failed to fetch counterfeit reports' });
+    return;
+  }
+
+  res.json({ reports: data });
+});
+
+reportsRouter.patch('/:id/status', requireAuth, requireRole('admin'), async (req, res: Response) => {
+  const { status } = req.body as { status?: string };
+  const allowedStatuses = ['pending', 'verified_fake', 'false_alarm'];
+
+  if (!status || !allowedStatuses.includes(status)) {
+    res.status(400).json({ error: 'Invalid report status' });
+    return;
+  }
+
+  const { data, error } = await supabase
+    .from('counterfeit_reports')
+    .update({ status })
+    .eq('id', req.params.id)
+    .select()
+    .single();
+
+  if (error) {
+    res.status(500).json({ error: 'Failed to update report status' });
+    return;
+  }
+
+  res.json({ report: data });
+});
+
+export default reportsRouter;

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,14 +2,16 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "CommonJS",
+    "moduleResolution": "node",
     "rootDir": "./src",
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "tests", "dist"]
+  "exclude": ["node_modules", "tests", "dist", ".tmp", "**/*.test.ts"]
 }

--- a/apps/api/tsconfig.test.json
+++ b/apps/api/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./.tmp/test-dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", ".tmp"]
+}


### PR DESCRIPTION
## 📋 PR Summary

Implemented JWT-based authentication for the counterfeit report backend flow using Supabase Auth. This secures report submission so only authenticated users can submit counterfeit reports, and adds admin-only access for report review/status management.

## 🔗 Related Issue

> Fixes #53

## 🏷️ PR Type

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [x] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

## 🗂️ Area Changed

- [ ] `apps/web` — Next.js Frontend
- [x] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

## 📝 What Was Done

- Added `apps/api/src/middleware/auth.ts` for Supabase JWT authentication.
- Verified bearer tokens using `supabase.auth.getUser(token)`.
- Added authenticated user context to protected requests.
- Protected counterfeit report submission via `requireAuth`.
- Added role-based access control with `requireRole('admin')`.
- Added admin-only report listing and report status update endpoints.
- Added focused unit tests for auth middleware behavior.
- Added backend test script and test TypeScript config.

## 📸 Screenshots / Demo

Backend test output:

```txt
npm.cmd test --workspace apps/api

✔ auth middleware
  ✔ rejects requests without an authorization header
  ✔ rejects malformed bearer tokens
  ✔ rejects invalid Supabase tokens
  ✔ attaches authenticated user details for valid user tokens
  ✔ allows admin-only handlers for admin users
  ✔ rejects user role requests for admin-only handlers

tests 6
pass 6
fail 0
