### PR TITLE
Add copy action for medicine verification details

### DIFF
--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -1,7 +1,17 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Camera, ShieldCheck, Info, AlertCircle, Layers, Copy, Check, Home, Share2 } from "lucide-react";
+import {
+    Camera,
+    ShieldCheck,
+    Info,
+    AlertCircle,
+    Layers,
+    Copy,
+    Check,
+    Home,
+    Share2,
+} from "lucide-react";
 import { Link } from "@/i18n/routing";
 import { PageHeader } from "../components/PageHeader";
 import { toast } from "sonner";
@@ -10,278 +20,348 @@ import { ExpiryBadge } from "@/components/scanner/ExpiryBadge";
 
 // Sleek Skeleton component for loading states
 function LoadingSkeleton() {
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-6 bg-black/80 backdrop-blur-md">
-      <div className="bg-white text-slate-900 w-full max-w-sm rounded-[2.5rem] p-8 shadow-2xl relative overflow-hidden">
-        <div className="absolute top-0 left-0 right-0 h-2 bg-emerald-500 animate-pulse"></div>
-        <div className="flex flex-col items-center text-center space-y-4">
-          <div className="w-20 h-20 rounded-full bg-slate-100 flex items-center justify-center animate-pulse">
-             <ShieldCheck size={40} className="text-slate-200" />
-          </div>
-          <div className="space-y-2 w-full">
-            <div className="h-7 bg-slate-100 rounded-lg animate-pulse w-3/4 mx-auto"></div>
-            <div className="h-4 bg-slate-100 rounded-lg animate-pulse w-1/2 mx-auto"></div>
-          </div>
-          <div className="w-full grid grid-cols-2 gap-3 pt-2">
-            <div className="bg-slate-50 p-3 rounded-2xl space-y-2 border border-slate-100">
-              <div className="h-3 bg-slate-200 rounded animate-pulse w-3/4 mx-auto"></div>
-              <div className="h-5 bg-slate-200 rounded animate-pulse w-1/2 mx-auto"></div>
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-6 backdrop-blur-md">
+            <div className="relative w-full max-w-sm overflow-hidden rounded-[2.5rem] bg-white p-8 text-slate-900 shadow-2xl">
+                <div className="absolute top-0 right-0 left-0 h-2 animate-pulse bg-emerald-500"></div>
+                <div className="flex flex-col items-center space-y-4 text-center">
+                    <div className="flex h-20 w-20 animate-pulse items-center justify-center rounded-full bg-slate-100">
+                        <ShieldCheck size={40} className="text-slate-200" />
+                    </div>
+                    <div className="w-full space-y-2">
+                        <div className="mx-auto h-7 w-3/4 animate-pulse rounded-lg bg-slate-100"></div>
+                        <div className="mx-auto h-4 w-1/2 animate-pulse rounded-lg bg-slate-100"></div>
+                    </div>
+                    <div className="grid w-full grid-cols-2 gap-3 pt-2">
+                        <div className="space-y-2 rounded-2xl border border-slate-100 bg-slate-50 p-3">
+                            <div className="mx-auto h-3 w-3/4 animate-pulse rounded bg-slate-200"></div>
+                            <div className="mx-auto h-5 w-1/2 animate-pulse rounded bg-slate-200"></div>
+                        </div>
+                        <div className="space-y-2 rounded-2xl border border-slate-100 bg-slate-50 p-3">
+                            <div className="mx-auto h-3 w-3/4 animate-pulse rounded bg-slate-200"></div>
+                            <div className="mx-auto h-5 w-1/2 animate-pulse rounded bg-slate-200"></div>
+                        </div>
+                    </div>
+                    <div className="w-full space-y-2 rounded-2xl border border-emerald-100/50 bg-emerald-50/50 p-4">
+                        <div className="h-3 w-full animate-pulse rounded bg-emerald-200/50"></div>
+                        <div className="h-3 w-5/6 animate-pulse rounded bg-emerald-200/50"></div>
+                    </div>
+                    <div className="h-12 w-full animate-pulse rounded-2xl bg-slate-100 py-4"></div>
+                    <div className="mx-auto h-4 w-24 animate-pulse rounded bg-slate-100"></div>
+                </div>
+                <div className="mt-4 animate-pulse text-center text-sm font-medium text-slate-400">
+                    Verifying with CDSCO Database...
+                </div>
             </div>
-            <div className="bg-slate-50 p-3 rounded-2xl space-y-2 border border-slate-100">
-              <div className="h-3 bg-slate-200 rounded animate-pulse w-3/4 mx-auto"></div>
-              <div className="h-5 bg-slate-200 rounded animate-pulse w-1/2 mx-auto"></div>
-            </div>
-          </div>
-          <div className="w-full bg-emerald-50/50 p-4 rounded-2xl space-y-2 border border-emerald-100/50">
-            <div className="h-3 bg-emerald-200/50 rounded animate-pulse w-full"></div>
-            <div className="h-3 bg-emerald-200/50 rounded animate-pulse w-5/6"></div>
-          </div>
-          <div className="w-full py-4 bg-slate-100 rounded-2xl animate-pulse h-12"></div>
-          <div className="h-4 bg-slate-100 rounded animate-pulse w-24 mx-auto"></div>
         </div>
-        <div className="text-center mt-4 text-sm text-slate-400 font-medium animate-pulse">
-          Verifying with CDSCO Database...
-        </div>
-      </div>
-    </div>
-  );
+    );
 }
 
 export default function ScanPage() {
-  const [isScanning, setIsScanning] = useState(false);
-  const [showResult, setShowResult] = useState(false);
-  const [uploadedImage, setUploadedImage] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
+    const [isScanning, setIsScanning] = useState(false);
+    const [showResult, setShowResult] = useState(false);
+    const [uploadedImage, setUploadedImage] = useState<string | null>(null);
+    const [copied, setCopied] = useState(false);
+    const [copiedDetails, setCopiedDetails] = useState(false);
 
-  const handleCopyBatch = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText("AUG625D");
-      setCopied(true);
-      toast.success("Batch number copied!");
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      const textArea = document.createElement("textarea");
-      textArea.value = "AUG625D";
-      document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand("copy");
-      document.body.removeChild(textArea);
-      setCopied(true);
-      toast.success("Batch number copied!");
-      setTimeout(() => setCopied(false), 2000);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (isScanning) {
-      const timer = setTimeout(() => {
-        setIsScanning(false);
-        setShowResult(true);
-      }, 3000);
-      return () => clearTimeout(timer);
-    }
-  }, [isScanning]);
-
-  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-
-  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-
-    if (file.size > MAX_FILE_SIZE) {
-      toast.error('File exceeds 10MB limit');
-      e.target.value = '';
-      return;
-    }
-
-    const reader = new FileReader();
-    reader.onloadend = () => {
-      setUploadedImage(reader.result as string);
-      setIsScanning(true);
-      setShowResult(false);
+    const medicineDetails = {
+        name: "Authentic Medicine",
+        batchNo: "AUG625D",
+        expiry: "12/2027",
+        manufacturer: "Cipla Ltd.",
+        status: "Verified by CDSCO Database",
     };
-    reader.readAsDataURL(file);
-  };
 
