### PR TITLE
fix(chat): route requests to internal API and improve error messaging

### DIFF
--- a/apps/web/app/components/health/ChatUI.tsx
+++ b/apps/web/app/components/health/ChatUI.tsx
@@ -87,14 +87,14 @@ export default function ChatUI() {
     
     try {
       const history = [...messages, userMsg].filter(m => !m.isError).map(m => ({ role: m.role, content: m.content }));
-      const res = await fetch("https://api.anthropic.com/v1/messages", {
+      const res = await fetch("/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model: "claude-sonnet-4-20250514", max_tokens: 1000, system: SYSTEM_PROMPT, messages: history }),
+        body: JSON.stringify({ messages: history }),
       });
       if (!res.ok) throw new Error();
       const data = await res.json();
-      const reply = data.content?.find((b: any) => b.type === "text")?.text || "I'm here to help! Could you rephrase that?";
+      const reply = data.text || "I'm here to help! Could you rephrase that?";
       setMessages(prev => [...prev, { id: genId(), role: "assistant", content: reply, timestamp: new Date() }]);
     } catch {
       setMessages(prev => [...prev, { id: genId(), role: "assistant", content: "", timestamp: new Date(), isError: true }]);

--- a/apps/web/app/components/health/components/ChatBubble.tsx
+++ b/apps/web/app/components/health/components/ChatBubble.tsx
@@ -55,9 +55,9 @@ const ErrorContent = ({ onRetry, msgId }: { onRetry?: (id: string) => void; msgI
                 <path d="M12 2L1 21h22L12 2zm0 3.5L20.5 19h-17L12 5.5zM11 10v4h2v-4h-2zm0 6v2h2v-2h-2z" />
             </svg>
             <div>
-                <p className="text-sm leading-snug font-semibold text-red-700">Connection issue</p>
+                <p className="text-sm leading-snug font-semibold text-red-700">AI Assistant Under Development</p>
                 <p className="mt-0.5 text-sm leading-relaxed text-slate-600">
-                    Unable to reach the health service. Please check your internet and try again.
+                    This feature is currently under development. Please check back soon!
                 </p>
             </div>
         </div>


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._

## 📋 PR Summary

- Replaced direct Anthropic API call with internal /api/chat route in ChatUI.tsx
- Removed hardcoded model/system params that were being sent to Anthropic directly
- Updated response parsing to match internal API response format
- Updated error message in ChatBubble.tsx from "Connection issue" to "AI Assistant Under Development" to better communicate feature status to users
- **Note:** The chat request is now correctly routed to the internal `/api/chat` endpoint (previously it was calling the Anthropic API directly from the frontend with no API key). The 500 error is expected locally as `GEMINI_API_KEY` is not configured — this needs to be added to Vercel environment variables by the maintainer to make the feature fully functional in production.
---

## 🔗 Related Issue

<!-- Link the issue this PR resolves. For example: Closes 123 -->

Closes #489

---

## 🏷️ PR Type

<!-- Select the type of changes. Replace [ ] with [x] for matching items. -->

- [x] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [x] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

<!-- Select the areas that have been modified by this PR. Replace [ ] with [x] for matching items. -->

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Replaced direct Anthropic API call with internal /api/chat route in ChatUI.tsx
- Removed hardcoded model/system params that were being sent to Anthropic directly
- Updated response parsing to match internal API response format
- Updated error message in ChatBubble.tsx from "Connection issue" to "AI Assistant Under Development" to better communicate feature status to users
- **Note:** The chat request is now correctly routed to the internal `/api/chat` endpoint (previously it was calling the Anthropic API directly from the frontend with no API key). The 500 error is expected locally as `GEMINI_API_KEY` is not configured — this needs to be added to Vercel environment variables by the maintainer to make the feature fully functional in production.

- ***

## 📸 Screenshots / Proof of Work (REQUIRED)

<img width="575" height="147" alt="Screenshot 2026-05-24 at 10 20 05 PM" src="https://github.com/user-attachments/assets/9fd3a804-0694-4d77-bddd-f71f2555112d" />

Terminal Logs:-

POST /api/chat 500 in 3.4s (next.js: 166ms, application-code: 3.2s)
API key should be set when using the Gemini API.
API key should be set when using the Gemini API.
AI Generation Error: Error: Could not load the default credentials. 

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
> - **Backend/API/ML changes:** You MUST attach terminal logs, curl/Postman outputs, or test run outputs proving the changes work.
>
> _Please drag & drop your screenshots/GIFs here, or paste terminal/console logs below:_

---

## ✅ Contributor Checklist

<!-- Ensure you have completed the following steps before requesting a review. Replace [ ] with [x]. -->

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [ ] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant