### PR TITLE
fix: improve VoiceErrorPanel accessibility

### DIFF
--- a/apps/web/app/[locale]/voice/VoicePanels.tsx
+++ b/apps/web/app/[locale]/voice/VoicePanels.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import {
     AlertTriangle,
     Mic,
@@ -271,10 +272,14 @@ export function VoiceErrorPanel({
     retryLabel: string;
     onRetry: () => void;
 }) {
+    const errorMessageId = useId();
+
     return (
         <div
             className="animate-in fade-in slide-in-from-bottom-8 w-full max-w-md rounded-[2.5rem] border border-red-100 bg-white p-8 shadow-xl duration-500 motion-reduce:animate-none"
-            aria-describedby="voice-error-message"
+            role="alert"
+            aria-live="assertive"
+            aria-describedby={errorMessageId}
         >
             <div className="mb-6 flex items-start gap-3">
                 <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-red-50 text-red-600">
@@ -283,7 +288,7 @@ export function VoiceErrorPanel({
                 <div>
                     <h2 className="font-black text-slate-900">{error.title}</h2>
                     <p
-                        id="voice-error-message"
+                        id={errorMessageId}
                         className="mt-2 text-sm leading-relaxed text-slate-600"
                     >
                         {error.message}


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

* [x] I am officially assigned to the issue this PR fixes.

## 📋 PR Summary

This PR improves the accessibility of the VoiceErrorPanel component by replacing the hardcoded error message ID with React's `useId()` hook and adding proper ARIA live region support for screen readers.

---

## 🔗 Related Issue

Closes #528

---

## 🏷️ PR Type

* [x] 🐛 Bug Fix
* [ ] ✨ New Feature / Enhancement
* [ ] 📖 Documentation
* [ ] 🌏 Translation (i18n)
* [ ] 🎨 UI / UX Improvement
* [ ] ⚙️ DevOps / CI-CD
* [ ] 🤖 ML / AI Feature
* [ ] 🔒 Security Fix
* [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

* [x] `apps/web` — Next.js Frontend
* [ ] `apps/api` — Node.js / Express Backend
* [ ] `apps/ml` — Python / FastAPI ML Service
* [ ] `data/` — Database seeds / migrations
* [ ] `docs/` — Documentation
* [ ] `.github/` — GitHub config, workflows
* [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

* Replaced hardcoded `voice-error-message` ID with React `useId()`
* Updated `aria-describedby` to use the generated unique ID
* Added `role="alert"` to VoiceErrorPanel
* Added `aria-live="assertive"` for automatic screen reader announcements
* Improved accessibility and prevented potential duplicate ID conflicts

---

## 📸 Screenshots / Proof of Work (REQUIRED)
<img width="760" height="317" alt="image" src="https://github.com/user-attachments/assets/3c698a23-c86b-4b79-bade-b4ebe8f26b34" />

Attached screenshot of the modified VoiceErrorPanel code and successful local implementation.

---

## ✅ Contributor Checklist

* [x] My PR has a linked issue (see above)
* [x] I have pulled the latest `main` and rebased/merged before opening this PR
* [x] My code follows the patterns and conventions in `docs/code-guide.md`
* [x] I ran the project locally and verified there are no compile/build errors
* [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
* [ ] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
* [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

* [x] I am a GSSoC 2026 participant
