### PR TITLE
docs(ml): add service setup troubleshooting guide

### DIFF
--- a/apps/ml/README.md
+++ b/apps/ml/README.md
@@ -1,0 +1,195 @@
+# SahiDawa ML Service
+
+FastAPI service for medicine verification, OCR, and ASR transcription workflows.
+
+## Prerequisites
+
+Install these before setting up the Python environment:
+
+- Python 3.11 or higher
+- pip
+- ffmpeg for audio normalization used by Whisper ASR
+- Tesseract OCR for OCR features
+
+Check Python and pip:
+
+```bash
+python --version
+pip --version
+```
+
+## System Binary Prerequisites
+
+The ASR endpoint converts uploaded audio to a 16 kHz mono WAV file before sending it to Whisper. That conversion calls the `ffmpeg` system binary, so `ffmpeg` must be installed and available on your `PATH`.
+
+Common binary locations:
+
+| OS | Install method | Expected binary path |
+| --- | --- | --- |
+| macOS Apple Silicon | Homebrew | `/opt/homebrew/bin/ffmpeg` |
+| macOS Intel | Homebrew | `/usr/local/bin/ffmpeg` |
+| Debian/Ubuntu | apt | `/usr/bin/ffmpeg` |
+| Windows | Chocolatey | `C:\ProgramData\chocolatey\bin\ffmpeg.exe` |
+| Windows | Manual install | `C:\ffmpeg\bin\ffmpeg.exe` |
+
+### macOS
+
+```bash
+brew install ffmpeg
+ffmpeg -version
+```
+
+### Debian/Ubuntu
+
+```bash
+sudo apt update
+sudo apt install ffmpeg
+ffmpeg -version
+```
+
+### Windows
+
+Using Chocolatey:
+
+```powershell
+choco install ffmpeg
+ffmpeg -version
+```
+
+Manual installation:
+
+1. Download a Windows build from the official ffmpeg download page.
+2. Extract it to a stable folder, for example `C:\ffmpeg`.
+3. Add the `bin` folder, for example `C:\ffmpeg\bin`, to the Windows system `Path` environment variable.
+4. Open a new PowerShell window and verify the binary is available:
+
+```powershell
+ffmpeg -version
+```
+
+If `ffmpeg` is installed but the command is not found, restart the terminal and confirm the `bin` directory is listed in `Path`.
+
+## Virtual Environment Isolation
+
+Use a dedicated virtual environment for the ML service. This avoids package collisions with other Python projects, global Python installs, or model tooling already present on your machine.
+
+From the repository root:
+
+```bash
+cd apps/ml
+```
+
+Create the environment:
+
+```bash
+python3 -m venv venv
+```
+
+Activate it on macOS/Linux:
+
+```bash
+source venv/bin/activate
+```
+
+Activate it on Windows PowerShell:
+
+```powershell
+.\venv\Scripts\Activate.ps1
+```
+
+If PowerShell blocks activation scripts, run this for the current terminal session and then activate again:
+
+```powershell
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
+.\venv\Scripts\Activate.ps1
+```
+
+Install dependencies after the virtual environment is active:
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+```
+
+## Model Download Test
+
+Start the FastAPI server from `apps/ml` to verify the service imports correctly and the Whisper model can download and load into memory:
+
+```bash
+python -m uvicorn main:app --reload --port 8000
+```
+
+During startup, the ASR router loads `faster-whisper` with the `medium` model on CPU. A successful startup should include log output similar to:
+
+```text
+Loading Whisper model...
+Whisper model loaded
+Uvicorn running on http://127.0.0.1:8000
+```
+
+Then verify the service is responding:
+
+```bash
+curl http://localhost:8000/health
+```
+
+Expected response:
+
+```json
+{
+  "status": "healthy"
+}
+```
+
+Open Swagger UI for endpoint testing:
+
+```text
+http://localhost:8000/docs
+```
+
+## Troubleshooting
+
+### `ffmpeg` Command Not Found
+
+Confirm the binary is installed:
+
+```bash
+ffmpeg -version
+```
+
+If the command fails:
+
+- macOS: rerun `brew install ffmpeg`.
+- Debian/Ubuntu: rerun `sudo apt install ffmpeg`.
+- Windows: confirm the ffmpeg `bin` folder is added to `Path`, then open a new PowerShell window.
+
+### Python Package Collisions
+
+If imports fail after installing dependencies, confirm the virtual environment is active before running commands:
+
+```bash
+python -m pip --version
+python -m pip install -r requirements.txt
+```
+
+The pip path should point inside `apps/ml/venv`. If it points to a global Python installation, reactivate the environment.
+
+### Whisper Model Download Fails
+
+The first server startup may download Whisper model files. If startup fails during model download:
+
+- Check that your internet connection is available.
+- Retry the `python -m uvicorn main:app --reload --port 8000` command.
+- Ensure the environment has enough disk space for local model cache files.
+
+### Server Starts Slowly
+
+Whisper loads into memory when the ASR router is imported. The first startup can take longer because the model is downloaded and cached. Later startups should be faster.
+
+### Port 8000 Already in Use
+
+Run the service on another port:
+
+```bash
+python -m uvicorn main:app --reload --port 8001
+```


### PR DESCRIPTION
## 📋 PR Summary

Added ML service setup troubleshooting documentation for local Python/audio model environments, including ffmpeg system binary setup, virtual environment isolation, and a FastAPI startup test to verify Whisper model loading.

---

## 🔗 Related Issue

Closes #299

---

## 🏷️ PR Type

* [ ] 🐛 Bug Fix
* [ ] ✨ New Feature / Enhancement
* [✓] 📖 Documentation
* [ ] 🌏 Translation (i18n)
* [ ] 🎨 UI / UX Improvement
* [ ] ⚙️ DevOps / CI-CD
* [ ] 🤖 ML / AI Feature
* [ ] 🔒 Security Fix
* [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

* [ ] `apps/web` — Next.js Frontend
* [ ] `apps/api` — Node.js / Express Backend
* [✓] `apps/ml` — Python / FastAPI ML Service
* [ ] `data/` — Database seeds / migrations
* [✓] `docs/` — Documentation
* [ ] `.github/` — GitHub config, workflows
* [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

* Created `apps/ml/README.md`
* Added ffmpeg installation commands for macOS, Debian/Ubuntu, and Windows
* Documented common ffmpeg binary paths and Windows PATH setup
* Added Python virtual environment setup commands
* Added activation commands for macOS/Linux and Windows PowerShell
* Added FastAPI server command to verify Whisper model download/load
* Added troubleshooting notes for ffmpeg PATH issues, package collisions, model download failures, slow startup, and port conflicts

---

## 📸 Screenshots / Demo

Not applicable. Documentation-only change.

---

## ✅ Contributor Checklist

* [✓] My PR has a linked issue (see above)
* [✓] I have pulled the latest `main` and rebased/merged before this PR
* [✓] My code follows the patterns in `docs/code-guide.md`
* [ ] I ran `npm run dev -w web` or `npm run dev -w api` — not applicable
* [ ] For backend: All responses return structured JSON `{ success, data, error }` — not applicable
* [ ] Screenshots/test output added — not applicable for docs-only change
* [✓] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

* [✓] I am a GSSoC 2026 participant