### PR TITLE
Add web push notifications for medicine recall alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,12 @@ ML_SERVICE_URL=http://localhost:8000
 # --- Caching (Redis/Upstash) ---
 REDIS_URL=your_redis_url
 
+# --- Web Push Notifications ---
+# Generate with: npx web-push generate-vapid-keys
+VAPID_PUBLIC_KEY=your_vapid_public_key
+VAPID_PRIVATE_KEY=your_vapid_private_key
+VAPID_SUBJECT=mailto:security@sahidawa.local
+
 # --- Cloudinary (Medicine Photo Storage) ---
 CLOUDINARY_CLOUD_NAME=your_cloud_name
 CLOUDINARY_API_KEY=your_api_key

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,14 +18,16 @@
     "helmet": "^8.1.0",
     "morgan": "^1.10.0",
     "redis": "^5.12.1",
-    "zod": "^4.4.3",
-    "winston": "^3.19.0"
+    "web-push": "^3.6.7",
+    "winston": "^3.19.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/morgan": "^1.9.9",
     "@types/node": "^25.7.0",
+    "@types/web-push": "^3.6.4",
     "ts-node-dev": "^2.0.0",
     "typescript": "^6.0.3"
   }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -27,6 +27,7 @@ import reportsRouter from './routes/reports';
 import pharmaciesRouter from './routes/pharmacies';
 import verifyRouter from './routes/verify';
 import analyticsRoutes from './routes/analytics';
+import notificationsRouter from './routes/notifications';
 import { supabase } from './db/client';
 
 import logger from './utils/logger';
@@ -118,6 +119,7 @@ app.use('/reports', reportsRouter);
 app.use('/api/pharmacies', pharmaciesRouter);
 app.use('/api/verify', verifyRouter);
 app.use('/api/analytics', analyticsRoutes);
+app.use('/api/notifications', notificationsRouter);
 
 app.use(errorHandler);
 

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -1,0 +1,96 @@
+import { Router } from "express";
+import { z } from "zod";
+import {
+    getMockRecallFeed,
+    getVapidPublicKey,
+    isWebPushConfigured,
+    pushSubscriptionSchema,
+    recallAlertSchema,
+    removePushSubscription,
+    savePushSubscription,
+    triggerRecallAlert,
+} from "../services/notifications";
+
+const router = Router();
+
+const unsubscribeSchema = z.object({
+    endpoint: z.string().url(),
+});
+
+router.get("/vapid-public-key", (_req, res) => {
+    const publicKey = getVapidPublicKey();
+    res.json({
+        publicKey,
+        configured: isWebPushConfigured(),
+    });
+});
+
+router.post("/subscriptions", async (req, res) => {
+    const parsed = pushSubscriptionSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+        res.status(400).json({
+            error: "Invalid push subscription",
+            issues: parsed.error.issues,
+        });
+        return;
+    }
+
+    const result = await savePushSubscription(parsed.data);
+
+    res.status(201).json({
+        endpoint: result.stored.endpoint,
+        persisted: result.persisted,
+        warning: result.persisted
+            ? undefined
+            : "Stored in memory because push_subscriptions table is unavailable.",
+    });
+});
+
+router.delete("/subscriptions", async (req, res) => {
+    const parsed = unsubscribeSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+        res.status(400).json({
+            error: "Invalid unsubscribe payload",
+            issues: parsed.error.issues,
+        });
+        return;
+    }
+
+    await removePushSubscription(parsed.data.endpoint);
+    res.status(204).send();
+});
+
+router.get("/recalls/mock", (_req, res) => {
+    res.json({ recalls: getMockRecallFeed() });
+});
+
+router.post("/recalls/mock/trigger", async (req, res) => {
+    const feed = getMockRecallFeed();
+    const parsed = recallAlertSchema.partial({ id: true }).safeParse(req.body ?? {});
+
+    if (!parsed.success) {
+        res.status(400).json({
+            error: "Invalid recall alert payload",
+            issues: parsed.error.issues,
+        });
+        return;
+    }
+
+    const alert = recallAlertSchema.parse({
+        ...feed[0],
+        ...parsed.data,
+        id: parsed.data.id ?? `manual-${Date.now()}`,
+        recalledAt: parsed.data.recalledAt ?? new Date().toISOString(),
+    });
+
+    const result = await triggerRecallAlert(alert);
+
+    res.json({
+        alert,
+        delivery: result,
+    });
+});
+
+export default router;

--- a/apps/api/src/services/notifications.test.ts
+++ b/apps/api/src/services/notifications.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+    buildRecallPayload,
+    getMockRecallFeed,
+    pushSubscriptionSchema,
+    recallAlertSchema,
+} from "./notifications";
+
+describe("notification service", () => {
+    it("validates browser push subscriptions", () => {
+        const parsed = pushSubscriptionSchema.safeParse({
+            endpoint: "https://push.example.test/subscription/1",
+            keys: {
+                p256dh: "public-key",
+                auth: "auth-secret",
+            },
+        });
+
+        assert.equal(parsed.success, true);
+    });
+
+    it("rejects subscriptions without key material", () => {
+        const parsed = pushSubscriptionSchema.safeParse({
+            endpoint: "https://push.example.test/subscription/1",
+            keys: {
+                p256dh: "",
+                auth: "",
+            },
+        });
+
+        assert.equal(parsed.success, false);
+    });
+
+    it("builds recall push payloads with medicine name and reason", () => {
+        const alert = recallAlertSchema.parse({
+            id: "recall-1",
+            medicineName: "Azithromycin 500mg",
+            reason: "Batch recalled due to failed dissolution quality checks.",
+            severity: "critical",
+        });
+
+        const payload = buildRecallPayload(alert);
+
+        assert.equal(payload.title, "Azithromycin 500mg recalled");
+        assert.equal(payload.medicineName, "Azithromycin 500mg");
+        assert.equal(
+            payload.recallReason,
+            "Batch recalled due to failed dissolution quality checks."
+        );
+        assert.equal(payload.severity, "critical");
+    });
+
+    it("exposes a mock CDSCO recall feed", () => {
+        const feed = getMockRecallFeed();
+
+        assert.ok(feed.length >= 1);
+        assert.ok(feed[0].medicineName);
+        assert.ok(feed[0].reason);
+    });
+});

