### PR TITLE
refactor(web): centralize layout colors into theme tokens

### DIFF
--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -10,289 +10,64 @@ import { supabase } from "@/lib/supabase";
 import { mapMedicineRow } from "@/src/lib/mapMedicineRow";
 
 const SELECT_FIELDS =
-  "id, brand_name, generic_name, composition, manufacturer, expiry_date, cdsco_approval_status";
+    "id, brand_name, generic_name, composition, manufacturer, expiry_date, cdsco_approval_status";
 
 async function searchMedicines(query: string): Promise<Medicine[]> {
-  const q = query.trim();
-  if (q.length < 2) return [];
+    const q = query.trim();
+    if (q.length < 2) return [];
 
-  const pattern = `%${q.replace(/[%_\\]/g, "\\$&")}%`;
-  const { data, error } = await supabase
-    .from("medicines")
-    .select(SELECT_FIELDS)
-    .or(`brand_name.ilike.${pattern},generic_name.ilike.${pattern}`)
-    .limit(25);
+    const pattern = `%${q.replace(/[%_\\]/g, "\\$&")}%`;
+    const { data, error } = await supabase
+        .from("medicines")
+        .select(SELECT_FIELDS)
+        .or(`brand_name.ilike.${pattern},generic_name.ilike.${pattern}`)
+        .limit(25);
 
-  if (error) {
-    console.error(error.message);
-    return [];
-  }
-  return (data ?? []).map((row) =>
-    mapMedicineRow(row as Record<string, unknown>)
-  );
+    if (error) {
+        console.error(error.message);
+        return [];
+    }
+    return (data ?? []).map((row) => mapMedicineRow(row as Record<string, unknown>));
 }
 
 export default function ComparePage() {
-  const [medicine1, setMedicine1] = useState<Medicine | null>(null);
-  const [medicine2, setMedicine2] = useState<Medicine | null>(null);
-  const handleSearch = useCallback((q: string) => searchMedicines(q), []);
+    const [medicine1, setMedicine1] = useState<Medicine | null>(null);
+    const [medicine2, setMedicine2] = useState<Medicine | null>(null);
+    const handleSearch = useCallback((q: string) => searchMedicines(q), []);
 
-  return (
-    <div className="min-h-screen bg-slate-50 text-slate-900">
-      <PageHeader
-        title="Compare medicines"
-        subtitle="Brand vs generic side by side"
-        backHref="/"
-        variant="light"
-      />
-      <main className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
-        <section className="rounded-xl border border-slate-200 bg-white p-5">
-          <div className="grid gap-4 sm:grid-cols-2">
-            <MedicineSearchSelect
-              label="First medicine"
-              value={medicine1}
-              onChange={setMedicine1}
-              onSearch={handleSearch}
-            />
-            <MedicineSearchSelect
-              label="Second medicine"
-              value={medicine2}
-              onChange={setMedicine2}
-              onSearch={handleSearch}
-            />
-          </div>
-        </section>
-        <ComparisonGrid medicine1={medicine1} medicine2={medicine2} />
-        <p className="text-center text-sm text-slate-500">
-          <Link href="/map" className="text-emerald-700 hover:underline">
-            Find pharmacies
-          </Link>
-        </p>
-      </main>
-      <Footer />
-    </div>
-  );
-}
-=======
-import { CalendarDays, Download, Pill, Printer, ShieldCheck } from "lucide-react";
-import { Link } from "@/i18n/routing";
-import { PageHeader } from "../components/PageHeader";
-import Footer from "../components/Footer";
-
-type MedicineComparison = {
-    brandName: string;
-    genericName: string;
-    manufacturer: string;
-    strength: string;
-    packSize: string;
-    batchNumber: string;
-    verifiedStatus: string;
-    listedPrice: string;
-    janAushadhiPrice: string;
-    savings: string;
-};
-
-const comparisonRows: MedicineComparison[] = [
-    {
-        brandName: "Dolo 650",
-        genericName: "Paracetamol",
-        manufacturer: "Micro Labs Ltd.",
-        strength: "650 mg",
-        packSize: "15 tablets",
-        batchNumber: "DL650A24",
-        verifiedStatus: "CDSCO verified",
-        listedPrice: "INR 33.60",
-        janAushadhiPrice: "INR 14.00",
-        savings: "58%",
-    },
-    {
-        brandName: "Azithral 500",
-        genericName: "Azithromycin",
-        manufacturer: "Alembic Pharmaceuticals",
-        strength: "500 mg",
-        packSize: "3 tablets",
-        batchNumber: "AZ500B11",
-        verifiedStatus: "CDSCO verified",
-        listedPrice: "INR 119.50",
-        janAushadhiPrice: "INR 42.00",
-        savings: "65%",
-    },
-    {
-        brandName: "Pantocid 40",
-        genericName: "Pantoprazole",
-        manufacturer: "Sun Pharma",
-        strength: "40 mg",
-        packSize: "15 tablets",
-        batchNumber: "PN40C07",
-        verifiedStatus: "CDSCO verified",
-        listedPrice: "INR 168.00",
-        janAushadhiPrice: "INR 31.50",
-        savings: "81%",
-    },
-];
-
-const generatedOn = "19 May 2026";
-
-export default function ComparePage() {
     return (
-        <div className="print-page flex min-h-screen flex-col bg-slate-50 text-slate-950">
+        <div className="min-h-screen bg-slate-50 text-slate-900">
             <PageHeader
-                title="Medicine Compare"
-                subtitle="Verified price receipt"
+                title="Compare medicines"
+                subtitle="Brand vs generic side by side"
                 backHref="/"
                 variant="light"
             />
-
-            <main className="print-container mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-4 py-8 sm:px-6 lg:px-8">
-                <section className="print-receipt rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-                    <div className="flex flex-col gap-6 border-b border-slate-200 pb-6 md:flex-row md:items-start md:justify-between">
-                        <div>
-                            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-bold text-emerald-700">
-                                <ShieldCheck size={14} />
-                                Verified medicine report
-                            </div>
-                            <h1 className="text-3xl font-black tracking-tight text-slate-950">
-                                Medicine Price Comparison
-                            </h1>
-                            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
-                                Printable comparison for health volunteers to share lower-cost
-                                equivalent medicine options with patients.
-                            </p>
-                        </div>
-
-                        <div className="flex flex-col gap-3 md:items-end">
-                            <div className="flex items-center gap-2 text-sm font-semibold text-slate-600">
-                                <CalendarDays size={16} />
-                                Generated: {generatedOn}
-                            </div>
-                            <button
-                                type="button"
-                                onClick={() => window.print()}
-                                className="no-print inline-flex items-center justify-center gap-2 rounded-xl bg-slate-950 px-4 py-2.5 text-sm font-bold text-white transition-colors hover:bg-slate-800"
-                            >
-                                <Printer size={16} />
-                                Print receipt
-                            </button>
-                        </div>
-                    </div>
-
-                    <div className="mt-6 grid gap-4 md:grid-cols-3">
-                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-                            <p className="text-xs font-bold tracking-wide text-slate-500 uppercase">
-                                Medicines checked
-                            </p>
-                            <p className="mt-2 text-3xl font-black text-slate-950">
-                                {comparisonRows.length}
-                            </p>
-                        </div>
-                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-                            <p className="text-xs font-bold tracking-wide text-slate-500 uppercase">
-                                Report type
-                            </p>
-                            <p className="mt-2 text-lg font-black text-slate-950">
-                                Price comparison
-                            </p>
-                        </div>
-                        <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-                            <p className="text-xs font-bold tracking-wide text-slate-500 uppercase">
-                                Use case
-                            </p>
-                            <p className="mt-2 text-lg font-black text-slate-950">
-                                Patient handout
-                            </p>
-                        </div>
+            <main className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
+                <section className="rounded-xl border border-slate-200 bg-white p-5">
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        <MedicineSearchSelect
+                            label="First medicine"
+                            value={medicine1}
+                            onChange={setMedicine1}
+                            onSearch={handleSearch}
+                        />
+                        <MedicineSearchSelect
+                            label="Second medicine"
+                            value={medicine2}
+                            onChange={setMedicine2}
+                            onSearch={handleSearch}
+                        />
                     </div>
                 </section>
-
-                <section className="comparison-grid grid gap-5 lg:grid-cols-3">
-                    {comparisonRows.map((medicine) => (
-                        <article
-                            key={medicine.batchNumber}
-                            className="comparison-card rounded-3xl border border-slate-200 bg-white p-5 shadow-sm"
-                        >
-                            <div className="flex items-start gap-3 border-b border-slate-200 pb-4">
-                                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-emerald-50 text-emerald-700">
-                                    <Pill size={22} />
-                                </div>
-                                <div>
-                                    <h2 className="text-xl font-black text-slate-950">
-                                        {medicine.brandName}
-                                    </h2>
-                                    <p className="text-sm font-semibold text-slate-500">
-                                        {medicine.genericName}
-                                    </p>
-                                </div>
-                            </div>
-
-                            <table className="mt-4 text-sm">
-                                <tbody>
-                                    <tr>
-                                        <th scope="row">Manufacturer</th>
-                                        <td>{medicine.manufacturer}</td>
-                                    </tr>
-                                    <tr>
-                                        <th scope="row">Strength</th>
-                                        <td>{medicine.strength}</td>
-                                    </tr>
-                                    <tr>
-                                        <th scope="row">Pack size</th>
-                                        <td>{medicine.packSize}</td>
-                                    </tr>
-                                    <tr>
-                                        <th scope="row">Batch</th>
-                                        <td>{medicine.batchNumber}</td>
-                                    </tr>
-                                    <tr>
-                                        <th scope="row">Status</th>
-                                        <td>{medicine.verifiedStatus}</td>
-                                    </tr>
-                                    <tr>
-                                        <th scope="row">Market price</th>
-                                        <td>{medicine.listedPrice}</td>
-                                    </tr>
-                                    <tr>
-                                        <th scope="row">Jan Aushadhi</th>
-                                        <td>{medicine.janAushadhiPrice}</td>
-                                    </tr>
-                                    <tr>
-                                        <th scope="row">Potential saving</th>
-                                        <td>{medicine.savings}</td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </article>
-                    ))}
-                </section>
-
-                <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
-                    <h2 className="text-lg font-black text-slate-950">Volunteer note</h2>
-                    <p className="mt-2 text-sm leading-6 text-slate-600">
-                        Prices are examples for print layout verification. Confirm medicine, dosage,
-                        substitution, and final pricing with a licensed pharmacist or doctor before
-                        changing treatment.
-                    </p>
-                    <div className="no-print mt-4 flex flex-wrap gap-3">
-                        <Link
-                            href="/scan"
-                            className="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-bold text-slate-700 transition-colors hover:bg-slate-100"
-                        >
-                            <Pill size={16} />
-                            Verify another medicine
-                        </Link>
-                        <button
-                            type="button"
-                            onClick={() => window.print()}
-                            className="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-4 py-2.5 text-sm font-bold text-slate-700 transition-colors hover:bg-slate-100"
-                        >
-                            <Download size={16} />
-                            Save as PDF
-                        </button>
-                    </div>
-                </section>
+                <ComparisonGrid medicine1={medicine1} medicine2={medicine2} />
+                <p className="text-center text-sm text-slate-500">
+                    <Link href="/map" className="text-emerald-700 hover:underline">
+                        Find pharmacies
+                    </Link>
+                </p>
             </main>
-
             <Footer />
         </div>
     );
 }
