### PR TITLE
Feature added Custom Verification Filters to restrict Upload MIME Types 

### DIFF
--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -22,13 +22,11 @@ logger.info("Whisper model loaded ✅")
 
 ALLOWED_TYPES = {
     "audio/wav",
-    "audio/x-wav",
-    "audio/mpeg",       # MP3
-    "audio/ogg",        # OGG / Opus
-    "audio/mp4",        # M4A / MP4
-    "audio/webm",       # WebM (browser MediaRecorder default)
-    "audio/flac",
+    "audio/mpeg",  # MP3
+    "audio/ogg",   # OGG / Opus
 }
+
+ALLOWED_EXTS = {".wav", ".mp3", ".ogg"}
 
 
 @router.post("/transcribe")
@@ -44,12 +42,17 @@ async def transcribe_audio(file: UploadFile = File(...)):
     passing to faster-whisper — ensures compatibility across all container
     environments regardless of libsndfile codec availability.
     """
-    # ── 1. Validate content type ──────────────────────────────────────────────
-    if file.content_type not in ALLOWED_TYPES:
+    # ── 1. Validate content type and filename extension ──────────────────────
+    original_name = file.filename or ""
+    ext = os.path.splitext(original_name)[1].lower()
+
+    if file.content_type not in ALLOWED_TYPES or ext not in ALLOWED_EXTS:
         raise HTTPException(
-            status_code=400,
-            detail=f"Unsupported audio format '{file.content_type}'. "
-                   f"Accepted: {', '.join(sorted(ALLOWED_TYPES))}"
+            status_code=415,
+            detail=(
+                f"Unsupported media type: content_type='{file.content_type}', "
+                f"extension='{ext or 'none'}'. Supported: audio/wav, audio/mpeg, audio/ogg"
+            )
         )
 
     tmp_path: str | None = None
@@ -59,9 +62,9 @@ async def transcribe_audio(file: UploadFile = File(...)):
         # ── 2. Write raw upload to disk ───────────────────────────────────────
         contents = await file.read()
 
-        # Guard against None filename (some clients omit it)
-        original_name = file.filename or "upload"
-        suffix = os.path.splitext(original_name)[-1].lower() or ".wav"
+        # Guard against missing filename and derive suffix for temp file
+        original_name = original_name or "upload"
+        suffix = ext or ".wav"
 
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
             tmp.write(contents)

--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -34,7 +34,7 @@ async def transcribe_audio(file: UploadFile = File(...)):
     """
     Accepts any supported audio file upload and returns transcribed text.
 
-    Supports: WAV, MP3, OGG, WebM, MP4, FLAC
+    Supports: WAV, MP3, OGG
     Returns: transcription text, detected language code, language confidence,
              and echoed filename.
 

--- a/apps/ml/tests/test_asr.py
+++ b/apps/ml/tests/test_asr.py
@@ -100,21 +100,21 @@ def test_filename_echoed_back():
 # ── 3. Input validation ───────────────────────────────────────────────────────
 
 def test_rejects_text_file():
-    """Non-audio MIME types must return 400."""
+    """Non-audio MIME types must return 415."""
     response = client.post(
         "/asr/transcribe",
         files={"file": ("notes.txt", io.BytesIO(b"not audio"), "text/plain")},
     )
-    assert response.status_code == 400
+    assert response.status_code == 415
 
 
 def test_rejects_image_file():
-    """Image MIME types must return 400."""
+    """Image MIME types must return 415."""
     response = client.post(
         "/asr/transcribe",
         files={"file": ("photo.jpg", io.BytesIO(b"\xff\xd8\xff"), "image/jpeg")},
     )
-    assert response.status_code == 400
+    assert response.status_code == 415
 
 
 def test_missing_file_returns_422():
@@ -130,12 +130,8 @@ def test_missing_file_returns_422():
 
 @pytest.mark.parametrize("content_type", [
     "audio/wav",
-    "audio/x-wav",
     "audio/mpeg",    # MP3
     "audio/ogg",     # OGG / Opus
-    "audio/webm",    # Browser MediaRecorder default
-    "audio/mp4",     # M4A / AAC
-    "audio/flac",
 ])
 def test_accepted_audio_mime_types_not_rejected(content_type):
     """


### PR DESCRIPTION
## 📋 PR Summary

Implemented strict file upload validation for the ASR transcription endpoint to ensure only supported audio formats are accepted. This improves service security by preventing malicious or unsupported file uploads and returning proper `415 Unsupported Media Type` responses.

---

## 🔗 Related Issue

Closes #294

---

## 🏷️ PR Type

- [x] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [x] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [ ] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [x] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

* Added validation for uploaded file MIME types.
* Restricted supported formats to:

  * `audio/wav`
  * `audio/mpeg`
  * `audio/ogg`
* Added file extension checks for:

  * `.wav`
  * `.mp3`
  * `.ogg`
* Implemented fail-fast validation before processing uploaded files.
* Added `415 Unsupported Media Type` responses for invalid uploads.
* Improved security by blocking non-audio and malicious payload uploads.

Files modified:

* `asr.py`

---

## ✅ Contributor Checklist

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before this PR
- [x] My code follows the patterns in `docs/code-guide.md`
- [x] I tested valid and invalid file uploads locally
- [x] Invalid uploads correctly return `415 Unsupported Media Type`
- [x] I performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant
