### PR TITLE
feat(web): add dynamic offline network status banner

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+import NetworkStatus from '@/components/NetworkStatus';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'SahiDawa',
+  description: "India's Medicine Verifier",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <NetworkStatus />
+        {children}
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
Closes #272

- Added `NetworkStatus.tsx` with online/offline event listeners
- Amber bar when offline, green briefly on reconnection, then auto-dismisses
- Registered in `layout.tsx` at root level — no layout shift

---

## 🎓 GSSoC 2026

* [✓] I am a GSSoC 2026 participant