### PR TITLE
fix(accessibility): add aria-describedby and id attributes to VoiceEr…

### DIFF
--- a/apps/web/app/[locale]/voice/VoicePanels.tsx
+++ b/apps/web/app/[locale]/voice/VoicePanels.tsx
@@ -266,14 +266,22 @@ export function VoiceErrorPanel({
     onRetry: () => void;
 }) {
     return (
-        <div className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-red-100 bg-white p-8 shadow-xl duration-500 motion-reduce:animate-none">
+        <div
+            className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-red-100 bg-white p-8 shadow-xl duration-500 motion-reduce:animate-none"
+            aria-describedby="voice-error-message"
+        >
             <div className="mb-6 flex items-start gap-3">
                 <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-red-50 text-red-600">
                     <AlertTriangle size={24} aria-hidden="true" />
                 </div>
                 <div>
                     <h2 className="font-black text-slate-900">{error.title}</h2>
-                    <p className="mt-2 text-sm leading-relaxed text-slate-600">{error.message}</p>
+                    <p
+                        id="voice-error-message"
+                        className="mt-2 text-sm leading-relaxed text-slate-600"
+                    >
+                        {error.message}
+                    </p>
                 </div>
             </div>
 

--- a/apps/web/tests/voice-accessibility.test.tsx
+++ b/apps/web/tests/voice-accessibility.test.tsx
@@ -67,6 +67,8 @@ describe("Voice Triage accessibility semantics", () => {
         );
 
         expect(markup).toContain("motion-reduce:animate-none");
+        expect(markup).toContain('aria-describedby="voice-error-message"');
+        expect(markup).toContain('id="voice-error-message"');
         expect(markup).toContain("focus-visible:ring-2");
         expect(markup).toContain("focus-visible:ring-slate-950");
     });


### PR DESCRIPTION
…rorPanel for improved accessibility

### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._

## 📋 PR Summary

<!-- Provide a brief summary of the changes introduced by this PR. -->
Added an accessibility link between the error container and its message in VoicePanels.tsx by giving the message paragraph an ID and pointing the panel’s [aria-describedby] at it. I also updated the static-markup test in voice-accessibility to assert both attributes are present.

---

## 🔗 Related Issue

<!-- Link the issue this PR resolves. For example: Closes #123 -->

Closes #478

---

## 🏷️ PR Type

<!-- Select the type of changes. Replace [ ] with [x] for matching items. -->

- [x] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [x] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

<!-- Select the areas that have been modified by this PR. Replace [ ] with [x] for matching items. -->

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

<!-- Provide a bulleted list of the exact changes made in this PR. -->

- Updated VoicePanels.tsx so VoiceErrorPanel now sets aria-describedby="voice-error-message" on the container.
- Added id="voice-error-message" to the error message paragraph so the error text is programmatically associated with the panel.
- Updated voice-accessibility.test.ts to assert that the rendered static markup includes both the aria-describedby attribute and the matching message id
- Verified the change with npm --workspace web test -- --runInBand tests/voice-accessibility.test.tsx, which passed.


## 📸 Screenshots / Proof of Work (REQUIRED)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
> - **Backend/API/ML changes:** You MUST attach terminal logs, curl/Postman outputs, or test run outputs proving the changes work.
>
> _Please drag & drop your screenshots/GIFs here, or paste terminal/console logs below:_
<img width="1919" height="972" alt="image" src="https://github.com/user-attachments/assets/8ff9375d-59ea-462d-a80c-d2710efdb01c" />

---

## ✅ Contributor Checklist

<!-- Ensure you have completed the following steps before requesting a review. Replace [ ] with [x]. -->

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [-] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [ ] I am a GSSoC 2026 participant
