### PR TITLE
Feat/unified print stylesheet 282

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2022",
         "module": "CommonJS",
         "moduleResolution": "node",
+        "ignoreDeprecations": "6.0",
         "rootDir": "./src",
         "outDir": "./dist",
 

--- a/apps/web/app/[locale]/compare/layout.tsx
+++ b/apps/web/app/[locale]/compare/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+    title: "Compare Medicine Prices - SahiDawa",
+    description:
+        "Print a clean medicine verification and price comparison report for patient handouts.",
+};
+
+export default function CompareLayout({ children }: { children: ReactNode }) {
+    return children;
+}

--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { CalendarDays, Download, Pill, Printer, ShieldCheck } from "lucide-react";
+import { Link } from "@/i18n/routing";
+import { PageHeader } from "../components/PageHeader";
+import Footer from "../components/Footer";
+
+type MedicineComparison = {
+    brandName: string;
+    genericName: string;
+    manufacturer: string;
+    strength: string;
+    packSize: string;
+    batchNumber: string;
+    verifiedStatus: string;
+    listedPrice: string;
+    janAushadhiPrice: string;
+    savings: string;
+};
+
+const comparisonRows: MedicineComparison[] = [
+    {
+        brandName: "Dolo 650",
+        genericName: "Paracetamol",
+        manufacturer: "Micro Labs Ltd.",
+        strength: "650 mg",
+        packSize: "15 tablets",
+        batchNumber: "DL650A24",
+        verifiedStatus: "CDSCO verified",
+        listedPrice: "INR 33.60",
+        janAushadhiPrice: "INR 14.00",
+        savings: "58%",
+    },
+    {
+        brandName: "Azithral 500",
+        genericName: "Azithromycin",
+        manufacturer: "Alembic Pharmaceuticals",
+        strength: "500 mg",
+        packSize: "3 tablets",
+        batchNumber: "AZ500B11",
+        verifiedStatus: "CDSCO verified",
+        listedPrice: "INR 119.50",
+        janAushadhiPrice: "INR 42.00",
+        savings: "65%",
+    },
+    {
+        brandName: "Pantocid 40",
+        genericName: "Pantoprazole",
+        manufacturer: "Sun Pharma",
+        strength: "40 mg",
+        packSize: "15 tablets",
+        batchNumber: "PN40C07",
+        verifiedStatus: "CDSCO verified",
+        listedPrice: "INR 168.00",
+        janAushadhiPrice: "INR 31.50",
+        savings: "81%",
+    },
+];
+
+const generatedOn = "19 May 2026";
+
+export default function ComparePage() {
+    return (
+        <div className="print-page flex min-h-screen flex-col bg-slate-50 text-slate-950">
+            <PageHeader
+                title="Medicine Compare"
+                subtitle="Verified price receipt"
+                backHref="/"
+                variant="light"
+            />
+
+            <main className="print-container mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-4 py-8 sm:px-6 lg:px-8">
+                <section className="print-receipt rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                    <div className="flex flex-col gap-6 border-b border-slate-200 pb-6 md:flex-row md:items-start md:justify-between">
+                        <div>
+                            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-bold text-emerald-700">
+                                <ShieldCheck size={14} />
+                                Verified medicine report
+                            </div>
+                            <h1 className="text-3xl font-black tracking-tight text-slate-950">
+                                Medicine Price Comparison
+                            </h1>
+                            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                                Printable comparison for health volunteers to share lower-cost
+                                equivalent medicine options with patients.
+                            </p>
+                        </div>
+
+                        <div className="flex flex-col gap-3 md:items-end">
+                            <div className="flex items-center gap-2 text-sm font-semibold text-slate-600">
+                                <CalendarDays size={16} />
+                                Generated: {generatedOn}
+                            </div>
+                            <button
+                                type="button"
+                                onClick={() => window.print()}
+                                className="no-print inline-flex items-center justify-center gap-2 rounded-xl bg-slate-950 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-slate-800"
+                            >
+                                <Printer size={16} />
+                                Print receipt
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 grid gap-4 md:grid-cols-3">
+                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                            <p className="text-xs font-bold tracking-wide text-slate-500 uppercase">
+                                Medicines checked
+                            </p>
+                            <p className="mt-2 text-3xl font-black text-slate-950">
+                                {comparisonRows.length}
+                            </p>
+                        </div>
+                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                            <p className="text-xs font-bold tracking-wide text-slate-500 uppercase">
+                                Report type
+                            </p>
+                            <p className="mt-2 text-lg font-black text-slate-950">
+                                Price comparison
+                            </p>
+                        </div>
+                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                            <p className="text-xs font-bold tracking-wide text-slate-500 uppercase">
+                                Use case
+                            </p>
+                            <p className="mt-2 text-lg font-black text-slate-950">
+                                Patient handout
+                            </p>
+                        </div>
+                    </div>
+                </section>
+
+                <section className="comparison-grid grid gap-5 lg:grid-cols-3">
+                    {comparisonRows.map((medicine) => (
+                        <article
+                            key={medicine.batchNumber}
+                            className="comparison-card rounded-3xl border border-slate-200 bg-white p-5 shadow-sm"
+                        >
+                            <div className="flex items-start gap-3 border-b border-slate-200 pb-4">
+                                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-emerald-50 text-emerald-700">
+                                    <Pill size={22} />
+                                </div>
+                                <div>
+                                    <h2 className="text-xl font-black text-slate-950">
+                                        {medicine.brandName}
+                                    </h2>
+                                    <p className="text-sm font-semibold text-slate-500">
+                                        {medicine.genericName}
+                                    </p>
+                                </div>
+                            </div>
+
+                            <table className="mt-4 text-sm">
+                                <tbody>
+                                    <tr>
+                                        <th scope="row">Manufacturer</th>
+                                        <td>{medicine.manufacturer}</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">Strength</th>
+                                        <td>{medicine.strength}</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">Pack size</th>
+                                        <td>{medicine.packSize}</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">Batch</th>
+                                        <td>{medicine.batchNumber}</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">Status</th>
+                                        <td>{medicine.verifiedStatus}</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">Market price</th>
+                                        <td>{medicine.listedPrice}</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">Jan Aushadhi</th>
+                                        <td>{medicine.janAushadhiPrice}</td>
+                                    </tr>
+                                    <tr>
+                                        <th scope="row">Potential saving</th>
+                                        <td>{medicine.savings}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </article>
+                    ))}
+                </section>
+
+                <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+                    <h2 className="text-lg font-black text-slate-950">Volunteer note</h2>
+                    <p className="mt-2 text-sm leading-6 text-slate-600">
+                        Prices are examples for print layout verification. Confirm medicine, dosage,
+                        substitution, and final pricing with a licensed pharmacist or doctor before
+                        changing treatment.
+                    </p>
+                    <div className="no-print mt-4 flex flex-wrap gap-3">
+                        <Link
+                            href="/scan"
+                            className="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-bold text-slate-700 transition-colors hover:bg-slate-100"
+                        >
+                            <Pill size={16} />
+                            Verify another medicine
+                        </Link>
+                        <button
+                            type="button"
+                            onClick={() => window.print()}
+                            className="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-bold text-slate-700 transition-colors hover:bg-slate-100"
+                        >
+                            <Download size={16} />
+                            Save as PDF
+                        </button>
+                    </div>
+                </section>
+            </main>
+
+            <Footer />
+        </div>
+    );
+}

