### PR TITLE
feat(ml): setup CORS middleware for transcription endpoints

### DIFF
--- a/apps/ml/main.py
+++ b/apps/ml/main.py
@@ -11,16 +11,15 @@ app = FastAPI(
     version="1.0.0"
 )
 
-# Configure CORS
-origins = [
-    "http://localhost:3000",
-    "http://localhost:4000",
-    "http://localhost:8000",
-]
+# Configure CORS - load dynamically from environment variables
+allowed_origins = os.getenv(
+    "ALLOWED_ORIGINS",
+    "http://localhost:3000,http://localhost:4000,http://localhost:8000"
+).split(",")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
Closes #278

## Changes Made
- Replaced hardcoded CORS origins with dynamic environment variable loading
- Added fallback to local Next.js ports (3000, 4000, 8000)
- Origins now loaded via `ALLOWED_ORIGINS` env variable using `os.getenv()`

## Testing
- Unauthorized external domains will be blocked by browser CORS policy
- Local development still works via fallback defaults