### PR TITLE
feat: add search history chips to SearchBar component

### DIFF
--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { SearchBar } from "apps/web/app/src/components/SearchBar";
+import { SearchBar } from "@/app/src/components/SearchBar";
 import {
     Camera,
     ShieldCheck,

--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { SearchBar } from "@/src/components/SearchBar";
+import { SearchBar } from "apps/web/app/src/components/SearchBar";
 import {
     Camera,
     ShieldCheck,

--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { SearchBar } from "@/src/components/SearchBar";
 import {
     Camera,
     ShieldCheck,
@@ -674,24 +675,7 @@ export default function ScanPage() {
             )}
 
             <div className="flex flex-col items-center gap-6 bg-linear-to-t from-black to-transparent p-8">
-                <form onSubmit={handleBatchSubmit} className="flex w-full max-w-sm gap-2">
-                    <input
-                        type="text"
-                        value={batchInput}
-                        onChange={(e) => setBatchInput(e.target.value)}
-                        placeholder="Enter batch number"
-                        className="flex-1 rounded-full border border-white/20 bg-white/10 px-4 py-3 text-sm font-medium text-white placeholder-white/40 focus:border-transparent focus:ring-2 focus:ring-emerald-500 focus:outline-none"
-                    />
-                    <button
-                        type="submit"
-                        disabled={isScanning}
-                        className="flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-3 text-sm font-bold text-white shadow-lg transition-colors hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                        <Search size={18} />
-                        Verify
-                    </button>
-                </form>
-
+               <SearchBar onSearch={handleVerify} placeholder="Enter batch number" />
                 <p className="max-w-xs text-center text-sm font-medium text-slate-400">
                     Enter the batch number from the medicine strip, or upload a photo from your
                     gallery.

--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { SearchBar } from "@/app/src/components/SearchBar";
+import { SearchBar } from "../../src/components/SearchBar";
 import {
     Camera,
     ShieldCheck,

--- a/apps/web/app/src/components/SearchBar.tsx
+++ b/apps/web/app/src/components/SearchBar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Search, X } from "lucide-react";
+
+const STORAGE_KEY = "sahidawa_search_history";
+const MAX_HISTORY = 5;
+
+interface SearchBarProps {
+    onSearch: (query: string) => void;
+    placeholder?: string;
+}
+
+export function SearchBar({ onSearch, placeholder = "Enter batch number" }: SearchBarProps) {
+    const [query, setQuery] = useState("");
+    const [history, setHistory] = useState<string[]>([]);
+
+    useEffect(() => {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored) setHistory(JSON.parse(stored));
+    }, []);
+
+    const pushToHistory = (value: string) => {
+        const updated = [value, ...history.filter((h) => h !== value)].slice(0, MAX_HISTORY);
+        setHistory(updated);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+    };
+
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!query.trim()) return;
+        pushToHistory(query.trim());
+        onSearch(query.trim());
+    };
+
+    const handleChipClick = (item: string) => {
+        setQuery(item);
+        onSearch(item);
+    };
+
+    const clearHistory = () => {
+        setHistory([]);
+        localStorage.removeItem(STORAGE_KEY);
+    };
+
+    return (
+        <div className="flex w-full max-w-sm flex-col gap-2">
+            <form onSubmit={handleSubmit} className="flex gap-2">
+                <input
+                    type="text"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder={placeholder}
+                    className="flex-1 rounded-full border border-white/20 bg-white/10 px-4 py-3 text-sm font-medium text-white placeholder-white/40 focus:border-transparent focus:ring-2 focus:ring-emerald-500 focus:outline-none"
+                />
+                <button
+                    type="submit"
+                    className="flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-3 text-sm font-bold text-white shadow-lg transition-colors hover:bg-emerald-400"
+                >
+                    <Search size={18} />
+                    Verify
+                </button>
+            </form>
+
+            {history.length > 0 && (
+                <div className="flex flex-wrap items-center gap-2">
+                    {history.map((item) => (
+                        <button
+                            key={item}
+                            onClick={() => handleChipClick(item)}
+                            className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-xs font-medium text-white/70 transition-colors hover:bg-white/20 hover:text-white"
+                        >
+                            {item}
+                        </button>
+                    ))}
+                    <button
+                        onClick={clearHistory}
+                        className="flex items-center gap-1 rounded-full px-2 py-1 text-xs text-white/40 transition-colors hover:text-red-400"
+                    >
+                        <X size={12} />
+                        Clear
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
Hey! @dipexplorer 

What I did:
Created a new SearchBar component that remembers the last 5 medicine batch numbers a user has searched. This makes it faster for returning users to re-verify medicines without retyping the batch number every time.

Features Added:
1.) Search History Chips: After every successful search, the batch number is saved and shown as a clickable chip below the search bar. Clicking a chip instantly fills the search box with that batch number.
2.) Max 5 History Items: Only the last 5 unique searches are stored. Older ones are automatically removed.
3.) No Duplicates: If you search the same batch number again it moves to the front instead of adding a duplicate.
4.) Clear History Button: A small "Clear" button lets users wipe their entire search history with one click.
5.) Persistent Storage: History is saved in localStorage under the key sahidawa_search_history so it stays even after closing and reopening the browser.

Files Changed:
1.) Created apps/web/app/src/components/SearchBar.tsx: the new reusable search component
2.) Modified apps/web/app/[locale]/scan/page.tsx: replaced the old hardcoded form with the new SearchBar component

How to Test:
1.) Go to /scan page
2.) Search any batch number
3.) You should see it appear as a chip below the search bar
4.) Click the chip: it should fill the search box instantly
5.) Click Clear: history should be wiped from localStorage

<img width="1882" height="914" alt="Screenshot 2026-05-19 122500" src="https://github.com/user-attachments/assets/e87e8571-30a5-449f-9842-b91cc4daed45" />