### PR TITLE
feat(web): add lazy image placeholders

### DIFF
--- a/apps/web/app/[locale]/report/ReportInfoPanel.tsx
+++ b/apps/web/app/[locale]/report/ReportInfoPanel.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import {
+  CheckCircle2,
+  ChevronRight,
+  Clock,
+  Lock,
+  Search,
+  ShieldCheck,
+} from "lucide-react";
+
+export default function ReportInfoPanel() {
+  return (
+    <div className="lg:col-span-5 space-y-6 lg:mt-24">
+      {/* Quick Verify */}
+      <div className="bg-white rounded-3xl p-6 shadow-sm border border-slate-200">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-10 h-10 rounded-xl bg-blue-50 text-blue-600 flex items-center justify-center">
+            <Search size={20} strokeWidth={2.5} />
+          </div>
+          <div>
+            <h3 className="font-bold text-slate-800">Quick Verify</h3>
+            <p className="text-xs text-slate-500 font-medium">Check if already reported</p>
+          </div>
+        </div>
+        <div className="relative">
+          <input
+            type="text"
+            placeholder="Enter batch number..."
+            className="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500 transition-all"
+          />
+          <button className="absolute right-2 top-2 bottom-2 bg-slate-900 text-white px-3 rounded-xl hover:bg-slate-800 transition-colors flex items-center justify-center">
+            <ChevronRight size={16} />
+          </button>
+        </div>
+      </div>
+
+      {/* Trust & Safety Card */}
+      <div className="bg-white rounded-[2rem] p-8 shadow-sm border border-slate-200 overflow-hidden relative">
+        <div className="absolute top-0 left-0 right-0 h-2 bg-emerald-500"></div>
+
+        <div className="flex items-center gap-3 mb-8">
+          <ShieldCheck className="text-emerald-500" size={28} strokeWidth={2.5} />
+          <h3 className="text-xl font-bold text-slate-800">Trust & Safety</h3>
+        </div>
+
+        <div className="space-y-6">
+          <div className="flex gap-4">
+            <div className="w-10 h-10 rounded-full bg-emerald-50 text-emerald-600 flex items-center justify-center shrink-0">
+              <Lock size={18} strokeWidth={2.5} />
+            </div>
+            <div>
+              <h4 className="font-bold text-slate-800">Anonymity Guaranteed</h4>
+              <p className="text-sm text-slate-500 font-medium leading-relaxed mt-1">
+                Your personal details are encrypted and never shared publicly.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex gap-4">
+            <div className="w-10 h-10 rounded-full bg-emerald-50 text-emerald-600 flex items-center justify-center shrink-0">
+              <CheckCircle2 size={18} strokeWidth={2.5} />
+            </div>
+            <div>
+              <h4 className="font-bold text-slate-800">Verified by Pharmacovigilance</h4>
+              <p className="text-sm text-slate-500 font-medium leading-relaxed mt-1">
+                Reports are cross-checked with official databases before alerts are issued.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex gap-4">
+            <div className="w-10 h-10 rounded-full bg-emerald-50 text-emerald-600 flex items-center justify-center shrink-0">
+              <Clock size={18} strokeWidth={2.5} />
+            </div>
+            <div>
+              <h4 className="font-bold text-slate-800">48h Review Cycle</h4>
+              <p className="text-sm text-slate-500 font-medium leading-relaxed mt-1">
+                Critical reports are prioritized and reviewed within 48 hours.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/[locale]/report/page.tsx
+++ b/apps/web/app/[locale]/report/page.tsx
@@ -1,6 +1,6 @@
-import { ShieldCheck, Search, Lock, CheckCircle2, Clock, ChevronRight } from "lucide-react";
 import ReportWizard from "@/components/reports/ReportWizard";
 import { PageHeader } from "../components/PageHeader";
+import ReportInfoPanel from "./ReportInfoPanel";
 
 export const metadata = {
   title: "Report Fake Medicine — MedWatch",
@@ -56,80 +56,7 @@ export default function ReportPage() {
           </div>
 
           {/* Right Column: Dashboard & Info */}
-          <div className="lg:col-span-5 space-y-6 lg:mt-24">
-            
-            {/* Quick Verify */}
-            <div className="bg-white rounded-3xl p-6 shadow-sm border border-slate-200">
-              <div className="flex items-center gap-3 mb-4">
-                <div className="w-10 h-10 rounded-xl bg-blue-50 text-blue-600 flex items-center justify-center">
-                  <Search size={20} strokeWidth={2.5} />
-                </div>
-                <div>
-                  <h3 className="font-bold text-slate-800">Quick Verify</h3>
-                  <p className="text-xs text-slate-500 font-medium">Check if already reported</p>
-                </div>
-              </div>
-              <div className="relative">
-                <input 
-                  type="text" 
-                  placeholder="Enter batch number..." 
-                  className="w-full bg-slate-50 border border-slate-200 rounded-2xl px-4 py-3 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500 transition-all"
-                />
-                <button className="absolute right-2 top-2 bottom-2 bg-slate-900 text-white px-3 rounded-xl hover:bg-slate-800 transition-colors flex items-center justify-center">
-                  <ChevronRight size={16} />
-                </button>
-              </div>
-            </div>
-
-            {/* Trust & Safety Card */}
-            <div className="bg-white rounded-[2rem] p-8 shadow-sm border border-slate-200 overflow-hidden relative">
-              <div className="absolute top-0 left-0 right-0 h-2 bg-emerald-500"></div>
-              
-              <div className="flex items-center gap-3 mb-8">
-                <ShieldCheck className="text-emerald-500" size={28} strokeWidth={2.5} />
-                <h3 className="text-xl font-bold text-slate-800">Trust & Safety</h3>
-              </div>
-
-              <div className="space-y-6">
-                <div className="flex gap-4">
-                  <div className="w-10 h-10 rounded-full bg-emerald-50 text-emerald-600 flex items-center justify-center shrink-0">
-                    <Lock size={18} strokeWidth={2.5} />
-                  </div>
-                  <div>
-                    <h4 className="font-bold text-slate-800">Anonymity Guaranteed</h4>
-                    <p className="text-sm text-slate-500 font-medium leading-relaxed mt-1">
-                      Your personal details are encrypted and never shared publicly.
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex gap-4">
-                  <div className="w-10 h-10 rounded-full bg-emerald-50 text-emerald-600 flex items-center justify-center shrink-0">
-                    <CheckCircle2 size={18} strokeWidth={2.5} />
-                  </div>
-                  <div>
-                    <h4 className="font-bold text-slate-800">Verified by Pharmacovigilance</h4>
-                    <p className="text-sm text-slate-500 font-medium leading-relaxed mt-1">
-                      Reports are cross-checked with official databases before alerts are issued.
-                    </p>
-                  </div>
-                </div>
-
-                <div className="flex gap-4">
-                  <div className="w-10 h-10 rounded-full bg-emerald-50 text-emerald-600 flex items-center justify-center shrink-0">
-                    <Clock size={18} strokeWidth={2.5} />
-                  </div>
-                  <div>
-                    <h4 className="font-bold text-slate-800">48h Review Cycle</h4>
-                    <p className="text-sm text-slate-500 font-medium leading-relaxed mt-1">
-                      Critical reports are prioritized and reviewed within 48 hours.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-          </div>
+          <ReportInfoPanel />
         </div>
       </main>
     </div>

--- a/apps/web/app/[locale]/reports/me/page.tsx
+++ b/apps/web/app/[locale]/reports/me/page.tsx
@@ -17,6 +17,8 @@ import {
 import { Link } from '@/i18n/routing';
 import { PageHeader } from '../../components/PageHeader';
 import Footer from '../../components/Footer';
+import Card from '@/components/Card';
+import LazyImage from '@/components/LazyImage';
 
 // `NEXT_PUBLIC_API_URL` must be the bare API origin with no path suffix
 // (e.g. `https://api.example.com`). The reports router is mounted at
@@ -103,13 +105,13 @@ function ReportCard({ report }: { report: MyReport }) {
     report.reported_brand_name?.trim() || report.scanned_barcode || 'Unnamed medicine';
 
   return (
-    <article className="bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden flex flex-col sm:flex-row">
+    <Card className="flex flex-col sm:flex-row">
       <div className="sm:w-32 sm:h-32 h-40 bg-slate-100 shrink-0 flex items-center justify-center">
         {isSafePhotoUrl(report.photo_url) ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
+          <LazyImage
             src={report.photo_url}
             alt={`Photo of reported medicine: ${title}`}
+            wrapperClassName="w-full h-full"
             className="w-full h-full object-cover"
           />
         ) : (
@@ -150,7 +152,7 @@ function ReportCard({ report }: { report: MyReport }) {
           )}
         </dl>
       </div>
-    </article>
+    </Card>
   );
 }
 

--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -22,6 +22,7 @@ import { toast } from "sonner";
 import Footer from "../components/Footer";
 import { ExpiryBadge } from "@/components/scanner/ExpiryBadge";
 import { verifyMedicine, VerifyResult, VerifiedMedicine, API_BASE } from "@/lib/api";
+import LazyImage from "@/components/LazyImage";
 
 function formatExpiryForBadge(isoDate: string | null | undefined): string | undefined {
     if (!isoDate) return undefined;
@@ -579,9 +580,10 @@ export default function ScanPage() {
             <div className="relative flex flex-1 items-center justify-center overflow-hidden">
                 <div className="absolute inset-0 overflow-hidden bg-slate-900">
                     {uploadedImage ? (
-                        <img
+                        <LazyImage
                             src={uploadedImage}
                             alt="Uploaded"
+                            wrapperClassName="h-full w-full"
                             className="h-full w-full object-cover opacity-60"
                         />
                     ) : (

--- a/apps/web/components/Card.tsx
+++ b/apps/web/components/Card.tsx
@@ -1,0 +1,21 @@
+import { HTMLAttributes } from "react";
+
+type CardProps = HTMLAttributes<HTMLElement> & {
+  as?: "article" | "div" | "section";
+};
+
+export default function Card({
+  as: Component = "article",
+  className = "",
+  children,
+  ...props
+}: CardProps) {
+  return (
+    <Component
+      className={`bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden ${className}`}
+      {...props}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/apps/web/components/LazyImage.tsx
+++ b/apps/web/components/LazyImage.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import {
+  ImgHTMLAttributes,
+  SyntheticEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+type LazyImageProps = Omit<ImgHTMLAttributes<HTMLImageElement>, "src"> & {
+  src: string;
+  wrapperClassName?: string;
+  placeholderClassName?: string;
+  rootMargin?: string;
+  threshold?: number;
+};
+
+export default function LazyImage({
+  src,
+  alt,
+  className = "",
+  wrapperClassName = "",
+  placeholderClassName = "",
+  rootMargin = "160px",
+  threshold = 0.1,
+  onLoad,
+  ...imgProps
+}: LazyImageProps) {
+  const wrapperRef = useRef<HTMLSpanElement | null>(null);
+  const [isInView, setIsInView] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    setIsLoaded(false);
+    setIsInView(false);
+
+    const node = wrapperRef.current;
+    if (!node || typeof IntersectionObserver === "undefined") {
+      setIsInView(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsInView(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin, threshold },
+    );
+
+    observer.observe(node);
+
+    return () => observer.disconnect();
+  }, [rootMargin, src, threshold]);
+
+  const handleLoad = (event: SyntheticEvent<HTMLImageElement>) => {
+    setIsLoaded(true);
+    onLoad?.(event);
+  };
+
+  return (
+    <span
+      ref={wrapperRef}
+      className={`relative block overflow-hidden bg-slate-100 ${wrapperClassName}`}
+    >
+      {!isLoaded && (
+        <span
+          aria-hidden="true"
+          className={`absolute inset-0 bg-slate-200/80 ${placeholderClassName}`}
+        />
+      )}
+      {isInView && (
+        <img
+          {...imgProps}
+          src={src}
+          alt={alt}
+          onLoad={handleLoad}
+          className={`transition-[filter,opacity] duration-300 ease-out ${
+            isLoaded ? "blur-0" : "blur-[10px]"
+          } ${className}`}
+        />
+      )}
+    </span>
+  );
+}

--- a/apps/web/components/reports/ReportWizard.tsx
+++ b/apps/web/components/reports/ReportWizard.tsx
@@ -13,6 +13,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { motion, AnimatePresence, Variants } from "framer-motion";
 import { submitReport, geocodePincode } from "@/lib/api";
+import LazyImage from "@/components/LazyImage";
 
 // ─── Cloudinary env ────────────────────────────────────────────────────────────
 // Uploads are now securely routed through our backend API (/api/upload),
@@ -350,8 +351,12 @@ function Step2({
                 exit={{ opacity: 0, scale: 0.88 }} transition={{ duration: 0.18 }}
                 className="relative group aspect-square rounded-xl overflow-hidden border border-slate-200 bg-slate-100 shadow-sm"
               >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={img.preview} alt={img.name} className="w-full h-full object-cover" />
+                <LazyImage
+                  src={img.preview}
+                  alt={img.name}
+                  wrapperClassName="w-full h-full"
+                  className="w-full h-full object-cover"
+                />
                 {/* Remove overlay */}
                 <div className="absolute inset-0 bg-slate-900/60 opacity-0 group-hover:opacity-100
                   transition-opacity flex items-center justify-center">


### PR DESCRIPTION
Closes #287

## Summary
- Added reusable LazyImage component with IntersectionObserver-based loading
- Added blurred placeholder transition for image loading
- Updated report and scanner image previews to use LazyImage
- Moved report page icon panel into a client component to fix the /en/report runtime error

## Testing
- Ran npm run lint --workspace web
- Manually tested /en/report page load
- Manually tested report image upload preview
- Manually tested /en/scan uploaded image preview

## Note
Full build currently has an unrelated existing lucide-react type declaration issue in the admin dashboard.