- main

--- a/apps/web/app/[locale]/globals.css
+++ b/apps/web/app/[locale]/globals.css
@@ -1,199 +1,266 @@
 @import "tailwindcss";
 
+:root {
+    --color-brand-primary: #10b981;
+    --color-brand-success: #16a34a;
+    --color-brand-primary-hover: #059669;
+    --color-brand-primary-dark: #047857;
+    --color-brand-primary-soft: #d1fae5;
+    --color-brand-primary-subtle: #dcfce7;
+    --color-brand-primary-text: #065f46;
+    --color-brand-primary-strong-text: #166534;
+    --color-brand-secondary: #2563eb;
+    --color-brand-secondary-bright: #3b82f6;
+    --color-brand-secondary-soft: #dbeafe;
+    --color-brand-secondary-subtle: #eff6ff;
+    --color-brand-primary-faint: #ecfdf5;
+    --color-accent-cyan: #0891b2;
+    --color-accent-cyan-soft: #06b6d4;
+    --color-accent-warning: #fbbf24;
+    --color-accent-warning-soft: #fef3c7;
+    --color-accent-warning-text: #92400e;
+    --color-accent-warning-strong-text: #b45309;
+    --color-accent-danger: #dc2626;
+    --color-accent-danger-soft: #fee2e2;
+    --color-accent-danger-bright: #ef4444;
+    --color-accent-danger-text: #991b1b;
+    --color-surface-page: #ffffff;
+    --color-surface-page-dark: #000000;
+    --color-surface-warm: #f8f7f4;
+    --color-surface-login: #f5f7fb;
+    --color-surface-muted: #f8fafc;
+    --color-surface-scrollbar: #f1f1f1;
+    --color-border-muted: #e2e8f0;
+    --color-text-primary: #1e293b;
+    --color-text-secondary: #64748b;
+    --color-text-muted: #94a3b8;
+    --color-text-subtle: #a1a1aa;
+    --color-text-neutral: #6b7280;
+    --color-text-inverse: #ffffff;
+    --color-print-ink: #000000;
+    --color-dark-surface: #0f172a;
+    --color-dark-surface-muted: #1e293b;
+    --color-dark-text: #e2e8f0;
+    --color-dark-scrollbar: #475569;
+    --color-dark-scrollbar-hover: #64748b;
+    --color-scrollbar-thumb: #cbd5e1;
+}
+
 @layer base {
-  /* Scanner sweep animation */
-  @keyframes scan {
-    0%, 100% { transform: translateY(0); }
-    50% { transform: translateY(280px); }
-  }
-
-  .animate-scan {
-    animation: scan 2.5s ease-in-out infinite;
-  }
-
-  /* Chat UI animations */
-  @keyframes slideIn {
-    from {
-      opacity: 0;
-      transform: translateY(10px);
+    /* Scanner sweep animation */
+    @keyframes scan {
+        0%,
+        100% {
+            transform: translateY(0);
+        }
+        50% {
+            transform: translateY(280px);
+        }
     }
-    to {
-      opacity: 1;
-      transform: translateY(0);
+
+    .animate-scan {
+        animation: scan 2.5s ease-in-out infinite;
     }
-  }
 
-  @keyframes bounce {
-    0%, 60%, 100% {
-      transform: translateY(0);
+    /* Chat UI animations */
+    @keyframes slideIn {
+        from {
+            opacity: 0;
+            transform: translateY(10px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
     }
-    30% {
-      transform: translateY(-10px);
+
+    @keyframes bounce {
+        0%,
+        60%,
+        100% {
+            transform: translateY(0);
+        }
+        30% {
+            transform: translateY(-10px);
+        }
     }
-  }
 
-  .animate-slideIn {
-    animation: slideIn 0.3s ease-out forwards;
-  }
-
-  .animate-bounce {
-    animation: bounce 1.4s ease-in-out infinite;
-  }
-
-  /* Leaflet Popup Overrides — match SahiDawa design */
-  .sahidawa-popup .leaflet-popup-content-wrapper {
-    border-radius: 20px !important;
-    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06) !important;
-    border: 1px solid #e2e8f0 !important;
-    padding: 0 !important;
-    overflow: hidden;
-  }
-
-  .sahidawa-popup .leaflet-popup-content {
-    margin: 0 !important;
-    line-height: 1.5;
-  }
-
-  .sahidawa-popup .leaflet-popup-close-button {
-    top: 8px !important;
-    right: 8px !important;
-    width: 24px !important;
-    height: 24px !important;
-    font-size: 18px !important;
-    color: #94a3b8 !important;
-    background: #f8fafc !important;
-    border-radius: 50% !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    padding: 0 !important;
-    line-height: 1 !important;
-    z-index: 10;
-    transition: all 0.15s ease;
-  }
-
-  .sahidawa-popup .leaflet-popup-close-button:hover {
-    color: #1e293b !important;
-    background: #e2e8f0 !important;
-  }
-
-  .sahidawa-popup .leaflet-popup-tip {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08) !important;
-    border: 1px solid #e2e8f0 !important;
-  }
-
-  /* User location pulse animation */
-  @keyframes sahidawa-pulse {
-    0% {
-      transform: scale(1);
-      opacity: 1;
+    .animate-slideIn {
+        animation: slideIn 0.3s ease-out forwards;
     }
-    50% {
-      transform: scale(2.5);
-      opacity: 0;
+
+    .animate-bounce {
+        animation: bounce 1.4s ease-in-out infinite;
     }
-    100% {
-      transform: scale(1);
-      opacity: 0;
+
+    /* Leaflet Popup Overrides — match SahiDawa design */
+    .sahidawa-popup .leaflet-popup-content-wrapper {
+        border-radius: 20px !important;
+        box-shadow:
+            0 10px 40px rgba(0, 0, 0, 0.12),
+            0 2px 8px rgba(0, 0, 0, 0.06) !important;
+        border: 1px solid var(--color-border-muted) !important;
+        padding: 0 !important;
+        overflow: hidden;
     }
-  }
 
-  /* Remove default Leaflet marker icon outline */
-  .sahidawa-marker {
-    background: transparent !important;
-    border: none !important;
-  }
-
-  .sahidawa-marker-shell {
-    transition: transform 0.2s ease-out, filter 0.2s ease-out;
-    transform-origin: 50% 100%;
-  }
-
-  /* iOS-style spring bounce on marker hover */
-  @keyframes marker-bounce-in {
-    0%   { transform: scale(1) translateY(0); }
-    30%  { transform: scale(1.22) translateY(-8px); }
-    55%  { transform: scale(1.06) translateY(-2px); }
-    80%  { transform: scale(1.14) translateY(-5px); }
-    100% { transform: scale(1.12) translateY(-4px); }
-  }
-
-  .sahidawa-marker-hover .sahidawa-marker-shell {
-    animation: marker-bounce-in 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-    filter: drop-shadow(0 10px 16px rgba(15, 23, 42, 0.22));
-  }
-
-  .sahidawa-marker-hover {
-    z-index: 1000 !important;
-  }
-
-  .user-location-marker {
-    background: transparent !important;
-    border: none !important;
-  }
-
-  /* No scrollbar utility */
-  .no-scrollbar::-webkit-scrollbar {
-    display: none;
-  }
-  .no-scrollbar {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
-  }
-
-  /* Animate-in for toasts */
-  @keyframes slide-in-from-top-2 {
-    from {
-      transform: translateY(-8px);
-      opacity: 0;
+    .sahidawa-popup .leaflet-popup-content {
+        margin: 0 !important;
+        line-height: 1.5;
     }
-    to {
-      transform: translateY(0);
-      opacity: 1;
+
+    .sahidawa-popup .leaflet-popup-close-button {
+        top: 8px !important;
+        right: 8px !important;
+        width: 24px !important;
+        height: 24px !important;
+        font-size: 18px !important;
+        color: var(--color-text-muted) !important;
+        background: var(--color-surface-muted) !important;
+        border-radius: 50% !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        padding: 0 !important;
+        line-height: 1 !important;
+        z-index: 10;
+        transition: all 0.15s ease;
     }
-  }
-  .animate-in.slide-in-from-top-2 {
-    animation: slide-in-from-top-2 0.3s ease-out;
-  }
+
+    .sahidawa-popup .leaflet-popup-close-button:hover {
+        color: var(--color-text-primary) !important;
+        background: var(--color-border-muted) !important;
+    }
+
+    .sahidawa-popup .leaflet-popup-tip {
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08) !important;
+        border: 1px solid var(--color-border-muted) !important;
+    }
+
+    /* User location pulse animation */
+    @keyframes sahidawa-pulse {
+        0% {
+            transform: scale(1);
+            opacity: 1;
+        }
+        50% {
+            transform: scale(2.5);
+            opacity: 0;
+        }
+        100% {
+            transform: scale(1);
+            opacity: 0;
+        }
+    }
+
+    /* Remove default Leaflet marker icon outline */
+    .sahidawa-marker {
+        background: transparent !important;
+        border: none !important;
+    }
+
+    .sahidawa-marker-shell {
+        transition:
+            transform 0.2s ease-out,
+            filter 0.2s ease-out;
+        transform-origin: 50% 100%;
+    }
+
+    /* iOS-style spring bounce on marker hover */
+    @keyframes marker-bounce-in {
+        0% {
+            transform: scale(1) translateY(0);
+        }
+        30% {
+            transform: scale(1.22) translateY(-8px);
+        }
+        55% {
+            transform: scale(1.06) translateY(-2px);
+        }
+        80% {
+            transform: scale(1.14) translateY(-5px);
+        }
+        100% {
+            transform: scale(1.12) translateY(-4px);
+        }
+    }
+
+    .sahidawa-marker-hover .sahidawa-marker-shell {
+        animation: marker-bounce-in 0.35s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+        filter: drop-shadow(0 10px 16px rgba(15, 23, 42, 0.22));
+    }
+
+    .sahidawa-marker-hover {
+        z-index: 1000 !important;
+    }
+
+    .user-location-marker {
+        background: transparent !important;
+        border: none !important;
+    }
+
+    /* No scrollbar utility */
+    .no-scrollbar::-webkit-scrollbar {
+        display: none;
+    }
+    .no-scrollbar {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+
+    /* Animate-in for toasts */
+    @keyframes slide-in-from-top-2 {
+        from {
+            transform: translateY(-8px);
+            opacity: 0;
+        }
+        to {
+            transform: translateY(0);
+            opacity: 1;
+        }
+    }
+    .animate-in.slide-in-from-top-2 {
+        animation: slide-in-from-top-2 0.3s ease-out;
+    }
 }
 
 @theme {
-  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+    --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
 }
 
 /* Custom scrollbar for chat */
 ::-webkit-scrollbar {
-  width: 6px;
+    width: 6px;
 }
 
 ::-webkit-scrollbar-track {
-  background: #f1f1f1;
-  border-radius: 10px;
+    background: var(--color-surface-scrollbar);
+    border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #cbd5e1;
-  border-radius: 10px;
+    background: var(--color-scrollbar-thumb);
+    border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #94a3b8;
+    background: var(--color-text-muted);
 }
 
 /* Dark mode support */
 .dark body {
-  background-color: #0f172a;
-  color: #e2e8f0;
+    background-color: var(--color-dark-surface);
+    color: var(--color-border-muted);
 }
 
 .dark ::-webkit-scrollbar-track {
-  background: #1e293b;
+    background: var(--color-text-primary);
 }
 
 .dark ::-webkit-scrollbar-thumb {
-  background: #475569;
+    background: var(--color-dark-scrollbar);
 }
 
 .dark ::-webkit-scrollbar-thumb:hover {
-  background: #64748b;
+    background: var(--color-text-secondary);
 }

--- a/apps/web/app/[locale]/health/page.tsx
+++ b/apps/web/app/[locale]/health/page.tsx
@@ -3,21 +3,50 @@
 import dynamic from "next/dynamic";
 
 const ChatUI = dynamic(() => import("@/app/components/health/ChatUI"), {
-  ssr: false,
-  loading: () => (
-    <div style={{ position: "fixed", inset: 0, display: "flex", alignItems: "center", justifyContent: "center", background: "#f8f7f4" }}>
-      <div style={{ textAlign: "center" }}>
-        <div style={{ width: 44, height: 44, borderRadius: 12, background: "#16a34a", display: "flex", alignItems: "center", justifyContent: "center", margin: "0 auto 12px", boxShadow: "0 2px 8px rgba(22,163,74,0.3)" }}>
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="white" aria-hidden="true">
-            <path d="M17 8C8 10 5.9 16.17 3.82 19.71L5.71 21l1-1.71c.19.13.39.26.59.37C9 21.07 11 22 14 22c3.56 0 6.83-1.63 9-4.56V3l-4 2-2-3-4.5 5.5C11.5 8 14 8 17 8z" />
-          </svg>
+    ssr: false,
+    loading: () => (
+        <div
+            style={{
+                position: "fixed",
+                inset: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                background: "var(--color-surface-warm)",
+            }}
+        >
+            <div style={{ textAlign: "center" }}>
+                <div
+                    style={{
+                        width: 44,
+                        height: 44,
+                        borderRadius: 12,
+                        background: "var(--color-brand-success)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        margin: "0 auto 12px",
+                        boxShadow: "0 2px 8px rgba(22,163,74,0.3)",
+                    }}
+                >
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="white" aria-hidden="true">
+                        <path d="M17 8C8 10 5.9 16.17 3.82 19.71L5.71 21l1-1.71c.19.13.39.26.59.37C9 21.07 11 22 14 22c3.56 0 6.83-1.63 9-4.56V3l-4 2-2-3-4.5 5.5C11.5 8 14 8 17 8z" />
+                    </svg>
+                </div>
+                <p
+                    style={{
+                        fontFamily: "system-ui",
+                        fontSize: 13,
+                        color: "var(--color-text-neutral)",
+                    }}
+                >
+                    Loading SahiDawa…
+                </p>
+            </div>
         </div>
-        <p style={{ fontFamily: "system-ui", fontSize: 13, color: "#6b7280" }}>Loading SahiDawa…</p>
-      </div>
-    </div>
-  ),
+    ),
 });
 
 export default function HealthPage() {
-  return <ChatUI />;
+    return <ChatUI />;
 }

--- a/apps/web/app/[locale]/login/page.tsx
+++ b/apps/web/app/[locale]/login/page.tsx
@@ -1,168 +1,148 @@
 "use client";
 
-
 import { Mail, Lock, ShieldCheck, ArrowRight } from "lucide-react";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@supabase/supabase-js";
 export default function LoginPage() {
-  const router = useRouter();
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
+    const router = useRouter();
+    const supabase = createClient(
+        process.env.NEXT_PUBLIC_SUPABASE_URL!,
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    );
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState("");
 
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
+    const handleLogin = async (e: React.FormEvent) => {
+        e.preventDefault();
 
-    setLoading(true);
-    setError("");
+        setLoading(true);
+        setError("");
 
-    try {
-      const { data, error } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      });
+        try {
+            const { data, error } = await supabase.auth.signInWithPassword({
+                email,
+                password,
+            });
 
-      if (error) {
-        setError(error.message);
+            if (error) {
+                setError(error.message);
+                setLoading(false);
+                return;
+            }
+
+            if (data?.session?.access_token) {
+                localStorage.setItem("sb-access-token", data.session.access_token);
+
+                router.push("/reports/me");
+            }
+        } catch (err) {
+            setError("Something went wrong. Please try again.");
+        }
+
         setLoading(false);
-        return;
-      }
+    };
 
-      if (data?.session?.access_token) {
-        localStorage.setItem(
-          "sb-access-token",
-          data.session.access_token
-        );
+    return (
+        <div className="flex min-h-screen items-center justify-center bg-[var(--color-surface-login)] px-4 py-10">
+            <div className="w-full max-w-md">
+                {/* Logo */}
+                <div className="mb-8 flex items-center justify-center gap-3">
+                    <div className="rounded-2xl bg-emerald-100 p-3 shadow-sm">
+                        <ShieldCheck className="h-7 w-7 text-emerald-600" />
+                    </div>
 
-        router.push("/reports/me");
-      }
-    } catch (err) {
-      setError("Something went wrong. Please try again.");
-    }
+                    <div>
+                        <h1 className="text-3xl font-bold text-slate-900">SahiDawa</h1>
+                        <p className="text-sm text-slate-500">Secure Health Verification</p>
+                    </div>
+                </div>
 
-    setLoading(false);
-  };
+                {/* Login Card */}
+                <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl">
+                    <div className="mb-7">
+                        <h2 className="text-3xl font-bold text-slate-900">Welcome Back 👋</h2>
 
-  return (
-    <div className="min-h-screen bg-[#f5f7fb] flex items-center justify-center px-4 py-10">
-      <div className="w-full max-w-md">
-        
-        {/* Logo */}
-        <div className="flex items-center justify-center gap-3 mb-8">
-          <div className="bg-emerald-100 p-3 rounded-2xl shadow-sm">
-            <ShieldCheck className="w-7 h-7 text-emerald-600" />
-          </div>
+                        <p className="mt-2 text-slate-500">
+                            Sign in to access your reports and continue using SahiDawa.
+                        </p>
+                    </div>
 
-          <div>
-            <h1 className="text-3xl font-bold text-slate-900">
-              SahiDawa
-            </h1>
-            <p className="text-sm text-slate-500">
-              Secure Health Verification
-            </p>
-          </div>
+                    {/* Error */}
+                    {error && (
+                        <div className="mb-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+                            {error}
+                        </div>
+                    )}
+
+                    <form onSubmit={handleLogin} className="space-y-5">
+                        {/* Email */}
+                        <div>
+                            <label className="text-sm font-medium text-slate-700">
+                                Email Address
+                            </label>
+
+                            <div className="mt-2 flex items-center gap-3 rounded-2xl border border-slate-300 bg-slate-50 px-4 py-3 transition focus-within:border-emerald-500 focus-within:bg-white">
+                                <Mail className="h-5 w-5 text-slate-400" />
+
+                                <input
+                                    type="email"
+                                    placeholder="Enter your email"
+                                    value={email}
+                                    onChange={(e) => setEmail(e.target.value)}
+                                    required
+                                    className="w-full bg-transparent text-slate-800 outline-none placeholder:text-slate-400"
+                                />
+                            </div>
+                        </div>
+
+                        {/* Password */}
+                        <div>
+                            <label className="text-sm font-medium text-slate-700">Password</label>
+
+                            <div className="mt-2 flex items-center gap-3 rounded-2xl border border-slate-300 bg-slate-50 px-4 py-3 transition focus-within:border-emerald-500 focus-within:bg-white">
+                                <Lock className="h-5 w-5 text-slate-400" />
+
+                                <input
+                                    type="password"
+                                    placeholder="Enter your password"
+                                    value={password}
+                                    onChange={(e) => setPassword(e.target.value)}
+                                    required
+                                    className="w-full bg-transparent text-slate-800 outline-none placeholder:text-slate-400"
+                                />
+                            </div>
+                        </div>
+
+                        {/* Button */}
+                        <button
+                            type="submit"
+                            disabled={loading}
+                            className="mt-2 flex w-full items-center justify-center gap-2 rounded-2xl bg-emerald-600 py-3.5 font-semibold text-white shadow-lg shadow-emerald-200 transition-all hover:bg-emerald-700"
+                        >
+                            {loading ? "Signing In..." : "Sign In"}
+
+                            {!loading && <ArrowRight className="h-5 w-5" />}
+                        </button>
+                    </form>
+
+                    {/* Footer */}
+                    <div className="mt-7 text-center text-sm text-slate-500">
+                        Don&apos;t have an account?{" "}
+                        <Link href="/" className="font-medium text-emerald-600 hover:underline">
+                            Return Home
+                        </Link>
+                    </div>
+                </div>
+
+                {/* Bottom Text */}
+                <p className="mt-6 text-center text-xs text-slate-400">
+                    Protected by Supabase Authentication • SahiDawa © 2026
+                </p>
+            </div>
         </div>
-
-        {/* Login Card */}
-        <div className="bg-white rounded-3xl border border-slate-200 shadow-xl p-8">
-          
-          <div className="mb-7">
-            <h2 className="text-3xl font-bold text-slate-900">
-              Welcome Back 👋
-            </h2>
-
-            <p className="text-slate-500 mt-2">
-              Sign in to access your reports and continue using SahiDawa.
-            </p>
-          </div>
-
-          {/* Error */}
-          {error && (
-            <div className="mb-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
-              {error}
-            </div>
-          )}
-
-          <form onSubmit={handleLogin} className="space-y-5">
-            
-            {/* Email */}
-            <div>
-              <label className="text-sm font-medium text-slate-700">
-                Email Address
-              </label>
-
-              <div className="mt-2 flex items-center gap-3 rounded-2xl border border-slate-300 bg-slate-50 px-4 py-3 focus-within:border-emerald-500 focus-within:bg-white transition">
-                <Mail className="w-5 h-5 text-slate-400" />
-
-                <input
-                  type="email"
-                  placeholder="Enter your email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  required
-                  className="w-full bg-transparent outline-none text-slate-800 placeholder:text-slate-400"
-                />
-              </div>
-            </div>
-
-            {/* Password */}
-            <div>
-              <label className="text-sm font-medium text-slate-700">
-                Password
-              </label>
-
-              <div className="mt-2 flex items-center gap-3 rounded-2xl border border-slate-300 bg-slate-50 px-4 py-3 focus-within:border-emerald-500 focus-within:bg-white transition">
-                <Lock className="w-5 h-5 text-slate-400" />
-
-                <input
-                  type="password"
-                  placeholder="Enter your password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  required
-                  className="w-full bg-transparent outline-none text-slate-800 placeholder:text-slate-400"
-                />
-              </div>
-            </div>
-
-            {/* Button */}
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full mt-2 rounded-2xl bg-emerald-600 hover:bg-emerald-700 transition-all text-white py-3.5 font-semibold flex items-center justify-center gap-2 shadow-lg shadow-emerald-200"
-            >
-              {loading ? "Signing In..." : "Sign In"}
-
-              {!loading && (
-                <ArrowRight className="w-5 h-5" />
-              )}
-            </button>
-          </form>
-
-          {/* Footer */}
-          <div className="mt-7 text-center text-sm text-slate-500">
-            Don&apos;t have an account?{" "}
-            <Link
-              href="/"
-              className="text-emerald-600 font-medium hover:underline"
-            >
-              Return Home
-            </Link>
-          </div>
-        </div>
-
-        {/* Bottom Text */}
-        <p className="text-center text-xs text-slate-400 mt-6">
-          Protected by Supabase Authentication • SahiDawa © 2026
-        </p>
-      </div>
-    </div>
-  );
+    );
 }

--- a/apps/web/app/[locale]/map/PharmacyMap.tsx
+++ b/apps/web/app/[locale]/map/PharmacyMap.tsx
@@ -212,8 +212,12 @@ export default function PharmacyMap({
             .forEach((hotspot) => {
                 const normalizedIntensity = Math.max(0.15, Math.min(1, hotspot.intensity));
                 const isCounterfeit = hotspot.category === "counterfeit";
-                const color = isCounterfeit ? "#dc2626" : "#0891b2";
-                const fillColor = isCounterfeit ? "#ef4444" : "#06b6d4";
+                const color = isCounterfeit
+                    ? "var(--color-accent-danger)"
+                    : "var(--color-accent-cyan)";
+                const fillColor = isCounterfeit
+                    ? "var(--color-accent-danger-bright)"
+                    : "var(--color-accent-cyan-soft)";
                 const radius = isCounterfeit
                     ? 1800 + normalizedIntensity * 4200
                     : 900 + normalizedIntensity * 2600;
@@ -262,7 +266,13 @@ export default function PharmacyMap({
 
             const isVerified = pharmacy.isVerified === true;
             const isGovt = pharmacy.type === "govt";
-            const markerColor = isVerified ? "#059669" : isGovt ? "#059669" : "#3b82f6";
+            const markerColor = isVerified
+                ? "var(--color-brand-primary-hover)"
+                : isGovt
+                  ? "var(--color-brand-primary-hover)"
+                  : "var(--color-brand-secondary-bright)";
+            const markerShadowColor =
+                isVerified || isGovt ? "rgba(5,150,105,0.25)" : "rgba(59,130,246,0.25)";
 
             let customMarker;
 
@@ -275,9 +285,9 @@ export default function PharmacyMap({
             <div style="
               width: 40px;
               height: 40px;
-              background: linear-gradient(135deg, #059669, #047857);
+              background: linear-gradient(135deg, var(--color-brand-primary-hover), var(--color-brand-primary-dark));
               border-radius: 6px 6px 50% 50%;
-              border: 3px solid #d1fae5;
+              border: 3px solid var(--color-brand-primary-soft);
               display: flex;
               align-items: center;
               justify-content: center;
@@ -295,7 +305,9 @@ export default function PharmacyMap({
                 });
             } else {
                 // Standard teardrop marker (green for govt, blue for private)
-                const markerBorder = isGovt ? "#d1fae5" : "#dbeafe";
+                const markerBorder = isGovt
+                    ? "var(--color-brand-primary-soft)"
+                    : "var(--color-brand-secondary-soft)";
 
                 customMarker = L.divIcon({
                     className: "sahidawa-marker",
@@ -312,7 +324,7 @@ export default function PharmacyMap({
               border-radius: 50% 50% 50% 4px;
               transform: rotate(-45deg);
               border: 3px solid ${markerBorder};
-              box-shadow: 0 4px 12px ${markerColor}40, 0 2px 4px rgba(0,0,0,0.1);
+              box-shadow: 0 4px 12px ${markerShadowColor}, 0 2px 4px rgba(0,0,0,0.1);
               display: flex;
               align-items: center;
               justify-content: center;
@@ -341,14 +353,14 @@ export default function PharmacyMap({
 
             // Rich popup matching SahiDawa's design
             const statusColor = isVerified
-                ? "background:#d1fae5;color:#065f46"
+                ? "background:var(--color-brand-primary-soft);color:var(--color-brand-primary-text)"
                 : pharmacy.status === "Verified" || pharmacy.status === "Govt. Verified"
-                  ? "background:#d1fae5;color:#065f46"
-                  : "background:#fef3c7;color:#92400e";
+                  ? "background:var(--color-brand-primary-soft);color:var(--color-brand-primary-text)"
+                  : "background:var(--color-accent-warning-soft);color:var(--color-accent-warning-text)";
 
             const verifiedBanner = isVerified
                 ? `<div style="
-                    background: linear-gradient(90deg, #059669, #047857);
+                    background: linear-gradient(90deg, var(--color-brand-primary-hover), var(--color-brand-primary-dark));
                     color: white;
                     padding: 4px 10px;
                     border-radius: 6px;
@@ -377,7 +389,7 @@ export default function PharmacyMap({
               width: 36px;
               height: 36px;
               border-radius: 10px;
-              background: ${isGovt ? "#ecfdf5" : "#eff6ff"};
+              background: ${isGovt ? "var(--color-brand-primary-faint)" : "var(--color-brand-secondary-subtle)"};
               color: ${markerColor};
               display: flex;
               align-items: center;
@@ -393,7 +405,7 @@ export default function PharmacyMap({
               </svg>
             </div>
             <div style="flex:1;min-width:0;">
-              <div style="font-weight:800;color:#1e293b;font-size:13px;line-height:1.3;">${escapeHtml(pharmacy.name)}</div>
+              <div style="font-weight:800;color:var(--color-text-primary);font-size:13px;line-height:1.3;">${escapeHtml(pharmacy.name)}</div>
               <span style="
                 font-size:10px;
                 font-weight:700;
@@ -405,16 +417,16 @@ export default function PharmacyMap({
               ">${escapeHtml(pharmacy.status)}</span>
             </div>
           </div>
-          ${pharmacy.address ? `<p style="font-size:12px;color:#64748b;margin:0 0 8px 0;line-height:1.4;">${escapeHtml(pharmacy.address)}</p>` : ""}
-          <div style="display:flex;align-items:center;gap:12px;font-size:12px;color:#94a3b8;margin-bottom:10px;">
+          ${pharmacy.address ? `<p style="font-size:12px;color:var(--color-text-secondary);margin:0 0 8px 0;line-height:1.4;">${escapeHtml(pharmacy.address)}</p>` : ""}
+          <div style="display:flex;align-items:center;gap:12px;font-size:12px;color:var(--color-text-muted);margin-bottom:10px;">
             ${pharmacy.distance && pharmacy.distance !== "—" ? `<span style="font-weight:600;">${escapeHtml(pharmacy.distance)} away</span>` : ""}
             ${
                 pharmacy.rating > 0
                     ? `<span style="display:flex;align-items:center;gap:2px;">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="#fbbf24" stroke="#fbbf24" stroke-width="0"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-              <span style="font-weight:700;color:#475569;">${pharmacy.rating}</span>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="var(--color-accent-warning)" stroke="var(--color-accent-warning)" stroke-width="0"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+              <span style="font-weight:700;color:var(--color-dark-scrollbar);">${pharmacy.rating}</span>
             </span>`
-                    : `<span style="font-weight:500;font-size:11px;color:#cbd5e1;">OpenStreetMap data</span>`
+                    : `<span style="font-weight:500;font-size:11px;color:var(--color-scrollbar-thumb);">OpenStreetMap data</span>`
             }
           </div>
           ${
@@ -426,7 +438,7 @@ export default function PharmacyMap({
               gap:6px;
               width:100%;
               padding:8px;
-              background:#0f172a;
+              background:var(--color-dark-surface);
               color:white;
               border-radius:10px;
               text-decoration:none;
@@ -516,7 +528,7 @@ export default function PharmacyMap({
             position:absolute;
             top:4px;left:4px;
             width:12px;height:12px;
-            background:#3b82f6;
+            background:var(--color-brand-secondary-bright);
             border-radius:50%;
             border:3px solid white;
             box-shadow:0 2px 8px rgba(59,130,246,0.5);

--- a/apps/web/app/[locale]/map/loading.tsx
+++ b/apps/web/app/[locale]/map/loading.tsx
@@ -1,120 +1,121 @@
 export default function MapLoading() {
-  return (
-    <div className="h-screen bg-slate-50 font-sans flex flex-col overflow-hidden">
+    return (
+        <div className="flex h-screen flex-col overflow-hidden bg-slate-50 font-sans">
+            <div className="z-30 flex items-center gap-3 border-b border-slate-100 bg-white px-4 py-3 shadow-sm">
+                <div className="h-9 w-9 shrink-0 animate-pulse rounded-xl bg-slate-100" />
+                <div className="h-10 flex-1 animate-pulse rounded-2xl bg-slate-100" />
+            </div>
 
-      <div className="bg-white px-4 py-3 flex items-center gap-3 shadow-sm z-30 border-b border-slate-100">
-        <div className="w-9 h-9 rounded-xl bg-slate-100 animate-pulse shrink-0" />
-        <div className="flex-1 h-10 rounded-2xl bg-slate-100 animate-pulse" />
-      </div>
+            <div className="z-20 border-b border-slate-100 bg-white px-4 pt-3 pb-5 shadow-sm">
+                <div className="flex gap-2">
+                    <div className="h-8 w-24 animate-pulse rounded-full bg-slate-200" />
+                    <div
+                        className="h-8 w-32 animate-pulse rounded-full bg-emerald-100"
+                        style={{ animationDelay: "80ms" }}
+                    />
+                    <div
+                        className="h-8 w-24 animate-pulse rounded-full bg-slate-100"
+                        style={{ animationDelay: "160ms" }}
+                    />
+                    <div
+                        className="h-8 w-20 animate-pulse rounded-full bg-slate-100"
+                        style={{ animationDelay: "240ms" }}
+                    />
+                </div>
+            </div>
 
-      <div className="bg-white px-4 pt-3 pb-5 shadow-sm z-20 border-b border-slate-100">
-        <div className="flex gap-2">
-          <div className="h-8 w-24 rounded-full bg-slate-200 animate-pulse" />
-          <div
-            className="h-8 w-32 rounded-full bg-emerald-100 animate-pulse"
-            style={{ animationDelay: "80ms" }}
-          />
-          <div
-            className="h-8 w-24 rounded-full bg-slate-100 animate-pulse"
-            style={{ animationDelay: "160ms" }}
-          />
-          <div
-            className="h-8 w-20 rounded-full bg-slate-100 animate-pulse"
-            style={{ animationDelay: "240ms" }}
-          />
-        </div>
-      </div>
-
-      <div className="flex-1 relative bg-slate-200 overflow-hidden">
-
-        <div
-          className="absolute inset-0 pointer-events-none"
-          style={{
-            background:
-              "linear-gradient(105deg, transparent 35%, rgba(255,255,255,0.16) 50%, transparent 65%)",
-            backgroundSize: "250% 100%",
-            animation: "map-shimmer 2.4s ease-in-out infinite",
-          }}
-        />
-
-        <div className="absolute top-1/3 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-2">
-          <div className="w-12 h-12 rounded-full bg-emerald-200 animate-pulse border-4 border-white shadow-lg" />
-          <div className="h-5 w-28 rounded-full bg-white/90 animate-pulse shadow" />
-        </div>
-
-        <div className="absolute top-1/2 right-1/4">
-          <div className="w-10 h-10 rounded-full bg-blue-200 animate-pulse border-4 border-white shadow-md" />
-        </div>
-
-        <div className="absolute bottom-1/4 left-1/4">
-          <div
-            className="w-10 h-10 rounded-full bg-blue-200 animate-pulse border-4 border-white shadow-md"
-            style={{ animationDelay: "300ms" }}
-          />
-        </div>
-
-        <div className="absolute right-4 top-4 flex flex-col gap-2">
-          <div className="w-10 h-10 rounded-xl bg-white shadow-md animate-pulse" />
-          <div
-            className="w-10 h-10 rounded-xl bg-white shadow-md animate-pulse"
-            style={{ animationDelay: "120ms" }}
-          />
-        </div>
-
-        <div className="absolute bottom-0 left-0 right-0 p-4 space-y-3">
-          {[0, 1, 2].map((i) => (
-            <div
-              key={i}
-              className="bg-white rounded-3xl p-5 shadow-xl border border-slate-100 flex items-center justify-between"
-              style={{ opacity: 1 - i * 0.15 }}
-            >
-              <div className="flex items-start gap-4">
+            <div className="relative flex-1 overflow-hidden bg-slate-200">
                 <div
-                  className="w-12 h-12 rounded-2xl animate-pulse shrink-0"
-                  style={{
-                    background: i === 0 ? "#d1fae5" : "#dbeafe",
-                    animationDelay: `${i * 100}ms`,
-                  }}
+                    className="pointer-events-none absolute inset-0"
+                    style={{
+                        background:
+                            "linear-gradient(105deg, transparent 35%, rgba(255,255,255,0.16) 50%, transparent 65%)",
+                        backgroundSize: "250% 100%",
+                        animation: "map-shimmer 2.4s ease-in-out infinite",
+                    }}
                 />
 
-                <div className="flex flex-col gap-2 pt-1">
-                  <div className="flex items-center gap-2">
-                    <div
-                      className="h-3 rounded-full bg-slate-200 animate-pulse"
-                      style={{
-                        width: [160, 110, 140][i],
-                        animationDelay: `${i * 80}ms`,
-                      }}
-                    />
-
-                    <div
-                      className="h-4 w-14 rounded-md bg-emerald-100 animate-pulse"
-                      style={{ animationDelay: `${i * 80 + 40}ms` }}
-                    />
-                  </div>
-
-                  <div className="flex items-center gap-3">
-                    <div
-                      className="h-2.5 w-16 rounded-full bg-slate-100 animate-pulse"
-                      style={{ animationDelay: `${i * 80 + 80}ms` }}
-                    />
-
-                    <div
-                      className="h-2.5 w-8 rounded-full bg-amber-100 animate-pulse"
-                      style={{ animationDelay: `${i * 80 + 120}ms` }}
-                    />
-                  </div>
+                <div className="absolute top-1/3 left-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2">
+                    <div className="h-12 w-12 animate-pulse rounded-full border-4 border-white bg-emerald-200 shadow-lg" />
+                    <div className="h-5 w-28 animate-pulse rounded-full bg-white/90 shadow" />
                 </div>
-              </div>
 
-              <div
-                className="w-10 h-10 rounded-full bg-slate-200 animate-pulse shrink-0"
-                style={{ animationDelay: `${i * 100 + 60}ms` }}
-              />
+                <div className="absolute top-1/2 right-1/4">
+                    <div className="h-10 w-10 animate-pulse rounded-full border-4 border-white bg-blue-200 shadow-md" />
+                </div>
+
+                <div className="absolute bottom-1/4 left-1/4">
+                    <div
+                        className="h-10 w-10 animate-pulse rounded-full border-4 border-white bg-blue-200 shadow-md"
+                        style={{ animationDelay: "300ms" }}
+                    />
+                </div>
+
+                <div className="absolute top-4 right-4 flex flex-col gap-2">
+                    <div className="h-10 w-10 animate-pulse rounded-xl bg-white shadow-md" />
+                    <div
+                        className="h-10 w-10 animate-pulse rounded-xl bg-white shadow-md"
+                        style={{ animationDelay: "120ms" }}
+                    />
+                </div>
+
+                <div className="absolute right-0 bottom-0 left-0 space-y-3 p-4">
+                    {[0, 1, 2].map((i) => (
+                        <div
+                            key={i}
+                            className="flex items-center justify-between rounded-3xl border border-slate-100 bg-white p-5 shadow-xl"
+                            style={{ opacity: 1 - i * 0.15 }}
+                        >
+                            <div className="flex items-start gap-4">
+                                <div
+                                    className="h-12 w-12 shrink-0 animate-pulse rounded-2xl"
+                                    style={{
+                                        background:
+                                            i === 0
+                                                ? "var(--color-brand-primary-soft)"
+                                                : "var(--color-brand-secondary-soft)",
+                                        animationDelay: `${i * 100}ms`,
+                                    }}
+                                />
+
+                                <div className="flex flex-col gap-2 pt-1">
+                                    <div className="flex items-center gap-2">
+                                        <div
+                                            className="h-3 animate-pulse rounded-full bg-slate-200"
+                                            style={{
+                                                width: [160, 110, 140][i],
+                                                animationDelay: `${i * 80}ms`,
+                                            }}
+                                        />
+
+                                        <div
+                                            className="h-4 w-14 animate-pulse rounded-md bg-emerald-100"
+                                            style={{ animationDelay: `${i * 80 + 40}ms` }}
+                                        />
+                                    </div>
+
+                                    <div className="flex items-center gap-3">
+                                        <div
+                                            className="h-2.5 w-16 animate-pulse rounded-full bg-slate-100"
+                                            style={{ animationDelay: `${i * 80 + 80}ms` }}
+                                        />
+
+                                        <div
+                                            className="h-2.5 w-8 animate-pulse rounded-full bg-amber-100"
+                                            style={{ animationDelay: `${i * 80 + 120}ms` }}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div
+                                className="h-10 w-10 shrink-0 animate-pulse rounded-full bg-slate-200"
+                                style={{ animationDelay: `${i * 100 + 60}ms` }}
+                            />
+                        </div>
+                    ))}
+                </div>
             </div>
-          ))}
         </div>
-      </div>
-    </div>
-  )
+    );
 }

--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -63,7 +63,7 @@ function parseExpiryDate(text: string): string | null {
     const genericRegex = /\b(0[1-9]|1[0-2])[/\s-](20[2-9][0-9]|[2-9][0-9])\b/g;
     let genericMatch;
     while ((genericMatch = genericRegex.exec(text)) !== null) {
-        let month = genericMatch[1];
+        const month = genericMatch[1];
         let year = genericMatch[2];
         if (year.length === 2) year = "20" + year;
         return `${month}/${year}`;
@@ -827,10 +827,7 @@ export default function ScanPage() {
             <div className="relative flex flex-1 items-center justify-center overflow-hidden">
                 <div className="absolute inset-0 overflow-hidden bg-slate-900">
                     {isCameraActive ? (
-                        <BarcodeScanner
-                            onScan={handleBarcodeScan}
-                            debounceMs={2500}
-                        />
+                        <BarcodeScanner onScan={handleBarcodeScan} debounceMs={2500} />
                     ) : uploadedImage ? (
                         <LazyImage
                             src={uploadedImage}

--- a/apps/web/app/components/Map.tsx
+++ b/apps/web/app/components/Map.tsx
@@ -6,22 +6,27 @@ import L, { Map as LeafletMap } from "leaflet";
 import "leaflet/dist/leaflet.css";
 
 // Fix marker icons - do this once globally
-if (typeof window !== 'undefined') {
-  delete (L.Icon.Default.prototype as any)._getIconUrl;
-  L.Icon.Default.mergeOptions({
-    iconRetinaUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png",
-    iconUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png",
-    shadowUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png",
-  });
+if (typeof window !== "undefined") {
+    delete (L.Icon.Default.prototype as any)._getIconUrl;
+    L.Icon.Default.mergeOptions({
+        iconRetinaUrl:
+            "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png",
+        iconUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png",
+        shadowUrl: "https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png",
+    });
 }
 
 const createCustomIcon = (type: string, isSelected: boolean = false) => {
-  const color = type === 'govt' ? '#059669' : '#2563eb';
-  const size = isSelected ? 32 : 26;
-  const ring = isSelected ? `box-shadow: 0 0 0 4px ${color}33, 0 3px 12px rgba(0,0,0,0.25);` : 'box-shadow: 0 2px 8px rgba(0,0,0,0.2);';
-  return L.divIcon({
-    className: 'custom-marker',
-    html: `<div style="
+    const color =
+        type === "govt" ? "var(--color-brand-primary-hover)" : "var(--color-brand-secondary)";
+    const ringColor = type === "govt" ? "rgba(5,150,105,0.2)" : "rgba(37,99,235,0.2)";
+    const size = isSelected ? 32 : 26;
+    const ring = isSelected
+        ? `box-shadow: 0 0 0 4px ${ringColor}, 0 3px 12px rgba(0,0,0,0.25);`
+        : "box-shadow: 0 2px 8px rgba(0,0,0,0.2);";
+    return L.divIcon({
+        className: "custom-marker",
+        html: `<div style="
       background-color: ${color};
       width: ${size}px;
       height: ${size}px;
@@ -39,147 +44,231 @@ const createCustomIcon = (type: string, isSelected: boolean = false) => {
       justify-content: center;
       font-size: ${isSelected ? 14 : 11}px;
     ">🏥</div></div>`,
-    iconSize: [size, size],
-    iconAnchor: [size / 2, size],
-    popupAnchor: [0, -size - 4]
-  });
+        iconSize: [size, size],
+        iconAnchor: [size / 2, size],
+        popupAnchor: [0, -size - 4],
+    });
 };
 
 function MapController({ center }: { center: [number, number] | null }) {
-  const map = useMap();
-  useEffect(() => {
-    if (center) {
-      map.flyTo(center, 15, { duration: 1.2, easeLinearity: 0.4 });
-    }
-  }, [center, map]);
-  return null;
+    const map = useMap();
+    useEffect(() => {
+        if (center) {
+            map.flyTo(center, 15, { duration: 1.2, easeLinearity: 0.4 });
+        }
+    }, [center, map]);
+    return null;
 }
 
 interface Pharmacy {
-  id: number;
-  name: string;
-  distance: string;
-  rating: number;
-  status: string;
-  type: string;
-  coordinates: [number, number];
-  address: string;
-  isOpen: boolean;
-  emergencyAvailable: boolean;
-  medicinesAvailable: number;
-  openHours: string;
-  phone: string;
-
+    id: number;
+    name: string;
+    distance: string;
+    rating: number;
+    status: string;
+    type: string;
+    coordinates: [number, number];
+    address: string;
+    isOpen: boolean;
+    emergencyAvailable: boolean;
+    medicinesAvailable: number;
+    openHours: string;
+    phone: string;
 }
 
-export default function Map({ pharmacies, selectedPharmacy, selectedPharmacyId, onMarkerClick }: { 
-  pharmacies: Pharmacy[]; 
-  selectedPharmacy: [number, number] | null;
-  selectedPharmacyId: number | null;
-  onMarkerClick: (id: number) => void;
+export default function Map({
+    pharmacies,
+    selectedPharmacy,
+    selectedPharmacyId,
+    onMarkerClick,
+}: {
+    pharmacies: Pharmacy[];
+    selectedPharmacy: [number, number] | null;
+    selectedPharmacyId: number | null;
+    onMarkerClick: (id: number) => void;
 }) {
-  const [isClient, setIsClient] = useState(false);
-  const mapRef = useRef<LeafletMap | null>(null);
-  const containerId = useRef(`map-${Date.now()}-${Math.random()}`);
+    const [isClient, setIsClient] = useState(false);
+    const mapRef = useRef<LeafletMap | null>(null);
+    const containerId = useRef(`map-${Date.now()}-${Math.random()}`);
 
-  useEffect(() => {
-    setIsClient(true);
-    return () => {
-      if (mapRef.current) {
-        mapRef.current.remove();
-        mapRef.current = null;
-      }
-    };
-  }, []);
+    useEffect(() => {
+        setIsClient(true);
+        return () => {
+            if (mapRef.current) {
+                mapRef.current.remove();
+                mapRef.current = null;
+            }
+        };
+    }, []);
 
-  if (!isClient) {
-    return (
-      <div className="w-full h-full bg-slate-100 flex items-center justify-center">
-        <div className="text-center">
-          <div className="w-8 h-8 border-2 border-emerald-600 border-t-transparent rounded-full animate-spin mx-auto mb-2"></div>
-          <p className="text-xs text-slate-500">Initializing map...</p>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <MapContainer
-      key={containerId.current}
-      center={[20.5937, 78.9629]}
-      zoom={5}
-      style={{ height: "100%", width: "100%" }}
-      zoomControl={false}
-      scrollWheelZoom={true}
-      className="z-0"
-      ref={(map: LeafletMap | null) => {
-        if (map) {
-          mapRef.current = map;
-        }
-      }}
-
-    >
-      <TileLayer
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>'
-        url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
-        maxZoom={19}
-      />
-      <MapController center={selectedPharmacy} />
-      
-      {pharmacies.map((pharmacy) => (
-        <Marker
-          key={pharmacy.id}
-          position={pharmacy.coordinates}
-          icon={createCustomIcon(pharmacy.type, selectedPharmacyId === pharmacy.id)}
-          eventHandlers={{ click: () => onMarkerClick(pharmacy.id) }}
-          zIndexOffset={selectedPharmacyId === pharmacy.id ? 1000 : 0}
-        >
-          <Popup className="pharmacy-popup" maxWidth={240}>
-            <div style={{ minWidth: 210, padding: '4px 2px' }}>
-              <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, marginBottom: 8 }}>
-                <div style={{
-                  width: 36, height: 36, borderRadius: 8,
-                  background: pharmacy.type === 'govt' ? '#d1fae5' : '#dbeafe',
-                  display: 'flex', alignItems: 'center', justifyContent: 'center',
-                  fontSize: 16, flexShrink: 0
-                }}>🏥</div>
-                <div>
-                  <p style={{ fontWeight: 700, fontSize: 12, color: '#1e293b', lineHeight: 1.3, margin: 0 }}>{pharmacy.name}</p>
-                  <p style={{ fontSize: 10, color: '#64748b', margin: '2px 0 0' }}>{pharmacy.address}</p>
+    if (!isClient) {
+        return (
+            <div className="flex h-full w-full items-center justify-center bg-slate-100">
+                <div className="text-center">
+                    <div className="mx-auto mb-2 h-8 w-8 animate-spin rounded-full border-2 border-emerald-600 border-t-transparent"></div>
+                    <p className="text-xs text-slate-500">Initializing map...</p>
                 </div>
-              </div>
-              <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap', marginBottom: 8 }}>
-                <span style={{ fontSize: 10, background: '#fef3c7', color: '#92400e', padding: '2px 6px', borderRadius: 99, fontWeight: 600 }}>
-                  ★ {pharmacy.rating}
-                </span>
-                <span style={{ 
-                  fontSize: 10, 
-                  background: pharmacy.isOpen ? '#dcfce7' : '#fee2e2', 
-                  color: pharmacy.isOpen ? '#166534' : '#991b1b', 
-                  padding: '2px 6px', borderRadius: 99, fontWeight: 600 
-                }}>
-                  {pharmacy.isOpen ? '● Open' : '● Closed'}
-                </span>
-                {pharmacy.emergencyAvailable && (
-                  <span style={{ fontSize: 10, background: '#fef3c7', color: '#b45309', padding: '2px 6px', borderRadius: 99, fontWeight: 600 }}>
-                    24/7
-                  </span>
-                )}
-              </div>
-              <button 
-                onClick={() => window.open(`https://maps.google.com?q=${pharmacy.coordinates[0]},${pharmacy.coordinates[1]}`, '_blank')}
-                style={{
-                  width: '100%', background: '#0f172a', color: 'white',
-                  fontSize: 11, fontWeight: 600, padding: '7px 12px',
-                  borderRadius: 8, border: 'none', cursor: 'pointer'
-                }}
-              >
-                Get Directions →
-              </button>
             </div>
-          </Popup>
-        </Marker>
-      ))}
-    </MapContainer>
-  );
+        );
+    }
+
+    return (
+        <MapContainer
+            key={containerId.current}
+            center={[20.5937, 78.9629]}
+            zoom={5}
+            style={{ height: "100%", width: "100%" }}
+            zoomControl={false}
+            scrollWheelZoom={true}
+            className="z-0"
+            ref={(map: LeafletMap | null) => {
+                if (map) {
+                    mapRef.current = map;
+                }
+            }}
+        >
+            <TileLayer
+                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>'
+                url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+                maxZoom={19}
+            />
+            <MapController center={selectedPharmacy} />
+
+            {pharmacies.map((pharmacy) => (
+                <Marker
+                    key={pharmacy.id}
+                    position={pharmacy.coordinates}
+                    icon={createCustomIcon(pharmacy.type, selectedPharmacyId === pharmacy.id)}
+                    eventHandlers={{ click: () => onMarkerClick(pharmacy.id) }}
+                    zIndexOffset={selectedPharmacyId === pharmacy.id ? 1000 : 0}
+                >
+                    <Popup className="pharmacy-popup" maxWidth={240}>
+                        <div style={{ minWidth: 210, padding: "4px 2px" }}>
+                            <div
+                                style={{
+                                    display: "flex",
+                                    alignItems: "flex-start",
+                                    gap: 8,
+                                    marginBottom: 8,
+                                }}
+                            >
+                                <div
+                                    style={{
+                                        width: 36,
+                                        height: 36,
+                                        borderRadius: 8,
+                                        background:
+                                            pharmacy.type === "govt"
+                                                ? "var(--color-brand-primary-soft)"
+                                                : "var(--color-brand-secondary-soft)",
+                                        display: "flex",
+                                        alignItems: "center",
+                                        justifyContent: "center",
+                                        fontSize: 16,
+                                        flexShrink: 0,
+                                    }}
+                                >
+                                    🏥
+                                </div>
+                                <div>
+                                    <p
+                                        style={{
+                                            fontWeight: 700,
+                                            fontSize: 12,
+                                            color: "var(--color-text-primary)",
+                                            lineHeight: 1.3,
+                                            margin: 0,
+                                        }}
+                                    >
+                                        {pharmacy.name}
+                                    </p>
+                                    <p
+                                        style={{
+                                            fontSize: 10,
+                                            color: "var(--color-text-secondary)",
+                                            margin: "2px 0 0",
+                                        }}
+                                    >
+                                        {pharmacy.address}
+                                    </p>
+                                </div>
+                            </div>
+                            <div
+                                style={{
+                                    display: "flex",
+                                    gap: 4,
+                                    flexWrap: "wrap",
+                                    marginBottom: 8,
+                                }}
+                            >
+                                <span
+                                    style={{
+                                        fontSize: 10,
+                                        background: "var(--color-accent-warning-soft)",
+                                        color: "var(--color-accent-warning-text)",
+                                        padding: "2px 6px",
+                                        borderRadius: 99,
+                                        fontWeight: 600,
+                                    }}
+                                >
+                                    ★ {pharmacy.rating}
+                                </span>
+                                <span
+                                    style={{
+                                        fontSize: 10,
+                                        background: pharmacy.isOpen
+                                            ? "var(--color-brand-primary-subtle)"
+                                            : "var(--color-accent-danger-soft)",
+                                        color: pharmacy.isOpen
+                                            ? "var(--color-brand-primary-strong-text)"
+                                            : "var(--color-accent-danger-text)",
+                                        padding: "2px 6px",
+                                        borderRadius: 99,
+                                        fontWeight: 600,
+                                    }}
+                                >
+                                    {pharmacy.isOpen ? "● Open" : "● Closed"}
+                                </span>
+                                {pharmacy.emergencyAvailable && (
+                                    <span
+                                        style={{
+                                            fontSize: 10,
+                                            background: "var(--color-accent-warning-soft)",
+                                            color: "var(--color-accent-warning-strong-text)",
+                                            padding: "2px 6px",
+                                            borderRadius: 99,
+                                            fontWeight: 600,
+                                        }}
+                                    >
+                                        24/7
+                                    </span>
+                                )}
+                            </div>
+                            <button
+                                onClick={() =>
+                                    window.open(
+                                        `https://maps.google.com?q=${pharmacy.coordinates[0]},${pharmacy.coordinates[1]}`,
+                                        "_blank"
+                                    )
+                                }
+                                style={{
+                                    width: "100%",
+                                    background: "var(--color-dark-surface)",
+                                    color: "white",
+                                    fontSize: 11,
+                                    fontWeight: 600,
+                                    padding: "7px 12px",
+                                    borderRadius: 8,
+                                    border: "none",
+                                    cursor: "pointer",
+                                }}
+                            >
+                                Get Directions →
+                            </button>
+                        </div>
+                    </Popup>
+                </Marker>
+            ))}
+        </MapContainer>
+    );
 }

--- a/apps/web/app/components/health/components/ActionCard.tsx
+++ b/apps/web/app/components/health/components/ActionCard.tsx
@@ -5,74 +5,79 @@
 // Displayed in the empty/welcome state of the chat.
 
 interface ActionCardProps {
-  icon: React.ReactNode;
-  label: string;
-  description: string;
-  onClick: () => void;
-  accentColor?: "emerald" | "sky" | "amber";
+    icon: React.ReactNode;
+    label: string;
+    description: string;
+    onClick: () => void;
+    accentColor?: "emerald" | "sky" | "amber";
 }
 
 const accentMap = {
-  emerald: {
-    iconBg: "bg-emerald-50 border border-emerald-200",
-    iconColor: "text-emerald-600",
-    hover: "hover:border-emerald-400 hover:bg-emerald-50/60",
-    label: "text-emerald-700",
-  },
-  sky: {
-    iconBg: "bg-sky-50 border border-sky-200",
-    iconColor: "text-sky-600",
-    hover: "hover:border-sky-400 hover:bg-sky-50/60",
-    label: "text-sky-700",
-  },
-  amber: {
-    iconBg: "bg-amber-50 border border-amber-200",
-    iconColor: "text-amber-600",
-    hover: "hover:border-amber-400 hover:bg-amber-50/60",
-    label: "text-amber-700",
-  },
+    emerald: {
+        iconBg: "bg-emerald-50 border border-emerald-200",
+        iconColor: "text-emerald-600",
+        hover: "hover:border-emerald-400 hover:bg-emerald-50/60",
+        label: "text-emerald-700",
+    },
+    sky: {
+        iconBg: "bg-sky-50 border border-sky-200",
+        iconColor: "text-sky-600",
+        hover: "hover:border-sky-400 hover:bg-sky-50/60",
+        label: "text-sky-700",
+    },
+    amber: {
+        iconBg: "bg-amber-50 border border-amber-200",
+        iconColor: "text-amber-600",
+        hover: "hover:border-amber-400 hover:bg-amber-50/60",
+        label: "text-amber-700",
+    },
 };
 
 export function ActionCard({
-  icon,
-  label,
-  description,
-  onClick,
-  accentColor = "emerald",
+    icon,
+    label,
+    description,
+    onClick,
+    accentColor = "emerald",
 }: ActionCardProps) {
-  const accent = accentMap[accentColor];
+    const accent = accentMap[accentColor];
 
-  return (
-    <button
-      onClick={onClick}
-      className={`w-full text-left bg-white border border-slate-200 rounded-2xl p-4 transition-all duration-200 active:scale-[0.98] shadow-sm ${accent.hover} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500`}
-      aria-label={label}
-    >
-      <div className="flex items-start gap-3">
-        {/* Icon */}
-        <div className={`w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0 ${accent.iconBg}`}>
-          <span className={`${accent.iconColor} w-5 h-5`} aria-hidden="true">{icon}</span>
-        </div>
-        {/* Text */}
-        <div className="min-w-0">
-          <p className={`text-sm font-semibold ${accent.label} leading-snug`}>{label}</p>
-          <p className="text-xs text-slate-500 mt-0.5 leading-relaxed">{description}</p>
-        </div>
-        {/* Chevron */}
-        <svg
-          width="14" height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="#94a3b8"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="flex-shrink-0 mt-1 ml-auto"
-          aria-hidden="true"
+    return (
+        <button
+            onClick={onClick}
+            className={`w-full rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm transition-all duration-200 active:scale-[0.98] ${accent.hover} focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:outline-none`}
+            aria-label={label}
         >
-          <polyline points="9 18 15 12 9 6" />
-        </svg>
-      </div>
-    </button>
-  );
+            <div className="flex items-start gap-3">
+                {/* Icon */}
+                <div
+                    className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl ${accent.iconBg}`}
+                >
+                    <span className={`${accent.iconColor} h-5 w-5`} aria-hidden="true">
+                        {icon}
+                    </span>
+                </div>
+                {/* Text */}
+                <div className="min-w-0">
+                    <p className={`text-sm font-semibold ${accent.label} leading-snug`}>{label}</p>
+                    <p className="mt-0.5 text-xs leading-relaxed text-slate-500">{description}</p>
+                </div>
+                {/* Chevron */}
+                <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="var(--color-text-muted)"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="mt-1 ml-auto flex-shrink-0"
+                    aria-hidden="true"
+                >
+                    <polyline points="9 18 15 12 9 6" />
+                </svg>
+            </div>
+        </button>
+    );
 }

--- a/apps/web/app/components/health/components/ChatBubble.tsx
+++ b/apps/web/app/components/health/components/ChatBubble.tsx
@@ -4,106 +4,115 @@
 // Single chat message: avatar · bubble · timestamp · optional error state.
 
 export interface Message {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  timestamp: Date;
-  isError?: boolean;
+    id: string;
+    role: "user" | "assistant";
+    content: string;
+    timestamp: Date;
+    isError?: boolean;
 }
 
 interface ChatBubbleProps {
-  msg: Message;
-  onRetry?: (id: string) => void;
+    msg: Message;
+    onRetry?: (id: string) => void;
 }
 
 const formatTime = (d: Date) =>
-  d.toLocaleTimeString("en-IN", { hour: "2-digit", minute: "2-digit", hour12: true });
+    d.toLocaleTimeString("en-IN", { hour: "2-digit", minute: "2-digit", hour12: true });
 
 const BotAvatar = () => (
-  <div
-    aria-hidden="true"
-    className="w-9 h-9 rounded-2xl bg-emerald-600 flex items-center justify-center flex-shrink-0 shadow-sm"
-  >
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="white">
-      <path d="M17 8C8 10 5.9 16.17 3.82 19.71L5.71 21l1-1.71c.19.13.39.26.59.37C9 21.07 11 22 14 22c3.56 0 6.83-1.63 9-4.56V3l-4 2-2-3-4.5 5.5C11.5 8 14 8 17 8z" />
-    </svg>
-  </div>
+    <div
+        aria-hidden="true"
+        className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl bg-emerald-600 shadow-sm"
+    >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="white">
+            <path d="M17 8C8 10 5.9 16.17 3.82 19.71L5.71 21l1-1.71c.19.13.39.26.59.37C9 21.07 11 22 14 22c3.56 0 6.83-1.63 9-4.56V3l-4 2-2-3-4.5 5.5C11.5 8 14 8 17 8z" />
+        </svg>
+    </div>
 );
 
 const UserAvatar = () => (
-  <div
-    aria-hidden="true"
-    className="w-9 h-9 rounded-2xl bg-slate-200 flex items-center justify-center flex-shrink-0"
-  >
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="#475569">
-      <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v2.4h19.2v-2.4c0-3.2-6.4-4.8-9.6-4.8z" />
-    </svg>
-  </div>
+    <div
+        aria-hidden="true"
+        className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-2xl bg-slate-200"
+    >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="var(--color-dark-scrollbar)">
+            <path d="M12 12c2.7 0 4.8-2.1 4.8-4.8S14.7 2.4 12 2.4 7.2 4.5 7.2 7.2 9.3 12 12 12zm0 2.4c-3.2 0-9.6 1.6-9.6 4.8v2.4h19.2v-2.4c0-3.2-6.4-4.8-9.6-4.8z" />
+        </svg>
+    </div>
 );
 
 const ErrorContent = ({ onRetry, msgId }: { onRetry?: (id: string) => void; msgId: string }) => (
-  <div>
-    <div className="flex items-start gap-2 mb-3">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="#dc2626" className="flex-shrink-0 mt-0.5" aria-hidden="true">
-        <path d="M12 2L1 21h22L12 2zm0 3.5L20.5 19h-17L12 5.5zM11 10v4h2v-4h-2zm0 6v2h2v-2h-2z" />
-      </svg>
-      <div>
-        <p className="text-sm font-semibold text-red-700 leading-snug">Connection issue</p>
-        <p className="text-sm text-slate-600 mt-0.5 leading-relaxed">
-          Unable to reach the health service. Please check your internet and try again.
-        </p>
-      </div>
+    <div>
+        <div className="mb-3 flex items-start gap-2">
+            <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="var(--color-accent-danger)"
+                className="mt-0.5 flex-shrink-0"
+                aria-hidden="true"
+            >
+                <path d="M12 2L1 21h22L12 2zm0 3.5L20.5 19h-17L12 5.5zM11 10v4h2v-4h-2zm0 6v2h2v-2h-2z" />
+            </svg>
+            <div>
+                <p className="text-sm leading-snug font-semibold text-red-700">Connection issue</p>
+                <p className="mt-0.5 text-sm leading-relaxed text-slate-600">
+                    Unable to reach the health service. Please check your internet and try again.
+                </p>
+            </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+            {onRetry && (
+                <button
+                    onClick={() => onRetry(msgId)}
+                    className="inline-flex min-h-[36px] items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-sm font-semibold text-white transition-all hover:bg-emerald-700 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:outline-none active:scale-95"
+                    aria-label="Retry last message"
+                >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="white" aria-hidden="true">
+                        <path d="M17.65 6.35A7.958 7.958 0 0 0 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
+                    </svg>
+                    Retry
+                </button>
+            )}
+            <span className="text-xs text-slate-400">or wait a moment</span>
+        </div>
     </div>
-    <div className="flex items-center gap-2 flex-wrap">
-      {onRetry && (
-        <button
-          onClick={() => onRetry(msgId)}
-          className="inline-flex items-center gap-1.5 text-sm font-semibold text-white bg-emerald-600 hover:bg-emerald-700 active:scale-95 transition-all px-3 py-1.5 rounded-lg min-h-[36px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
-          aria-label="Retry last message"
-        >
-          <svg width="13" height="13" viewBox="0 0 24 24" fill="white" aria-hidden="true">
-            <path d="M17.65 6.35A7.958 7.958 0 0 0 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
-          </svg>
-          Retry
-        </button>
-      )}
-      <span className="text-xs text-slate-400">or wait a moment</span>
-    </div>
-  </div>
 );
 
 export function ChatBubble({ msg, onRetry }: ChatBubbleProps) {
-  const isUser = msg.role === "user";
+    const isUser = msg.role === "user";
 
-  return (
-    <div
-      role="listitem"
-      className={`flex items-end gap-2.5 sd-slide-in ${isUser ? "flex-row-reverse" : "flex-row"}`}
-    >
-      {isUser ? <UserAvatar /> : <BotAvatar />}
-
-      <div className={`flex flex-col gap-1 max-w-[78%] ${isUser ? "items-end" : "items-start"}`}>
-        <span className="sr-only">{isUser ? "You" : "SahiDawa"} said:</span>
-
+    return (
         <div
-          className={`px-4 py-3 rounded-2xl text-sm leading-relaxed shadow-sm ${
-            msg.isError
-              ? "bg-red-50 border border-red-200 rounded-bl-sm"
-              : isUser
-              ? "bg-emerald-600 text-white rounded-br-sm"
-              : "bg-white border border-slate-200 text-slate-700 rounded-bl-sm"
-          }`}
+            role="listitem"
+            className={`sd-slide-in flex items-end gap-2.5 ${isUser ? "flex-row-reverse" : "flex-row"}`}
         >
-          {msg.isError ? <ErrorContent onRetry={onRetry} msgId={msg.id} /> : msg.content}
-        </div>
+            {isUser ? <UserAvatar /> : <BotAvatar />}
 
-        <time
-          className="text-[11px] text-slate-400 px-1"
-          dateTime={msg.timestamp.toISOString()}
-        >
-          {formatTime(msg.timestamp)}
-        </time>
-      </div>
-    </div>
-  );
+            <div
+                className={`flex max-w-[78%] flex-col gap-1 ${isUser ? "items-end" : "items-start"}`}
+            >
+                <span className="sr-only">{isUser ? "You" : "SahiDawa"} said:</span>
+
+                <div
+                    className={`rounded-2xl px-4 py-3 text-sm leading-relaxed shadow-sm ${
+                        msg.isError
+                            ? "rounded-bl-sm border border-red-200 bg-red-50"
+                            : isUser
+                              ? "rounded-br-sm bg-emerald-600 text-white"
+                              : "rounded-bl-sm border border-slate-200 bg-white text-slate-700"
+                    }`}
+                >
+                    {msg.isError ? <ErrorContent onRetry={onRetry} msgId={msg.id} /> : msg.content}
+                </div>
+
+                <time
+                    className="px-1 text-[11px] text-slate-400"
+                    dateTime={msg.timestamp.toISOString()}
+                >
+                    {formatTime(msg.timestamp)}
+                </time>
+            </div>
+        </div>
+    );
 }

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -3,80 +3,79 @@
 import Link from "next/link";
 
 export default function NotFound() {
-  return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: "100vh",
-        backgroundColor: "#000000",
-        fontFamily:
-          "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-        padding: "0 16px",
-        textAlign: "center",
-      }}
-    >
-      <h1
-        style={{
-          fontSize: "120px",
-          fontWeight: "800",
-          color: "#10b981",
-          margin: "0 0 16px 0",
-          lineHeight: 1,
-          letterSpacing: "-4px",
-        }}
-      >
-        404
-      </h1>
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                minHeight: "100vh",
+                backgroundColor: "var(--color-surface-page-dark)",
+                fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+                padding: "0 16px",
+                textAlign: "center",
+            }}
+        >
+            <h1
+                style={{
+                    fontSize: "120px",
+                    fontWeight: "800",
+                    color: "var(--color-brand-primary)",
+                    margin: "0 0 16px 0",
+                    lineHeight: 1,
+                    letterSpacing: "-4px",
+                }}
+            >
+                404
+            </h1>
 
-      <h2
-        style={{
-          fontSize: "24px",
-          fontWeight: "600",
-          color: "#ffffff",
-          margin: "0 0 12px 0",
-        }}
-      >
-        Medicine not found... but we can help!
-      </h2>
+            <h2
+                style={{
+                    fontSize: "24px",
+                    fontWeight: "600",
+                    color: "var(--color-text-inverse)",
+                    margin: "0 0 12px 0",
+                }}
+            >
+                Medicine not found... but we can help!
+            </h2>
 
-      <p
-        style={{
-          fontSize: "16px",
-          color: "#a1a1aa",
-          margin: "0 0 32px 0",
-          maxWidth: "420px",
-        }}
-      >
-        The page you&apos;re looking for doesn&apos;t exist or has been moved.
-      </p>
+            <p
+                style={{
+                    fontSize: "16px",
+                    color: "var(--color-text-subtle)",
+                    margin: "0 0 32px 0",
+                    maxWidth: "420px",
+                }}
+            >
+                The page you&apos;re looking for doesn&apos;t exist or has been moved.
+            </p>
 
-      <Link
-        href="/"
-        style={{
-          display: "inline-block",
-          backgroundColor: "#10b981",
-          color: "#ffffff",
-          fontSize: "15px",
-          fontWeight: "600",
-          textDecoration: "none",
-          borderRadius: "9999px",
-          padding: "12px 24px",
-          transition: "background-color 0.2s ease",
-        }}
-        onMouseOver={(e) =>
-        ((e.currentTarget as HTMLAnchorElement).style.backgroundColor =
-          "#059669")
-        }
-        onMouseOut={(e) =>
-        ((e.currentTarget as HTMLAnchorElement).style.backgroundColor =
-          "#10b981")
-        }
-      >
-        Back to Home
-      </Link>
-    </div>
-  );
+            <Link
+                href="/"
+                style={{
+                    display: "inline-block",
+                    backgroundColor: "var(--color-brand-primary)",
+                    color: "var(--color-text-inverse)",
+                    fontSize: "15px",
+                    fontWeight: "600",
+                    textDecoration: "none",
+                    borderRadius: "9999px",
+                    padding: "12px 24px",
+                    transition: "background-color 0.2s ease",
+                }}
+                onMouseOver={(e) =>
+                    ((e.currentTarget as HTMLAnchorElement).style.backgroundColor =
+                        "var(--color-brand-primary-hover)")
+                }
+                onMouseOut={(e) =>
+                    ((e.currentTarget as HTMLAnchorElement).style.backgroundColor =
+                        "var(--color-brand-primary)")
+                }
+            >
+                Back to Home
+            </Link>
+        </div>
+    );
 }

--- a/apps/web/src/styles/print.css
+++ b/apps/web/src/styles/print.css
@@ -8,14 +8,14 @@
     *::after {
         background: transparent !important;
         box-shadow: none !important;
-        color: #000 !important;
+        color: var(--color-print-ink) !important;
         text-shadow: none !important;
     }
 
     html,
     body {
         width: 100%;
-        background: #fff !important;
+        background: var(--color-surface-page) !important;
         font-size: 11pt;
         line-height: 1.45;
     }
@@ -25,7 +25,7 @@
     }
 
     a {
-        color: #000 !important;
+        color: var(--color-print-ink) !important;
         text-decoration: none !important;
     }
 
@@ -55,7 +55,7 @@
     }
 
     .print-receipt {
-        border: 1px solid #000 !important;
+        border: 1px solid var(--color-print-ink) !important;
         border-radius: 0 !important;
         break-inside: avoid;
         padding: 16pt !important;
@@ -69,7 +69,7 @@
         width: 100% !important;
         max-width: none !important;
         break-inside: avoid;
-        border: 1px solid #000 !important;
+        border: 1px solid var(--color-print-ink) !important;
         border-radius: 0 !important;
         margin: 0 0 12pt !important;
         padding: 12pt !important;
@@ -84,13 +84,13 @@
     .comparison-card td,
     .print-table th,
     .print-table td {
-        border: 1px solid #000 !important;
+        border: 1px solid var(--color-print-ink) !important;
         padding: 6pt !important;
         text-align: left !important;
         vertical-align: top !important;
     }
 
     .print-divider {
-        border-color: #000 !important;
+        border-color: var(--color-print-ink) !important;
     }
 }


### PR DESCRIPTION
## 📋 PR Summary

Centralizes repeated web layout colors behind CSS theme tokens and replaces hardcoded layout color literals with token references so the frontend can keep visual colors consistent from one source.

---

## 🔗 Related Issue

Closes #250

---

## 🏷️ PR Type

- [ ] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [x] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Added shared layout color tokens in `apps/web/app/[locale]/globals.css`.
- Replaced repeated hardcoded layout colors across global styles, print styles, map/loading/not-found surfaces, map UI, and health cards/chat bubbles with CSS custom properties.
- Replaced the newly added login page background hex with a theme token.
- Removed a stray conflict payload from the compare page and fixed one upstream lint error so the rebased web checks run cleanly.

---

## 📸 Screenshots / Proof of Work (REQUIRED)

This is a visual-token refactor with no intended UI behavior change. Terminal proof:

```bash
git diff --check origin/main..HEAD
# passed
```

```bash
node hardcoded-layout-hex-scan
# no non-token layout hex rows
```

```bash
npm run lint -w apps/web
# passed with existing warnings only, 0 errors
```

```bash
node node_modules/typescript/bin/tsc --noEmit -p apps/web/tsconfig.json --ignoreDeprecations 6.0
# passed
```

```bash
npm run build -w apps/web
# passed
```

---

## ✅ Contributor Checklist

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [x] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant

AI assistance was used to prepare, rebase, and verify this refactor.