### PR TITLE
feat(etl): add row-level failure logging

### DIFF
--- a/apps/ml/etl/loader.py
+++ b/apps/ml/etl/loader.py
@@ -28,6 +28,7 @@ import re
 import time
 from collections import Counter
 from datetime import datetime, timezone
+from hashlib import sha256
 from pathlib import Path
 
 import pandas as pd
@@ -166,7 +167,6 @@ class SupabaseLoader:
 
             try:
                 self._upsert_payloads([row_payload], table)
-                inserted += 1
                 self._update_retry_row(
                     retry_row["id"],
                     {
@@ -176,11 +176,12 @@ class SupabaseLoader:
                         "updated_at": self._utc_now(),
                     },
                 )
+                inserted += 1
             except Exception as e:
                 failure = self._build_failure(row_payload, row_index, e)
                 failures.append(failure)
                 self._log_failure(failure)
-                self._update_retry_row(
+                self._safe_update_retry_row(
                     retry_row["id"],
                     {
                         "status": "failed",
@@ -237,6 +238,7 @@ class SupabaseLoader:
             "db_error_code": db_error_code,
             "error_category": self._categorize_error(error_message, db_error_code),
             "error_message": error_message,
+            "row_fingerprint": self._row_fingerprint(payload),
             "row_payload": payload,
         }
 
@@ -245,27 +247,53 @@ class SupabaseLoader:
         print(json.dumps(log_payload, sort_keys=True, default=str))
 
     def _persist_failure(self, failure: dict, source_table: str) -> None:
-        retry_payload = {
-            "pipeline_name": self.pipeline_name,
-            "source_table": source_table,
-            "row_payload": failure["row_payload"],
-            "medicine_name": failure["medicine_name"],
-            "unresolved_value": failure["unresolved_value"],
-            "error_category": failure["error_category"],
-            "db_error_code": failure["db_error_code"],
-            "error_message": failure["error_message"],
-            "attempt_count": 1,
-            "status": "failed",
-            "last_attempt_at": self._utc_now(),
-        }
-
         try:
-            self.client.table(RETRY_TABLE).insert(retry_payload).execute()
+            existing_retry_row = self._find_retry_row(failure, source_table)
+            attempt_count = int(existing_retry_row.get("attempt_count") or 0) + 1 if existing_retry_row else 1
+            retry_payload = {
+                "pipeline_name": self.pipeline_name,
+                "source_table": source_table,
+                "row_fingerprint": failure["row_fingerprint"],
+                "row_payload": failure["row_payload"],
+                "medicine_name": failure["medicine_name"],
+                "unresolved_value": failure["unresolved_value"],
+                "error_category": failure["error_category"],
+                "db_error_code": failure["db_error_code"],
+                "error_message": failure["error_message"],
+                "attempt_count": attempt_count,
+                "status": "failed",
+                "last_attempt_at": self._utc_now(),
+                "updated_at": self._utc_now(),
+            }
+
+            if existing_retry_row:
+                self._update_retry_row(existing_retry_row["id"], retry_payload)
+            else:
+                self.client.table(RETRY_TABLE).insert(retry_payload).execute()
         except Exception as e:
             print(f"[Loader] ⚠️ Failed to persist retry row: {e}")
 
+    def _find_retry_row(self, failure: dict, source_table: str) -> dict | None:
+        response = (
+            self.client.table(RETRY_TABLE)
+            .select("id, attempt_count")
+            .eq("pipeline_name", self.pipeline_name)
+            .eq("source_table", source_table)
+            .eq("row_fingerprint", failure["row_fingerprint"])
+            .limit(1)
+            .execute()
+        )
+        rows = getattr(response, "data", None) or []
+        return rows[0] if rows else None
+
     def _update_retry_row(self, row_id: str, payload: dict) -> None:
         self.client.table(RETRY_TABLE).update(payload).eq("id", row_id).execute()
+
+    def _safe_update_retry_row(self, row_id: str, payload: dict) -> None:
+        try:
+            self._update_retry_row(row_id, payload)
+        except Exception as e:
+            print(f"[Loader] ⚠️ Failed to update retry row {row_id}: {e}")
 
     def _export_failed_rows(self, failures: list[dict]) -> str | None:
         if not failures:
@@ -286,6 +314,7 @@ class SupabaseLoader:
                     "db_error_code": failure["db_error_code"],
                     "error_category": failure["error_category"],
                     "error_message": failure["error_message"],
+                    "row_fingerprint": failure["row_fingerprint"],
                 }
             )
             rows.append(row)
@@ -342,6 +371,15 @@ class SupabaseLoader:
     def _extract_db_error_code(self, error_message: str) -> str | None:
         match = re.search(r"\b([0-9A-Z]{5})\b", error_message)
         return match.group(1) if match else None
