### PR TITLE
feat(voice): improve accessibility and assistive feedback

### DIFF
--- a/apps/web/app/[locale]/voice/VoiceAudioVisualizer.tsx
+++ b/apps/web/app/[locale]/voice/VoiceAudioVisualizer.tsx
@@ -170,6 +170,10 @@ export function VoiceAudioVisualizer({
 
             if (volumeFillRef.current) {
                 volumeFillRef.current.style.transform = `scaleX(${Math.max(0.08, volume)})`;
+                const progressbar = volumeFillRef.current.closest('[role="progressbar"]');
+                if (progressbar) {
+                    progressbar.setAttribute("aria-valuenow", String(Math.round(volume * 100)));
+                }
             }
 
             animationFrame = window.requestAnimationFrame(draw);
@@ -220,7 +224,14 @@ export function VoiceAudioVisualizer({
                 </div>
             )}
 
-            <div className="mt-3 w-full max-w-[13rem]">
+            <div
+                className="mt-3 w-full max-w-[13rem]"
+                role="progressbar"
+                aria-label={volumeLabel}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-valuenow={showCanvas ? 8 : 18}
+            >
                 <div className="flex items-center justify-between text-[10px] font-bold tracking-widest text-emerald-700 uppercase">
                     <span>{volumeLabel}</span>
                     <span aria-hidden="true">

--- a/apps/web/app/[locale]/voice/VoicePanels.tsx
+++ b/apps/web/app/[locale]/voice/VoicePanels.tsx
@@ -130,15 +130,15 @@ export function VoiceListeningPanel({
 export function VoiceProcessingPanel({ title, subtitle }: { title: string; subtitle: string }) {
     return (
         <div
-            className="animate-in fade-in flex flex-col items-center space-y-6 duration-300"
+            className="animate-in fade-in flex flex-col items-center space-y-6 duration-300 motion-reduce:animate-none"
             role="status"
             aria-live="polite"
             aria-label={title}
         >
             <div className="relative" aria-hidden="true">
-                <div className="h-24 w-24 animate-spin rounded-full border-4 border-slate-200 border-t-emerald-500"></div>
+                <div className="h-24 w-24 animate-spin rounded-full border-4 border-slate-200 border-t-emerald-500 motion-reduce:animate-none"></div>
                 <Sparkles
-                    className="absolute inset-0 m-auto animate-pulse text-emerald-500"
+                    className="absolute inset-0 m-auto animate-pulse text-emerald-500 motion-reduce:animate-none"
                     size={32}
                     aria-hidden="true"
                 />
@@ -201,7 +201,7 @@ export function VoiceReviewPanel({
     showEmergency: boolean;
 }) {
     return (
-        <div className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-slate-100 bg-white p-8 shadow-xl duration-500">
+        <div className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-slate-100 bg-white p-8 shadow-xl duration-500 motion-reduce:animate-none">
             {showEmergency && (
                 <div className="mb-6 rounded-2xl border border-red-200 bg-red-50 p-4 text-left">
                     <div className="flex items-start gap-3">
@@ -241,13 +241,13 @@ export function VoiceReviewPanel({
             <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <button
                     onClick={onRetry}
-                    className="w-full rounded-2xl bg-slate-100 py-3 font-bold text-slate-800 transition-colors hover:bg-slate-200"
+                    className="w-full rounded-2xl bg-slate-100 py-3 font-bold text-slate-800 transition-colors hover:bg-slate-200 focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                 >
                     {retryLabel}
                 </button>
                 <button
                     onClick={onAnalyse}
-                    className="w-full rounded-2xl bg-emerald-600 py-3 font-bold text-white transition-colors hover:bg-emerald-700"
+                    className="w-full rounded-2xl bg-emerald-600 py-3 font-bold text-white transition-colors hover:bg-emerald-700 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                 >
                     {analyseLabel}
                 </button>
@@ -266,7 +266,7 @@ export function VoiceErrorPanel({
     onRetry: () => void;
 }) {
     return (
-        <div className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-red-100 bg-white p-8 shadow-xl duration-500">
+        <div className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-red-100 bg-white p-8 shadow-xl duration-500 motion-reduce:animate-none">
             <div className="mb-6 flex items-start gap-3">
                 <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-red-50 text-red-600">
                     <AlertTriangle size={24} aria-hidden="true" />
@@ -279,7 +279,7 @@ export function VoiceErrorPanel({
 
             <button
                 onClick={onRetry}
-                className="w-full rounded-2xl bg-slate-900 py-4 font-bold text-white transition-all hover:bg-slate-800"
+                className="w-full rounded-2xl bg-slate-900 py-4 font-bold text-white transition-all hover:bg-slate-800 focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 focus-visible:outline-none"
             >
                 {retryLabel}
             </button>
@@ -332,7 +332,7 @@ export function VoiceResultPanel({
 }) {
     return (
         <div
-            className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-slate-100 bg-white p-8 shadow-xl duration-500"
+            className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-slate-100 bg-white p-8 shadow-xl duration-500 motion-reduce:animate-none"
             role="region"
             aria-labelledby="voice-ai-analysis-heading"
         >
@@ -417,7 +417,7 @@ export function VoiceResultPanel({
                 <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                     <button
                         onClick={onShare}
-                        className="flex w-full items-center justify-center gap-2 rounded-2xl bg-slate-100 py-3 font-bold text-slate-800 transition-colors hover:bg-slate-200"
+                        className="flex w-full items-center justify-center gap-2 rounded-2xl bg-slate-100 py-3 font-bold text-slate-800 transition-colors hover:bg-slate-200 focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                     >
                         <Share2 size={18} aria-hidden="true" />
                         {shareLabel}
@@ -425,7 +425,7 @@ export function VoiceResultPanel({
                     {isSpeaking ? (
                         <button
                             onClick={onStopSpeaking}
-                            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-red-50 py-3 font-bold text-red-700 transition-colors hover:bg-red-100"
+                            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-red-50 py-3 font-bold text-red-700 transition-colors hover:bg-red-100 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                         >
                             <Square size={18} aria-hidden="true" />
                             {stopSpeakingLabel}
@@ -433,7 +433,7 @@ export function VoiceResultPanel({
                     ) : (
                         <button
                             onClick={onReplay}
-                            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-blue-50 py-3 font-bold text-blue-700 transition-colors hover:bg-blue-100"
+                            className="flex w-full items-center justify-center gap-2 rounded-2xl bg-blue-50 py-3 font-bold text-blue-700 transition-colors hover:bg-blue-100 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:outline-none"
                         >
                             <Play size={18} aria-hidden="true" />
                             {speakLabel}
@@ -443,7 +443,7 @@ export function VoiceResultPanel({
 
                 <button
                     onClick={onTryAgain}
-                    className="flex w-full items-center justify-center gap-2 rounded-2xl bg-slate-900 py-4 font-bold text-white transition-all hover:bg-slate-800"
+                    className="flex w-full items-center justify-center gap-2 rounded-2xl bg-slate-900 py-4 font-bold text-white transition-all hover:bg-slate-800 focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 focus-visible:outline-none"
                 >
                     <RotateCcw size={20} aria-hidden="true" />
                     {tryAgainLabel}

--- a/apps/web/app/[locale]/voice/lib/accessibility.ts
+++ b/apps/web/app/[locale]/voice/lib/accessibility.ts
@@ -1,0 +1,5 @@
+import type { VoiceStep } from "../types";
+
+export function shouldAutoFocusVoicePanel(step: VoiceStep) {
+    return step !== "initial" && step !== "listening";
+}

--- a/apps/web/app/[locale]/voice/page.tsx
+++ b/apps/web/app/[locale]/voice/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "./lib/browser";
 import { getConfidenceMeta, type ConfidenceMeta } from "./lib/confidence";
 import { detectEmergencyKeywords } from "./lib/emergency";
+import { shouldAutoFocusVoicePanel } from "./lib/accessibility";
 import {
     DEFAULT_VOICE_LANGUAGE,
     getVoiceLanguageOption,
@@ -247,6 +248,10 @@ export default function VoiceTriagePage() {
 
         if (announcement) {
             setSrAnnouncement(announcement);
+        }
+
+        if (!shouldAutoFocusVoicePanel(step)) {
+            return;
         }
 
         const focusTimer = window.setTimeout(() => {

--- a/apps/web/app/[locale]/voice/page.tsx
+++ b/apps/web/app/[locale]/voice/page.tsx
@@ -109,6 +109,7 @@ export default function VoiceTriagePage() {
     const [audioStream, setAudioStream] = useState<MediaStream | null>(null);
     const [animationsEnabled, setAnimationsEnabled] = useState(true);
     const [isVisualizerFading, setIsVisualizerFading] = useState(false);
+    const [srAnnouncement, setSrAnnouncement] = useState("");
 
     const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
     const audioStreamRef = useRef<MediaStream | null>(null);
@@ -119,6 +120,7 @@ export default function VoiceTriagePage() {
     const manualStopRef = useRef(false);
     const startSessionIdRef = useRef(0);
     const autoSpokenKeyRef = useRef("");
+    const panelRef = useRef<HTMLDivElement | null>(null);
 
     const selectedLanguageOption = getVoiceLanguageOption(selectedLanguage);
     const resultLanguageOption = getVoiceLanguageOption(resultLanguageCode ?? selectedLanguage);
@@ -210,6 +212,49 @@ export default function VoiceTriagePage() {
         autoSpokenKeyRef.current = autoSpokenKey;
         handleReplaySummary();
     }, [result, resultLanguageOption.speechSynthesisLang, step]);
+
+    useEffect(() => {
+        if (step === "initial") {
+            setSrAnnouncement("");
+            return;
+        }
+
+        let announcement = "";
+
+        switch (step) {
+            case "listening":
+                announcement = t("listening_status");
+                break;
+            case "processing":
+                announcement = t("processing_subtitle");
+                break;
+            case "review":
+                announcement = `${t("review_title")}. ${t("review_message")}`;
+                break;
+            case "result":
+                if (result) {
+                    announcement = result.emergency
+                        ? `${t("result_heading")} - ${t("emergency_title")}. ${t("result_subheading")}`
+                        : `${t("result_heading")}. ${t("result_subheading")}`;
+                }
+                break;
+            case "error":
+                announcement = error
+                    ? `${t("errors.generic_title")} - ${error.title}. ${error.message}`
+                    : t("errors.generic_title");
+                break;
+        }
+
+        if (announcement) {
+            setSrAnnouncement(announcement);
+        }
+
+        const focusTimer = window.setTimeout(() => {
+            panelRef.current?.focus();
+        }, 100);
+
+        return () => window.clearTimeout(focusTimer);
+    }, [error, result, step, t]);
 
     function resetFlow(nextStep: VoiceStep = "initial") {
         startSessionIdRef.current += 1;
@@ -610,6 +655,10 @@ export default function VoiceTriagePage() {
 
     return (
         <div className="relative flex min-h-screen flex-col overflow-hidden bg-slate-50 font-sans">
+            <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+                {srAnnouncement}
+            </div>
+
             <div
                 className="absolute top-0 right-0 -mt-20 -mr-20 h-96 w-96 rounded-full bg-emerald-100/40 blur-3xl"
                 aria-hidden="true"
@@ -674,92 +723,98 @@ export default function VoiceTriagePage() {
                     />
                 </div>
 
-                {step === "initial" && (
-                    <VoiceIntroPanel
-                        title={t("title")}
-                        subtitle={t("subtitle")}
-                        exampleLabel={t("example_label")}
-                        exampleText={t("example_text")}
-                        assistantLabel={t("assistant_label")}
-                        assistantValue={t("assistant_value")}
-                    />
-                )}
+                <div
+                    ref={panelRef}
+                    tabIndex={-1}
+                    className="w-full max-w-md rounded-[2.5rem] focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/20 focus-visible:ring-offset-2"
+                >
+                    {step === "initial" && (
+                        <VoiceIntroPanel
+                            title={t("title")}
+                            subtitle={t("subtitle")}
+                            exampleLabel={t("example_label")}
+                            exampleText={t("example_text")}
+                            assistantLabel={t("assistant_label")}
+                            assistantValue={t("assistant_value")}
+                        />
+                    )}
 
-                {step === "listening" && (
-                    <VoiceListeningPanel
-                        transcript={transcript || t("listening_placeholder")}
-                        statusLabel={t("listening_status")}
-                        stream={audioStream}
-                        isListening={isListening}
-                        isFading={isVisualizerFading}
-                        animationsEnabled={animationsEnabled}
-                        visualizerLabel={t("visualizer_label")}
-                        volumeLabel={t("volume_label")}
-                        liveVolumeLabel={t("volume_live_label")}
-                        stillVolumeLabel={t("volume_still_label")}
-                        visualizerUnavailableLabel={t("visualizer_unavailable")}
-                    />
-                )}
+                    {step === "listening" && (
+                        <VoiceListeningPanel
+                            transcript={transcript || t("listening_placeholder")}
+                            statusLabel={t("listening_status")}
+                            stream={audioStream}
+                            isListening={isListening}
+                            isFading={isVisualizerFading}
+                            animationsEnabled={animationsEnabled}
+                            visualizerLabel={t("visualizer_label")}
+                            volumeLabel={t("volume_label")}
+                            liveVolumeLabel={t("volume_live_label")}
+                            stillVolumeLabel={t("volume_still_label")}
+                            visualizerUnavailableLabel={t("visualizer_unavailable")}
+                        />
+                    )}
 
-                {step === "processing" && (
-                    <VoiceProcessingPanel
-                        title={t("processing_title")}
-                        subtitle={t("processing_subtitle")}
-                    />
-                )}
+                    {step === "processing" && (
+                        <VoiceProcessingPanel
+                            title={t("processing_title")}
+                            subtitle={t("processing_subtitle")}
+                        />
+                    )}
 
-                {step === "review" && (
-                    <VoiceReviewPanel
-                        title={t("review_title")}
-                        message={t("review_message")}
-                        transcript={transcript}
-                        confidence={confidence}
-                        confidenceLabelPrefix={t("confidence_label")}
-                        confidenceValueLabel={getConfidenceValueLabel(confidence, t)}
-                        retryLabel={t("retry_button")}
-                        analyseLabel={t("analyse_anyway_button")}
-                        onRetry={() => resetFlow()}
-                        onAnalyse={() =>
-                            void analyseTranscript(transcript, confidence, emergencyMatches)
-                        }
-                        emergencyTitle={t("emergency_title")}
-                        emergencyBody={t("emergency_body")}
-                        showEmergency={emergencyMatches.length > 0}
-                    />
-                )}
+                    {step === "review" && (
+                        <VoiceReviewPanel
+                            title={t("review_title")}
+                            message={t("review_message")}
+                            transcript={transcript}
+                            confidence={confidence}
+                            confidenceLabelPrefix={t("confidence_label")}
+                            confidenceValueLabel={getConfidenceValueLabel(confidence, t)}
+                            retryLabel={t("retry_button")}
+                            analyseLabel={t("analyse_anyway_button")}
+                            onRetry={() => resetFlow()}
+                            onAnalyse={() =>
+                                void analyseTranscript(transcript, confidence, emergencyMatches)
+                            }
+                            emergencyTitle={t("emergency_title")}
+                            emergencyBody={t("emergency_body")}
+                            showEmergency={emergencyMatches.length > 0}
+                        />
+                    )}
 
-                {step === "error" && error && (
-                    <VoiceErrorPanel
-                        error={error}
-                        retryLabel={t("retry_button")}
-                        onRetry={() => resetFlow()}
-                    />
-                )}
+                    {step === "error" && error && (
+                        <VoiceErrorPanel
+                            error={error}
+                            retryLabel={t("retry_button")}
+                            onRetry={() => resetFlow()}
+                        />
+                    )}
 
-                {step === "result" && result && (
-                    <VoiceResultPanel
-                        heading={t("result_heading")}
-                        subheading={t("result_subheading")}
-                        transcriptLabel={t("transcript_label")}
-                        transcript={transcript}
-                        confidence={confidence}
-                        confidenceLabelPrefix={t("confidence_label")}
-                        confidenceValueLabel={getConfidenceValueLabel(confidence, t)}
-                        result={result}
-                        emergencyTitle={t("emergency_title")}
-                        emergencyBody={t("emergency_body")}
-                        recommendationsLabel={t("recommendations_label")}
-                        shareLabel={t("share_button")}
-                        speakLabel={t("speak_button")}
-                        stopSpeakingLabel={t("stop_speaking_button")}
-                        tryAgainLabel={t("try_again_button")}
-                        isSpeaking={isSpeaking}
-                        onReplay={handleReplaySummary}
-                        onStopSpeaking={handleStopSpeaking}
-                        onShare={handleShare}
-                        onTryAgain={() => resetFlow()}
-                    />
-                )}
+                    {step === "result" && result && (
+                        <VoiceResultPanel
+                            heading={t("result_heading")}
+                            subheading={t("result_subheading")}
+                            transcriptLabel={t("transcript_label")}
+                            transcript={transcript}
+                            confidence={confidence}
+                            confidenceLabelPrefix={t("confidence_label")}
+                            confidenceValueLabel={getConfidenceValueLabel(confidence, t)}
+                            result={result}
+                            emergencyTitle={t("emergency_title")}
+                            emergencyBody={t("emergency_body")}
+                            recommendationsLabel={t("recommendations_label")}
+                            shareLabel={t("share_button")}
+                            speakLabel={t("speak_button")}
+                            stopSpeakingLabel={t("stop_speaking_button")}
+                            tryAgainLabel={t("try_again_button")}
+                            isSpeaking={isSpeaking}
+                            onReplay={handleReplaySummary}
+                            onStopSpeaking={handleStopSpeaking}
+                            onShare={handleShare}
+                            onTryAgain={() => resetFlow()}
+                        />
+                    )}
+                </div>
             </main>
 
             {showMicFooter && (
@@ -771,7 +826,11 @@ export default function VoiceTriagePage() {
                                 ? t("stop_listening_aria")
                                 : t("start_listening_aria")
                         }
-                        className={`relative flex h-24 w-24 items-center justify-center rounded-full transition-all duration-500 ${step === "listening" ? "scale-125 bg-red-500" : "bg-emerald-500 shadow-xl shadow-emerald-500/30 hover:scale-110"} `}
+                        className={`relative flex h-24 w-24 items-center justify-center rounded-full transition-all duration-500 focus-visible:ring-4 focus-visible:ring-offset-4 focus-visible:outline-none ${
+                            step === "listening"
+                                ? "scale-125 bg-red-500 focus-visible:ring-red-500/50"
+                                : "bg-emerald-500 shadow-xl shadow-emerald-500/30 hover:scale-110 focus-visible:ring-emerald-500/50"
+                        } `}
                     >
                         {step === "listening" ? (
                             <div

--- a/apps/web/tests/voice-accessibility.test.tsx
+++ b/apps/web/tests/voice-accessibility.test.tsx
@@ -1,0 +1,129 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { VoiceAudioVisualizer } from "../app/[locale]/voice/VoiceAudioVisualizer";
+import {
+    VoiceErrorPanel,
+    VoiceProcessingPanel,
+    VoiceResultPanel,
+    VoiceReviewPanel,
+} from "../app/[locale]/voice/VoicePanels";
+
+describe("Voice Triage accessibility semantics", () => {
+    it("renders VoiceProcessingPanel with status semantics and reduced-motion classes", () => {
+        const markup = renderToStaticMarkup(
+            <VoiceProcessingPanel
+                title="Checking symptoms"
+                subtitle="Analyzing with SahiDawa AI..."
+            />
+        );
+
+        expect(markup).toContain('role="status"');
+        expect(markup).toContain('aria-live="polite"');
+        expect(markup).toContain('aria-label="Checking symptoms"');
+        expect(markup).toContain("motion-reduce:animate-none");
+    });
+
+    it("renders VoiceReviewPanel with visible focus styles and reduced-motion support", () => {
+        const markup = renderToStaticMarkup(
+            <VoiceReviewPanel
+                title="Please review your transcript"
+                message="The microphone picked up low confidence audio."
+                transcript="I have cold and headache"
+                confidence={{ id: "low", score: 0.2, tone: "critical" }}
+                confidenceLabelPrefix="Confidence"
+                confidenceValueLabel="Low"
+                retryLabel="Try Again"
+                analyseLabel="Analyse Anyway"
+                onRetry={() => undefined}
+                onAnalyse={() => undefined}
+                emergencyTitle="Urgent Care Needed"
+                emergencyBody="Please seek clinical attention"
+                showEmergency={true}
+            />
+        );
+
+        expect(markup).toContain("motion-reduce:animate-none");
+        expect(markup).toContain("focus-visible:ring-2");
+        expect(markup).toContain("focus-visible:ring-slate-500");
+        expect(markup).toContain("focus-visible:ring-emerald-500");
+    });
+
+    it("renders VoiceErrorPanel with retry focus styles and reduced-motion support", () => {
+        const markup = renderToStaticMarkup(
+            <VoiceErrorPanel
+                error={{
+                    title: "Access Denied",
+                    message: "Microphone blocked",
+                    isRecoverable: true,
+                }}
+                retryLabel="Try Again"
+                onRetry={() => undefined}
+            />
+        );
+
+        expect(markup).toContain("motion-reduce:animate-none");
+        expect(markup).toContain("focus-visible:ring-2");
+        expect(markup).toContain("focus-visible:ring-slate-950");
+    });
+
+    it("renders VoiceResultPanel with landmark semantics and focus states", () => {
+        const markup = renderToStaticMarkup(
+            <VoiceResultPanel
+                heading="AI Triage Result"
+                subheading="Clinical Assessment"
+                transcriptLabel="Transcript"
+                transcript="I have high fever"
+                confidence={{ id: "high", score: 0.95, tone: "positive" }}
+                confidenceLabelPrefix="Confidence"
+                confidenceValueLabel="High"
+                result={{
+                    summary: "Fever needs monitoring.",
+                    recommendations: ["Rest well", "Drink water"],
+                    emergency: false,
+                    disclaimer: "Informational use only.",
+                }}
+                emergencyTitle="Urgent Care"
+                emergencyBody="Seek help"
+                recommendationsLabel="Recommended Actions"
+                shareLabel="Share"
+                speakLabel="Read Aloud"
+                stopSpeakingLabel="Stop"
+                tryAgainLabel="New Check"
+                isSpeaking={false}
+                onReplay={() => undefined}
+                onStopSpeaking={() => undefined}
+                onShare={() => undefined}
+                onTryAgain={() => undefined}
+            />
+        );
+
+        expect(markup).toContain('role="region"');
+        expect(markup).toContain('aria-labelledby="voice-ai-analysis-heading"');
+        expect(markup).toContain("focus-visible:ring-2");
+        expect(markup).toContain("focus-visible:ring-slate-500");
+        expect(markup).toContain("focus-visible:ring-blue-500");
+        expect(markup).toContain("focus-visible:ring-slate-950");
+    });
+
+    it("renders VoiceAudioVisualizer volume progressbar semantics", () => {
+        const markup = renderToStaticMarkup(
+            <VoiceAudioVisualizer
+                stream={null}
+                isActive={true}
+                isFading={false}
+                animationsEnabled={false}
+                visualizerLabel="Audio Wave"
+                volumeLabel="Volume"
+                liveVolumeLabel="Live"
+                stillVolumeLabel="Still"
+                visualizerUnavailableLabel="Wave unavailable"
+            />
+        );
+
+        expect(markup).toContain('role="progressbar"');
+        expect(markup).toContain('aria-label="Volume"');
+        expect(markup).toContain('aria-valuemin="0"');
+        expect(markup).toContain('aria-valuemax="100"');
+        expect(markup).toContain('aria-valuenow="18"');
+    });
+});

--- a/apps/web/tests/voice-helpers.test.ts
+++ b/apps/web/tests/voice-helpers.test.ts
@@ -1,5 +1,6 @@
 import { getConfidenceMeta } from "../app/[locale]/voice/lib/confidence";
 import { detectEmergencyKeywords } from "../app/[locale]/voice/lib/emergency";
+import { shouldAutoFocusVoicePanel } from "../app/[locale]/voice/lib/accessibility";
 import {
     DEFAULT_VOICE_LANGUAGE,
     VOICE_LANGUAGE_OPTIONS,
@@ -81,5 +82,22 @@ describe("formatVoiceShareReport", () => {
         expect(report).toContain("Emergency Alert: Yes");
         expect(report).toContain("1. Call 112 immediately");
         expect(report).toContain("Disclaimer: This is not a diagnosis. Consult a doctor.");
+    });
+});
+
+describe("shouldAutoFocusVoicePanel", () => {
+    it("keeps focus on the mic button while listening", () => {
+        expect(shouldAutoFocusVoicePanel("listening")).toBe(false);
+    });
+
+    it("moves focus to the active panel for review, processing, result, and error states", () => {
+        expect(shouldAutoFocusVoicePanel("review")).toBe(true);
+        expect(shouldAutoFocusVoicePanel("processing")).toBe(true);
+        expect(shouldAutoFocusVoicePanel("result")).toBe(true);
+        expect(shouldAutoFocusVoicePanel("error")).toBe(true);
+    });
+
+    it("does not auto-focus the panel on the initial state", () => {
+        expect(shouldAutoFocusVoicePanel("initial")).toBe(false);
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._

## 📋 PR Summary

Improves Voice Triage accessibility and assistive feedback to better meet the requirements of issue #442. This PR adds clear screen reader announcements across the voice flow, stronger keyboard focus handling, visible focus states for interactive controls, reduced-motion support for animated panels, and accessible progressbar semantics for the audio visualizer.

---

## 🔗 Related Issue

Closes #442

---

## 🏷️ PR Type

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [x] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Added a hidden `role="status"` live region to announce listening, processing, review, result, and error states for assistive technologies
- Added panel focus management so keyboard users are moved to the active voice panel as the flow changes
- Added visible `focus-visible` rings to the microphone button and result/review/error action buttons
- Added `motion-reduce:animate-none` support to animated voice panels and processing indicators
- Added accessible `progressbar` semantics to the audio visualizer volume meter, including `aria-valuemin`, `aria-valuemax`, and dynamic `aria-valuenow`
- Added focused accessibility tests for voice panels and audio visualizer semantics
- Kept this PR scoped only to accessibility improvements and removed the unrelated recording/transcription work from the earlier attempt

## 📸 Screenshots / Proof of Work (REQUIRED)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
> - **Backend/API/ML changes:** You MUST attach terminal logs, curl/Postman outputs, or test run outputs proving the changes work.
>
> _Please drag & drop your screenshots/GIFs here, or paste terminal/console logs below:_


[Screencast from 05-23-2026 07:53:41 AM.webm](https://github.com/user-attachments/assets/ee32afc0-b814-4b08-86c0-00680b642cb9)

<img width="813" height="277" alt="image" src="https://github.com/user-attachments/assets/539c1741-f622-4e07-89fa-577306310bbf" />
<img width="813" height="692" alt="image" src="https://github.com/user-attachments/assets/eab43ba9-788b-4b03-bf13-bd5869893127" />

### Terminal
 verification

```bash
npm test -w web -- --runTestsByPath tests/voice-accessibility.test.tsx tests/voice-audio-visualizer.test.tsx

Test Suites: 2 passed, 2 total
Tests:       13 passed, 13 total
Snapshots:   0 total
```

```bash
npm run build -w web

✓ Compiled successfully
✓ Finished TypeScript
✓ Generating static pages
✓ Finalizing page optimization
```

---

## ✅ Contributor Checklist

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [ ] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant
