### PR TITLE
fix(api): route backend console logs through winston

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -54,24 +54,17 @@ app.use(
 app.use(express.json({ limit: "1mb" }));
 app.use(limiter);
 
-morgan.token("status", (req: Request, res: Response) => {
-    const status = res.statusCode;
-    if (status >= 500) return "error";
-    if (status >= 400) return "warn";
-    return "info";
-});
-
-app.use(morgan(":method :url :status - :response-time ms"));
-
-morgan((tokens, req: Request, res: Response) => {
-    const status = res.statusCode;
-    const level = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
-    logger.log({
-        level,
-        message: `${tokens.method(req, res)} ${tokens.url(req, res)} ${status} - ${tokens["response-time"](req, res)} ms`,
-    });
-    return undefined;
-});
+app.use(
+    morgan((tokens, req: Request, res: Response) => {
+        const status = res.statusCode;
+        const level = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
+        logger.log({
+            level,
+            message: `${tokens.method(req, res)} ${tokens.url(req, res)} ${status} - ${tokens["response-time"](req, res)} ms`,
+        });
+        return undefined;
+    })
+);
 
 app.get("/", (req: Request, res: Response) => {
     logger.info("Root route accessed");

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,37 +1,41 @@
-import express, { Express, Request, Response } from 'express';
-import dotenv from 'dotenv';
-import path from 'path';
+import express, { Express, Request, Response } from "express";
+import dotenv from "dotenv";
+import path from "path";
+import logger from "./utils/logger";
 
 // Load environment variables before other imports use process.env
-const rootEnvPath = path.resolve(__dirname, '../../../.env');
+const rootEnvPath = path.resolve(__dirname, "../../../.env");
 dotenv.config({ path: rootEnvPath });
 
 // Fallback to local .env if root doesn't exist
 if (!process.env.SUPABASE_URL) {
-  dotenv.config();
+    dotenv.config();
 }
 
 if (!process.env.SUPABASE_URL || !process.env.SUPABASE_ANON_KEY) {
-  console.error('\n❌ CRITICAL: Missing SUPABASE_URL or SUPABASE_ANON_KEY environment variables.');
-  console.error('Please ensure you have a .env file at the repository root.');
-  console.error(`Attempted locations:\n- ${rootEnvPath}\n- ${process.cwd()}/.env\n`);
-  process.exit(1);
+    logger.error("Missing SUPABASE_URL or SUPABASE_ANON_KEY environment variables", {
+        attemptedLocations: [rootEnvPath, path.join(process.cwd(), ".env")],
+        missingVars: {
+            SUPABASE_URL: !process.env.SUPABASE_URL,
+            SUPABASE_ANON_KEY: !process.env.SUPABASE_ANON_KEY,
+        },
+    });
+    process.exit(1);
 }
 
-import cors from 'cors';
-import helmet from 'helmet';
-import morgan from 'morgan';
-import adminRoutes from './routes/admin.routes';
-import { limiter } from './middleware/rateLimit';
-import reportsRouter from './routes/reports';
-import pharmaciesRouter from './routes/pharmacies';
-import verifyRouter from './routes/verify';
-import analyticsRoutes from './routes/analytics';
-import notificationsRouter from './routes/notifications';
-import { supabase } from './db/client';
+import cors from "cors";
+import helmet from "helmet";
+import morgan from "morgan";
+import adminRoutes from "./routes/admin.routes";
+import { limiter } from "./middleware/rateLimit";
+import reportsRouter from "./routes/reports";
+import pharmaciesRouter from "./routes/pharmacies";
+import verifyRouter from "./routes/verify";
+import analyticsRoutes from "./routes/analytics";
+import notificationsRouter from "./routes/notifications";
+import { supabase } from "./db/client";
 
-import logger from './utils/logger';
-import { errorHandler } from './middleware/errorHandler';
+import { errorHandler } from "./middleware/errorHandler";
 
 const app: Express = express();
 const port = process.env.PORT || 4000;
@@ -39,94 +43,87 @@ const port = process.env.PORT || 4000;
 app.use(helmet());
 
 // Security: restrict CORS to known origins instead of wildcard
-const allowedOrigins = [
-  'http://localhost:3000',
-  'http://localhost:4000',
-  'http://localhost:8000',
-];
-app.use(cors({
-  origin: allowedOrigins,
-  credentials: true,
-}));
-
-app.use(express.json({ limit: '1mb' }));
-app.use(limiter);
-
-morgan.token('status', (req: Request, res: Response) => {
-  const status = res.statusCode;
-  if (status >= 500) return 'error';
-  if (status >= 400) return 'warn';
-  return 'info';
-});
-
+const allowedOrigins = ["http://localhost:3000", "http://localhost:4000", "http://localhost:8000"];
 app.use(
-  morgan(':method :url :status - :response-time ms'),
+    cors({
+        origin: allowedOrigins,
+        credentials: true,
+    })
 );
 
-morgan((tokens, req: Request, res: Response) => {
-  const status = res.statusCode;
-  const level = status >= 500 ? 'error' : status >= 400 ? 'warn' : 'info';
-  logger.log({
-    level,
-    message: `${tokens.method(req, res)} ${tokens.url(req, res)} ${status} - ${tokens['response-time'](req, res)} ms`,
-  });
-  return undefined;
+app.use(express.json({ limit: "1mb" }));
+app.use(limiter);
+
+morgan.token("status", (req: Request, res: Response) => {
+    const status = res.statusCode;
+    if (status >= 500) return "error";
+    if (status >= 400) return "warn";
+    return "info";
 });
 
-app.get('/', (req: Request, res: Response) => {
-  logger.info('Root route accessed');
-  res.send('SahiDawa-India API is running successfully!');
+app.use(morgan(":method :url :status - :response-time ms"));
+
+morgan((tokens, req: Request, res: Response) => {
+    const status = res.statusCode;
+    const level = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
+    logger.log({
+        level,
+        message: `${tokens.method(req, res)} ${tokens.url(req, res)} ${status} - ${tokens["response-time"](req, res)} ms`,
+    });
+    return undefined;
+});
+
+app.get("/", (req: Request, res: Response) => {
+    logger.info("Root route accessed");
+    res.send("SahiDawa-India API is running successfully!");
 });
 
 // Admin Routes
-app.use('/api/v1/admin', adminRoutes);
+app.use("/api/v1/admin", adminRoutes);
 
-app.get('/health', async (req: Request, res: Response) => {
-  logger.info('Health check endpoint accessed');
-  
-  try {
-    const { error } = await supabase
-      .from('medicines')
-      .select('id')
-      .limit(1);
+app.get("/health", async (req: Request, res: Response) => {
+    logger.info("Health check endpoint accessed");
 
-    if (error) {
-      return res.status(503).json({
-        status: 'degraded',
-        db: 'unreachable',
-        error: error.message,
-        timestamp: new Date().toISOString(),
-      });
+    try {
+        const { error } = await supabase.from("medicines").select("id").limit(1);
+
+        if (error) {
+            return res.status(503).json({
+                status: "degraded",
+                db: "unreachable",
+                error: error.message,
+                timestamp: new Date().toISOString(),
+            });
+        }
+
+        return res.json({
+            status: "ok",
+            db: "connected",
+            timestamp: new Date().toISOString(),
+        });
+    } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        return res.status(500).json({
+            status: "error",
+            db: "unreachable",
+            error: message,
+            timestamp: new Date().toISOString(),
+        });
     }
-
-    return res.json({
-      status: 'ok',
-      db: 'connected',
-      timestamp: new Date().toISOString(),
-    });
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return res.status(500).json({
-      status: 'error',
-      db: 'unreachable',
-      error: message,
-      timestamp: new Date().toISOString(),
-    });
-  }
 });
 
-app.use('/reports', reportsRouter);
-app.use('/api/pharmacies', pharmaciesRouter);
-app.use('/api/verify', verifyRouter);
-app.use('/api/analytics', analyticsRoutes);
-app.use('/api/notifications', notificationsRouter);
+app.use("/reports", reportsRouter);
+app.use("/api/pharmacies", pharmaciesRouter);
+app.use("/api/verify", verifyRouter);
+app.use("/api/analytics", analyticsRoutes);
+app.use("/api/notifications", notificationsRouter);
 
 app.use(errorHandler);
 
-if (process.env.NODE_ENV !== 'test') {
-  app.listen(port, () => {
-    logger.info(`SahiDawa API is running at http://localhost:${port}`);
-  });
+if (process.env.NODE_ENV !== "test") {
+    app.listen(port, () => {
+        logger.info(`SahiDawa API is running at http://localhost:${port}`);
+    });
 }
 
 export default app;

--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -1,155 +1,176 @@
-import { Router, Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
-import supabase from '../db/supabase';
+import { Router, Request, Response, NextFunction } from "express";
+import { z } from "zod";
+import supabase from "../db/supabase";
+import logger from "../utils/logger";
 
 const router = Router();
 
 const nearestQuerySchema = z.object({
-  lat: z.coerce.number().min(-90).max(90),
-  lng: z.coerce.number().min(-180).max(180),
+    lat: z.coerce.number().min(-90).max(90),
+    lng: z.coerce.number().min(-180).max(180),
 });
 
 // Haversine formula fallback
 function calculateDistanceKM(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const R = 6371; // Earth's radius in kilometers
-  const dLat = (lat2 - lat1) * (Math.PI / 180);
-  const dLon = (lon2 - lon1) * (Math.PI / 180);
-  const a =
-    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    Math.cos(lat1 * (Math.PI / 180)) * Math.cos(lat2 * (Math.PI / 180)) *
-    Math.sin(dLon / 2) * Math.sin(dLon / 2);
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-  return R * c;
+    const R = 6371; // Earth's radius in kilometers
+    const dLat = (lat2 - lat1) * (Math.PI / 180);
+    const dLon = (lon2 - lon1) * (Math.PI / 180);
+    const a =
+        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+        Math.cos(lat1 * (Math.PI / 180)) *
+            Math.cos(lat2 * (Math.PI / 180)) *
+            Math.sin(dLon / 2) *
+            Math.sin(dLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return R * c;
 }
 
 /**
  * GET /api/pharmacies/nearest?lat=...&lng=...
  * Returns up to 3 nearby Jan Aushadhi Kendras.
  */
-router.get('/nearest', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const result = nearestQuerySchema.safeParse(req.query);
+router.get("/nearest", async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const result = nearestQuerySchema.safeParse(req.query);
 
-    if (!result.success) {
-      res.status(400).json({
-        error: 'Invalid coordinates',
-        details: result.error.flatten().fieldErrors,
-      });
-      return;
-    }
-
-    const { lat, lng } = result.data;
-
-    // 1. Validate environment configuration
-    // This provides a clear API response if developers forgot to setup their .env file
-    const hasSupabaseUrl = !!process.env.SUPABASE_URL;
-    const hasSupabaseKey = !!(process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY);
-
-    if (!hasSupabaseUrl || !hasSupabaseKey) {
-      console.error('❌ Configuration Error: Missing Supabase credentials in /nearest route.');
-      return res.status(500).json({
-        error: 'Server Configuration Error',
-        message: 'The backend is missing database credentials.',
-        hint: 'Please ensure SUPABASE_URL and SUPABASE_ANON_KEY are set in your root .env file.',
-        missing_vars: {
-          SUPABASE_URL: !hasSupabaseUrl,
-          SUPABASE_KEY: !hasSupabaseKey
-        }
-      });
-    }
-
-    // Call the PostGIS RPC function via Supabase
-    const { data: rpcData, error: rpcError } = await supabase.rpc('get_nearest_pharmacies', {
-      query_lat: lat,
-      query_lng: lng,
-    });
-
-    if (!rpcError && rpcData) {
-      // Map response to match expected format ("1.6 km")
-      const pharmacies = rpcData.map((p: any) => ({
-        name: p.name,
-        address: p.address,
-        lat: p.lat,
-        lng: p.lng,
-        distance: `${Number(p.distance).toFixed(1)} km`,
-      }));
-
-      return res.json({ pharmacies });
-    }
-
-    console.warn('⚠️ PostGIS RPC failed or unavailable, falling back to Haversine calculation.', rpcError?.message);
-
-    // Fallback: PostGIS might not be configured, or the RPC migration is unapplied.
-    // We attempt to fetch all pharmacies and calculate in memory.
-    const { data: allPharmacies, error: fetchError } = await supabase
-      .from('pharmacies')
-      .select('*');
-
-    if (fetchError) {
-      console.error('❌ Fallback database query failed. Details:', fetchError);
-
-      const errMsg = fetchError.message?.toLowerCase() || '';
-      let hint = 'Check your SUPABASE_URL and ensure your database is running.';
-
-      // Provide developer-friendly hints based on the error type
-      if (errMsg.includes('api key') || errMsg.includes('jwt')) {
-        hint = 'Your Supabase API key is invalid or expired. Check your .env setup.';
-      } else if (errMsg.includes('relation "public.pharmacies" does not exist') || fetchError.code === '42P01') {
-        hint = 'The "pharmacies" table is missing. Did you forget to run the Supabase migrations/seeds?';
-      }
-
-      res.status(500).json({
-        error: 'Database Query Failed',
-        details: fetchError.message,
-        code: fetchError.code || 'UNKNOWN',
-        hint
-      });
-      return;
-    }
-
-    // Attempt to extract lat/lng and compute distance
-    const computedPharmacies = (allPharmacies || [])
-      .map((p: any) => {
-        let pLat = 0;
-        let pLng = 0;
-
-        if (p.lat !== undefined && p.lng !== undefined) {
-          // Backward compatibility if developers bypassed the PostGIS 'location' column directly
-          pLat = Number(p.lat);
-          pLng = Number(p.lng);
-        } else if (p.location && typeof p.location === 'object' && p.location.coordinates) {
-          // If it resolves as a GeoJSON Point object (standard in some query conversions)
-          pLng = Number(p.location.coordinates[0]);
-          pLat = Number(p.location.coordinates[1]);
+        if (!result.success) {
+            res.status(400).json({
+                error: "Invalid coordinates",
+                details: result.error.flatten().fieldErrors,
+            });
+            return;
         }
 
-        // Extremely distant fallback (this prevents crashing if coordinates fail to parse)
-        const distanceKm = calculateDistanceKM(lat, lng, pLat, pLng);
+        const { lat, lng } = result.data;
 
-        return {
-          name: p.name || 'Unknown Pharmacy',
-          address: p.address || 'Unknown Address',
-          lat: pLat,
-          lng: pLng,
-          rawDistance: distanceKm,
-          distance: `${distanceKm.toFixed(1)} km`,
-        };
-      })
-      .filter((p) => p.lat !== 0 && p.lng !== 0) // Strip invalid parses
-      .sort((a, b) => a.rawDistance - b.rawDistance)
-      .slice(0, 3); // Take top 3 closest
+        // 1. Validate environment configuration
+        // This provides a clear API response if developers forgot to setup their .env file
+        const hasSupabaseUrl = !!process.env.SUPABASE_URL;
+        const hasSupabaseKey = !!(
+            process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY
+        );
 
-    // Strip internal sorting field to preserve API contract exactly
-    const formattedPharmacies = computedPharmacies.map(p => {
-      const { rawDistance, ...rest } = p;
-      return rest;
-    });
+        if (!hasSupabaseUrl || !hasSupabaseKey) {
+            logger.error("Missing Supabase credentials in /nearest route", {
+                missingVars: {
+                    SUPABASE_URL: !hasSupabaseUrl,
+                    SUPABASE_KEY: !hasSupabaseKey,
+                },
+            });
+            return res.status(500).json({
+                error: "Server Configuration Error",
+                message: "The backend is missing database credentials.",
+                hint: "Please ensure SUPABASE_URL and SUPABASE_ANON_KEY are set in your root .env file.",
+                missing_vars: {
+                    SUPABASE_URL: !hasSupabaseUrl,
+                    SUPABASE_KEY: !hasSupabaseKey,
+                },
+            });
+        }
 
-    res.json({ pharmacies: formattedPharmacies });
+        // Call the PostGIS RPC function via Supabase
+        const { data: rpcData, error: rpcError } = await supabase.rpc("get_nearest_pharmacies", {
+            query_lat: lat,
+            query_lng: lng,
+        });
 
-  } catch (err) {
-    next(err);
-  }
+        if (!rpcError && rpcData) {
+            // Map response to match expected format ("1.6 km")
+            const pharmacies = rpcData.map((p: any) => ({
+                name: p.name,
+                address: p.address,
+                lat: p.lat,
+                lng: p.lng,
+                distance: `${Number(p.distance).toFixed(1)} km`,
+            }));
+
+            return res.json({ pharmacies });
+        }
+
+        logger.warn("PostGIS RPC failed or unavailable, falling back to Haversine calculation", {
+            error: rpcError?.message,
+            code: rpcError?.code,
+        });
+
+        // Fallback: PostGIS might not be configured, or the RPC migration is unapplied.
+        // We attempt to fetch all pharmacies and calculate in memory.
+        const { data: allPharmacies, error: fetchError } = await supabase
+            .from("pharmacies")
+            .select("*");
+
+        if (fetchError) {
+            logger.error("Fallback database query failed", {
+                message: fetchError.message,
+                code: fetchError.code,
+                details: fetchError.details,
+                hint: fetchError.hint,
+            });
+
+            const errMsg = fetchError.message?.toLowerCase() || "";
+            let hint = "Check your SUPABASE_URL and ensure your database is running.";
+
+            // Provide developer-friendly hints based on the error type
+            if (errMsg.includes("api key") || errMsg.includes("jwt")) {
+                hint = "Your Supabase API key is invalid or expired. Check your .env setup.";
+            } else if (
+                errMsg.includes('relation "public.pharmacies" does not exist') ||
+                fetchError.code === "42P01"
+            ) {
+                hint =
+                    'The "pharmacies" table is missing. Did you forget to run the Supabase migrations/seeds?';
+            }
+
+            res.status(500).json({
+                error: "Database Query Failed",
+                details: fetchError.message,
+                code: fetchError.code || "UNKNOWN",
+                hint,
+            });
+            return;
+        }
+
+        // Attempt to extract lat/lng and compute distance
+        const computedPharmacies = (allPharmacies || [])
+            .map((p: any) => {
+                let pLat = 0;
+                let pLng = 0;
+
+                if (p.lat !== undefined && p.lng !== undefined) {
+                    // Backward compatibility if developers bypassed the PostGIS 'location' column directly
+                    pLat = Number(p.lat);
+                    pLng = Number(p.lng);
+                } else if (p.location && typeof p.location === "object" && p.location.coordinates) {
+                    // If it resolves as a GeoJSON Point object (standard in some query conversions)
+                    pLng = Number(p.location.coordinates[0]);
+                    pLat = Number(p.location.coordinates[1]);
+                }
+
+                // Extremely distant fallback (this prevents crashing if coordinates fail to parse)
+                const distanceKm = calculateDistanceKM(lat, lng, pLat, pLng);
+
+                return {
+                    name: p.name || "Unknown Pharmacy",
+                    address: p.address || "Unknown Address",
+                    lat: pLat,
+                    lng: pLng,
+                    rawDistance: distanceKm,
+                    distance: `${distanceKm.toFixed(1)} km`,
+                };
+            })
+            .filter((p) => p.lat !== 0 && p.lng !== 0) // Strip invalid parses
+            .sort((a, b) => a.rawDistance - b.rawDistance)
+            .slice(0, 3); // Take top 3 closest
+
+        // Strip internal sorting field to preserve API contract exactly
+        const formattedPharmacies = computedPharmacies.map((p) => {
+            const { rawDistance, ...rest } = p;
+            return rest;
+        });
+
+        res.json({ pharmacies: formattedPharmacies });
+    } catch (err) {
+        next(err);
+    }
 });
 
 export default router;

--- a/apps/api/src/services/audit.service.ts
+++ b/apps/api/src/services/audit.service.ts
@@ -1,21 +1,28 @@
-import { supabase } from '../db/client';
+import { supabase } from "../db/client";
+import logger from "../utils/logger";
 
 export const logAdminAction = async (
-  adminId: string,
-  action: string,
-  targetType: 'REPORT' | 'MEDICINE',
-  targetId: string,
-  details: Record<string, unknown>
+    adminId: string,
+    action: string,
+    targetType: "REPORT" | "MEDICINE",
+    targetId: string,
+    details: Record<string, unknown>
 ) => {
-  const { error } = await supabase.from('audit_logs').insert({
-    admin_id: adminId,
-    action,
-    target_type: targetType,
-    target_id: targetId,
-    details,
-  });
+    const { error } = await supabase.from("audit_logs").insert({
+        admin_id: adminId,
+        action,
+        target_type: targetType,
+        target_id: targetId,
+        details,
+    });
 
-  if (error) {
-    console.error('[audit] Failed to write log:', error.message);
-  }
+    if (error) {
+        logger.error("Failed to write audit log", {
+            adminId,
+            action,
+            targetType,
+            targetId,
+            error: error.message,
+        });
+    }
 };


### PR DESCRIPTION
## PR Summary

Replaces the remaining backend direct console logging paths with the shared Winston logger so production diagnostics keep structured metadata.

Updated areas:

- Startup environment validation in `apps/api/src/index.ts`
- Nearest-pharmacy config, RPC fallback, and database fallback logging in `apps/api/src/routes/pharmacies.ts`
- Audit-log write failure handling in `apps/api/src/services/audit.service.ts`

---

## Related Issue

Closes #208

---

## PR Type

- [ ] Bug Fix
- [ ] New Feature / Enhancement
- [ ] Documentation
- [ ] Translation (i18n)
- [ ] UI / UX Improvement
- [ ] DevOps / CI-CD
- [ ] ML / AI Feature
- [ ] Security Fix
- [x] Refactor / Code Quality

---

## Area Changed

- [ ] `apps/web` - Next.js Frontend
- [x] `apps/api` - Node.js / Express Backend
- [ ] `apps/ml` - Python / FastAPI ML Service
- [ ] `data/` - Database seeds / migrations
- [ ] `docs/` - Documentation
- [ ] `.github/` - GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## What Was Done

- Imported and used the shared Winston logger in the remaining backend files called out by #208.
- Replaced direct `console.error` / `console.warn` calls with `logger.error` / `logger.warn`.
- Preserved useful structured metadata for missing environment variables, PostGIS RPC fallback, database fallback failures, and audit-log write failures.

---

## Screenshots / Demo

Backend-only refactor; no UI screenshots.

Verification run locally:

```bash
npm run build -w apps/api
npm run test -w apps/api
```

The API test suite passed with 10 tests.

---

## Contributor Checklist

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before this PR
- [x] My code follows the patterns in `docs/code-guide.md`
- [x] I ran backend build/test checks - no build errors
- [x] For backend: all changed logging paths keep structured metadata where useful
- [x] Screenshots/test output added (for UI or API changes)
- [x] I have performed a self-review of my own code

---

## GSSoC 2026

- [x] I am a GSSoC 2026 participant

---

## AI Assistance

AI assistance was used to prepare this patch and run the local verification above.