--- a/apps/api/src/services/notifications.ts
+++ b/apps/api/src/services/notifications.ts
@@ -1,0 +1,189 @@
+import webPush, { PushSubscription } from "web-push";
+import { z } from "zod";
+import { supabase } from "../db/client";
+
+export const pushSubscriptionSchema = z.object({
+    endpoint: z.string().url(),
+    expirationTime: z.number().nullable().optional(),
+    keys: z.object({
+        p256dh: z.string().min(1),
+        auth: z.string().min(1),
+    }),
+});
+
+export const recallAlertSchema = z.object({
+    id: z.string().min(1),
+    medicineName: z.string().min(2),
+    batchNumber: z.string().optional(),
+    manufacturer: z.string().optional(),
+    reason: z.string().min(8),
+    severity: z.enum(["medium", "high", "critical"]).default("high"),
+    source: z.string().default("CDSCO mock feed"),
+    recalledAt: z.string().datetime().optional(),
+});
+
+export type RecallAlert = z.infer<typeof recallAlertSchema>;
+export type StoredSubscription = {
+    endpoint: string;
+    subscription: PushSubscription;
+    createdAt: string;
+};
+
+const memorySubscriptions = new Map<string, StoredSubscription>();
+
+const mockRecallFeed: RecallAlert[] = [
+    {
+        id: "cdsco-mock-azithro-001",
+        medicineName: "Azithromycin 500mg",
+        batchNumber: "BATCH-CIPLA-001",
+        manufacturer: "Cipla Ltd.",
+        reason: "Mock CDSCO feed: batch recalled due to failed dissolution quality checks.",
+        severity: "critical",
+        source: "CDSCO mock feed",
+        recalledAt: new Date().toISOString(),
+    },
+    {
+        id: "cdsco-mock-para-002",
+        medicineName: "Paracetamol 650mg",
+        batchNumber: "BATCH-SUN-002",
+        manufacturer: "Sun Pharmaceuticals",
+        reason: "Mock CDSCO feed: packaging mismatch reported for selected strips.",
+        severity: "high",
+        source: "CDSCO mock feed",
+        recalledAt: new Date().toISOString(),
+    },
+];
+
+function configureWebPush() {
+    const publicKey = process.env.VAPID_PUBLIC_KEY;
+    const privateKey = process.env.VAPID_PRIVATE_KEY;
+    const subject = process.env.VAPID_SUBJECT || "mailto:security@sahidawa.local";
+
+    if (!publicKey || !privateKey) {
+        return false;
+    }
+
+    webPush.setVapidDetails(subject, publicKey, privateKey);
+    return true;
+}
+
+export function isWebPushConfigured() {
+    return configureWebPush();
+}
+
+export function getVapidPublicKey() {
+    return process.env.VAPID_PUBLIC_KEY ?? null;
+}
+
+export function getMockRecallFeed() {
+    return mockRecallFeed;
+}
+
+export async function savePushSubscription(subscription: PushSubscription) {
+    const stored: StoredSubscription = {
+        endpoint: subscription.endpoint,
+        subscription,
+        createdAt: new Date().toISOString(),
+    };
+    memorySubscriptions.set(subscription.endpoint, stored);
+
+    const { error } = await supabase.from("push_subscriptions").upsert(
+        {
+            endpoint: subscription.endpoint,
+            subscription,
+            updated_at: stored.createdAt,
+        },
+        { onConflict: "endpoint" }
+    );
+
+    return { stored, persisted: !error, error };
+}
+
+export async function removePushSubscription(endpoint: string) {
+    memorySubscriptions.delete(endpoint);
+    await supabase.from("push_subscriptions").delete().eq("endpoint", endpoint);
+}
+
+async function listPersistedSubscriptions(): Promise<StoredSubscription[]> {
+    const { data, error } = await supabase
+        .from("push_subscriptions")
+        .select("endpoint, subscription, created_at")
+        .order("created_at", { ascending: false });
+
+    if (error || !data) {
+        return [];
+    }
+
+    return data
+        .map((row) => {
+            const parsed = pushSubscriptionSchema.safeParse(row.subscription);
+            if (!parsed.success) return null;
+            return {
+                endpoint: row.endpoint as string,
+                subscription: parsed.data as PushSubscription,
+                createdAt: (row.created_at as string | null) ?? new Date().toISOString(),
+            };
+        })
+        .filter((row): row is StoredSubscription => row !== null);
+}
+
+export async function listPushSubscriptions() {
+    const persisted = await listPersistedSubscriptions();
+    if (persisted.length > 0) {
+        return persisted;
+    }
+
+    return [...memorySubscriptions.values()];
+}
+
+export function buildRecallPayload(alert: RecallAlert) {
+    return {
+        title: `${alert.medicineName} recalled`,
+        body: alert.reason,
+        medicineName: alert.medicineName,
+        recallReason: alert.reason,
+        severity: alert.severity,
+        batchNumber: alert.batchNumber,
+        manufacturer: alert.manufacturer,
+        source: alert.source,
+        url: "/alerts",
+        recalledAt: alert.recalledAt ?? new Date().toISOString(),
+    };
+}
+
+export async function triggerRecallAlert(alert: RecallAlert) {
+    const configured = configureWebPush();
+    const subscriptions = await listPushSubscriptions();
+    const payload = buildRecallPayload(alert);
+
+    if (!configured) {
+        return {
+            configured: false,
+            attempted: 0,
+            sent: 0,
+            failed: 0,
+            payload,
+        };
+    }
+
+    const results = await Promise.allSettled(
+        subscriptions.map((item) =>
+            webPush.sendNotification(item.subscription, JSON.stringify(payload))
+        )
+    );
+
+    const failedEndpoints = results
+        .map((result, index) => ({ result, endpoint: subscriptions[index].endpoint }))
+        .filter(({ result }) => result.status === "rejected")
+        .map(({ endpoint }) => endpoint);
+
+    await Promise.all(failedEndpoints.map(removePushSubscription));
+
+    return {
+        configured: true,
+        attempted: subscriptions.length,
+        sent: results.filter((result) => result.status === "fulfilled").length,
+        failed: failedEndpoints.length,
+        payload,
+    };
+}

