### PR TITLE
test(api): add unit test suite for CDSCO drug alerts route

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -32,19 +32,22 @@ import verifyRouter from "./routes/verify";
 import analyticsRoutes from "./routes/analytics";
 import notificationsRouter from "./routes/notifications";
 import scanRouter from "./routes/scan";
+import alertsRouter from "./routes/alerts";
 import { supabase } from "./db/client";
 
 import { errorHandler } from "./middleware/errorHandler";
 
 const app: Express = express();
 
-app.use(helmet({
-    contentSecurityPolicy: {
-        directives: {
-            connectSrc: ["'self'", process.env.SUPABASE_URL || ""],
+app.use(
+    helmet({
+        contentSecurityPolicy: {
+            directives: {
+                connectSrc: ["'self'", process.env.SUPABASE_URL || ""],
+            },
         },
-    },
-}));
+    })
+);
 
 // Security: restrict CORS to known origins instead of wildcard
 const allowedOrigins = ["http://localhost:3000", "http://localhost:4000", "http://localhost:8000"];
@@ -115,6 +118,7 @@ app.use("/api/verify", verifyRouter);
 app.use("/api/analytics", analyticsRoutes);
 app.use("/api/notifications", notificationsRouter);
 app.use("/api/v1/scan", scanRouter);
+app.use("/api/alerts", alertsRouter);
 
 app.use(errorHandler);
 

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -1,0 +1,36 @@
+import { Router, Request, Response } from "express";
+import { supabase } from "../db/client";
+
+const alertsRouter = Router();
+
+const PAGE_SIZE = 20;
+
+alertsRouter.get("/", async (req: Request, res: Response) => {
+    const page = parseInt((req.query.page as string) ?? "1", 10);
+    const pageSize = parseInt((req.query.pageSize as string) ?? String(PAGE_SIZE), 10);
+
+    if (isNaN(page) || page < 1 || isNaN(pageSize) || pageSize < 1) {
+        res.status(400).json({ error: "Invalid pagination parameters" });
+        return;
+    }
+
+    const from = (page - 1) * pageSize;
+    const to = from + pageSize - 1;
+
+    const { data, error } = await supabase
+        .from("drug_alerts")
+        .select(
+            "id, reported_brand_name, manufacturer, batch_number, alert_type, risk_level, district, state, reported_at, created_at"
+        )
+        .order("created_at", { ascending: false })
+        .range(from, to);
+
+    if (error) {
+        res.status(500).json({ error: "Failed to fetch alerts" });
+        return;
+    }
+
+    res.json({ alerts: data ?? [], page, pageSize });
+});
+
+export default alertsRouter;

--- a/apps/api/tests/alerts.test.ts
+++ b/apps/api/tests/alerts.test.ts
@@ -1,0 +1,140 @@
+import request from "supertest";
+import app from "../src/app";
+
+jest.mock("../src/db/client", () => {
+    return {
+        supabase: {
+            from: jest.fn().mockReturnThis(),
+            select: jest.fn().mockReturnThis(),
+            order: jest.fn().mockReturnThis(),
+            range: jest.fn().mockReturnThis(),
+            limit: jest.fn().mockReturnThis(),
+            maybeSingle: jest.fn(),
+        },
+    };
+});
+
+import { supabase } from "../src/db/client";
+
+const mockAlerts = [
+    {
+        id: "uuid-1",
+        reported_brand_name: "Paracetamol 500mg",
+        manufacturer: "ABC Pharma",
+        batch_number: "BAT001",
+        alert_type: "nsq",
+        risk_level: "high",
+        district: "Mumbai",
+        state: "Maharashtra",
+        reported_at: "2024-01-10",
+        created_at: "2024-01-10T10:00:00Z",
+    },
+    {
+        id: "uuid-2",
+        reported_brand_name: "Amoxicillin 250mg",
+        manufacturer: "XYZ Labs",
+        batch_number: "BAT002",
+        alert_type: "recalled",
+        risk_level: "high",
+        district: "Delhi",
+        state: "Delhi",
+        reported_at: "2024-01-11",
+        created_at: "2024-01-11T10:00:00Z",
+    },
+];
+
+describe("GET /api/alerts", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should return 200 with an array of alerts for a valid query", async () => {
+        ((supabase as any).range as jest.Mock).mockResolvedValue({
+            data: mockAlerts,
+            error: null,
+        });
+
+        const res = await request(app).get("/api/alerts");
+
+        expect(res.status).toBe(200);
+        expect(Array.isArray(res.body.alerts)).toBe(true);
+        expect(res.body.alerts).toHaveLength(2);
+        expect(res.body.alerts[0].batch_number).toBe("BAT001");
+        expect(res.body.page).toBe(1);
+    });
+
+    it("should return 200 with paginated results on page 2", async () => {
+        const page2Alerts = [
+            {
+                id: "uuid-3",
+                reported_brand_name: "Ibuprofen 400mg",
+                manufacturer: "DEF Pharma",
+                batch_number: "BAT003",
+                alert_type: "counterfeit",
+                risk_level: "high",
+                district: "Pune",
+                state: "Maharashtra",
+                reported_at: "2024-01-12",
+                created_at: "2024-01-12T10:00:00Z",
+            },
+        ];
+
+        ((supabase as any).range as jest.Mock).mockResolvedValue({
+            data: page2Alerts,
+            error: null,
+        });
+
+        const res = await request(app).get("/api/alerts?page=2&pageSize=20");
+
+        expect(res.status).toBe(200);
+        expect(Array.isArray(res.body.alerts)).toBe(true);
+        expect(res.body.alerts).toHaveLength(1);
+        expect(res.body.page).toBe(2);
+        expect(res.body.pageSize).toBe(20);
+    });
+
+    it("should return 200 with an empty array when page is out of bounds", async () => {
+        ((supabase as any).range as jest.Mock).mockResolvedValue({
+            data: [],
+            error: null,
+        });
+
+        const res = await request(app).get("/api/alerts?page=9999");
+
+        expect(res.status).toBe(200);
+        expect(Array.isArray(res.body.alerts)).toBe(true);
+        expect(res.body.alerts).toHaveLength(0);
+    });
+
+    it("should return 200 with an empty array when database has no alerts", async () => {
+        ((supabase as any).range as jest.Mock).mockResolvedValue({
+            data: null,
+            error: null,
+        });
+
+        const res = await request(app).get("/api/alerts");
+
+        expect(res.status).toBe(200);
+        expect(Array.isArray(res.body.alerts)).toBe(true);
+        expect(res.body.alerts).toHaveLength(0);
+    });
+
+    it("should return 400 for invalid page parameter", async () => {
+        const res = await request(app).get("/api/alerts?page=0");
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe("Invalid pagination parameters");
+    });
+
+    it("should return 500 when the database query fails", async () => {
+        ((supabase as any).range as jest.Mock).mockResolvedValue({
+            data: null,
+            error: { message: "connection refused" },
+        });
+
+        const res = await request(app).get("/api/alerts");
+
+        expect(res.status).toBe(500);
+        expect(res.body.error).toBe("Failed to fetch alerts");
+    });
+});


### PR DESCRIPTION
closes #276

## Summary

- Introduces `GET /api/alerts` — a paginated endpoint backed by the existing `drug_alerts` table (CDSCO NSQ/recall data). Supports `page` and `pageSize` query params, returns `{ alerts, page, pageSize }`.
- Registers the route in `app.ts` as `/api/alerts` alongside the other API routes.
- Adds `tests/alerts.test.ts` with 6 test cases covering: multi-row results, paginated second-page results, out-of-bounds page returning an empty array, null DB data coerced to `[]`, invalid pagination params (400), and upstream DB errors (500).

## Implementation

The route uses `.range(from, to)` for Supabase offset pagination — `from = (page-1) * pageSize`, `to = from + pageSize - 1`. Any page beyond the last row of data returns an empty array with a `200`. The mock follows the `(supabase as any).chain` pattern established in `verify.test.ts` so the mock factory stays consistent across the test suite.