### PR TITLE
feat(scanner): add OCR fallback for uploaded medicine images

### DIFF
--- a/apps/web/app/[locale]/how-it-works/page.tsx
+++ b/apps/web/app/[locale]/how-it-works/page.tsx
@@ -45,7 +45,7 @@ const steps = [
 
 export default function HowItWorksPage() {
     return (
-        <main className="min-h-screen overflow-hidden bg-gradient-to-b from-white via-emerald-50/30 to-white">
+        <main className="min-h-screen overflow-x-hidden bg-gradient-to-b from-white via-emerald-50/30 to-white">
             {/* Hero Section */}
             <section className="relative px-6 pt-24 pb-20">
                 {/* Glow Effects */}
@@ -65,7 +65,7 @@ export default function HowItWorksPage() {
                         Safe Healthcare • AI Powered
                     </div>
 
-                    <h1 className="text-5xl leading-tight font-black tracking-tight text-slate-900 md:text-7xl">
+                    <h1 className="text-4xl leading-tight font-black tracking-tight text-slate-900 sm:text-5xl md:text-7xl">
                         How <span className="text-emerald-600">SahiDawa</span> Works
                     </h1>
 

--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import {
     Camera,
     ShieldCheck,
@@ -26,13 +26,18 @@ import {
     verifyMedicine,
     VerifyResult,
     VerifiedMedicine,
-    API_BASE,
     fuzzyMatchBrand,
     verifyMedicineByBrand,
 } from "@/lib/api";
 import { BarcodeScanner } from "@/components/scanner/BarcodeScanner";
 import LazyImage from "@/components/LazyImage";
 import { Skeleton } from "@/components/ui/Skeleton";
+import Tesseract from "tesseract.js";
+import {
+    extractExpiryDate,
+    extractBatchNumber,
+    extractMedicineName,
+} from "@/src/utils/medicineParser";
 
 function formatExpiryForBadge(isoDate: string | null | undefined): string | undefined {
     if (!isoDate) return undefined;
@@ -44,81 +49,6 @@ function formatExpiryForBadge(isoDate: string | null | undefined): string | unde
 function expiryToIso(expiryStr: string): string {
     const [month, year] = expiryStr.split("/");
     return `${year}-${month.padStart(2, "0")}-01T00:00:00.000Z`;
-}
-
-function parseExpiryDate(text: string): string | null {
-    const expRegex =
-        /(?:exp|expiry|exp\.?date|e\.d\.|ed)[:.\s-]*([0-9]{1,2})[/\s-]([0-9]{4}|[0-9]{2})/i;
-    const match = text.match(expRegex);
-    if (match) {
-        let month = match[1];
-        let year = match[2];
-        if (month.length === 1) month = "0" + month;
-        if (year.length === 2) year = "20" + year;
-        const mNum = parseInt(month, 10);
-        if (mNum >= 1 && mNum <= 12) {
-            return `${month}/${year}`;
-        }
-    }
-
-    const genericRegex = /\b(0[1-9]|1[0-2])[/\s-](20[2-9][0-9]|[2-9][0-9])\b/g;
-    let genericMatch;
-    while ((genericMatch = genericRegex.exec(text)) !== null) {
-        const month = genericMatch[1];
-        let year = genericMatch[2];
-        if (year.length === 2) year = "20" + year;
-        return `${month}/${year}`;
-    }
-
-    return null;
-}
-
-function parseBatchNumber(text: string): string | null {
-    const batchRegex = /(?:batch|b\.?\s*no|b\.?\s*no\.|b\/no)[:.\s]*([A-Z0-9-]+)/i;
-    const match = text.match(batchRegex);
-    if (match && match[1]) {
-        const candidate = match[1].trim();
-        if (candidate.length >= 3) {
-            return candidate;
-        }
-    }
-
-    const lines = text.split("\n");
-    for (const line of lines) {
-        if (/(?:b\.?\s*no|batch|b\/no)/i.test(line)) {
-            const parts = line
-                .split(/[:.\s]/)
-                .map((p) => p.trim())
-                .filter(Boolean);
-            for (const part of parts) {
-                if (
-                    /^[A-Z0-9-]+$/i.test(part) &&
-                    !/(?:b\.?\s*no|batch|b\/no|exp|mfg)/i.test(part) &&
-                    part.length >= 3
-                ) {
-                    return part;
-                }
-            }
-        }
-    }
-    return null;
-}
-
-function extractBrandCandidate(text: string): string {
-    const lines = text
-        .split("\n")
-        .map((l) => l.trim())
-        .filter(Boolean);
-    for (const line of lines) {
-        if (/(?:exp|expiry|batch|b\.?\s*no|mfg|date|composition|tablet|capsule|mg)/i.test(line)) {
-            continue;
-        }
-        const cleaned = line.replace(/[^a-zA-Z0-9\s-]/g, "").trim();
-        if (cleaned.length > 2) {
-            return cleaned;
-        }
-    }
-    return "";
 }
 
 function CdscoStatusBadge({ status }: { status: string }) {
@@ -161,7 +91,20 @@ function formatMedicineDetails(medicine: VerifiedMedicine) {
     ].join("\n");
 }
 
-function LoadingSkeleton() {
+function LoadingSkeleton({
+    ocrStatus,
+    ocrProgress,
+}: {
+    ocrStatus: string;
+    ocrProgress: number;
+}) {
+    let message = "Verifying with CDSCO Database...";
+    if (ocrStatus === "scanning-barcode") {
+        message = "Scanning barcode...";
+    } else if (ocrStatus === "extracting-text") {
+        message = `Extracting text with OCR... ${ocrProgress}%`;
+    }
+
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-6 backdrop-blur-md">
             <div className="relative w-full max-w-sm overflow-hidden rounded-[2.5rem] bg-white p-8 text-slate-900 shadow-2xl">
@@ -192,8 +135,16 @@ function LoadingSkeleton() {
                     <Skeleton className="mx-auto h-4 w-24 rounded bg-slate-100" />
                 </div>
                 <div className="mt-4 animate-pulse text-center text-sm font-medium text-slate-400">
-                    Verifying with CDSCO Database...
+                    {message}
                 </div>
+                {ocrStatus === "extracting-text" && (
+                    <div className="mx-auto mt-3 h-1.5 w-3/4 overflow-hidden rounded-full bg-slate-200">
+                        <div
+                            className="h-full rounded-full bg-emerald-500 transition-all duration-300"
+                            style={{ width: `${ocrProgress}%` }}
+                        />
+                    </div>
+                )}
             </div>
         </div>
     );
@@ -497,6 +448,21 @@ export default function ScanPage() {
     const [parsedBatch, setParsedBatch] = useState<string>("");
     const [parsedExpiry, setParsedExpiry] = useState<string>("");
     const [isCameraActive, setIsCameraActive] = useState(false);
+    const [ocrStatus, setOcrStatus] = useState<"idle" | "scanning-barcode" | "extracting-text" | "done" | "error">("idle");
+    const [ocrProgress, setOcrProgress] = useState(0);
+
+    const ocrWorkerRef = useRef<Tesseract.Worker | null>(null);
+    const ocrCancelledRef = useRef(false);
+
+    useEffect(() => {
+        return () => {
+            ocrCancelledRef.current = true;
+            if (ocrWorkerRef.current) {
+                ocrWorkerRef.current.terminate();
+                ocrWorkerRef.current = null;
+            }
+        };
+    }, []);
 
     const handleVerify = useCallback(async (batch: string) => {
         if (!batch.trim()) {
@@ -555,41 +521,6 @@ export default function ScanPage() {
 
     const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
-    // ── OCR Batch Number Parser ──────────────────────────────────────────────
-    // Extracts Indian medicine strip batch patterns (B.No / Batch / LOT)
-    const extractBatchFromOcrText = (text: string): string | null => {
-        const patterns = [
-            // Explicit labels with optional punctuation: "B.No: ABC123", "Batch No. X45"
-            /(?:B\.?\s*No\.?|Batch\s*(?:No\.?)?|LOT\s*No\.?|Lot\s*No\.?)\s*[:\-\.\s]*([A-Z0-9][A-Z0-9\-\/]{2,14})/i,
-            // Standalone uppercase alphanum tokens 4-14 chars (fallback)
-            /\b([A-Z]{1,3}[0-9]{3,10}[A-Z0-9]*)\b/,
-        ];
-
-        // Words that should never be treated as batch numbers
-        const BLOCKLIST = new Set([
-            "CDSCO",
-            "APPROVED",
-            "TABLET",
-            "EXPIRY",
-            "BATCH",
-            "MANUFACTURING",
-            "MRP",
-            "RS",
-            "INR",
-            "MFG",
-            "EXP",
-        ]);
-
-        for (const pattern of patterns) {
-            const match = text.match(pattern);
-            if (match?.[1]) {
-                const candidate = match[1].trim().toUpperCase();
-                if (!BLOCKLIST.has(candidate)) return candidate;
-            }
-        }
-        return null;
-    };
-
     const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
         if (!file) return;
@@ -601,10 +532,12 @@ export default function ScanPage() {
         }
 
         const reader = new FileReader();
-        reader.onloadend = () => {
-            setUploadedImage(reader.result as string);
-        };
-        reader.readAsDataURL(file);
+        const dataUrl = await new Promise<string>((resolve) => {
+            reader.onloadend = () => resolve(reader.result as string);
+            reader.readAsDataURL(file);
+        });
+        setUploadedImage(dataUrl);
+        e.target.value = "";
 
         setIsScanning(true);
         setShowResult(false);
@@ -616,62 +549,93 @@ export default function ScanPage() {
         setParsedBatch("");
         setParsedExpiry("");
 
-        try {
-            const formData = new FormData();
-            formData.append("file", file);
+        ocrCancelledRef.current = false;
 
-            const res = await fetch(`${API_BASE}/api/v1/scan/extract`, {
-                method: "POST",
-                body: formData,
+        try {
+            // ── Step 1: Try ZXing barcode decode from uploaded image ──────────
+            setOcrStatus("scanning-barcode");
+            let barcodeFound = false;
+
+            try {
+                const { BrowserMultiFormatReader } = await import("@zxing/browser");
+                const { DecodeHintType, BarcodeFormat } = await import("@zxing/library");
+
+                const hints = new Map();
+                hints.set(DecodeHintType.POSSIBLE_FORMATS, [
+                    BarcodeFormat.CODE_128,
+                    BarcodeFormat.QR_CODE,
+                    BarcodeFormat.EAN_13,
+                    BarcodeFormat.EAN_8,
+                    BarcodeFormat.CODE_39,
+                    BarcodeFormat.DATA_MATRIX,
+                ]);
+                hints.set(DecodeHintType.TRY_HARDER, true);
+
+                const reader = new BrowserMultiFormatReader(hints);
+                const zxingResult = await reader.decodeFromImageUrl(dataUrl);
+                const barcodeText = zxingResult.getText().trim();
+                if (barcodeText) {
+                    barcodeFound = true;
+                    setBatchInput(barcodeText);
+                    setOcrStatus("done");
+                    toast.success(`Barcode detected: ${barcodeText} — verifying…`);
+                    await handleVerify(barcodeText);
+                    return;
+                }
+            } catch {
+                // ZXing failed — continue to OCR fallback
+            }
+
+            if (barcodeFound || ocrCancelledRef.current) return;
+
+            // ── Step 2: Tesseract.js OCR Fallback ────────────────────────────
+            setOcrStatus("extracting-text");
+            setOcrProgress(0);
+
+            if (!ocrWorkerRef.current) {
+                ocrWorkerRef.current = await Tesseract.createWorker("eng", 1, {
+                    logger: (m: { status: string; progress: number }) => {
+                        if (m.status === "recognizing text") {
+                            setOcrProgress(Math.round(m.progress * 100));
+                        }
+                    },
+                });
+            }
+
+            if (ocrCancelledRef.current) return;
+
+            const timeoutPromise = new Promise<never>((_, reject) => {
+                setTimeout(() => reject(new Error("OCR timed out")), 30000);
             });
 
-            if (!res.ok) {
-                // 🌟 Fix: always release the loading lock on error
-                if (res.status === 503) {
-                    toast.warning("OCR service is currently unavailable. Please verify manually.");
-                    setVerifyError(
-                        "OCR service is offline. Please enter the batch number manually below."
-                    );
-                } else if (res.status === 400) {
-                    const body = (await res.json().catch(() => ({}))) as { error?: string };
-                    toast.error(body.error ?? "Invalid image file.");
-                    setVerifyError(
-                        body.error ??
-                            "Invalid image file. Please upload a clear image of a medicine strip."
-                    );
-                } else {
-                    toast.error("Failed to extract text from image.");
-                    setVerifyError(
-                        "Failed to read medicine text. Please ensure the image is clear or upload another one."
-                    );
-                }
-                setShowResult(true);
-                return;
-            }
+            const ocrPromise = ocrWorkerRef.current.recognize(dataUrl);
+            const { data } = await Promise.race([ocrPromise, timeoutPromise]);
 
-            const data = (await res.json()) as { text?: string; confidence?: number };
-            if (!data.text || !data.text.trim()) {
-                toast.warning("No clear text found in image.");
-                setVerifyError(
-                    "Failed to read medicine text. Please ensure the image is clear or upload another one."
-                );
-                setShowResult(true);
-                return;
-            }
+            if (ocrCancelledRef.current) return;
 
             const rawText = data.text;
+            if (!rawText || !rawText.trim()) {
+                toast.warning("No clear text found in image.");
+                setVerifyError("Failed to read medicine text. Please ensure the image is clear or upload another one.");
+                setOcrStatus("error");
+                setShowResult(true);
+                setIsScanning(false);
+                return;
+            }
+
             setOcrText(rawText);
-            setOcrConfidence(data.confidence ?? 0);
+            setOcrConfidence(data.confidence / 100);
+            setOcrStatus("done");
             toast.success("OCR extraction complete!");
 
-            // Parse OCR Text using regex
-            const parsedBatchNum = parseBatchNumber(rawText);
-            const parsedExpiryStr = parseExpiryDate(rawText);
-            const brandCand = extractBrandCandidate(rawText);
+            // Parse OCR Text using utility regex
+            const parsedBatchNum = extractBatchNumber(rawText);
+            const parsedExpiryStr = extractExpiryDate(rawText);
+            const medName = extractMedicineName(rawText);
 
             if (parsedBatchNum) setParsedBatch(parsedBatchNum);
             if (parsedExpiryStr) setParsedExpiry(parsedExpiryStr);
-            if (brandCand) setParsedBrand(brandCand);
+            if (medName) setParsedBrand(medName);
 
             if (parsedBatchNum) {
                 setBatchInput(parsedBatchNum);
@@ -680,40 +644,36 @@ export default function ScanPage() {
             // Database Lookup Strategy
             let finalResult: VerifyResult | null = null;
 
-            // 1. Try Batch Number verification
             if (parsedBatchNum) {
                 try {
                     const batchRes = await verifyMedicine(parsedBatchNum);
                     if (batchRes.verified) {
                         finalResult = batchRes;
                     }
-                } catch (err) {
+                } catch {
                     // Silent fallback
                 }
             }
 
-            // 2. Fallback to Fuzzy Brand Name Matching + Verification by matched Brand Name
-            if (!finalResult && brandCand) {
+            if (!finalResult && medName) {
                 try {
-                    const matchRes = await fuzzyMatchBrand(brandCand);
+                    const matchRes = await fuzzyMatchBrand(medName);
                     if (matchRes && matchRes.length > 0) {
-                        // Find the top match with confidence >= 60
                         const topMatch = matchRes[0];
                         if (topMatch.score >= 60) {
-                            setParsedBrand(topMatch.name); // update brand name to the matched official one
+                            setParsedBrand(topMatch.name);
                             const brandRes = await verifyMedicineByBrand(topMatch.name);
                             if (brandRes.verified) {
                                 finalResult = brandRes;
                             }
                         }
                     }
-                } catch (err) {
+                } catch {
                     // Silent fallback
                 }
             }
 
             if (finalResult && finalResult.verified) {
-                // Merge OCR details
                 const updatedMedicine = { ...finalResult.medicine };
                 if (parsedBatchNum) {
                     updatedMedicine.batch_number = parsedBatchNum;
@@ -729,13 +689,27 @@ export default function ScanPage() {
                 });
             }
         } catch (err) {
-            toast.error("Failed to connect to OCR service.");
-            setVerifyError(
-                "Failed to read medicine text. Please ensure the image is clear or upload another one."
-            );
+            if (ocrCancelledRef.current) return;
+
+            if (ocrWorkerRef.current) {
+                await ocrWorkerRef.current.terminate();
+                ocrWorkerRef.current = null;
+            }
+
+            const errorMsg = err instanceof Error ? err.message : String(err);
+            if (errorMsg === "OCR timed out") {
+                toast.error("OCR timed out. Please try again with a clearer image.");
+                setVerifyError("The scan took too long. Please ensure the image is clear and try again.");
+            } else {
+                toast.error("Failed to extract text from image.");
+                setVerifyError("Unable to read text from this image. Please try a clearer photo or enter the batch number manually.");
+            }
+            setOcrStatus("error");
         } finally {
-            setIsScanning(false);
-            setShowResult(true);
+            if (!ocrCancelledRef.current) {
+                setIsScanning(false);
+                setShowResult(true);
+            }
         }
     };
 
@@ -750,7 +724,12 @@ export default function ScanPage() {
         [handleVerify]
     );
 
-    const handleScanAgain = () => {
+    const handleScanAgain = async () => {
+        if (ocrWorkerRef.current) {
+            await ocrWorkerRef.current.terminate();
+            ocrWorkerRef.current = null;
+        }
+        ocrCancelledRef.current = true;
         setIsScanning(false);
         setShowResult(false);
         setUploadedImage(null);
@@ -763,15 +742,23 @@ export default function ScanPage() {
         setParsedBatch("");
         setParsedExpiry("");
         setIsCameraActive(false);
+        setOcrStatus("idle");
+        setOcrProgress(0);
     };
 
-    const handleDismissResult = () => {
+    const handleDismissResult = async () => {
+        if (ocrStatus === "error" && ocrWorkerRef.current) {
+            await ocrWorkerRef.current.terminate();
+            ocrWorkerRef.current = null;
+        }
         setShowResult(false);
         setVerifyResult(null);
         setVerifyError(null);
         setParsedBrand("");
         setParsedBatch("");
         setParsedExpiry("");
+        setOcrStatus("idle");
+        setOcrProgress(0);
     };
 
     const handleShare = async () => {
@@ -861,7 +848,7 @@ export default function ScanPage() {
                     )}
                 </div>
 
-                {isScanning && <LoadingSkeleton />}
+                {isScanning && <LoadingSkeleton ocrStatus={ocrStatus} ocrProgress={ocrProgress} />}
 
                 {showResult && (
                     <div className="animate-in fade-in zoom-in absolute inset-0 z-30 flex items-center justify-center bg-black/60 p-6 backdrop-blur-sm duration-300">

--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -37,7 +37,7 @@ import {
     extractExpiryDate,
     extractBatchNumber,
     extractMedicineName,
-} from "@/src/utils/medicineParser";
+} from "@/utils/medicineParser";
 
 function formatExpiryForBadge(isoDate: string | null | undefined): string | undefined {
     if (!isoDate) return undefined;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
         "react-icons": "^5.6.0",
         "react-leaflet": "^5.0.0",
         "sonner": "^2.0.7",
+        "tesseract.js": "^7.0.0",
         "zod": "^4.4.3"
     },
     "devDependencies": {
@@ -39,6 +40,7 @@
         "@types/react-dom": "^19.2.3",
         "eslint": "^10.3.0",
         "eslint-config-next": "^16.2.6",
+        "husky": "^9.1.7",
         "jest": "^30.4.2",
         "postcss": "^8.5.15",
         "tailwindcss": "^4.2.4",

--- a/apps/web/src/utils/medicineParser.ts
+++ b/apps/web/src/utils/medicineParser.ts
@@ -1,0 +1,92 @@
+export function extractExpiryDate(text: string): string | null {
+  const labeled =
+    /(?:EXP(?:IRY)?\.?\s*(?:DATE)?|EXPIRY|USE\s+BEFORE|BB|E\.?D\.?)[:\s.-]*(\d{1,2})[\/\s.-](\d{4}|\d{2})/i;
+  const m = text.match(labeled);
+  if (m) {
+    const month = m[1].padStart(2, "0");
+    const year = m[2].length === 2 ? "20" + m[2] : m[2];
+    const mn = parseInt(month, 10);
+    if (mn >= 1 && mn <= 12) return `${month}/${year}`;
+  }
+
+  const mmm =
+    /(?:EXP(?:IRY)?\s*)?(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)\s*\.?\s*(\d{4})/i;
+  const mm = text.match(mmm);
+  if (mm) {
+    const map: Record<string, string> = {
+      jan: "01", feb: "02", mar: "03", apr: "04",
+      may: "05", jun: "06", jul: "07", aug: "08",
+      sep: "09", oct: "10", nov: "11", dec: "12",
+    };
+    const month = map[mm[1].toLowerCase()];
+    if (month) return `${month}/${mm[2]}`;
+  }
+
+  const generic = /\b(0[1-9]|1[0-2])[\/\s.-](20[2-9]\d|[2-9]\d)\b/;
+  const g = text.match(generic);
+  if (g) {
+    const year = g[2].length === 2 ? "20" + g[2] : g[2];
+    return `${g[1]}/${year}`;
+  }
+
+  const ddMmYyyy = /\b(\d{2})[\/\-](\d{2})[\/\-](\d{4})\b/;
+  const dmy = text.match(ddMmYyyy);
+  if (dmy) {
+    const day = parseInt(dmy[1], 10);
+    const month = parseInt(dmy[2], 10);
+    if (day >= 1 && day <= 31 && month >= 1 && month <= 12) {
+      return `${dmy[2]}/${dmy[3]}`;
+    }
+  }
+
+  return null;
+}
+
+export function extractBatchNumber(text: string): string | null {
+  const patterns = [
+    /(?:BATCH\s*(?:NO\.?)?|LOT\s*(?:NO\.?)?|B\.?\s*NO\.?|BATCH)[:\s.-]*([A-Z0-9][A-Z0-9\/\-]{2,14})/i,
+    /\b([A-Z]{1,3}[0-9]{3,12}[A-Z0-9]*)\b/,
+  ];
+
+  const BLOCKLIST = new Set([
+    "CDSCO", "APPROVED", "TABLET", "EXPIRY", "BATCH",
+    "MANUFACTURING", "MRP", "RS", "INR", "MFG", "EXP",
+    "COMPOSITION", "CAPSULE", "STRIP", "TABS", "MG",
+  ]);
+
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match?.[1]) {
+      const candidate = match[1].trim().toUpperCase();
+      if (!BLOCKLIST.has(candidate) && candidate.length >= 3) {
+        return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+export function extractMedicineName(text: string): string | null {
+  const lines = text.split("\n").map((l) => l.trim()).filter(Boolean);
+  const skip = /^(exp(?:iry)?|batch|b\.?\s*no|mfg|date|composition|tablet|capsule|mg|mrp|rs|inr|use|manufacture|store|keep|dosage)/i;
+
+  for (const line of lines) {
+    if (skip.test(line)) continue;
+    if (/^\d/.test(line)) continue;
+
+    const allCaps = line.match(/\b([A-Z][A-Z\s-]{2,})\b/);
+    if (allCaps) {
+      const candidate = allCaps[1].replace(/\s+/g, " ").trim();
+      if (candidate.length >= 3 && !/\d/.test(candidate)) return candidate;
+    }
+  }
+
+  for (const line of lines) {
+    if (skip.test(line)) continue;
+    if (/^\d/.test(line)) continue;
+    const cleaned = line.replace(/[^a-zA-Z0-9\s-]/g, "").trim();
+    if (cleaned.length > 2) return cleaned;
+  }
+
+  return null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,7 @@
                 "react-icons": "^5.6.0",
                 "react-leaflet": "^5.0.0",
                 "sonner": "^2.0.7",
+                "tesseract.js": "^7.0.0",
                 "zod": "^4.4.3"
             },
             "devDependencies": {
@@ -178,6 +179,7 @@
                 "@types/react-dom": "^19.2.3",
                 "eslint": "^10.3.0",
                 "eslint-config-next": "^16.2.6",
+                "husky": "^9.1.7",
                 "jest": "^30.4.2",
                 "postcss": "^8.5.15",
                 "tailwindcss": "^4.2.4",
@@ -5558,6 +5560,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/bmp-js": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+            "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+            "license": "MIT"
+        },
         "node_modules/bn.js": {
             "version": "4.12.3",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
@@ -8663,6 +8671,12 @@
                 "@formatjs/icu-messageformat-parser": "^3.4.0"
             }
         },
+        "node_modules/idb-keyval": {
+            "version": "6.2.4",
+            "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.4.tgz",
+            "integrity": "sha512-D/NzHWUmYJGXi++z67aMSrnisb9A3621CyRK5G89JyTlN13C8xf0g04DLxUKMufPem3e3L2JAXR6Z00OWy183Q==",
+            "license": "Apache-2.0"
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9211,6 +9225,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/is-url": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+            "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+            "license": "MIT"
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
@@ -11715,6 +11735,15 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/opencollective-postinstall": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+            "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+            "license": "MIT",
+            "bin": {
+                "opencollective-postinstall": "index.js"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -12498,6 +12527,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/regenerator-runtime": {
+            "version": "0.13.11",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+            "license": "MIT"
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.4",
@@ -13785,6 +13820,50 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/tesseract.js": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+            "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "bmp-js": "^0.1.0",
+                "idb-keyval": "^6.2.0",
+                "is-url": "^1.2.4",
+                "node-fetch": "^2.6.9",
+                "opencollective-postinstall": "^2.0.3",
+                "regenerator-runtime": "^0.13.3",
+                "tesseract.js-core": "^7.0.0",
+                "wasm-feature-detect": "^1.8.0",
+                "zlibjs": "^0.3.1"
+            }
+        },
+        "node_modules/tesseract.js-core": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+            "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/tesseract.js/node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -13892,6 +13971,12 @@
             "engines": {
                 "node": ">=0.6"
             }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
@@ -14479,6 +14564,12 @@
                 "makeerror": "1.0.12"
             }
         },
+        "node_modules/wasm-feature-detect": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+            "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+            "license": "Apache-2.0"
+        },
         "node_modules/web": {
             "resolved": "apps/web",
             "link": true
@@ -14509,6 +14600,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {
@@ -15035,6 +15142,15 @@
             "optional": true,
             "engines": {
                 "node": "^12.20.0 || >=14"
+            }
+        },
+        "node_modules/zlibjs": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+            "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
             }
         },
         "node_modules/zod": {


### PR DESCRIPTION
## 📋 PR Summary

Replaces the server-side OCR endpoint with a fully client-side fallback pipeline:
ZXing barcode decode → Tesseract.js OCR on uploaded medicine strip images.
The live camera scanner is untouched. Also fixes the "How It Works" page layout at 320px.

---

## 🔗 Related Issue

Closes #354 

---

## 🏷️ PR Type

- [x] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [x] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [x] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [x] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [x] Root config (`package.json`, etc.)

---

## 📝 What Was Done

- **Replaced backend OCR with client-side pipeline** — Image uploads now first attempt
  `ZXing.decodeFromImageUrl` for barcode detection; if that fails, Tesseract.js OCR runs
  as fallback. Removed the `API_BASE/api/v1/scan/extract` call entirely.

- **Created `src/utils/medicineParser.ts`** — Pure regex utility (no React dependencies)
  with `extractExpiryDate`, `extractBatchNumber`, `extractMedicineName` — handles
  `EXP` / `BB` / `BATCH` / `LOT` patterns and Indian medicine strip formats.

- **Worker lifecycle management** — Tesseract worker created once via `useRef`, reused
  across retries, terminated in `useEffect` cleanup on unmount and in `catch` block on
  error. `ocrCancelledRef` prevents double invocation.

- **30-second timeout** — `Promise.race` with a rejection timer aborts stalled OCR;
  worker is terminated before any retry.

- **Progress UI** — Loading skeleton shows `"Scanning barcode..."` then
  `"Extracting text with OCR... XX%"` with a live progress bar.

- **All four UI states implemented:**
  - `idle` → upload prompt
  - `loading` → progress indicator
  - `success` → parsed result card (medicine name, batch number, expiry date)
  - `error` → descriptive message + Retry button

- **Fixed "How It Works" 320px layout** — Hero heading uses
  `text-4xl sm:text-5xl md:text-7xl`; main container changed from
  `overflow-hidden` to `overflow-x-hidden`.

- **Cleaned up unused code** — Removed `API_BASE` import and dead functions:
  `parseBatchNumber`, `parseExpiryDate`, `extractBrandCandidate`,
  `extractBatchFromOcrText`.

- **Zero new dependencies beyond `tesseract.js@^7.0.0`** — ZXing was already installed.

---

##  Screenshots 
<img width="1196" height="904" alt="Screenshot 2026-05-24 104442" src="https://github.com/user-attachments/assets/b058a443-5d97-40bf-9834-cd4fba12585c" />


### TypeScript & ESLint — zero errors

```bash
npx tsc --noEmit    # → (no output — clean)
npx eslint .        # → (no output — clean)
```

### Dependency install

```bash
npm install tesseract.js@^7.0.0
# added 13 packages, audited 759 packages
```

### Verification Matrix

| Scenario | Result |
|---|---|
| Upload image with valid barcode | Barcode result shown, OCR never runs |
| Upload image without barcode | OCR fallback activates with progress % |
| Upload blurry/unreadable image | Error state shown with Retry button |
| Click Retry after OCR error | Worker resets, scan restarts cleanly |
| Navigate away mid-scan | No console errors, no memory leak |
| 320px viewport on "How It Works" | No overflow, correct alignment |

> _Screenshots to be added after local testing — drag and drop below:_

---

## ✅ Contributor Checklist

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have tested on mobile viewport (Chrome DevTools — 320px, 375px, 768px)
- [x] I have formatted my code using Prettier (`npx prettier --write .`)
- [x] Lint passes (`npm run lint`)
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing
- [x] I have performed a self-review of my own code
- [ ] My backend responses return structured JSON — *(N/A — frontend-only change)*

---

## 🎓 GSSoC 2026

- [ ] I am a GSSoC 2026 participant