### PR TITLE
Potential fix for code scanning alert no. 7: Clear text storage of sensitive information

### DIFF
--- a/apps/web/app/[locale]/login/page.tsx
+++ b/apps/web/app/[locale]/login/page.tsx
@@ -35,8 +35,6 @@ export default function LoginPage() {
             }
 
             if (data?.session?.access_token) {
-                localStorage.setItem("sb-access-token", data.session.access_token);
-
                 router.push("/reports/me");
             }
         } catch (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/RatLoopz/sahidawa-india/security/code-scanning/7](https://github.com/RatLoopz/sahidawa-india/security/code-scanning/7)

Best fix: **remove explicit token storage in `localStorage`** and rely on Supabase’s built-in session handling (or server-side/session-cookie handling elsewhere). This preserves login behavior (successful auth + redirect) while eliminating the direct clear-text persistence call flagged by CodeQL.

In `apps/web/app/[locale]/login/page.tsx`, update the `if (data?.session?.access_token)` block so it no longer calls:
- `localStorage.setItem("sb-access-token", data.session.access_token);`

Keep the redirect logic intact. No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
