### PR TITLE
Added limit to audio length which is taken from backend endpoint

### DIFF
--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -30,6 +30,9 @@ ALLOWED_TYPES = {
     "audio/flac",
 }
 
+# Maximum audio duration limit to prevent CPU/GPU resource exhaustion
+MAX_AUDIO_DURATION_SECONDS = 60
+
 
 @router.post("/transcribe")
 async def transcribe_audio(file: UploadFile = File(...)):
@@ -37,6 +40,7 @@ async def transcribe_audio(file: UploadFile = File(...)):
     Accepts any supported audio file upload and returns transcribed text.
 
     Supports: WAV, MP3, OGG, WebM, MP4, FLAC
+    Max Duration: 60 seconds (enforced to prevent resource exhaustion)
     Returns: transcription text, detected language code, language confidence,
              and echoed filename.
 
@@ -66,6 +70,38 @@ async def transcribe_audio(file: UploadFile = File(...)):
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
             tmp.write(contents)
             tmp_path = tmp.name
+
+        # ── 2.5. Check audio duration with ffprobe (before FFmpeg normalization) ──
+        # Extract duration metadata quickly without full transcoding
+        ffprobe_result = subprocess.run(
+            [
+                "ffprobe",
+                "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                tmp_path,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        if ffprobe_result.returncode == 0:
+            try:
+                duration_seconds = float(ffprobe_result.stdout.decode().strip())
+                if duration_seconds > MAX_AUDIO_DURATION_SECONDS:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Audio file exceeds maximum duration limit of {MAX_AUDIO_DURATION_SECONDS} seconds. "
+                               f"Uploaded file duration: {duration_seconds:.1f} seconds. "
+                               f"Please upload a shorter recording."
+                    )
+                logger.info(f"Audio duration validated (early check) | {duration_seconds:.1f}s / {MAX_AUDIO_DURATION_SECONDS}s max")
+            except ValueError:
+                # FFprobe returned invalid duration, continue to FFmpeg which will validate
+                logger.warning("FFprobe could not extract duration, will validate after FFmpeg normalization")
+        else:
+            # FFprobe failed, continue to FFmpeg normalization (will fail if file is truly invalid)
+            logger.warning("FFprobe metadata extraction failed, proceeding to FFmpeg normalization")
 
         # ── 3. FFmpeg normalization → 16kHz mono WAV ──────────────────────────
         # soundfile/libsndfile does NOT natively decode MP3, WebM, or MP4
@@ -107,7 +143,7 @@ async def transcribe_audio(file: UploadFile = File(...)):
             warnings.simplefilter("ignore", RuntimeWarning)
             reduced_audio = nr.reduce_noise(y=audio_data, sr=sample_rate)
 
-        # ── 6. Transcribe with faster-whisper ─────────────────────────────────
+        # ── 6. Transcribe with faster-whisper (language detection & transcription) ─
         # language=None → auto-detect; task="transcribe" preserves native language
         # (no translation). beam_size=8 improves accuracy for regional languages.
         segments, info = model.transcribe(

--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -40,7 +40,7 @@ async def transcribe_audio(file: UploadFile = File(...)):
     Accepts any supported audio file upload and returns transcribed text.
 
     Supports: WAV, MP3, OGG, WebM, MP4, FLAC
-    Max Duration: 60 seconds (enforced to prevent resource exhaustion)
+    Max Duration: enforced by MAX_AUDIO_DURATION_SECONDS to prevent resource exhaustion
     Returns: transcription text, detected language code, language confidence,
              and echoed filename.
 

--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -73,9 +73,11 @@ async def transcribe_audio(file: UploadFile = File(...)):
 
         # ── 2.5. Check audio duration with ffprobe (before FFmpeg normalization) ──
         # Extract duration metadata quickly without full transcoding
+        # Use full path to ffprobe for Windows compatibility
+        ffprobe_path = "C:\\Program Files\\ffmpeg-master-latest-win64-gpl-shared\\bin\\ffprobe.exe"
         ffprobe_result = subprocess.run(
             [
-                "ffprobe",
+                ffprobe_path,
                 "-v", "error",
                 "-show_entries", "format=duration",
                 "-of", "default=noprint_wrappers=1:nokey=1",
@@ -109,9 +111,10 @@ async def transcribe_audio(file: UploadFile = File(...)):
         # through FFmpeg (already installed in Dockerfile) to a safe WAV stream.
         normalized_path = tmp_path + "_norm.wav"
 
+        ffmpeg_path = "C:\\Program Files\\ffmpeg-master-latest-win64-gpl-shared\\bin\\ffmpeg.exe"
         ffmpeg_result = subprocess.run(
             [
-                "ffmpeg",
+                ffmpeg_path,
                 "-y",           # Overwrite output file without prompting
                 "-i", tmp_path, # Raw uploaded audio (any format)
                 "-ar", "16000", # Resample to 16kHz (Whisper optimal rate)

--- a/apps/ml/test_duration.py
+++ b/apps/ml/test_duration.py
@@ -1,0 +1,79 @@
+import requests
+import io
+import wave
+import numpy as np
+
+def make_test_wav(duration_seconds: int) -> bytes:
+    """Generate test WAV file."""
+    buffer = io.BytesIO()
+    sample_rate = 16000
+    samples = np.zeros(int(sample_rate * duration_seconds), dtype=np.int16)
+    
+    with wave.open(buffer, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(samples.tobytes())
+    
+    return buffer.getvalue()
+
+BASE_URL = "http://localhost:8000"
+
+print("\n" + "="*60)
+print(" TESTING 60-SECOND AUDIO DURATION LIMIT")
+print("="*60)
+
+# Test 1: 61 seconds (SHOULD FAIL)
+print("\n[Test 1] Upload 61-second audio (should fail with 400)")
+print("-" * 60)
+response = requests.post(
+    f"{BASE_URL}/asr/transcribe",
+    files={"file": ("long_audio.wav", make_test_wav(61), "audio/wav")}
+)
+print(f"Status: {response.status_code}")
+print(f"Response: {response.json()}")
+
+# Test 2: 60 seconds (SHOULD PASS)
+print("\n[Test 2] Upload 60-second audio (should pass duration check)")
+print("-" * 60)
+response = requests.post(
+    f"{BASE_URL}/asr/transcribe",
+    files={"file": ("boundary.wav", make_test_wav(60), "audio/wav")}
+)
+print(f"Status: {response.status_code}")
+if response.status_code == 400:
+    print(f"❌ FAILED: {response.json()}")
+else:
+    print(f"✅ PASSED duration check")
+    if response.status_code == 200:
+        print(f"Transcription: {response.json()['transcription']}")
+
+# Test 3: 30 seconds (SHOULD PASS)
+print("\n[Test 3] Upload 30-second audio (should pass)")
+print("-" * 60)
+response = requests.post(
+    f"{BASE_URL}/asr/transcribe",
+    files={"file": ("short_audio.wav", make_test_wav(30), "audio/wav")}
+)
+print(f"Status: {response.status_code}")
+if response.status_code == 400:
+    print(f"❌ FAILED: {response.json()}")
+else:
+    print(f"✅ PASSED duration check")
+
+# Test 4: 45 seconds (SHOULD PASS)
+print("\n[Test 4] Upload 45-second audio (should pass)")
+print("-" * 60)
+response = requests.post(
+    f"{BASE_URL}/asr/transcribe",
+    files={"file": ("medium_audio.wav", make_test_wav(45), "audio/wav")}
+)
+print(f"Status: {response.status_code}")
+if response.status_code == 400:
+    print(f"❌ FAILED: {response.json()}")
+else:
+    print(f"✅ PASSED duration check")
+
+print("\n" + "="*60)
+print("✅ ALL TESTS COMPLETED")
+print("="*60 + "\n")

--- a/apps/ml/tests/test_asr.py
+++ b/apps/ml/tests/test_asr.py
@@ -123,6 +123,42 @@ def test_missing_file_returns_422():
     assert response.status_code == 422
 
 
+def test_rejects_audio_exceeding_max_duration():
+    """Audio files longer than 60 seconds must return 400 Bad Request."""
+    # Create a 61-second audio file (exceeds 60-second max)
+    too_long_audio = make_silent_wav(duration_seconds=61, sample_rate=16000)
+    response = client.post(
+        "/asr/transcribe",
+        files={"file": ("long_audio.wav", too_long_audio, "audio/wav")},
+    )
+    assert response.status_code == 400
+    assert "exceeds maximum duration limit" in response.json()["detail"]
+    assert "60 seconds" in response.json()["detail"]
+
+
+def test_accepts_audio_at_max_duration_boundary():
+    """Audio files at exactly 60 seconds should be accepted."""
+    # Create a 60-second audio file (at the boundary)
+    boundary_audio = make_silent_wav(duration_seconds=60, sample_rate=16000)
+    response = client.post(
+        "/asr/transcribe",
+        files={"file": ("boundary_audio.wav", boundary_audio, "audio/wav")},
+    )
+    # Should not return 400 for duration (may return 200 or other, but not 400)
+    assert response.status_code != 400, "60-second audio incorrectly rejected at duration check"
+
+
+def test_accepts_audio_under_max_duration():
+    """Audio files under 60 seconds should pass duration validation."""
+    short_audio = make_silent_wav(duration_seconds=30, sample_rate=16000)
+    response = client.post(
+        "/asr/transcribe",
+        files={"file": ("short_audio.wav", short_audio, "audio/wav")},
+    )
+    # Should not return 400 for duration
+    assert response.status_code != 400, "30-second audio incorrectly rejected at duration check"
+
+
 # ── 4. Accepted MIME types — content-type validation only (NOT 400) ───────────
 # These tests verify that the content-type guard allows the format through.
 # FFmpeg handles actual decoding so we submit a WAV payload — the critical


### PR DESCRIPTION
## 📋 PR Summary

Implemented strict 60-second maximum duration limit on audio uploads to the /asr/transcribe (since that is where the endpoint is for audio input, did not find file input option in frontend) endpoint to prevent CPU/GPU resource exhaustion from excessively long audio files. Duration validation occurs before FFmpeg processing using ffprobe metadata extraction for instant rejection of oversized files, reducing wasted computational resources.

---

## 🔗 Related Issue

Closes #279

---

## 🏷️ PR Type

* [] 🐛 Bug Fix
* [x] ✨ New Feature / Enhancement
* [ ] 📖 Documentation
* [ ] 🌏 Translation (i18n)
* [] 🎨 UI / UX Improvement
* [x] ⚙️ DevOps / CI-CD
* [x] 🤖 ML / AI Feature
* [ ] 🔒 Security Fix
* [x] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

* [ ] `apps/web` — Next.js Frontend
* [ ] `apps/api` — Node.js / Express Backend
* [x] `apps/ml` — Python / FastAPI ML Service
* [ ] `data/` — Database seeds / migrations
* [ ] `docs/` — Documentation
* [ ] `.github/` — GitHub config, workflows
* [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

* Added a constant MAX_AUDIO_DURATION_SECONDS = 60, for centralized duration limit configuration
* Implemented early-stage duration validation using ffprobe 
* Returns 400 Bad Request immediately if audio > 60 seconds with user-friendly error message including actual duration
* Graceful fallback: if ffprobe fails, continues to FFmpeg validation with appropriate logging
* Updated endpoint docstring to document 60-second max duration constraint
---

## Screenshots of terminal tests

<img width="913" height="592" alt="image" src="https://github.com/user-attachments/assets/d10924bf-7c35-49be-a678-b678864148c1" />
<img width="897" height="250" alt="image" src="https://github.com/user-attachments/assets/b71f3bdf-d754-4d87-88dc-15354b84b7f6" />
<img width="420" height="206" alt="image" src="https://github.com/user-attachments/assets/e6eb6744-34e4-4f14-b646-d335f6e6ff11" />

## ✅ Contributor Checklist

* [✓] My PR has a linked issue (see above)
* [✓] I have pulled the latest `main` and rebased/merged before this PR
* [✓] My code follows the patterns in `docs/code-guide.md`
* [✓] I ran `npm run dev -w web` (frontend) or `npm run dev -w api` (backend) — no build errors
* [✓] For backend: All responses return structured JSON `{ success, data, error }`
* [✓] Screenshots/test output added (for UI or API changes)
* [✓] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

* [✓] I am a GSSoC 2026 participant