-  const handleScanAgain = () => {
-    setIsScanning(false);
-    setShowResult(false);
-    setUploadedImage(null);
-  };
+    const copyText = useCallback(async (text: string) => {
+        if (navigator.clipboard?.writeText) {
+            await navigator.clipboard.writeText(text);
+            return;
+        }
 
-  const handleShare = async () => {
-    const shareText = `
-Medicine: Authentic Medicine
-Batch No: AUG625D
-Expiry: 12/2027
-Status: Verified by CDSCO Database
+        const textArea = document.createElement("textarea");
+        textArea.value = text;
+        textArea.setAttribute("readonly", "");
+        textArea.style.position = "fixed";
+        textArea.style.opacity = "0";
+        document.body.appendChild(textArea);
+        textArea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textArea);
+    }, []);
+
+    const handleCopyBatch = useCallback(async () => {
+        try {
+            await copyText(medicineDetails.batchNo);
+            setCopied(true);
+            toast.success("Batch number copied!");
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            toast.error("Unable to copy batch number");
+        }
+    }, [copyText, medicineDetails.batchNo]);
+
+    const handleCopyDetails = useCallback(async () => {
+        const detailsText = [
+            `Medicine: ${medicineDetails.name}`,
+            `Batch No: ${medicineDetails.batchNo}`,
+            `Manufacturer: ${medicineDetails.manufacturer}`,
+            `Expiry: ${medicineDetails.expiry}`,
+            `Status: ${medicineDetails.status}`,
+        ].join("\n");
+
+        try {
+            await copyText(detailsText);
+            setCopiedDetails(true);
+            toast.success("Medicine details copied!");
+            setTimeout(() => setCopiedDetails(false), 2000);
+        } catch {
+            toast.error("Unable to copy medicine details");
+        }
+    }, [copyText, medicineDetails]);
+
+    useEffect(() => {
+        if (isScanning) {
+            const timer = setTimeout(() => {
+                setIsScanning(false);
+                setShowResult(true);
+            }, 3000);
+            return () => clearTimeout(timer);
+        }
+    }, [isScanning]);
+
+    const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+
+        if (file.size > MAX_FILE_SIZE) {
+            toast.error("File exceeds 10MB limit");
+            e.target.value = "";
+            return;
+        }
+
+        const reader = new FileReader();
+        reader.onloadend = () => {
+            setUploadedImage(reader.result as string);
+            setIsScanning(true);
+            setShowResult(false);
+        };
+        reader.readAsDataURL(file);
+    };
+
+    const handleScanAgain = () => {
+        setIsScanning(false);
+        setShowResult(false);
+        setUploadedImage(null);
+    };
+
+    const handleShare = async () => {
+        const shareText = `
+Medicine: ${medicineDetails.name}
+Batch No: ${medicineDetails.batchNo}
+Manufacturer: ${medicineDetails.manufacturer}
+Expiry: ${medicineDetails.expiry}
+Status: ${medicineDetails.status}
     `.trim();
 
-    const shareData = {
-      title: "Medicine Verification Result",
-      text: shareText,
-      url: window.location.href,
+        const shareData = {
+            title: "Medicine Verification Result",
+            text: shareText,
+            url: window.location.href,
+        };
+
+        try {
+            if (navigator.share) {
+                await navigator.share(shareData);
+                toast.success("Result shared successfully");
+            } else {
+                await copyText(`${shareText}\n\n${window.location.href}`);
+                toast.success("Result copied to clipboard");
+            }
+        } catch (error: any) {
+            if (error?.name !== "AbortError") {
+                toast.error("Failed to share result");
+            }
+        }
     };
 
-    try {
-      if (navigator.share) {
-        await navigator.share(shareData);
-        toast.success("Result shared successfully");
-      } else {
-        await navigator.clipboard.writeText(`${shareText}\n\n${window.location.href}`);
-        toast.success("Result copied to clipboard");
-      }
-    } catch (error: any) {
-      if (error?.name !== "AbortError") {
-        toast.error("Failed to share result");
-      }
-    }
-  };
+    return (
+        <div className="relative flex min-h-screen flex-col bg-black font-sans text-white">
+            <input
+                type="file"
+                id="medicine-upload"
+                className="hidden"
+                accept="image/*"
+                onChange={handleFileUpload}
+            />
 
-  return (
-    <div className="min-h-screen bg-black text-white font-sans relative flex flex-col">
-      <input 
-        type="file" 
-        id="medicine-upload" 
-        className="hidden" 
-        accept="image/*" 
-        onChange={handleFileUpload}
-      />
+            <PageHeader
+                title="Scanner Mode"
+                subtitle="Position the Barcode"
+                backHref="/"
+                variant="dark"
+            />
 
-      <PageHeader 
-        title="Scanner Mode" 
-        subtitle="Position the Barcode" 
-        backHref="/" 
-        variant="dark" 
-      />
-
-      <div className="flex-1 relative flex items-center justify-center overflow-hidden">
-        <div className="absolute inset-0 bg-slate-900 overflow-hidden">
-          {uploadedImage ? (
-            <img src={uploadedImage} alt="Uploaded" className="w-full h-full object-cover opacity-60" />
-          ) : (
-            <>
-              <div className="absolute inset-0 opacity-20 bg-[url('https://www.transparenttextures.com/patterns/carbon-fibre.png')]"></div>
-              <div className="absolute inset-0 animate-pulse bg-emerald-500/5"></div>
-            </>
-          )}
-        </div>
-
-        <div className="relative w-72 h-72 md:w-96 md:h-96 z-10">
-          <div className="absolute top-0 left-0 w-12 h-12 border-t-4 border-l-4 border-emerald-500 rounded-tl-2xl"></div>
-          <div className="absolute top-0 right-0 w-12 h-12 border-t-4 border-r-4 border-emerald-500 rounded-tr-2xl"></div>
-          <div className="absolute bottom-0 left-0 w-12 h-12 border-b-4 border-l-4 border-emerald-500 rounded-bl-2xl"></div>
-          <div className="absolute bottom-0 right-0 w-12 h-12 border-b-4 border-r-4 border-emerald-500 rounded-br-2xl"></div>
-
-          {isScanning && (
-            <div className="absolute left-4 right-4 h-[2px] bg-emerald-400 shadow-[0_0_15px_rgba(52,211,153,0.8)] animate-scan z-20"></div>
-          )}
-          
-          {!isScanning && !showResult && (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <Camera size={48} className="text-emerald-500/30 animate-pulse" />
-            </div>
-          )}
-        </div>
-
-        {/* Loading Skeleton */}
-        {isScanning && <LoadingSkeleton />}
-
-        {/* Result Overlay */}
-        {showResult && (
-          <div className="absolute inset-0 z-30 flex items-center justify-center p-6 bg-black/60 backdrop-blur-sm animate-in fade-in zoom-in duration-300">
-            <div className="bg-white text-slate-900 w-full max-w-sm rounded-[2.5rem] p-8 shadow-2xl relative overflow-hidden">
-              <div className="absolute top-0 left-0 right-0 h-2 bg-emerald-500"></div>
-              
-              <div className="flex flex-col items-center text-center space-y-4">
-                <div className="w-20 h-20 rounded-full bg-emerald-100 text-emerald-600 flex items-center justify-center shadow-inner">
-                  <ShieldCheck size={40} strokeWidth={2.5} />
-                </div>
-                <div>
-                  <h3 className="text-2xl font-black tracking-tight">Authentic Medicine</h3>
-                  <p className="text-slate-500 font-medium">Verified by CDSCO Database</p>
+            <div className="relative flex flex-1 items-center justify-center overflow-hidden">
+                <div className="absolute inset-0 overflow-hidden bg-slate-900">
+                    {uploadedImage ? (
+                        <img
+                            src={uploadedImage}
+                            alt="Uploaded"
+                            className="h-full w-full object-cover opacity-60"
+                        />
+                    ) : (
+                        <>
+                            <div className="absolute inset-0 bg-[url('https://www.transparenttextures.com/patterns/carbon-fibre.png')] opacity-20"></div>
+                            <div className="absolute inset-0 animate-pulse bg-emerald-500/5"></div>
+                        </>
+                    )}
                 </div>
 
-                <div className="w-full grid grid-cols-2 gap-3 pt-2">
-                  <div className="bg-slate-50 p-3 rounded-2xl border border-slate-100 relative group">
-                    <span className="block text-[10px] uppercase font-bold text-slate-400 tracking-wider">Batch No.</span>
-                    <div className="flex items-center justify-between gap-1">
-                      <span className="font-bold text-slate-700">AUG625D</span>
-                      <button
-                        onClick={handleCopyBatch}
-                        className={`p-1.5 rounded-lg transition-all duration-200 shrink-0 ${
-                          copied
-                            ? "bg-emerald-100 text-emerald-600"
-                            : "bg-slate-200/60 text-slate-400 hover:bg-slate-200 hover:text-slate-600"
-                        }`}
-                      >
-                        {copied ? <Check size={14} strokeWidth={3} /> : <Copy size={14} />}
-                      </button>
+                <div className="relative z-10 h-72 w-72 md:h-96 md:w-96">
+                    <div className="absolute top-0 left-0 h-12 w-12 rounded-tl-2xl border-t-4 border-l-4 border-emerald-500"></div>
+                    <div className="absolute top-0 right-0 h-12 w-12 rounded-tr-2xl border-t-4 border-r-4 border-emerald-500"></div>
+                    <div className="absolute bottom-0 left-0 h-12 w-12 rounded-bl-2xl border-b-4 border-l-4 border-emerald-500"></div>
+                    <div className="absolute right-0 bottom-0 h-12 w-12 rounded-br-2xl border-r-4 border-b-4 border-emerald-500"></div>
+
+                    {isScanning && (
+                        <div className="animate-scan absolute right-4 left-4 z-20 h-[2px] bg-emerald-400 shadow-[0_0_15px_rgba(52,211,153,0.8)]"></div>
+                    )}
+
+                    {!isScanning && !showResult && (
+                        <div className="absolute inset-0 flex items-center justify-center">
+                            <Camera size={48} className="animate-pulse text-emerald-500/30" />
+                        </div>
+                    )}
+                </div>
+
+                {/* Loading Skeleton */}
+                {isScanning && <LoadingSkeleton />}
+
+                {/* Result Overlay */}
+                {showResult && (
+                    <div className="animate-in fade-in zoom-in absolute inset-0 z-30 flex items-center justify-center bg-black/60 p-6 backdrop-blur-sm duration-300">
+                        <div className="relative w-full max-w-sm overflow-hidden rounded-[2.5rem] bg-white p-8 text-slate-900 shadow-2xl">
+                            <div className="absolute top-0 right-0 left-0 h-2 bg-emerald-500"></div>
+                            <button
+                                type="button"
+                                onClick={handleCopyDetails}
+                                aria-label="Copy medicine details"
+                                className={`absolute top-6 right-6 flex h-10 w-10 items-center justify-center rounded-2xl border transition-all duration-200 ${
+                                    copiedDetails
+                                        ? "border-emerald-200 bg-emerald-100 text-emerald-700"
+                                        : "border-slate-200 bg-slate-50 text-slate-500 hover:bg-slate-100 hover:text-slate-700"
+                                }`}
+                            >
+                                {copiedDetails ? (
+                                    <Check size={18} strokeWidth={3} />
+                                ) : (
+                                    <Copy size={18} />
+                                )}
+                            </button>
+
+                            <div className="flex flex-col items-center space-y-4 text-center">
+                                <div className="flex h-20 w-20 items-center justify-center rounded-full bg-emerald-100 text-emerald-600 shadow-inner">
+                                    <ShieldCheck size={40} strokeWidth={2.5} />
+                                </div>
+                                <div>
+                                    <h3 className="text-2xl font-black tracking-tight">
+                                        {medicineDetails.name}
+                                    </h3>
+                                    <p className="font-medium text-slate-500">
+                                        {medicineDetails.status}
+                                    </p>
+                                </div>
+
+                                <div className="grid w-full grid-cols-2 gap-3 pt-2">
+                                    <div className="group relative rounded-2xl border border-slate-100 bg-slate-50 p-3">
+                                        <span className="block text-[10px] font-bold tracking-wider text-slate-400 uppercase">
+                                            Batch No.
+                                        </span>
+                                        <div className="flex items-center justify-between gap-1">
+                                            <span className="font-bold text-slate-700">
+                                                {medicineDetails.batchNo}
+                                            </span>
+                                            <button
+                                                type="button"
+                                                onClick={handleCopyBatch}
+                                                aria-label="Copy batch number"
+                                                className={`shrink-0 rounded-lg p-1.5 transition-all duration-200 ${
+                                                    copied
+                                                        ? "bg-emerald-100 text-emerald-600"
+                                                        : "bg-slate-200/60 text-slate-400 hover:bg-slate-200 hover:text-slate-600"
+                                                }`}
+                                            >
+                                                {copied ? (
+                                                    <Check size={14} strokeWidth={3} />
+                                                ) : (
+                                                    <Copy size={14} />
+                                                )}
+                                            </button>
+                                        </div>
+                                    </div>
+
+                                    <ExpiryBadge expiryDate="12/2027" />
+                                </div>
+
+                                <div className="flex w-full items-start gap-3 rounded-2xl border border-emerald-100 bg-emerald-50 p-4 text-left">
+                                    <Info size={18} className="mt-0.5 shrink-0 text-emerald-600" />
+                                    <p className="text-xs leading-relaxed font-medium text-emerald-800">
+                                        This medicine matches the official records. Always check the
+                                        physical seal before use.
+                                    </p>
+                                </div>
+
+                                <div className="grid w-full grid-cols-1 gap-3">
+                                    <button
+                                        onClick={handleScanAgain}
+                                        className="w-full rounded-2xl bg-slate-900 py-4 font-bold text-white shadow-lg shadow-slate-900/20 transition-colors hover:bg-slate-800"
+                                    >
+                                        Scan Another
+                                    </button>
+                                    <div className="grid grid-cols-2 gap-3">
+                                        <Link
+                                            href="/"
+                                            className="flex items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-slate-100 py-3.5 font-semibold text-slate-700 transition-all hover:bg-slate-200"
+                                        >
+                                            <Home size={18} />
+                                            <span>Home</span>
+                                        </Link>
+                                        <button
+                                            onClick={handleShare}
+                                            className="flex items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-slate-100 py-3.5 font-semibold text-slate-700 transition-all hover:bg-slate-200"
+                                        >
+                                            <Share2 size={18} />
+                                            <span>Share</span>
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                  </div>
-                  
-                  <ExpiryBadge expiryDate="12/2027" />
-
-
-
-                  
-                </div>
-
-                <div className="w-full bg-emerald-50 border border-emerald-100 p-4 rounded-2xl flex items-start gap-3 text-left">
-                  <Info size={18} className="text-emerald-600 shrink-0 mt-0.5" />
-                  <p className="text-xs text-emerald-800 font-medium leading-relaxed">
-                    This medicine matches the official records. Always check the physical seal before use.
-                  </p>
-                </div>
-
-                <div className="w-full grid grid-cols-1 gap-3">
-                  <button 
-                    onClick={handleScanAgain}
-                    className="w-full py-4 bg-slate-900 text-white font-bold rounded-2xl hover:bg-slate-800 transition-colors shadow-lg shadow-slate-900/20"
-                  >
-                    Scan Another
-                  </button>
-                  <div className="grid grid-cols-2 gap-3">
-                    <Link
-                      href="/"
-                      className="flex items-center justify-center gap-2 py-3.5 rounded-2xl bg-slate-100 border border-slate-200 text-slate-700 font-semibold hover:bg-slate-200 transition-all"
-                    >
-                      <Home size={18} />
-                      <span>Home</span>
-                    </Link>
-                    <button
-                      onClick={handleShare}
-                      className="flex items-center justify-center gap-2 py-3.5 rounded-2xl bg-slate-100 border border-slate-200 text-slate-700 font-semibold hover:bg-slate-200 transition-all"
-                    >
-                      <Share2 size={18} />
-                      <span>Share</span>
-                    </button>
-                  </div>
-                </div>
-              </div>
+                )}
             </div>
-          </div>
-        )}
-      </div>
 
-      <div className="p-8 bg-gradient-to-t from-black to-transparent flex flex-col items-center gap-6">
-        <p className="text-slate-400 text-sm font-medium text-center max-w-xs">
-          Hold the medicine strip steady inside the frame or upload a photo from your gallery.
-        </p>
-        <div className="flex gap-4">
-          <label 
-            htmlFor="medicine-upload" 
-            className="px-6 py-3 rounded-full bg-white text-black font-bold text-sm flex items-center gap-2 cursor-pointer hover:bg-slate-200 transition-colors shadow-lg"
-          >
-            <Layers size={18} />
-            Upload Photo
-          </label>
-          <div className="w-12 h-12 rounded-2xl bg-white/5 border border-white/10 flex items-center justify-center">
-            <AlertCircle size={20} className="text-white/50" />
-          </div>
+            <div className="flex flex-col items-center gap-6 bg-gradient-to-t from-black to-transparent p-8">
+                <p className="max-w-xs text-center text-sm font-medium text-slate-400">
+                    Hold the medicine strip steady inside the frame or upload a photo from your
+                    gallery.
+                </p>
+                <div className="flex gap-4">
+                    <label
+                        htmlFor="medicine-upload"
+                        className="flex cursor-pointer items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-bold text-black shadow-lg transition-colors hover:bg-slate-200"
+                    >
+                        <Layers size={18} />
+                        Upload Photo
+                    </label>
+                    <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/10 bg-white/5">
+                        <AlertCircle size={20} className="text-white/50" />
+                    </div>
+                </div>
+            </div>
+            <Footer />
         </div>
-      </div>
-      <Footer />
-    </div>
-  );
+    );
 }


### PR DESCRIPTION
## Summary
- adds a result-card copy button with `aria-label="Copy medicine details"`
- copies formatted medicine name, batch number, manufacturer, expiry, and verification status
- keeps two-second copied feedback and uses a no-library clipboard fallback with error toasts
- reuses the same fallback path for share-copy behavior

## Verification
- `npx tsc --noEmit -p apps/web/tsconfig.json`
- `git diff --check`

Note: `npm run build -w apps/web` is blocked in this local Node 20 environment by missing native optional packages required by Next/next-intl (`@parcel/watcher` / `@swc/core-darwin-arm64`).

Addresses #196