--- a/apps/web/app/[locale]/components/Footer.tsx
+++ b/apps/web/app/[locale]/components/Footer.tsx
@@ -3,7 +3,7 @@ import { GitBranch } from "lucide-react";
 
 export default function Footer() {
     return (
-        <footer className="mt-auto border-t border-slate-800 bg-slate-950 text-slate-400">
+        <footer className="no-print mt-auto border-t border-slate-800 bg-slate-950 text-slate-400">
             <div className="container mx-auto px-4 py-10 md:px-6">
                 <div className="grid grid-cols-1 gap-8 border-b border-slate-800 pb-8 md:grid-cols-3">
                     {/* Brand Section */}

--- a/apps/web/app/[locale]/components/PageHeader.tsx
+++ b/apps/web/app/[locale]/components/PageHeader.tsx
@@ -26,7 +26,7 @@ export const PageHeader = ({
   const isDark = variant === "dark";
   
   return (
-    <header className={`${isDark ? "absolute top-0 left-0 right-0 bg-gradient-to-b from-black/70 to-transparent text-white" : "relative bg-white border-b border-slate-100 shadow-sm text-slate-900"} z-50 p-4 flex flex-col gap-4`}>
+    <header className={`no-print ${isDark ? "absolute top-0 left-0 right-0 bg-gradient-to-b from-black/70 to-transparent text-white" : "relative bg-white border-b border-slate-100 shadow-sm text-slate-900"} z-50 p-4 flex flex-col gap-4`}>
       <div className="flex items-center justify-between gap-2">
         <Link 
           href={backHref} 

--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -7,6 +7,7 @@ import { routing } from "../../i18n/routing";
 import { ThemeProvider } from "./components/ThemeProvider";
 import Chatbot from "./components/Chatbot";
 import "./globals.css";
+import "../../src/styles/print.css";
 import { Toaster } from "sonner";
 
 export const metadata: Metadata = {
@@ -58,9 +59,13 @@ export default async function LocaleLayout({
                 <ThemeProvider>
                     <NextIntlClientProvider messages={messages}>
                         {children}
-                        <Chatbot />
+                        <div className="no-print">
+                            <Chatbot />
+                        </div>
                     </NextIntlClientProvider>
-                    <Toaster richColors position="top-center" />
+                    <div className="no-print">
+                        <Toaster richColors position="top-center" />
+                    </div>
                 </ThemeProvider>
             </body>
         </html>

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -16,7 +16,6 @@ import {
     Activity,
     Search,
     MessageCircle,
-    ReceiptText,
 } from "lucide-react";
 
 import { useRouter, useParams } from "next/navigation";
@@ -116,9 +115,6 @@ export default function SahiDawaHome() {
               <Link href="/map" className="hover:text-emerald-600 transition-colors">
                 {tNav("pharmacy_map")}
               </Link>
-              <Link href="/compare" className="hover:text-emerald-600 transition-colors">
-                Compare Prices
-              </Link>
               <Link href="/reports/me" className="hover:text-emerald-600 transition-colors flex items-center gap-1">
                 <History size={14} /> My Reports
               </Link>
@@ -189,7 +185,7 @@ export default function SahiDawaHome() {
                 </button>
 
                 {/* ── Secondary Action Cards ── */}
-                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
                     {/* Upload Photo */}
                     <button
                         onClick={() => handleNavigation("scan")}
@@ -243,23 +239,6 @@ export default function SahiDawaHome() {
                             </h3>
                             <p className="mt-0.5 text-sm leading-snug font-medium text-slate-500">
                                 {tHome("pharmacy_subtitle")}
-                            </p>
-                        </div>
-                    </button>
-
-                    {/* Compare Prices */}
-                    <button
-                        onClick={() => handleNavigation("compare")}
-                        className="group flex w-full items-center gap-5 rounded-3xl border border-slate-200 bg-white p-6 text-left transition-all hover:border-cyan-200 hover:shadow-lg hover:shadow-cyan-100/50 active:scale-95"
-                        aria-label="Compare medicine prices"
-                    >
-                        <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-cyan-50 text-cyan-600 transition-colors duration-300 group-hover:bg-cyan-500 group-hover:text-white">
-                            <ReceiptText size={28} strokeWidth={2.5} />
-                        </div>
-                        <div>
-                            <h3 className="text-lg font-bold text-slate-800">Compare Prices</h3>
-                            <p className="mt-0.5 text-sm leading-snug font-medium text-slate-500">
-                                Print patient receipt
                             </p>
                         </div>
                     </button>

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -16,6 +16,7 @@ import {
     Activity,
     Search,
     MessageCircle,
+    ReceiptText,
 } from "lucide-react";
 
 import { useRouter, useParams } from "next/navigation";
@@ -115,6 +116,9 @@ export default function SahiDawaHome() {
               <Link href="/map" className="hover:text-emerald-600 transition-colors">
                 {tNav("pharmacy_map")}
               </Link>
+              <Link href="/compare" className="hover:text-emerald-600 transition-colors">
+                Compare Prices
+              </Link>
               <Link href="/reports/me" className="hover:text-emerald-600 transition-colors flex items-center gap-1">
                 <History size={14} /> My Reports
               </Link>
@@ -185,7 +189,7 @@ export default function SahiDawaHome() {
                 </button>
 
                 {/* ── Secondary Action Cards ── */}
-                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
                     {/* Upload Photo */}
                     <button
                         onClick={() => handleNavigation("scan")}
@@ -239,6 +243,23 @@ export default function SahiDawaHome() {
                             </h3>
                             <p className="mt-0.5 text-sm leading-snug font-medium text-slate-500">
                                 {tHome("pharmacy_subtitle")}
+                            </p>
+                        </div>
+                    </button>
+
+                    {/* Compare Prices */}
+                    <button
+                        onClick={() => handleNavigation("compare")}
+                        className="group flex w-full items-center gap-5 rounded-3xl border border-slate-200 bg-white p-6 text-left transition-all hover:border-cyan-200 hover:shadow-lg hover:shadow-cyan-100/50 active:scale-95"
+                        aria-label="Compare medicine prices"
+                    >
+                        <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-cyan-50 text-cyan-600 transition-colors duration-300 group-hover:bg-cyan-500 group-hover:text-white">
+                            <ReceiptText size={28} strokeWidth={2.5} />
+                        </div>
+                        <div>
+                            <h3 className="text-lg font-bold text-slate-800">Compare Prices</h3>
+                            <p className="mt-0.5 text-sm leading-snug font-medium text-slate-500">
+                                Print patient receipt
                             </p>
                         </div>
                     </button>

--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -310,7 +310,7 @@ function ErrorResult({ message, onRetry }: { message: string; onRetry: () => voi
 
 function ResultActions({ onScanAgain, onShare }: { onScanAgain: () => void; onShare: () => void }) {
     return (
-        <div className="grid w-full grid-cols-1 gap-3">
+        <div className="no-print grid w-full grid-cols-1 gap-3">
             <button
                 onClick={onScanAgain}
                 className="w-full rounded-2xl bg-slate-900 py-4 font-bold text-white shadow-lg shadow-slate-900/20 transition-colors hover:bg-slate-800"

--- a/apps/web/src/styles/print.css
+++ b/apps/web/src/styles/print.css
@@ -1,0 +1,96 @@
+@media print {
+    @page {
+        margin: 14mm;
+    }
+
+    *,
+    *::before,
+    *::after {
+        background: transparent !important;
+        box-shadow: none !important;
+        color: #000 !important;
+        text-shadow: none !important;
+    }
+
+    html,
+    body {
+        width: 100%;
+        background: #fff !important;
+        font-size: 11pt;
+        line-height: 1.45;
+    }
+
+    body {
+        margin: 0 !important;
+    }
+
+    a {
+        color: #000 !important;
+        text-decoration: none !important;
+    }
+
+    img,
+    svg {
+        break-inside: avoid;
+        max-width: 100% !important;
+    }
+
+    button,
+    input,
+    select,
+    textarea,
+    .no-print {
+        display: none !important;
+    }
+
+    .print-page {
+        min-height: auto !important;
+        padding: 0 !important;
+    }
+
+    .print-container {
+        max-width: none !important;
+        width: 100% !important;
+        padding: 0 !important;
+    }
+
+    .print-receipt {
+        border: 1px solid #000 !important;
+        border-radius: 0 !important;
+        break-inside: avoid;
+        padding: 16pt !important;
+    }
+
+    .comparison-grid {
+        display: block !important;
+    }
+
+    .comparison-card {
+        width: 100% !important;
+        max-width: none !important;
+        break-inside: avoid;
+        border: 1px solid #000 !important;
+        border-radius: 0 !important;
+        margin: 0 0 12pt !important;
+        padding: 12pt !important;
+    }
+
+    .comparison-card table {
+        border-collapse: collapse !important;
+        width: 100% !important;
+    }
+
+    .comparison-card th,
+    .comparison-card td,
+    .print-table th,
+    .print-table td {
+        border: 1px solid #000 !important;
+        padding: 6pt !important;
+        text-align: left !important;
+        vertical-align: top !important;
+    }
+
+    .print-divider {
+        border-color: #000 !important;
+    }
+}


### PR DESCRIPTION
## 📋 PR Summary

Added a unified print stylesheet for medicine reports and a clean printable medicine comparison page. The print view hides non-printable UI like headers, footers, chat widgets, and action buttons, while rendering comparison cards as full-width black-and-white receipt-style blocks.

---

## 🔗 Related Issue

Closes #282

---

## 🏷️ PR Type

* [ ] 🐛 Bug Fix
* [✓] ✨ New Feature / Enhancement
* [ ] 📖 Documentation
* [ ] 🌏 Translation (i18n)
* [✓] 🎨 UI / UX Improvement
* [ ] ⚙️ DevOps / CI-CD
* [ ] 🤖 ML / AI Feature
* [ ] 🔒 Security Fix
* [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

* [✓] `apps/web` — Next.js Frontend
* [ ] `apps/api` — Node.js / Express Backend
* [ ] `apps/ml` — Python / FastAPI ML Service
* [ ] `data/` — Database seeds / migrations
* [ ] `docs/` — Documentation
* [ ] `.github/` — GitHub config, workflows
* [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

* Added `apps/web/src/styles/print.css`
* Added `@media print` rules for white backgrounds and high-contrast black text
* Added `.no-print` handling for header, footer, chatbot/toast, and action buttons
* Imported the print stylesheet in the App Router layout
* Added a printable `/compare` medicine comparison page
* Ensured comparison cards expand to full width in print preview

---

## 📸 Screenshots / Demo

<img width="932" height="475" alt="image" src="https://github.com/user-attachments/assets/8e0a72a3-21c3-4252-ace4-9be520dc5d4f" />
<img width="955" height="471" alt="image" src="https://github.com/user-attachments/assets/0b024f93-d394-475e-99cc-e9c4dfd9e322" />

* `Ctrl + P` print preview screenshot

---

## ✅ Contributor Checklist

* [✓] My PR has a linked issue (see above)
* [✓] I have pulled the latest `main` and rebased/merged before this PR
* [✓] My code follows the project patterns
* [✓] I ran `npm.cmd run dev -- -p 3000` — no build errors
* [✓] I ran `npm.cmd run lint` — passes with existing warnings only
* [✓] Screenshots/test output added for UI changes
* [✓] I have performed a self-review of my own code

---

## 🧪 Testing

* Tested `/en/compare` in browser
* Tested print preview using `Ctrl + P`
* Confirmed header/footer/buttons are hidden in print
* Confirmed print layout uses white background, black text, and full-width comparison cards
* Ran `npm.cmd run lint`

---

## 🎓 GSSoC 2026

* [✓] I am a GSSoC 2026 participant