+
+    def _row_fingerprint(self, payload: dict) -> str:
+        encoded_payload = json.dumps(
+            payload,
+            default=str,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        return sha256(encoded_payload.encode("utf-8")).hexdigest()
 
     def _categorize_error(self, error_message: str, db_error_code: str | None) -> str:
         lower = error_message.lower()

--- a/apps/ml/etl/loader.py
+++ b/apps/ml/etl/loader.py
@@ -22,12 +22,17 @@ BATCH INSERTS:
     This reduces the number of network round-trips to Supabase from 2,400 to ~24.
 """
 
+import json
 import os
+import re
 import time
-import pandas as pd
+from collections import Counter
+from datetime import datetime, timezone
 from pathlib import Path
-from supabase import create_client, Client
+
+import pandas as pd
 from dotenv import load_dotenv
+from supabase import Client, create_client
 
 
 # ── Load environment variables ─────────────────────────────────────────────────
@@ -42,6 +47,10 @@ SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 
 BATCH_SIZE = 100   # Insert this many rows per Supabase API call
 DELAY_SEC  = 0.5   # Wait between batches to avoid rate-limiting
+PIPELINE_NAME = "janaushadhi"
+FAILED_ROWS_DIR = Path(__file__).resolve().parents[3] / "data" / "failed" / PIPELINE_NAME
+RETRY_TABLE = "etl_failed_rows"
+SUCCESS_RATE_ALERT_THRESHOLD = 95.0
 
 
 # ── Loader Class ──────────────────────────────────────────────────────────────
@@ -52,7 +61,19 @@ class SupabaseLoader:
     Uses batched upserts for efficiency and reliability.
     """
 
-    def __init__(self):
+    def __init__(
+        self,
+        client: Client | None = None,
+        failed_rows_dir: Path | None = None,
+        pipeline_name: str = PIPELINE_NAME,
+    ):
+        self.pipeline_name = pipeline_name
+        self.failed_rows_dir = failed_rows_dir or FAILED_ROWS_DIR
+
+        if client is not None:
+            self.client = client
+            return
+
         if not SUPABASE_URL or not SUPABASE_SERVICE_ROLE_KEY:
             raise ValueError(
                 "❌ Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env file.\n"
@@ -70,60 +91,273 @@ class SupabaseLoader:
             table: Supabase table name (default: "medicines")
             
         Returns:
-            dict with stats: {"inserted": N, "failed": N, "total": N}
+            dict with stats, success rate, error counts, and failed CSV path.
         """
         total = len(df)
         print(f"[Loader] Starting load of {total} records into '{table}'...")
-        
+
         # Convert DataFrame to list of dicts (Supabase expects this format)
         raw_records = df.to_dict(orient="records")
         records = []
-        for record in raw_records:
+        for row_index, record in enumerate(raw_records):
             clean_record = {}
             for k, v in record.items():
                 if pd.isna(v):
                     clean_record[k] = None
                 else:
                     clean_record[k] = v
-            records.append(clean_record)
-        
+            records.append({"row_index": row_index, "payload": clean_record})
+
         # Supabase/Postgres treats None as NULL, but NaN would cause a JSON encoding error
-        
+
         inserted = 0
-        failed = 0
-        
+        failures = []
+
         # Process in batches
         for batch_start in range(0, total, BATCH_SIZE):
             batch = records[batch_start : batch_start + BATCH_SIZE]
             batch_end = batch_start + len(batch)
-            
+
             try:
-                # UPSERT: Insert if not exists, update if exists.
-                # on_conflict tells Supabase WHICH columns to check for duplicates.
-                # If a row with the same (generic_name, strength, dosage_form, source)
-                # already exists, it will be updated instead of duplicated.
-                self.client.table(table).upsert(
-                    batch,
-                    on_conflict="generic_name,strength,dosage_form,source"
-                ).execute()
-                
+                self._upsert_payloads([item["payload"] for item in batch], table)
                 inserted += len(batch)
                 print(
                     f"[Loader] Batch {batch_start}–{batch_end} ✅  "
                     f"({inserted}/{total} done)"
                 )
-                
             except Exception as e:
-                failed += len(batch)
                 print(f"[Loader] Batch {batch_start}–{batch_end} ❌ Error: {e}")
-            
+                print("[Loader] Retrying failed batch row by row...")
+                batch_inserted, batch_failures = self._load_batch_row_by_row(batch, table)
+                inserted += batch_inserted
+                failures.extend(batch_failures)
+
             # Small delay between batches to be respectful to Supabase rate limits
             if batch_end < total:
                 time.sleep(DELAY_SEC)
-        
-        stats = {"inserted": inserted, "failed": failed, "total": total}
-        print(f"\n[Loader] ✅ Load complete: {inserted} inserted, {failed} failed")
+
+        stats = self._build_stats(total, inserted, failures)
+        stats["failed_rows_csv"] = self._export_failed_rows(failures)
+        self._print_summary(stats)
         return stats
+
+    def retry_failed_rows(self, table: str = "medicines") -> dict:
+        """
+        Reprocesses rows previously captured in the ETL retry table.
+        """
+        response = (
+            self.client.table(RETRY_TABLE)
+            .select("*")
+            .eq("pipeline_name", self.pipeline_name)
+            .eq("status", "failed")
+            .execute()
+        )
+        retry_rows = getattr(response, "data", None) or []
+        total = len(retry_rows)
+        print(f"[Loader] Retrying {total} failed rows from '{RETRY_TABLE}'...")
+
+        inserted = 0
+        failures = []
+
+        for index, retry_row in enumerate(retry_rows):
+            row_payload = retry_row.get("row_payload") or {}
+            row_index = retry_row.get("row_index", index)
+            attempt_count = int(retry_row.get("attempt_count") or 0) + 1
+
+            try:
+                self._upsert_payloads([row_payload], table)
+                inserted += 1
+                self._update_retry_row(
+                    retry_row["id"],
+                    {
+                        "status": "retry_succeeded",
+                        "attempt_count": attempt_count,
+                        "last_attempt_at": self._utc_now(),
+                        "updated_at": self._utc_now(),
+                    },
+                )
+            except Exception as e:
+                failure = self._build_failure(row_payload, row_index, e)
+                failures.append(failure)
+                self._log_failure(failure)
+                self._update_retry_row(
+                    retry_row["id"],
+                    {
+                        "status": "failed",
+                        "attempt_count": attempt_count,
+                        "error_category": failure["error_category"],
+                        "db_error_code": failure["db_error_code"],
+                        "error_message": failure["error_message"],
+                        "last_attempt_at": self._utc_now(),
+                        "updated_at": self._utc_now(),
+                    },
+                )
+
+        stats = self._build_stats(total, inserted, failures)
+        stats["failed_rows_csv"] = self._export_failed_rows(failures)
+        self._print_summary(stats)
+        return stats
+
+    def _load_batch_row_by_row(self, batch: list[dict], table: str) -> tuple[int, list[dict]]:
+        inserted = 0
+        failures = []
+
+        for item in batch:
+            payload = item["payload"]
+            row_index = item["row_index"]
+
+            try:
+                self._upsert_payloads([payload], table)
+                inserted += 1
+            except Exception as e:
+                failure = self._build_failure(payload, row_index, e)
+                failures.append(failure)
+                self._log_failure(failure)
+                self._persist_failure(failure, table)
+
+        return inserted, failures
+
+    def _upsert_payloads(self, payloads: list[dict], table: str) -> None:
+        # If a row with the same (generic_name, strength, dosage_form, source)
+        # already exists, Supabase updates it instead of duplicating it.
+        self.client.table(table).upsert(
+            payloads,
+            on_conflict="generic_name,strength,dosage_form,source",
+        ).execute()
+
+    def _build_failure(self, payload: dict, row_index: int, error: Exception) -> dict:
+        error_message = str(error)
+        db_error_code = self._extract_db_error_code(error_message)
+        return {
+            "event": "etl_row_failure",
+            "pipeline": self.pipeline_name,
+            "row_index": row_index,
+            "medicine_name": self._extract_medicine_name(payload),
+            "unresolved_value": self._extract_unresolved_value(payload),
+            "db_error_code": db_error_code,
+            "error_category": self._categorize_error(error_message, db_error_code),
+            "error_message": error_message,
+            "row_payload": payload,
+        }
+
+    def _log_failure(self, failure: dict) -> None:
+        log_payload = {k: v for k, v in failure.items() if k != "row_payload"}
+        print(json.dumps(log_payload, sort_keys=True, default=str))
+
+    def _persist_failure(self, failure: dict, source_table: str) -> None:
+        retry_payload = {
+            "pipeline_name": self.pipeline_name,
+            "source_table": source_table,
+            "row_payload": failure["row_payload"],
+            "medicine_name": failure["medicine_name"],
+            "unresolved_value": failure["unresolved_value"],
+            "error_category": failure["error_category"],
+            "db_error_code": failure["db_error_code"],
+            "error_message": failure["error_message"],
+            "attempt_count": 1,
+            "status": "failed",
+            "last_attempt_at": self._utc_now(),
+        }
+
+        try:
+            self.client.table(RETRY_TABLE).insert(retry_payload).execute()
+        except Exception as e:
+            print(f"[Loader] ⚠️ Failed to persist retry row: {e}")
+
+    def _update_retry_row(self, row_id: str, payload: dict) -> None:
+        self.client.table(RETRY_TABLE).update(payload).eq("id", row_id).execute()
+
+    def _export_failed_rows(self, failures: list[dict]) -> str | None:
+        if not failures:
+            return None
+
+        self.failed_rows_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+        output_path = self.failed_rows_dir / f"failed_rows_{timestamp}.csv"
+
+        rows = []
+        for failure in failures:
+            row = dict(failure["row_payload"])
+            row.update(
+                {
+                    "row_index": failure["row_index"],
+                    "medicine_name": failure["medicine_name"],
+                    "unresolved_value": failure["unresolved_value"],
+                    "db_error_code": failure["db_error_code"],
+                    "error_category": failure["error_category"],
+                    "error_message": failure["error_message"],
+                }
+            )
+            rows.append(row)
+
+        pd.DataFrame(rows).to_csv(output_path, index=False)
+        return str(output_path)
+
+    def _build_stats(self, total: int, inserted: int, failures: list[dict]) -> dict:
+        failed = len(failures)
+        success_rate = round((inserted / total) * 100, 2) if total else 100.0
+        return {
+            "inserted": inserted,
+            "failed": failed,
+            "total": total,
+            "success_rate": success_rate,
+            "error_counts": dict(Counter(failure["error_category"] for failure in failures)),
+        }
+
+    def _print_summary(self, stats: dict) -> None:
+        print("\n[Loader] Load summary")
+        print(f"[Loader] Total rows processed: {stats['total']}")
+        print(f"[Loader] Successful inserts/updates: {stats['inserted']}")
+        print(f"[Loader] Failed rows: {stats['failed']}")
+        print(f"[Loader] Success rate: {stats['success_rate']}%")
+
+        if stats["error_counts"]:
+            print(f"[Loader] Error categories: {json.dumps(stats['error_counts'], sort_keys=True)}")
+
+        if stats.get("failed_rows_csv"):
+            print(f"[Loader] Failed rows CSV: {stats['failed_rows_csv']}")
+
+        if stats["success_rate"] < SUCCESS_RATE_ALERT_THRESHOLD:
+            print(
+                f"[Loader] ALERT: Success rate below {int(SUCCESS_RATE_ALERT_THRESHOLD)}% "
+                "threshold. Review failed row logs before trusting this load."
+            )
+
+        print(f"\n[Loader] ✅ Load complete: {stats['inserted']} inserted, {stats['failed']} failed")
+
+    def _extract_medicine_name(self, payload: dict) -> str | None:
+        for key in ("medicine_name", "generic_name", "brand_name", "raw_name"):
+            value = payload.get(key)
+            if value:
+                return str(value)
+        return None
+
+    def _extract_unresolved_value(self, payload: dict) -> str | None:
+        for key in ("strength", "mrp", "price", "dosage_form", "generic_name", "brand_name"):
+            value = payload.get(key)
+            if value is not None:
+                return str(value)
+        return None
+
+    def _extract_db_error_code(self, error_message: str) -> str | None:
+        match = re.search(r"\b([0-9A-Z]{5})\b", error_message)
+        return match.group(1) if match else None
+
+    def _categorize_error(self, error_message: str, db_error_code: str | None) -> str:
+        lower = error_message.lower()
+
+        if db_error_code == "23505" or "duplicate key" in lower:
+            return "duplicate_key"
+        if db_error_code and db_error_code.startswith("23"):
+            return "constraint_violation"
+        if db_error_code and db_error_code.startswith("22"):
+            return "data_type_mismatch"
+        if "validation" in lower or "invalid" in lower:
+            return "validation_error"
+        return "unknown_error"
+
+    def _utc_now(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
 
 
 # ── Runner ────────────────────────────────────────────────────────────────────

--- a/apps/ml/run_pipeline.py
+++ b/apps/ml/run_pipeline.py
@@ -15,6 +15,9 @@ Usage:
     # Or only scrape (don't load to DB):
     python run_pipeline.py --scrape-only
 
+    # Or retry only rows that previously failed during load:
+    python run_pipeline.py --retry-failed
+
 Prerequisite (one-time):
     pip install -r requirements.txt
     playwright install chromium
@@ -32,10 +35,30 @@ from etl.normalizer import JanAushadhiNormalizer, normalize_latest
 from etl.loader import SupabaseLoader
 
 
-async def run_full_pipeline(skip_scrape: bool = False, scrape_only: bool = False):
+async def run_full_pipeline(
+    skip_scrape: bool = False,
+    scrape_only: bool = False,
+    retry_failed: bool = False,
+):
     print("\n" + "="*60)
     print("  SahiDawa ETL Pipeline — Jan Aushadhi")
     print("="*60 + "\n")
+
+    if retry_failed:
+        print("🔁 RETRY MODE: Reprocessing previously failed ETL rows...")
+        loader = SupabaseLoader()
+        stats = loader.retry_failed_rows()
+
+        print("\n" + "="*60)
+        print("  Retry Complete!")
+        print(f"  Total processed : {stats['total']}")
+        print(f"  Successfully loaded : {stats['inserted']}")
+        print(f"  Failed : {stats['failed']}")
+        print(f"  Success rate : {stats['success_rate']}%")
+        if stats.get("failed_rows_csv"):
+            print(f"  Failed rows CSV : {stats['failed_rows_csv']}")
+        print("="*60 + "\n")
+        return stats
 
     # ── STEP 1: SCRAPE ─────────────────────────────────────────────────────────
     raw_csv_path = None
@@ -79,7 +102,12 @@ async def run_full_pipeline(skip_scrape: bool = False, scrape_only: bool = False
     print(f"  Total processed : {stats['total']}")
     print(f"  Successfully loaded : {stats['inserted']}")
     print(f"  Failed : {stats['failed']}")
+    print(f"  Success rate : {stats['success_rate']}%")
+    if stats.get("failed_rows_csv"):
+        print(f"  Failed rows CSV : {stats['failed_rows_csv']}")
     print("="*60 + "\n")
+
+    return stats
 
 
 if __name__ == "__main__":
@@ -88,9 +116,12 @@ if __name__ == "__main__":
                         help="Skip scraping and use the latest existing raw file")
     parser.add_argument("--scrape-only", action="store_true",
                         help="Only scrape — don't normalize or load to DB")
+    parser.add_argument("--retry-failed", action="store_true",
+                        help="Retry only rows saved in the ETL failed rows table")
     args = parser.parse_args()
 
     asyncio.run(run_full_pipeline(
         skip_scrape=args.skip_scrape,
         scrape_only=args.scrape_only,
+        retry_failed=args.retry_failed,
     ))

--- a/apps/ml/tests/test_loader.py
+++ b/apps/ml/tests/test_loader.py
@@ -22,6 +22,7 @@ class FakeTable:
         self.pending_update = None
         self.eq_filters = []
         self.operation = None
+        self.limit_value = None
 
     def upsert(self, payload, on_conflict=None):
         self.operation = "upsert"
@@ -48,15 +49,33 @@ class FakeTable:
         self.eq_filters.append((column, value))
         return self
 
+    def limit(self, value):
+        self.limit_value = value
+        return self
+
     def execute(self):
         if self.operation == "select":
-            return FakeExecuteResponse(self.client.retry_rows)
+            rows = self.client.retry_rows
+            for column, value in self.eq_filters:
+                rows = [row for row in rows if row.get(column) == value]
+            if self.limit_value is not None:
+                rows = rows[: self.limit_value]
+            return FakeExecuteResponse(rows)
 
         if self.operation == "update":
+            row_id = next((value for column, value in self.eq_filters if column == "id"), None)
+            if row_id in self.client.update_fail_ids:
+                raise Exception("503: retry metadata update failed")
             self.client.update_calls.append((self.name, self.pending_update, self.eq_filters))
+            for row in self.client.retry_rows:
+                if row.get("id") == row_id:
+                    row.update(self.pending_update)
             return FakeExecuteResponse()
 
         if self.operation == "insert":
+            payload = dict(self.pending_payload)
+            payload.setdefault("id", f"insert-{len(self.client.retry_rows) + 1}")
+            self.client.retry_rows.append(payload)
             return FakeExecuteResponse()
 
         if self.operation == "upsert":
@@ -81,11 +100,13 @@ class FakeSupabaseClient:
         fail_generic_names=None,
         retry_rows=None,
         errors_by_generic_name=None,
+        update_fail_ids=None,
     ):
         self.fail_batches = fail_batches
         self.fail_generic_names = set(fail_generic_names or [])
         self.errors_by_generic_name = errors_by_generic_name or {}
         self.retry_rows = retry_rows or []
+        self.update_fail_ids = set(update_fail_ids or [])
         self.upsert_calls = []
         self.insert_calls = []
         self.update_calls = []
@@ -217,11 +238,15 @@ def test_retry_failed_rows_updates_successful_and_failed_retry_records(tmp_path)
     retry_rows = [
         {
             "id": "row-1",
+            "pipeline_name": "janaushadhi",
+            "status": "failed",
             "row_payload": {"generic_name": "Paracetamol", "strength": "500mg", "dosage_form": "Tablet"},
             "attempt_count": 1,
         },
         {
             "id": "row-2",
+            "pipeline_name": "janaushadhi",
+            "status": "failed",
             "row_payload": {"generic_name": "Bad Float", "strength": "not-a-float", "dosage_form": "Tablet"},
             "attempt_count": 2,
         },
@@ -241,3 +266,43 @@ def test_retry_failed_rows_updates_successful_and_failed_retry_records(tmp_path)
     assert updates[1]["status"] == "failed"
     assert updates[1]["attempt_count"] == 3
     assert updates[1]["error_category"] == "duplicate_key"
+
+
+def test_retry_success_is_counted_only_after_retry_metadata_update_succeeds(tmp_path):
+    retry_rows = [
+        {
+            "id": "row-1",
+            "pipeline_name": "janaushadhi",
+            "status": "failed",
+            "row_payload": {"generic_name": "Paracetamol", "strength": "500mg", "dosage_form": "Tablet"},
+            "attempt_count": 1,
+        },
+    ]
+    client = FakeSupabaseClient(retry_rows=retry_rows, update_fail_ids={"row-1"})
+    loader = make_loader(client, tmp_path)
+
+    stats = loader.retry_failed_rows()
+
+    assert stats["total"] == 1
+    assert stats["inserted"] == 0
+    assert stats["failed"] == 1
+
+
+def test_persist_failure_updates_existing_retry_row_for_same_payload(tmp_path):
+    client = FakeSupabaseClient(fail_generic_names={"Bad Float"})
+    loader = make_loader(client, tmp_path)
+    df = pd.DataFrame(
+        [
+            {"generic_name": "Bad Float", "strength": "not-a-float", "dosage_form": "Tablet"},
+        ]
+    )
+
+    first_stats = loader.load(df)
+    second_stats = loader.load(df)
+
+    assert first_stats["failed"] == 1
+    assert second_stats["failed"] == 1
+    assert len(client.insert_calls) == 1
+    retry_updates = [call[1] for call in client.update_calls if call[0] == "etl_failed_rows"]
+    assert retry_updates[-1]["attempt_count"] == 2
+    assert len(client.retry_rows) == 1

--- a/apps/ml/tests/test_loader.py
+++ b/apps/ml/tests/test_loader.py
@@ -1,0 +1,243 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from etl.loader import SupabaseLoader
+
+
+class FakeExecuteResponse:
+    def __init__(self, data=None):
+        self.data = data or []
+
+
+class FakeTable:
+    def __init__(self, name, client):
+        self.name = name
+        self.client = client
+        self.pending_payload = None
+        self.pending_update = None
+        self.eq_filters = []
+        self.operation = None
+
+    def upsert(self, payload, on_conflict=None):
+        self.operation = "upsert"
+        self.pending_payload = payload
+        self.client.upsert_calls.append((self.name, payload, on_conflict))
+        return self
+
+    def insert(self, payload):
+        self.operation = "insert"
+        self.pending_payload = payload
+        self.client.insert_calls.append((self.name, payload))
+        return self
+
+    def select(self, *_args):
+        self.operation = "select"
+        return self
+
+    def update(self, payload):
+        self.operation = "update"
+        self.pending_update = payload
+        return self
+
+    def eq(self, column, value):
+        self.eq_filters.append((column, value))
+        return self
+
+    def execute(self):
+        if self.operation == "select":
+            return FakeExecuteResponse(self.client.retry_rows)
+
+        if self.operation == "update":
+            self.client.update_calls.append((self.name, self.pending_update, self.eq_filters))
+            return FakeExecuteResponse()
+
+        if self.operation == "insert":
+            return FakeExecuteResponse()
+
+        if self.operation == "upsert":
+            payload = self.pending_payload
+            if isinstance(payload, list) and len(payload) > 1 and self.client.fail_batches:
+                raise Exception("22P02: invalid input syntax for type double precision")
+            row = payload[0] if isinstance(payload, list) else payload
+            if row.get("generic_name") in self.client.errors_by_generic_name:
+                raise Exception(self.client.errors_by_generic_name[row.get("generic_name")])
+            if row.get("generic_name") in self.client.fail_generic_names:
+                raise Exception("23505: duplicate key value violates unique constraint")
+            return FakeExecuteResponse()
+
+        return FakeExecuteResponse()
+
+
+class FakeSupabaseClient:
+    def __init__(
+        self,
+        *,
+        fail_batches=False,
+        fail_generic_names=None,
+        retry_rows=None,
+        errors_by_generic_name=None,
+    ):
+        self.fail_batches = fail_batches
+        self.fail_generic_names = set(fail_generic_names or [])
+        self.errors_by_generic_name = errors_by_generic_name or {}
+        self.retry_rows = retry_rows or []
+        self.upsert_calls = []
+        self.insert_calls = []
+        self.update_calls = []
+
+    def table(self, name):
+        return FakeTable(name, self)
+
+
+def make_loader(client, tmp_path):
+    loader = SupabaseLoader.__new__(SupabaseLoader)
+    loader.client = client
+    loader.failed_rows_dir = tmp_path
+    loader.pipeline_name = "janaushadhi"
+    return loader
+
+
+def test_batch_success_returns_summary_without_failed_rows_csv(tmp_path):
+    client = FakeSupabaseClient()
+    loader = make_loader(client, tmp_path)
+    df = pd.DataFrame(
+        [
+            {"generic_name": "Paracetamol", "strength": "500mg", "dosage_form": "Tablet"},
+            {"generic_name": "Cetirizine", "strength": "10mg", "dosage_form": "Tablet"},
+        ]
+    )
+
+    stats = loader.load(df)
+
+    assert stats["total"] == 2
+    assert stats["inserted"] == 2
+    assert stats["failed"] == 0
+    assert stats["success_rate"] == 100.0
+    assert stats["error_counts"] == {}
+    assert stats["failed_rows_csv"] is None
+    assert len(client.upsert_calls) == 1
+
+
+def test_failed_batch_falls_back_to_row_level_upserts_and_logs_bad_row(tmp_path, capsys):
+    client = FakeSupabaseClient(fail_batches=True, fail_generic_names={"Bad Float"})
+    loader = make_loader(client, tmp_path)
+    df = pd.DataFrame(
+        [
+            {"generic_name": "Paracetamol", "strength": "500mg", "dosage_form": "Tablet"},
+            {"generic_name": "Bad Float", "strength": "not-a-float", "dosage_form": "Tablet"},
+            {"generic_name": "Cetirizine", "strength": "10mg", "dosage_form": "Tablet"},
+        ]
+    )
+
+    stats = loader.load(df)
+
+    assert stats["inserted"] == 2
+    assert stats["failed"] == 1
+    assert stats["error_counts"] == {"duplicate_key": 1}
+    assert len(client.upsert_calls) == 4
+
+    log_lines = [line for line in capsys.readouterr().out.splitlines() if '"event": "etl_row_failure"' in line]
+    assert len(log_lines) == 1
+    log = json.loads(log_lines[0])
+    assert log["medicine_name"] == "Bad Float"
+    assert log["unresolved_value"] == "not-a-float"
+    assert log["db_error_code"] == "23505"
+    assert log["error_category"] == "duplicate_key"
+    assert log["row_index"] == 1
+    assert log["pipeline"] == "janaushadhi"
+
+
+def test_failed_rows_are_exported_to_csv_with_error_columns(tmp_path):
+    client = FakeSupabaseClient(fail_batches=True, fail_generic_names={"Bad Float"})
+    loader = make_loader(client, tmp_path)
+    df = pd.DataFrame(
+        [
+            {"generic_name": "Bad Float", "strength": "not-a-float", "dosage_form": "Tablet"},
+        ]
+    )
+
+    stats = loader.load(df)
+
+    failed_rows_csv = Path(stats["failed_rows_csv"])
+    assert failed_rows_csv.exists()
+    failed = pd.read_csv(failed_rows_csv, dtype=str)
+    assert failed.loc[0, "generic_name"] == "Bad Float"
+    assert failed.loc[0, "error_category"] == "duplicate_key"
+    assert failed.loc[0, "db_error_code"] == "23505"
+    assert failed.loc[0, "error_message"]
+
+
+def test_validation_failure_log_includes_required_debug_fields(tmp_path, capsys):
+    client = FakeSupabaseClient(
+        errors_by_generic_name={"Missing Name": "validation failed: generic_name is required"}
+    )
+    loader = make_loader(client, tmp_path)
+    df = pd.DataFrame(
+        [
+            {"generic_name": "Missing Name", "strength": "", "dosage_form": "Tablet"},
+        ]
+    )
+
+    stats = loader.load(df)
+
+    assert stats["failed"] == 1
+    assert stats["error_counts"] == {"validation_error": 1}
+    log_lines = [line for line in capsys.readouterr().out.splitlines() if '"event": "etl_row_failure"' in line]
+    log = json.loads(log_lines[0])
+    assert log["medicine_name"] == "Missing Name"
+    assert log["unresolved_value"] == ""
+    assert log["db_error_code"] is None
+    assert log["error_category"] == "validation_error"
+
+
+def test_summary_prints_alert_when_success_rate_is_below_threshold(tmp_path, capsys):
+    client = FakeSupabaseClient(fail_batches=True, fail_generic_names={"Bad Float"})
+    loader = make_loader(client, tmp_path)
+    df = pd.DataFrame(
+        [
+            {"generic_name": "Bad Float", "strength": "not-a-float", "dosage_form": "Tablet"},
+            {"generic_name": "Paracetamol", "strength": "500mg", "dosage_form": "Tablet"},
+        ]
+    )
+
+    stats = loader.load(df)
+
+    assert stats["success_rate"] == 50.0
+    output = capsys.readouterr().out
+    assert "ALERT" in output
+    assert "95%" in output
+
+
+def test_retry_failed_rows_updates_successful_and_failed_retry_records(tmp_path):
+    retry_rows = [
+        {
+            "id": "row-1",
+            "row_payload": {"generic_name": "Paracetamol", "strength": "500mg", "dosage_form": "Tablet"},
+            "attempt_count": 1,
+        },
+        {
+            "id": "row-2",
+            "row_payload": {"generic_name": "Bad Float", "strength": "not-a-float", "dosage_form": "Tablet"},
+            "attempt_count": 2,
+        },
+    ]
+    client = FakeSupabaseClient(fail_generic_names={"Bad Float"}, retry_rows=retry_rows)
+    loader = make_loader(client, tmp_path)
+
+    stats = loader.retry_failed_rows()
+
+    assert stats["total"] == 2
+    assert stats["inserted"] == 1
+    assert stats["failed"] == 1
+
+    updates = [call[1] for call in client.update_calls if call[0] == "etl_failed_rows"]
+    assert updates[0]["status"] == "retry_succeeded"
+    assert updates[0]["attempt_count"] == 2
+    assert updates[1]["status"] == "failed"
+    assert updates[1]["attempt_count"] == 3
+    assert updates[1]["error_category"] == "duplicate_key"

--- a/supabase/migrations/20260520000000_create_etl_failed_rows.sql
+++ b/supabase/migrations/20260520000000_create_etl_failed_rows.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS etl_failed_rows (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     pipeline_name VARCHAR(100) NOT NULL,
     source_table VARCHAR(100) NOT NULL,
+    row_fingerprint VARCHAR(64) NOT NULL,
     row_payload JSONB NOT NULL,
     medicine_name VARCHAR(500),
     unresolved_value TEXT,
@@ -20,3 +21,6 @@ CREATE INDEX IF NOT EXISTS idx_etl_failed_rows_status
 
 CREATE INDEX IF NOT EXISTS idx_etl_failed_rows_pipeline_name
     ON etl_failed_rows(pipeline_name);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_etl_failed_rows_unique_logical_row
+    ON etl_failed_rows(pipeline_name, source_table, row_fingerprint);

--- a/supabase/migrations/20260520000000_create_etl_failed_rows.sql
+++ b/supabase/migrations/20260520000000_create_etl_failed_rows.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS etl_failed_rows (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    pipeline_name VARCHAR(100) NOT NULL,
+    source_table VARCHAR(100) NOT NULL,
+    row_payload JSONB NOT NULL,
+    medicine_name VARCHAR(500),
+    unresolved_value TEXT,
+    error_category VARCHAR(100),
+    db_error_code VARCHAR(20),
+    error_message TEXT,
+    attempt_count INTEGER DEFAULT 1,
+    status VARCHAR(50) DEFAULT 'failed',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_attempt_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX IF NOT EXISTS idx_etl_failed_rows_status
+    ON etl_failed_rows(status);
+
+CREATE INDEX IF NOT EXISTS idx_etl_failed_rows_pipeline_name
+    ON etl_failed_rows(pipeline_name);


### PR DESCRIPTION
## 📋 PR Summary

Adds row-level failure handling for the Jan Aushadhi ETL loader. If a batch upsert fails, the loader now retries that batch row by row, logs the exact failed row as structured JSON, keeps importing valid rows, and prints a load summary at the end.

---

## 🔗 Related Issue

Closes #264

---

## 🏷️ PR Type

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [x] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [ ] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [x] `apps/ml` — Python / FastAPI ML Service
- [x] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Added row-level retry fallback when a Supabase batch upsert fails.
- Added structured JSON failure logs with `medicine_name`, `unresolved_value`, `db_error_code`, `row_index`, `pipeline`, and `error_category`.
- Added end-of-run summary stats with total rows, successful rows, failed rows, success rate, and error counts.
- Added failed-row CSV export under `data/failed/janaushadhi/`.
- Added a 95% success-rate warning so bad source data is easier to catch.
- Added an `etl_failed_rows` retry table migration.
- Added `--retry-failed` support to reprocess rows saved in the retry queue.
- Added loader tests covering success, row-level fallback, JSON logs, CSV export, threshold alerting, and retry updates.

## 📸 Screenshots 
<img width="679" height="403" alt="Screenshot from 2026-05-20 18-12-34" src="https://github.com/user-attachments/assets/c55de22c-18b2-49a1-ae01-cbb30a14f8ab" />

Loader tests passing and `--retry-failed` CLI flag available.


```bash
$ python3 -m pytest apps/ml/tests/test_loader.py -q
......                                                                   [100%]
6 passed, 1 warning in 0.86s