--- a/apps/web/app/[locale]/alerts/page.tsx
+++ b/apps/web/app/[locale]/alerts/page.tsx
@@ -3,6 +3,7 @@ import { Activity, ArrowLeft, Filter, AlertTriangle, AlertCircle } from "lucide-
 import Link from "next/link";
 import { supabase } from "@/lib/supabase";
 import { Globe } from "lucide-react";
+import RecallPushSubscriber from "@/components/alerts/RecallPushSubscriber";
 
 export const revalidate = 0;
 
@@ -84,6 +85,8 @@ export default async function FullAlertsLogPage() {
                     Database synchronization error encountered while fetching active logs.
                 </div>
             )}
+
+            <RecallPushSubscriber />
 
             <div className="space-y-4">
                 {allAlerts && allAlerts.length > 0 ? (

--- a/apps/web/components/alerts/RecallPushSubscriber.tsx
+++ b/apps/web/components/alerts/RecallPushSubscriber.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+import { Bell, BellOff } from "lucide-react";
+import { API_BASE } from "@/lib/api";
+
+type SubscribeState = "idle" | "subscribing" | "subscribed" | "unsupported" | "error";
+
+function urlBase64ToUint8Array(value: string) {
+    const padding = "=".repeat((4 - (value.length % 4)) % 4);
+    const base64 = `${value}${padding}`.replace(/-/g, "+").replace(/_/g, "/");
+    const raw = window.atob(base64);
+    return Uint8Array.from([...raw].map((char) => char.charCodeAt(0)));
+}
+
+async function getVapidPublicKey() {
+    const res = await fetch(`${API_BASE}/api/notifications/vapid-public-key`, {
+        cache: "no-store",
+    });
+
+    if (!res.ok) {
+        throw new Error("Failed to load push configuration");
+    }
+
+    const data = (await res.json()) as { publicKey: string | null; configured: boolean };
+    if (!data.configured || !data.publicKey) {
+        throw new Error("Push notifications are not configured yet");
+    }
+
+    return data.publicKey;
+}
+
+export default function RecallPushSubscriber() {
+    const [state, setState] = useState<SubscribeState>("idle");
+    const [message, setMessage] = useState<string | null>(null);
+
+    async function subscribe() {
+        if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+            setState("unsupported");
+            setMessage("Push notifications are not supported in this browser.");
+            return;
+        }
+
+        setState("subscribing");
+        setMessage(null);
+
+        try {
+            const permission = await Notification.requestPermission();
+            if (permission !== "granted") {
+                setState("error");
+                setMessage("Notification permission was not granted.");
+                return;
+            }
+
+            const publicKey = await getVapidPublicKey();
+            const registration = await navigator.serviceWorker.register("/sw.js");
+            const subscription = await registration.pushManager.subscribe({
+                userVisibleOnly: true,
+                applicationServerKey: urlBase64ToUint8Array(publicKey),
+            });
+
+            const res = await fetch(`${API_BASE}/api/notifications/subscriptions`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(subscription),
+            });
+
+            if (!res.ok) {
+                throw new Error("Failed to save push subscription");
+            }
+
+            setState("subscribed");
+            setMessage("Recall notifications are active for this device.");
+        } catch (error) {
+            setState("error");
+            setMessage(error instanceof Error ? error.message : "Unable to enable recall alerts.");
+        }
+    }
+
+    const isSubscribed = state === "subscribed";
+
+    return (
+        <section className="mb-6 rounded-2xl border border-emerald-100 bg-white p-4 shadow-sm">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div className="flex items-start gap-3">
+                    <div className="rounded-full bg-emerald-50 p-2 text-emerald-600">
+                        {isSubscribed ? <Bell size={18} /> : <BellOff size={18} />}
+                    </div>
+                    <div>
+                        <h2 className="text-sm font-bold text-slate-900">Recall push alerts</h2>
+                        <p className="mt-1 max-w-2xl text-sm font-medium text-slate-500">
+                            Get notified when the mock CDSCO recall feed flags a medicine you should
+                            avoid.
+                        </p>
+                        {message && (
+                            <p
+                                className={`mt-2 text-xs font-semibold ${
+                                    isSubscribed ? "text-emerald-600" : "text-slate-500"
+                                }`}
+                            >
+                                {message}
+                            </p>
+                        )}
+                    </div>
+                </div>
+                <button
+                    type="button"
+                    onClick={subscribe}
+                    disabled={state === "subscribing" || isSubscribed}
+                    className="rounded-xl bg-emerald-600 px-4 py-2 text-sm font-bold text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+                >
+                    {state === "subscribing"
+                        ? "Enabling..."
+                        : isSubscribed
+                          ? "Enabled"
+                          : "Enable alerts"}
+                </button>
+            </div>
+        </section>
+    );
+}

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,42 @@
+self.addEventListener("push", (event) => {
+    const payload = event.data
+        ? event.data.json()
+        : {
+              title: "Medicine recall alert",
+              body: "A medicine recall alert was issued.",
+              url: "/alerts",
+          };
+
+    event.waitUntil(
+        self.registration.showNotification(payload.title || "Medicine recall alert", {
+            body: payload.body || payload.recallReason,
+            icon: "/icons/icon-192.png",
+            badge: "/icons/icon-192.png",
+            data: {
+                url: payload.url || "/alerts",
+                medicineName: payload.medicineName,
+                recallReason: payload.recallReason,
+            },
+            tag: payload.medicineName ? `recall-${payload.medicineName}` : "medicine-recall",
+            requireInteraction: payload.severity === "critical",
+        })
+    );
+});
+
+self.addEventListener("notificationclick", (event) => {
+    event.notification.close();
+    const targetUrl = event.notification.data?.url || "/alerts";
+
+    event.waitUntil(
+        self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
+            for (const client of clients) {
+                if ("focus" in client) {
+                    client.navigate(targetUrl);
+                    return client.focus();
+                }
+            }
+
+            return self.clients.openWindow(targetUrl);
+        })
+    );
+});

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -18,6 +18,7 @@ The platform runs two backend services:
   * [GET /](#get-)
   * [GET /health](#get-health)
   * [POST /api/verify](#post-apiverify)
+  * [Recall Push Notifications](#recall-push-notifications)
 * [apps/ml — FastAPI ML Service](#appsml--fastapi-ml-service-port-8000)
 
   * [GET /](#get--1)
@@ -137,6 +138,36 @@ Verifies whether a medicine is genuine by checking its batch number against the 
   "details": "batch_number is required and must be at least 4 characters"
 }
 ```
+
+---
+
+## Recall Push Notifications
+
+Browser recall alerts are exposed under `/api/notifications`.
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `GET` | `/api/notifications/vapid-public-key` | Returns the public VAPID key and whether push is configured |
+| `POST` | `/api/notifications/subscriptions` | Stores a browser Push API subscription |
+| `DELETE` | `/api/notifications/subscriptions` | Removes a subscription by endpoint |
+| `GET` | `/api/notifications/recalls/mock` | Returns the mock CDSCO recall feed |
+| `POST` | `/api/notifications/recalls/mock/trigger` | Sends a recall notification to stored subscriptions |
+
+Subscription payload:
+
+```json
+{
+  "endpoint": "https://push.example.test/subscription/1",
+  "keys": {
+    "p256dh": "browser-public-key",
+    "auth": "browser-auth-secret"
+  }
+}
+```
+
+Recall trigger payloads include `medicineName` and `reason`; the push payload
+returns them as `medicineName` and `recallReason` so the service worker can show
+the safety alert clearly.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
                 "helmet": "^8.1.0",
                 "morgan": "^1.10.0",
                 "redis": "^5.12.1",
+                "web-push": "^3.6.7",
                 "winston": "^3.19.0",
                 "zod": "^4.4.3"
             },
@@ -49,6 +50,7 @@
                 "@types/express": "^5.0.0",
                 "@types/morgan": "^1.9.9",
                 "@types/node": "^25.7.0",
+                "@types/web-push": "^3.6.4",
                 "ts-node-dev": "^2.0.0",
                 "typescript": "^6.0.3"
             }
@@ -1620,6 +1622,16 @@
             "version": "1.3.5",
             "license": "MIT"
         },
+        "node_modules/@types/web-push": {
+            "version": "3.6.4",
+            "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+            "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.59.2",
             "dev": true,
@@ -2175,6 +2187,18 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/asn1.js": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+            "license": "MIT",
+            "dependencies": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
         "node_modules/ast-types-flow": {
             "version": "0.0.8",
             "dev": true,
@@ -2286,6 +2310,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/bn.js": {
+            "version": "4.12.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+            "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+            "license": "MIT"
         },
         "node_modules/body-parser": {
             "version": "2.2.2",
@@ -4171,6 +4201,15 @@
                 "hermes-estree": "0.25.1"
             }
         },
+        "node_modules/http_ece": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+            "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/http-errors": {
             "version": "2.0.1",
             "license": "MIT",
@@ -5278,6 +5317,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "license": "ISC"
+        },
         "node_modules/minimatch": {
             "version": "3.1.5",
             "dev": true,
@@ -5291,7 +5336,6 @@
         },
         "node_modules/minimist": {
             "version": "1.2.8",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -7643,6 +7687,25 @@
         "node_modules/web": {
             "resolved": "apps/web",
             "link": true
+        },
+        "node_modules/web-push": {
+            "version": "3.6.7",
+            "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+            "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+            "license": "MPL-2.0",
+            "dependencies": {
+                "asn1.js": "^5.3.0",
+                "http_ece": "1.2.0",
+                "https-proxy-agent": "^7.0.0",
+                "jws": "^4.0.0",
+                "minimist": "^1.2.5"
+            },
+            "bin": {
+                "web-push": "src/cli.js"
+            },
+            "engines": {
+                "node": ">= 16"
+            }
         },
         "node_modules/web-streams-polyfill": {
             "version": "3.3.3",

--- a/supabase/migrations/20260518000000_create_push_subscriptions.sql
+++ b/supabase/migrations/20260518000000_create_push_subscriptions.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    endpoint TEXT NOT NULL UNIQUE,
+    subscription JSONB NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_updated_at
+    ON push_subscriptions(updated_at DESC);


### PR DESCRIPTION
## Summary
- add backend recall notification routes under `/api/notifications`
- add `web-push` VAPID support with subscription storage and recall trigger delivery
- add a mock CDSCO recall feed and payload builder that includes medicine name and recall reason
- add Supabase migration for `push_subscriptions`, with in-memory fallback for local development
- add frontend service worker support plus an alerts-page subscription card
- document notification endpoints and VAPID env vars

Fixes #50

## Testing
- `npm --workspace apps/api run test` ✅ 10 passed
- `npm --workspace apps/api run build` ✅
- `npm exec --workspace apps/web -- tsc -p tsconfig.json --noEmit` ✅
- `npm exec -- prettier --check apps/api/src/routes/notifications.ts apps/api/src/services/notifications.ts apps/api/src/services/notifications.test.ts apps/web/components/alerts/RecallPushSubscriber.tsx apps/web/public/sw.js supabase/migrations/20260518000000_create_push_subscriptions.sql` ✅
- `git diff --check` ✅

## Local environment note
- `npm --workspace apps/web run build` is blocked in this local Codex macOS checkout before application code loads because Next cannot find a native `@parcel/watcher-darwin-arm64` prebuild/local build. Web TypeScript validation passes with `tsc --noEmit`.

## GSSoC label request
This is for assigned issue #50. Please add the scoring labels when reviewing/merging:
- `gssoc:approved`
- `level:advanced`
- `quality:clean` or `quality:exceptional` if it meets the project bar
- `type:feature`
- `type:security` if you count recall alerting as public-safety/security-sensitive
