### PR TITLE
feat(voice): improve accessibility and assistive feedback

### DIFF
--- a/apps/web/app/[locale]/voice/VoiceAudioVisualizer.tsx
+++ b/apps/web/app/[locale]/voice/VoiceAudioVisualizer.tsx
@@ -170,6 +170,10 @@ export function VoiceAudioVisualizer({
 
             if (volumeFillRef.current) {
                 volumeFillRef.current.style.transform = `scaleX(${Math.max(0.08, volume)})`;
+                const progressbar = volumeFillRef.current.closest('[role="progressbar"]');
+                if (progressbar) {
+                    progressbar.setAttribute("aria-valuenow", String(Math.round(volume * 100)));
+                }
             }
 
             animationFrame = window.requestAnimationFrame(draw);
@@ -220,7 +224,14 @@ export function VoiceAudioVisualizer({
                 </div>
             )}
 
-            <div className="mt-3 w-full max-w-[13rem]">
+            <div
+                className="mt-3 w-full max-w-[13rem]"
+                role="progressbar"
+                aria-label={volumeLabel}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={showCanvas ? 8 : 18}
+            >
                 <div className="flex items-center justify-between text-[10px] font-bold tracking-widest text-emerald-700 uppercase">
                     <span>{volumeLabel}</span>
                     <span aria-hidden="true">

--- a/apps/web/app/[locale]/voice/VoicePanels.tsx
+++ b/apps/web/app/[locale]/voice/VoicePanels.tsx
@@ -130,15 +130,15 @@ export function VoiceListeningPanel({
 export function VoiceProcessingPanel({ title, subtitle }: { title: string; subtitle: string }) {
     return (
         <div
-            className="animate-in fade-in flex flex-col items-center space-y-6 duration-300"
+            className="animate-in fade-in flex flex-col items-center space-y-6 duration-300 motion-reduce:animate-none"
             role="status"
             aria-live="polite"
             aria-label={title}
         >
             <div className="relative" aria-hidden="true">
-                <div className="h-24 w-24 animate-spin rounded-full border-4 border-slate-200 border-t-emerald-500"></div>
+                <div className="h-24 w-24 animate-spin rounded-full border-4 border-slate-200 border-t-emerald-500 motion-reduce:animate-none"></div>
                 <Sparkles
-                    className="absolute inset-0 m-auto animate-pulse text-emerald-500"
+                    className="absolute inset-0 m-auto animate-pulse text-emerald-500 motion-reduce:animate-none"
                     size={32}
                     aria-hidden="true"
                 />
@@ -201,7 +201,7 @@ export function VoiceReviewPanel({
     showEmergency: boolean;
 }) {
     return (
-        <div className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-slate-100 bg-white p-8 shadow-xl duration-500">
+        <div className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-slate-100 bg-white p-8 shadow-xl duration-500 motion-reduce:animate-none">
             {showEmergency && (
                 <div className="mb-6 rounded-2xl border border-red-200 bg-red-50 p-4 text-left">
                     <div className="flex items-start gap-3">
@@ -241,13 +241,13 @@ export function VoiceReviewPanel({
             <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <button
                     onClick={onRetry}
-                    className="w-full rounded-2xl bg-slate-100 py-3 font-bold text-slate-800 transition-colors hover:bg-slate-200"
+                    className="w-full rounded-2xl bg-slate-100 py-3 font-bold text-slate-800 transition-colors hover:bg-slate-200 focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                 >
                     {retryLabel}
                 </button>
                 <button
                     onClick={onAnalyse}
-                    className="w-full rounded-2xl bg-emerald-600 py-3 font-bold text-white transition-colors hover:bg-emerald-700"
+                    className="w-full rounded-2xl bg-emerald-600 py-3 font-bold text-white transition-colors hover:bg-emerald-700 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                 >
                     {analyseLabel}
                 </button>
@@ -266,7 +266,7 @@ export function VoiceErrorPanel({
     onRetry: () => void;
 }) {
     return (
-        <div className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-red-100 bg-white p-8 shadow-xl duration-500">
+        <div className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-red-100 bg-white p-8 shadow-xl duration-500 motion-reduce:animate-none">
             <div className="mb-6 flex items-start gap-3">
                 <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-red-50 text-red-600">
                     <AlertTriangle size={24} aria-hidden="true" />
@@ -279,7 +279,7 @@ export function VoiceErrorPanel({
 
             <button
                 onClick={onRetry}
-                className="w-full rounded-2xl bg-slate-900 py-4 font-bold text-white transition-all hover:bg-slate-800"
+                className="w-full rounded-2xl bg-slate-900 py-4 font-bold text-white transition-all hover:bg-slate-800 focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 focus-visible:outline-none"
             >
                 {retryLabel}
             </button>
@@ -332,7 +332,7 @@ export function VoiceResultPanel({
 }) {
     return (
         <div
-            className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-slate-100 bg-white p-8 shadow-xl duration-500"
+            className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-slate-100 bg-white p-8 shadow-xl duration-500 motion-reduce:animate-none"
             role="region"
             aria-labelledby="voice-ai-analysis-heading"
         >
@@ -417,7 +417,7 @@ export function VoiceResultPanel({
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                     <button
                         onClick={onShare}
-                        className="flex w-full items-center justify-center gap-2 rounded-2xl bg-slate-100 py-3 font-bold text-slate-800 transition-colors hover:bg-slate-200"
+                        className="flex w-full items-center justify-center gap-2 rounded-2xl bg-slate-100 py-3 font-bold text-slate-800 transition-colors hover:bg-slate-200 focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                     >
                         <Share2 size={18} aria-hidden="true" />
                         {shareLabel}
@@ -425,7 +425,7 @@ export function VoiceResultPanel({
                     {isSpeaking ? (
                         <button
                             onClick={onStopSpeaking}
-                            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-red-50 py-3 font-bold text-red-700 transition-colors hover:bg-red-100"
+                            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-red-50 py-3 font-bold text-red-700 transition-colors hover:bg-red-100 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                         >
                             <Square size={18} aria-hidden="true" />
                             {stopSpeakingLabel}
@@ -433,7 +433,7 @@ export function VoiceResultPanel({
                     ) : (
                         <button
                             onClick={onReplay}
-                            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-blue-50 py-3 font-bold text-blue-700 transition-colors hover:bg-blue-100"
+                            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-blue-50 py-3 font-bold text-blue-700 transition-colors hover:bg-blue-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                         >
                             <Play size={18} aria-hidden="true" />
                             {speakLabel}
@@ -443,7 +443,7 @@ export function VoiceResultPanel({
 
                 <button
                     onClick={onTryAgain}
-                    className="flex w-full items-center justify-center gap-2 rounded-2xl bg-slate-900 py-4 font-bold text-white transition-all hover:bg-slate-800"
+                    className="flex w-full items-center justify-center gap-2 rounded-2xl bg-slate-900 py-4 font-bold text-white transition-all hover:bg-slate-800 focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 focus-visible:outline-none"
                 >
                     <RotateCcw size={20} aria-hidden="true" />
                     {tryAgainLabel}

--- a/apps/web/app/[locale]/voice/page.tsx
+++ b/apps/web/app/[locale]/voice/page.tsx
@@ -14,12 +14,14 @@ import {
 } from "./lib/browser";
 import { getConfidenceMeta, type ConfidenceMeta } from "./lib/confidence";
 import { detectEmergencyKeywords } from "./lib/emergency";
+import { getPreferredRecordingMimeType, supportsAudioRecording } from "./lib/recording";
 import {
     DEFAULT_VOICE_LANGUAGE,
     getVoiceLanguageOption,
     VOICE_LANGUAGE_OPTIONS,
 } from "./lib/languages";
 import { formatVoiceShareReport } from "./lib/report";
+import { shouldReviewTranscription, transcribeRecordedAudio } from "./lib/transcription";
 import {
     VoiceErrorPanel,
     VoiceIntroPanel,
@@ -109,9 +111,12 @@ export default function VoiceTriagePage() {
     const [audioStream, setAudioStream] = useState<MediaStream | null>(null);
     const [animationsEnabled, setAnimationsEnabled] = useState(true);
     const [isVisualizerFading, setIsVisualizerFading] = useState(false);
+    const [srAnnouncement, setSrAnnouncement] = useState("");
 
     const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+    const mediaRecorderRef = useRef<MediaRecorder | null>(null);
     const audioStreamRef = useRef<MediaStream | null>(null);
+    const recordingChunksRef = useRef<Blob[]>([]);
     const latestTranscriptRef = useRef("");
     const latestDisplayedTranscriptRef = useRef("");
     const latestConfidenceRef = useRef<number | undefined>(undefined);
@@ -119,6 +124,7 @@ export default function VoiceTriagePage() {
     const manualStopRef = useRef(false);
     const startSessionIdRef = useRef(0);
     const autoSpokenKeyRef = useRef("");
+    const panelRef = useRef<HTMLDivElement | null>(null);
 
     const selectedLanguageOption = getVoiceLanguageOption(selectedLanguage);
     const resultLanguageOption = getVoiceLanguageOption(resultLanguageCode ?? selectedLanguage);
@@ -132,6 +138,17 @@ export default function VoiceTriagePage() {
         recognition.onresult = null;
         recognition.onerror = null;
         recognition.onend = null;
+    }
+
+    function detachMediaRecorderHandlers(mediaRecorder: MediaRecorder | null) {
+        if (!mediaRecorder) {
+            return;
+        }
+
+        mediaRecorder.onstart = null;
+        mediaRecorder.ondataavailable = null;
+        mediaRecorder.onerror = null;
+        mediaRecorder.onstop = null;
     }
 
     function setActiveAudioStream(stream: MediaStream | null) {
@@ -166,6 +183,12 @@ export default function VoiceTriagePage() {
             recognitionRef.current = null;
             detachRecognitionHandlers(recognition);
             recognition?.stop();
+            const mediaRecorder = mediaRecorderRef.current;
+            mediaRecorderRef.current = null;
+            detachMediaRecorderHandlers(mediaRecorder);
+            if (mediaRecorder && mediaRecorder.state !== "inactive") {
+                mediaRecorder.stop();
+            }
             clearAudioStream();
             if (typeof window !== "undefined") {
                 stopSpeaking(window);
@@ -211,17 +234,70 @@ export default function VoiceTriagePage() {
         handleReplaySummary();
     }, [result, resultLanguageOption.speechSynthesisLang, step]);
 
+    useEffect(() => {
+        if (step === "initial") {
+            setSrAnnouncement("");
+            return;
+        }
+
+        let announcement = "";
+        switch (step) {
+            case "listening":
+                announcement = t("listening_status");
+                break;
+            case "processing":
+                announcement = t("processing_subtitle");
+                break;
+            case "review":
+                announcement = `${t("review_title")}. ${t("review_message")}`;
+                break;
+            case "result":
+                if (result) {
+                    announcement = result.emergency
+                        ? `${t("result_heading")} - ${t("emergency_title")}. ${t("result_subheading")}`
+                        : `${t("result_heading")}. ${t("result_subheading")}`;
+                }
+                break;
+            case "error":
+                if (error) {
+                    announcement = `${t("errors.generic_title")} - ${error.title}. ${error.message}`;
+                } else {
+                    announcement = t("errors.generic_title");
+                }
+                break;
+        }
+
+        if (announcement) {
+            setSrAnnouncement(announcement);
+        }
+
+        const timer = setTimeout(() => {
+            if (panelRef.current) {
+                panelRef.current.focus();
+            }
+        }, 100);
+
+        return () => clearTimeout(timer);
+    }, [step, error, result, t]);
+
     function resetFlow(nextStep: VoiceStep = "initial") {
         startSessionIdRef.current += 1;
         const recognition = recognitionRef.current;
         recognitionRef.current = null;
         detachRecognitionHandlers(recognition);
         recognition?.stop();
+        const mediaRecorder = mediaRecorderRef.current;
+        mediaRecorderRef.current = null;
+        detachMediaRecorderHandlers(mediaRecorder);
+        if (mediaRecorder && mediaRecorder.state !== "inactive") {
+            mediaRecorder.stop();
+        }
         clearAudioStream();
         if (typeof window !== "undefined") {
             stopSpeaking(window);
         }
 
+        recordingChunksRef.current = [];
         latestTranscriptRef.current = "";
         latestDisplayedTranscriptRef.current = "";
         latestConfidenceRef.current = undefined;
@@ -272,6 +348,60 @@ export default function VoiceTriagePage() {
         }
 
         void analyseTranscript(normalizedTranscript, confidenceMeta, emergencyResult.matches);
+    }
+
+    async function handleRecordedAudioStop(mediaBlob: Blob) {
+        if (!mediaBlob.size) {
+            setError(getRecognitionErrorState("no-speech", t));
+            setStep("error");
+            return;
+        }
+
+        setStep("processing");
+        setError(null);
+
+        try {
+            const file = new File([mediaBlob], "voice-triage.webm", {
+                type: mediaBlob.type || "audio/webm",
+            });
+            const transcription = await transcribeRecordedAudio(file, selectedLanguage);
+            const normalizedTranscript = transcription.transcript.trim();
+
+            if (!normalizedTranscript) {
+                setError(getRecognitionErrorState("no-speech", t));
+                setStep("error");
+                return;
+            }
+
+            const confidenceMeta = getConfidenceMeta(undefined);
+            const emergencyResult = detectEmergencyKeywords(normalizedTranscript);
+
+            setTranscript(normalizedTranscript);
+            setConfidence(confidenceMeta);
+            setEmergencyMatches(emergencyResult.matches);
+            setError(null);
+
+            if (
+                shouldReviewTranscription(normalizedTranscript, {
+                    selectedLanguage,
+                    detectedLanguage: transcription.language,
+                })
+            ) {
+                setStep("review");
+                return;
+            }
+
+            await analyseTranscript(normalizedTranscript, confidenceMeta, emergencyResult.matches);
+        } catch (transcriptionError) {
+            setError({
+                title: t("errors.generic_title"),
+                message:
+                    transcriptionError instanceof Error && transcriptionError.message
+                        ? transcriptionError.message
+                        : t("errors.generic_message"),
+            });
+            setStep("error");
+        }
     }
 
     async function analyseTranscript(
@@ -360,7 +490,10 @@ export default function VoiceTriagePage() {
             utterance.voice = bestVoice;
         }
 
-        utterance.onstart = () => setIsSpeaking(true);
+        utterance.onstart = () => {
+            setIsSpeaking(true);
+            setSrAnnouncement("Reading AI Analysis summary aloud.");
+        };
         utterance.onend = () => setIsSpeaking(false);
         utterance.onerror = () => setIsSpeaking(false);
 
@@ -372,6 +505,7 @@ export default function VoiceTriagePage() {
             stopSpeaking(window);
         }
         setIsSpeaking(false);
+        setSrAnnouncement("Stopped reading summary.");
     }
 
     async function handleShare() {
@@ -442,6 +576,15 @@ export default function VoiceTriagePage() {
         setIsListening(false);
         setIsVisualizerFading(true);
 
+        if (mediaRecorderRef.current) {
+            if (mediaRecorderRef.current.state !== "inactive") {
+                mediaRecorderRef.current.stop();
+                return;
+            }
+
+            mediaRecorderRef.current = null;
+        }
+
         if (!recognitionRef.current) {
             startSessionIdRef.current += 1;
             clearAudioStream();
@@ -453,54 +596,11 @@ export default function VoiceTriagePage() {
         recognitionRef.current?.stop();
     }
 
-    async function startListening() {
-        if (typeof window === "undefined") {
-            return;
-        }
-
+    function startSpeechRecognitionFallback(sessionId: number) {
         const SpeechRecognition = getSpeechRecognitionConstructor(window);
         if (!SpeechRecognition) {
             setError(getRecognitionErrorState("unsupported", t));
             setStep("error");
-            return;
-        }
-
-        handleStopSpeaking();
-
-        const sessionId = startSessionIdRef.current + 1;
-        startSessionIdRef.current = sessionId;
-        clearAudioStream();
-
-        latestTranscriptRef.current = "";
-        latestDisplayedTranscriptRef.current = "";
-        latestConfidenceRef.current = undefined;
-        didHandleRecognitionEndRef.current = false;
-        manualStopRef.current = false;
-
-        setTranscript("");
-        setConfidence(DEFAULT_FLOW_CONFIDENCE);
-        setResult(null);
-        setError(null);
-        setEmergencyMatches([]);
-        setIsVisualizerFading(false);
-        setStep("listening");
-
-        if (navigator.mediaDevices?.getUserMedia) {
-            try {
-                const nextAudioStream = await navigator.mediaDevices.getUserMedia({ audio: true });
-
-                if (startSessionIdRef.current !== sessionId) {
-                    stopMediaStream(nextAudioStream);
-                    return;
-                }
-
-                setActiveAudioStream(nextAudioStream);
-            } catch {
-                setActiveAudioStream(null);
-            }
-        }
-
-        if (startSessionIdRef.current !== sessionId) {
             return;
         }
 
@@ -597,6 +697,149 @@ export default function VoiceTriagePage() {
         }
     }
 
+    async function startListening() {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        handleStopSpeaking();
+
+        const sessionId = startSessionIdRef.current + 1;
+        startSessionIdRef.current = sessionId;
+        clearAudioStream();
+
+        const recognition = recognitionRef.current;
+        recognitionRef.current = null;
+        detachRecognitionHandlers(recognition);
+        recognition?.stop();
+
+        const mediaRecorder = mediaRecorderRef.current;
+        mediaRecorderRef.current = null;
+        detachMediaRecorderHandlers(mediaRecorder);
+        if (mediaRecorder && mediaRecorder.state !== "inactive") {
+            mediaRecorder.stop();
+        }
+
+        recordingChunksRef.current = [];
+        latestTranscriptRef.current = "";
+        latestDisplayedTranscriptRef.current = "";
+        latestConfidenceRef.current = undefined;
+        didHandleRecognitionEndRef.current = false;
+        manualStopRef.current = false;
+
+        setTranscript("");
+        setConfidence(DEFAULT_FLOW_CONFIDENCE);
+        setResult(null);
+        setError(null);
+        setEmergencyMatches([]);
+        setIsVisualizerFading(false);
+
+        const canRecordAudio =
+            typeof navigator !== "undefined" &&
+            Boolean(navigator.mediaDevices?.getUserMedia) &&
+            supportsAudioRecording(window);
+
+        if (!canRecordAudio) {
+            startSpeechRecognitionFallback(sessionId);
+            return;
+        }
+
+        let nextAudioStream: MediaStream;
+        try {
+            nextAudioStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        } catch (captureError) {
+            const errorName =
+                captureError instanceof DOMException ? captureError.name : "audio-capture";
+
+            if (errorName === "NotAllowedError" || errorName === "PermissionDeniedError") {
+                setError(getRecognitionErrorState("not-allowed", t));
+            } else if (errorName === "NotFoundError" || errorName === "DevicesNotFoundError") {
+                setError(getRecognitionErrorState("audio-capture", t));
+            } else {
+                setError(getRecognitionErrorState("generic", t));
+            }
+            setStep("error");
+            return;
+        }
+
+        if (startSessionIdRef.current !== sessionId) {
+            stopMediaStream(nextAudioStream);
+            return;
+        }
+
+        let mediaRecorderInstance: MediaRecorder;
+
+        try {
+            const mimeType = getPreferredRecordingMimeType(window.MediaRecorder);
+            mediaRecorderInstance = new MediaRecorder(
+                nextAudioStream,
+                mimeType ? { mimeType } : undefined
+            );
+        } catch {
+            stopMediaStream(nextAudioStream);
+            startSpeechRecognitionFallback(sessionId);
+            return;
+        }
+
+        mediaRecorderRef.current = mediaRecorderInstance;
+        setActiveAudioStream(nextAudioStream);
+        setStep("listening");
+
+        mediaRecorderInstance.onstart = () => {
+            setIsListening(true);
+            setIsVisualizerFading(false);
+            setStep("listening");
+        };
+
+        mediaRecorderInstance.ondataavailable = (event) => {
+            if (event.data.size > 0) {
+                recordingChunksRef.current.push(event.data);
+            }
+        };
+
+        mediaRecorderInstance.onerror = () => {
+            if (mediaRecorderRef.current === mediaRecorderInstance) {
+                mediaRecorderRef.current = null;
+            }
+            detachMediaRecorderHandlers(mediaRecorderInstance);
+            clearAudioStream();
+            setIsListening(false);
+            setIsVisualizerFading(false);
+            setError(getRecognitionErrorState("generic", t));
+            setStep("error");
+        };
+
+        mediaRecorderInstance.onstop = async () => {
+            if (mediaRecorderRef.current === mediaRecorderInstance) {
+                mediaRecorderRef.current = null;
+            }
+
+            const mediaBlob = new Blob(recordingChunksRef.current, {
+                type: mediaRecorderInstance.mimeType || "audio/webm",
+            });
+
+            recordingChunksRef.current = [];
+            detachMediaRecorderHandlers(mediaRecorderInstance);
+            clearAudioStream();
+            setIsListening(false);
+            setIsVisualizerFading(false);
+
+            await handleRecordedAudioStop(mediaBlob);
+        };
+
+        try {
+            mediaRecorderInstance.start();
+        } catch {
+            if (mediaRecorderRef.current === mediaRecorderInstance) {
+                mediaRecorderRef.current = null;
+            }
+            detachMediaRecorderHandlers(mediaRecorderInstance);
+            stopMediaStream(nextAudioStream);
+            setActiveAudioStream(null);
+            startSpeechRecognitionFallback(sessionId);
+        }
+    }
+
     function handleMicAction() {
         if (step === "listening") {
             stopListening();
@@ -610,6 +853,11 @@ export default function VoiceTriagePage() {
 
     return (
         <div className="relative flex min-h-screen flex-col overflow-hidden bg-slate-50 font-sans">
+            {/* Dynamic Screen Reader Announcement Live Region */}
+            <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+                {srAnnouncement}
+            </div>
+
             <div
                 className="absolute top-0 right-0 -mt-20 -mr-20 h-96 w-96 rounded-full bg-emerald-100/40 blur-3xl"
                 aria-hidden="true"
@@ -674,92 +922,98 @@ export default function VoiceTriagePage() {
                     />
                 </div>
 
-                {step === "initial" && (
-                    <VoiceIntroPanel
-                        title={t("title")}
-                        subtitle={t("subtitle")}
-                        exampleLabel={t("example_label")}
-                        exampleText={t("example_text")}
-                        assistantLabel={t("assistant_label")}
-                        assistantValue={t("assistant_value")}
-                    />
-                )}
+                <div
+                    ref={panelRef}
+                    tabIndex={-1}
+                    className="w-full max-w-md rounded-[2.5rem] focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/20 focus-visible:ring-offset-2"
+                >
+                    {step === "initial" && (
+                        <VoiceIntroPanel
+                            title={t("title")}
+                            subtitle={t("subtitle")}
+                            exampleLabel={t("example_label")}
+                            exampleText={t("example_text")}
+                            assistantLabel={t("assistant_label")}
+                            assistantValue={t("assistant_value")}
+                        />
+                    )}
 
-                {step === "listening" && (
-                    <VoiceListeningPanel
-                        transcript={transcript || t("listening_placeholder")}
-                        statusLabel={t("listening_status")}
-                        stream={audioStream}
-                        isListening={isListening}
-                        isFading={isVisualizerFading}
-                        animationsEnabled={animationsEnabled}
-                        visualizerLabel={t("visualizer_label")}
-                        volumeLabel={t("volume_label")}
-                        liveVolumeLabel={t("volume_live_label")}
-                        stillVolumeLabel={t("volume_still_label")}
-                        visualizerUnavailableLabel={t("visualizer_unavailable")}
-                    />
-                )}
+                    {step === "listening" && (
+                        <VoiceListeningPanel
+                            transcript={transcript || t("listening_placeholder")}
+                            statusLabel={t("listening_status")}
+                            stream={audioStream}
+                            isListening={isListening}
+                            isFading={isVisualizerFading}
+                            animationsEnabled={animationsEnabled}
+                            visualizerLabel={t("visualizer_label")}
+                            volumeLabel={t("volume_label")}
+                            liveVolumeLabel={t("volume_live_label")}
+                            stillVolumeLabel={t("volume_still_label")}
+                            visualizerUnavailableLabel={t("visualizer_unavailable")}
+                        />
+                    )}
 
-                {step === "processing" && (
-                    <VoiceProcessingPanel
-                        title={t("processing_title")}
-                        subtitle={t("processing_subtitle")}
-                    />
-                )}
+                    {step === "processing" && (
+                        <VoiceProcessingPanel
+                            title={t("processing_title")}
+                            subtitle={t("processing_subtitle")}
+                        />
+                    )}
 
-                {step === "review" && (
-                    <VoiceReviewPanel
-                        title={t("review_title")}
-                        message={t("review_message")}
-                        transcript={transcript}
-                        confidence={confidence}
-                        confidenceLabelPrefix={t("confidence_label")}
-                        confidenceValueLabel={getConfidenceValueLabel(confidence, t)}
-                        retryLabel={t("retry_button")}
-                        analyseLabel={t("analyse_anyway_button")}
-                        onRetry={() => resetFlow()}
-                        onAnalyse={() =>
-                            void analyseTranscript(transcript, confidence, emergencyMatches)
-                        }
-                        emergencyTitle={t("emergency_title")}
-                        emergencyBody={t("emergency_body")}
-                        showEmergency={emergencyMatches.length > 0}
-                    />
-                )}
+                    {step === "review" && (
+                        <VoiceReviewPanel
+                            title={t("review_title")}
+                            message={t("review_message")}
+                            transcript={transcript}
+                            confidence={confidence}
+                            confidenceLabelPrefix={t("confidence_label")}
+                            confidenceValueLabel={getConfidenceValueLabel(confidence, t)}
+                            retryLabel={t("retry_button")}
+                            analyseLabel={t("analyse_anyway_button")}
+                            onRetry={() => resetFlow()}
+                            onAnalyse={() =>
+                                void analyseTranscript(transcript, confidence, emergencyMatches)
+                            }
+                            emergencyTitle={t("emergency_title")}
+                            emergencyBody={t("emergency_body")}
+                            showEmergency={emergencyMatches.length > 0}
+                        />
+                    )}
 
-                {step === "error" && error && (
-                    <VoiceErrorPanel
-                        error={error}
-                        retryLabel={t("retry_button")}
-                        onRetry={() => resetFlow()}
-                    />
-                )}
+                    {step === "error" && error && (
+                        <VoiceErrorPanel
+                            error={error}
+                            retryLabel={t("retry_button")}
+                            onRetry={() => resetFlow()}
+                        />
+                    )}
 
-                {step === "result" && result && (
-                    <VoiceResultPanel
-                        heading={t("result_heading")}
-                        subheading={t("result_subheading")}
-                        transcriptLabel={t("transcript_label")}
-                        transcript={transcript}
-                        confidence={confidence}
-                        confidenceLabelPrefix={t("confidence_label")}
-                        confidenceValueLabel={getConfidenceValueLabel(confidence, t)}
-                        result={result}
-                        emergencyTitle={t("emergency_title")}
-                        emergencyBody={t("emergency_body")}
-                        recommendationsLabel={t("recommendations_label")}
-                        shareLabel={t("share_button")}
-                        speakLabel={t("speak_button")}
-                        stopSpeakingLabel={t("stop_speaking_button")}
-                        tryAgainLabel={t("try_again_button")}
-                        isSpeaking={isSpeaking}
-                        onReplay={handleReplaySummary}
-                        onStopSpeaking={handleStopSpeaking}
-                        onShare={handleShare}
-                        onTryAgain={() => resetFlow()}
-                    />
-                )}
+                    {step === "result" && result && (
+                        <VoiceResultPanel
+                            heading={t("result_heading")}
+                            subheading={t("result_subheading")}
+                            transcriptLabel={t("transcript_label")}
+                            transcript={transcript}
+                            confidence={confidence}
+                            confidenceLabelPrefix={t("confidence_label")}
+                            confidenceValueLabel={getConfidenceValueLabel(confidence, t)}
+                            result={result}
+                            emergencyTitle={t("emergency_title")}
+                            emergencyBody={t("emergency_body")}
+                            recommendationsLabel={t("recommendations_label")}
+                            shareLabel={t("share_button")}
+                            speakLabel={t("speak_button")}
+                            stopSpeakingLabel={t("stop_speaking_button")}
+                            tryAgainLabel={t("try_again_button")}
+                            isSpeaking={isSpeaking}
+                            onReplay={handleReplaySummary}
+                            onStopSpeaking={handleStopSpeaking}
+                            onShare={handleShare}
+                            onTryAgain={() => resetFlow()}
+                        />
+                    )}
+                </div>
             </main>
 
             {showMicFooter && (
@@ -771,7 +1025,11 @@ export default function VoiceTriagePage() {
                                 ? t("stop_listening_aria")
                                 : t("start_listening_aria")
                         }
-                        className={`relative flex h-24 w-24 items-center justify-center rounded-full transition-all duration-500 ${step === "listening" ? "scale-125 bg-red-500" : "bg-emerald-500 shadow-xl shadow-emerald-500/30 hover:scale-110"} `}
+                        className={`relative flex h-24 w-24 items-center justify-center rounded-full transition-all duration-500 focus-visible:ring-4 focus-visible:ring-offset-4 focus-visible:outline-none ${
+                            step === "listening"
+                                ? "scale-125 bg-red-500 focus-visible:ring-red-500/50"
+                                : "bg-emerald-500 shadow-xl shadow-emerald-500/30 hover:scale-110 focus-visible:ring-emerald-500/50"
+                        } `}
                     >
                         {step === "listening" ? (
                             <div

--- a/apps/web/tests/voice-accessibility.test.tsx
+++ b/apps/web/tests/voice-accessibility.test.tsx
@@ -1,0 +1,141 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+    VoiceProcessingPanel,
+    VoiceReviewPanel,
+    VoiceErrorPanel,
+    VoiceResultPanel,
+} from "../app/[locale]/voice/VoicePanels";
+import { VoiceAudioVisualizer } from "../app/[locale]/voice/VoiceAudioVisualizer";
+
+describe("Voice Triage Accessibility Semantics", () => {
+    it("renders VoiceProcessingPanel with correct role, live properties, and motion-reduction features", () => {
+        const markup = renderToStaticMarkup(
+            <VoiceProcessingPanel
+                title="Checking symptoms"
+                subtitle="Analyzing with SahiDawa AI..."
+            />
+        );
+
+        // Semantics
+        expect(markup).toContain('role="status"');
+        expect(markup).toContain('aria-live="polite"');
+        expect(markup).toContain('aria-label="Checking symptoms"');
+
+        // Motion reduction utilities
+        expect(markup).toContain("motion-reduce:animate-none");
+    });
+
+    it("renders VoiceReviewPanel with focus rings, motion reduction, and correct ARIA structures", () => {
+        const markup = renderToStaticMarkup(
+            <VoiceReviewPanel
+                title="Please review your transcript"
+                message="The microphone picked up low confidence audio."
+                transcript="I have cold and headache"
+                confidence={{ id: "low", score: 0.2, tone: "critical" }}
+                confidenceLabelPrefix="Confidence"
+                confidenceValueLabel="Low"
+                retryLabel="Try Again"
+                analyseLabel="Analyse Anyway"
+                onRetry={() => undefined}
+                onAnalyse={() => undefined}
+                emergencyTitle="Urgent Care Needed"
+                emergencyBody="Please seek clinical attention"
+                showEmergency={true}
+            />
+        );
+
+        expect(markup).toContain("motion-reduce:animate-none");
+        expect(markup).toContain("Urgent Care Needed");
+
+        // Focus state indicators
+        expect(markup).toContain("focus-visible:ring-2");
+        expect(markup).toContain("focus-visible:ring-slate-500");
+        expect(markup).toContain("focus-visible:ring-emerald-500");
+    });
+
+    it("renders VoiceErrorPanel with retry focus styles and motion-reduction", () => {
+        const markup = renderToStaticMarkup(
+            <VoiceErrorPanel
+                error={{
+                    title: "Access Denied",
+                    message: "Microphone blocked",
+                    isRecoverable: true,
+                }}
+                retryLabel="Try Again"
+                onRetry={() => undefined}
+            />
+        );
+
+        expect(markup).toContain("motion-reduce:animate-none");
+        expect(markup).toContain("Access Denied");
+        expect(markup).toContain("focus-visible:ring-2");
+        expect(markup).toContain("focus-visible:ring-slate-950");
+    });
+
+    it("renders VoiceResultPanel with robust focus states, region role, and labels", () => {
+        const markup = renderToStaticMarkup(
+            <VoiceResultPanel
+                heading="AI Triage Result"
+                subheading="Clinical Assessment"
+                transcriptLabel="Transcript"
+                transcript="I have high fever"
+                confidence={{ id: "high", score: 0.95, tone: "positive" }}
+                confidenceLabelPrefix="Confidence"
+                confidenceValueLabel="High"
+                result={{
+                    summary: "Fever needs monitoring.",
+                    recommendations: ["Rest well", "Drink water"],
+                    emergency: false,
+                    disclaimer: "Informational use only.",
+                }}
+                emergencyTitle="Urgent Care"
+                emergencyBody="Seek help"
+                recommendationsLabel="Recommended Actions"
+                shareLabel="Share"
+                speakLabel="Read Aloud"
+                stopSpeakingLabel="Stop"
+                tryAgainLabel="New Check"
+                isSpeaking={false}
+                onReplay={() => undefined}
+                onStopSpeaking={() => undefined}
+                onShare={() => undefined}
+                onTryAgain={() => undefined}
+            />
+        );
+
+        // Regional landmark
+        expect(markup).toContain('role="region"');
+        expect(markup).toContain('aria-labelledby="voice-ai-analysis-heading"');
+
+        // Button focus indicators
+        expect(markup).toContain("focus-visible:ring-2");
+        expect(markup).toContain("focus-visible:ring-slate-500");
+        expect(markup).toContain("focus-visible:ring-blue-500");
+        expect(markup).toContain("focus-visible:ring-slate-950");
+    });
+
+    it("renders VoiceAudioVisualizer volume progressbar with correct roles and attributes", () => {
+        const markup = renderToStaticMarkup(
+            <VoiceAudioVisualizer
+                stream={null}
+                isActive={true}
+                isFading={false}
+                animationsEnabled={false}
+                visualizerLabel="Audio Wave"
+                volumeLabel="Volume"
+                liveVolumeLabel="Live"
+                stillVolumeLabel="Still"
+                visualizerUnavailableLabel="Wave unavailable"
+            />
+        );
+
+        // Progress bar semantics
+        expect(markup).toContain('role="progressbar"');
+        expect(markup).toContain('aria-label="Volume"');
+        expect(markup).toContain('aria-valuemin="0"');
+        expect(markup).toContain('aria-valuemax="100"');
+
+        // Default valuenow for showCanvas=false
+        expect(markup).toContain('aria-valuenow="18"');
+    });
+});


### PR DESCRIPTION
## 📋 PR Summary

Improves Voice Triage accessibility and assistive feedback to meet WCAG 2.1 AA standards. Adds dynamic screen reader announcements for all voice flow states, keyboard focus management across step transitions, visible `focus-visible` rings on all interactive buttons, `motion-reduce` support for all animations, and accessible progressbar semantics on the audio visualizer.

---

## 🔗 Related Issue

Closes #442

---

## 🏷️ PR Type

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [x] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Added a hidden `role="status" aria-live="polite"` region in `page.tsx` that announces every step transition: listening → processing → review → result → error, and TTS play/stop actions
- Wrapped all voice panels in a focusable `div` (`tabIndex={-1}`, `panelRef`) with programmatic focus redirect on each step change
- Added `focus-visible:ring-4 focus-visible:ring-offset-4` to the floating microphone button (emerald idle / red listening)
- Added `focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none` to all buttons in `VoicePanels` (retry, analyse, share, read aloud, stop, new check)
- Added `motion-reduce:animate-none` to the processing spinner, sparkle pulse, and all panel slide-in animations
- Upgraded `VoiceAudioVisualizer` volume bar to `role="progressbar"` with `aria-label`, `aria-valuemin={0}`, `aria-valuemax={100}`, and live `aria-valuenow` updated from the canvas animation loop
- Added `apps/web/tests/voice-accessibility.test.tsx` — 5 new tests covering ARIA roles, focus rings, motion-reduce classes, and progressbar semantics

---

## 📸 Screenshots / Proof of Work (REQUIRED)



<img width="744" height="397" alt="image" src="https://github.com/user-attachments/assets/e9693dc6-2386-43b9-804a-75914e30b227" />

Jest test run — 10 suites, 59 tests, all passing:

    PASS tests/voice-accessibility.test.tsx
    PASS tests/voice-audio-visualizer.test.tsx
    PASS tests/voice-helpers.test.ts
    PASS tests/chat-route.test.ts
    PASS tests/voice-transcribe-route.test.ts
    PASS tests/compare-pricing.test.tsx
    PASS tests/chatbot-position.test.ts
    PASS tests/voice-emergency.test.ts
    PASS tests/pharmacy-panels.test.tsx
    PASS tests/pharmacy-map-layout.test.tsx

    Test Suites: 10 passed, 10 total
    Tests:       59 passed, 59 total
    Time:        4.015 s

---

## ✅ Contributor Checklist

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [x] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant
