### PR TITLE
Codex/ml telemetry logging

### DIFF
--- a/apps/ml/main.py
+++ b/apps/ml/main.py
@@ -3,7 +3,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 import os
 
+from services.telemetry import configure_telemetry_logging
+
 load_dotenv()
+configure_telemetry_logging()
 
 app = FastAPI(
     title="SahiDawa ML Service",

--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -9,9 +9,16 @@ import logging
 import os
 
 from faster_whisper import WhisperModel
+from services.telemetry import (
+    get_audio_duration_seconds,
+    get_memory_usage_mb,
+    get_telemetry_logger,
+    log_transcription_finished,
+    start_timer,
+)
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+telemetry_logger = get_telemetry_logger()
 
 router = APIRouter(prefix="/asr", tags=["ASR"])
 
@@ -54,6 +61,9 @@ async def transcribe_audio(file: UploadFile = File(...)):
 
     tmp_path: str | None = None
     normalized_path: str | None = None
+    transcription_started_at: float | None = None
+    audio_duration_seconds = 0.0
+    memory_before_mb = 0.0
 
     try:
         # ── 2. Write raw upload to disk ───────────────────────────────────────
@@ -97,6 +107,7 @@ async def transcribe_audio(file: UploadFile = File(...)):
 
         # ── 4. Read normalized WAV with soundfile (always safe) ───────────────
         audio_data, sample_rate = sf.read(normalized_path)
+        audio_duration_seconds = get_audio_duration_seconds(audio_data, sample_rate)
 
         # Ensure float32 — required by noisereduce and faster-whisper
         audio_data = audio_data.astype(np.float32)
@@ -110,6 +121,8 @@ async def transcribe_audio(file: UploadFile = File(...)):
         # ── 6. Transcribe with faster-whisper ─────────────────────────────────
         # language=None → auto-detect; task="transcribe" preserves native language
         # (no translation). beam_size=8 improves accuracy for regional languages.
+        transcription_started_at = start_timer()
+        memory_before_mb = get_memory_usage_mb()
         segments, info = model.transcribe(
             reduced_audio,
             language=None,
@@ -124,6 +137,12 @@ async def transcribe_audio(file: UploadFile = File(...)):
         )
 
         transcript = " ".join(seg.text for seg in segments).strip()
+        log_transcription_finished(
+            started_at=transcription_started_at,
+            audio_duration_seconds=audio_duration_seconds,
+            memory_before_mb=memory_before_mb,
+            logger=telemetry_logger,
+        )
 
         logger.info(
             f"Transcription complete | lang={info.language} "

--- a/apps/ml/services/telemetry.py
+++ b/apps/ml/services/telemetry.py
@@ -1,0 +1,125 @@
+import logging
+import os
+import time
+import tracemalloc
+from typing import Any
+
+
+TELEMETRY_LOGGER_NAME = "sahidawa.ml.telemetry"
+
+
+def configure_telemetry_logging(level: int = logging.INFO) -> None:
+    """Configure process-wide telemetry logging for the ML service."""
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
+
+    if not tracemalloc.is_tracing():
+        tracemalloc.start()
+
+
+def get_telemetry_logger() -> logging.Logger:
+    return logging.getLogger(TELEMETRY_LOGGER_NAME)
+
+
+def start_timer() -> float:
+    return time.perf_counter()
+
+
+def get_memory_usage_mb() -> float:
+    try:
+        import psutil
+
+        return psutil.Process(os.getpid()).memory_info().rss / (1024 * 1024)
+    except Exception:
+        pass
+
+    if os.name == "nt":
+        try:
+            import ctypes
+            from ctypes import wintypes
+
+            class ProcessMemoryCounters(ctypes.Structure):
+                _fields_ = [
+                    ("cb", wintypes.DWORD),
+                    ("PageFaultCount", wintypes.DWORD),
+                    ("PeakWorkingSetSize", ctypes.c_size_t),
+                    ("WorkingSetSize", ctypes.c_size_t),
+                    ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+                    ("QuotaPagedPoolUsage", ctypes.c_size_t),
+                    ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+                    ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+                    ("PagefileUsage", ctypes.c_size_t),
+                    ("PeakPagefileUsage", ctypes.c_size_t),
+                ]
+
+            psapi = ctypes.WinDLL("psapi")
+            kernel32 = ctypes.WinDLL("kernel32")
+            psapi.GetProcessMemoryInfo.argtypes = [
+                wintypes.HANDLE,
+                ctypes.POINTER(ProcessMemoryCounters),
+                wintypes.DWORD,
+            ]
+            psapi.GetProcessMemoryInfo.restype = wintypes.BOOL
+            kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+
+            counters = ProcessMemoryCounters()
+            counters.cb = ctypes.sizeof(ProcessMemoryCounters)
+            process_handle = kernel32.GetCurrentProcess()
+            psapi.GetProcessMemoryInfo(
+                process_handle,
+                ctypes.byref(counters),
+                counters.cb,
+            )
+            return counters.WorkingSetSize / (1024 * 1024)
+        except Exception:
+            pass
+
+    try:
+        import resource
+
+        usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if os.name == "posix":
+            return usage / 1024
+        return usage / (1024 * 1024)
+    except Exception:
+        pass
+
+    try:
+        if not tracemalloc.is_tracing():
+            tracemalloc.start()
+        _, peak = tracemalloc.get_traced_memory()
+        return peak / (1024 * 1024)
+    except Exception:
+        return 0.0
+
+
+def get_audio_duration_seconds(audio_data: Any, sample_rate: int | float) -> float:
+    if not sample_rate:
+        return 0.0
+
+    audio_shape = getattr(audio_data, "shape", None)
+    sample_count = audio_shape[0] if audio_shape else len(audio_data)
+    return float(sample_count) / float(sample_rate)
+
+
+def log_transcription_finished(
+    *,
+    started_at: float,
+    audio_duration_seconds: float,
+    memory_before_mb: float,
+    logger: logging.Logger | None = None,
+) -> None:
+    elapsed_seconds = time.perf_counter() - started_at
+    memory_after_mb = get_memory_usage_mb()
+    memory_delta_mb = memory_after_mb - memory_before_mb
+
+    (logger or get_telemetry_logger()).info(
+        "transcription finished in %.2f seconds for %.2f seconds of audio clip | "
+        "memory %.2f MB (delta %.2f MB)",
+        elapsed_seconds,
+        audio_duration_seconds,
+        memory_after_mb,
+        memory_delta_mb,
+    )

--- a/apps/ml/tests/test_telemetry.py
+++ b/apps/ml/tests/test_telemetry.py
@@ -1,0 +1,36 @@
+import logging
+import os
+import sys
+import time
+
+import numpy as np
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from services.telemetry import (
+    get_audio_duration_seconds,
+    log_transcription_finished,
+)
+
+
+def test_get_audio_duration_seconds():
+    audio_data = np.zeros(32000, dtype=np.float32)
+
+    assert get_audio_duration_seconds(audio_data, 16000) == 2.0
+
+
+def test_log_transcription_finished_outputs_latency_message(caplog):
+    logger = logging.getLogger("test.telemetry")
+
+    with caplog.at_level(logging.INFO, logger=logger.name):
+        log_transcription_finished(
+            started_at=time.perf_counter(),
+            audio_duration_seconds=2.0,
+            memory_before_mb=0.0,
+            logger=logger,
+        )
+
+    assert "transcription finished in" in caplog.text
+    assert "for 2.00 seconds of audio clip" in caplog.text
+    assert "memory" in caplog.text


### PR DESCRIPTION
Closes #293

## Summary
- Added ML telemetry logging helpers for transcription latency, audio duration, and memory usage.
- Wired telemetry logging into the Whisper transcription flow.
- Configured app-level logging for clean terminal telemetry output.

## Testing
- Verified touched Python files compile successfully.
- Verified telemetry logging helper with a direct smoke test.
- `python -m compileall apps/ml/main.py apps/ml/routers/asr.py apps/ml/services/telemetry.py`
- Direct telemetry smoke test printed the expected `transcription finished in X.XX seconds for Y.YY seconds of audio clip` log.
