### PR TITLE
feat(web): offload report image enhancement to worker

### DIFF
--- a/apps/web/components/reports/ReportWizard.tsx
+++ b/apps/web/components/reports/ReportWizard.tsx
@@ -22,10 +22,19 @@ import LazyImage from "@/components/LazyImage";
 
 // ─── Constants ─────────────────────────────────────────────────────────────────
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB per file
+const WEBP_FILE_EXTENSION = ".webp";
 
 // ─── Input sanitisation ────────────────────────────────────────────────────────
 /** Strip HTML/script tags and trim whitespace to prevent stored XSS. */
 const sanitize = (v: string) => v.replace(/<[^>]*>/g, "").trim();
+
+const renameFileForMimeType = (fileName: string, mimeType: string) => {
+    if (mimeType !== "image/webp" || fileName.toLowerCase().endsWith(WEBP_FILE_EXTENSION)) {
+        return fileName;
+    }
+
+    return fileName.replace(/\.[^.]+$/, "") + WEBP_FILE_EXTENSION;
+};
 
 // ─── Zod schema ────────────────────────────────────────────────────────────────
 const schema = z.object({
@@ -388,10 +397,14 @@ function Step2({
                                 typeof optimizedBlob !== "string" &&
                                 optimizedBlob instanceof Blob
                             ) {
-                                fileToProcess = new File([optimizedBlob], f.name, {
-                                    type: optimizedBlob.type || "image/jpeg",
-                                    lastModified: Date.now(),
-                                });
+                                fileToProcess = new File(
+                                    [optimizedBlob],
+                                    renameFileForMimeType(f.name, optimizedBlob.type),
+                                    {
+                                        type: optimizedBlob.type || f.type,
+                                        lastModified: Date.now(),
+                                    }
+                                );
                             }
                         } catch (error) {
                             console.error(

--- a/apps/web/lib/imageEnhancer.shared.ts
+++ b/apps/web/lib/imageEnhancer.shared.ts
@@ -1,0 +1,205 @@
+export const WEBP_OUTPUT_TYPE = "image/webp";
+export const WEBP_OUTPUT_QUALITY = 0.8;
+
+const SAMPLE_STRIDE = 16;
+const PHOTO_CONTRAST_FILTER = 1.06;
+const DARK_IMAGE_BRIGHTNESS_FILTER = 1.08;
+const BRIGHT_IMAGE_BRIGHTNESS_FILTER = 0.94;
+
+export type ImageEnhancementRequest = {
+    id: string;
+    width: number;
+    height: number;
+    pixels: Uint8ClampedArray;
+};
+
+export type ImageEnhancementResponse = {
+    id: string;
+    pixels?: Uint8ClampedArray;
+    error?: string;
+};
+
+export type ImageEnhancementPlan = {
+    filter: string;
+    shouldRunWorker: boolean;
+};
+
+export function createImageEnhancementPlan(pixels: Uint8ClampedArray): ImageEnhancementPlan {
+    let extremeCount = 0;
+    let sampleCount = 0;
+    let sumLuminance = 0;
+
+    for (let index = 0; index < pixels.length; index += SAMPLE_STRIDE) {
+        const luminance =
+            0.299 * pixels[index] + 0.587 * pixels[index + 1] + 0.114 * pixels[index + 2];
+
+        sumLuminance += luminance;
+        if (luminance < 15 || luminance > 240) {
+            extremeCount++;
+        }
+        sampleCount++;
+    }
+
+    if (!sampleCount) {
+        return {
+            filter: "none",
+            shouldRunWorker: false,
+        };
+    }
+
+    const isDigitalGraphic = extremeCount / sampleCount > 0.1;
+    if (isDigitalGraphic) {
+        return {
+            filter: "none",
+            shouldRunWorker: false,
+        };
+    }
+
+    const avgLuminance = sumLuminance / sampleCount;
+    const filters = [`contrast(${PHOTO_CONTRAST_FILTER})`];
+
+    if (avgLuminance < 100) {
+        filters.push(`brightness(${DARK_IMAGE_BRIGHTNESS_FILTER})`);
+    } else if (avgLuminance > 180) {
+        filters.push(`brightness(${BRIGHT_IMAGE_BRIGHTNESS_FILTER})`);
+    }
+
+    return {
+        filter: filters.join(" "),
+        shouldRunWorker: true,
+    };
+}
+
+function clampChannel(value: number): number {
+    return Math.min(255, Math.max(0, value));
+}
+
+function rgbToHsl(red: number, green: number, blue: number): [number, number, number] {
+    const normalizedRed = red / 255;
+    const normalizedGreen = green / 255;
+    const normalizedBlue = blue / 255;
+    const max = Math.max(normalizedRed, normalizedGreen, normalizedBlue);
+    const min = Math.min(normalizedRed, normalizedGreen, normalizedBlue);
+    const lightness = (max + min) / 2;
+
+    if (max === min) {
+        return [0, 0, lightness];
+    }
+
+    const delta = max - min;
+    const saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+
+    let hue = 0;
+    switch (max) {
+        case normalizedRed:
+            hue =
+                (normalizedGreen - normalizedBlue) / delta +
+                (normalizedGreen < normalizedBlue ? 6 : 0);
+            break;
+        case normalizedGreen:
+            hue = (normalizedBlue - normalizedRed) / delta + 2;
+            break;
+        default:
+            hue = (normalizedRed - normalizedGreen) / delta + 4;
+            break;
+    }
+
+    return [hue / 6, saturation, lightness];
+}
+
+function hslToRgb(hue: number, saturation: number, lightness: number): [number, number, number] {
+    if (saturation === 0) {
+        const channel = lightness * 255;
+        return [channel, channel, channel];
+    }
+
+    const q =
+        lightness < 0.5
+            ? lightness * (1 + saturation)
+            : lightness + saturation - lightness * saturation;
+    const p = 2 * lightness - q;
+    const hueToChannel = (offset: number) => {
+        let channelHue = offset;
+        if (channelHue < 0) channelHue += 1;
+        if (channelHue > 1) channelHue -= 1;
+        if (channelHue < 1 / 6) return p + (q - p) * 6 * channelHue;
+        if (channelHue < 1 / 2) return q;
+        if (channelHue < 2 / 3) return p + (q - p) * (2 / 3 - channelHue) * 6;
+        return p;
+    };
+
+    return [
+        hueToChannel(hue + 1 / 3) * 255,
+        hueToChannel(hue) * 255,
+        hueToChannel(hue - 1 / 3) * 255,
+    ];
+}
+
+function applySelectiveSaturation(pixels: Uint8ClampedArray): Uint8ClampedArray {
+    const enhanced = new Uint8ClampedArray(pixels);
+
+    for (let index = 0; index < enhanced.length; index += 4) {
+        const [hue, saturation, lightness] = rgbToHsl(
+            enhanced[index],
+            enhanced[index + 1],
+            enhanced[index + 2]
+        );
+
+        if (lightness <= 0.15 || lightness >= 0.85 || saturation <= 0.05) {
+            continue;
+        }
+
+        const luminanceMask = 1 - Math.abs(lightness - 0.5) * 2;
+        const nextSaturation = Math.min(
+            1,
+            Math.max(0, saturation + saturation * (1 - saturation) * 0.3 * luminanceMask)
+        );
+        const [red, green, blue] = hslToRgb(hue, nextSaturation, lightness);
+
+        enhanced[index] = clampChannel(red);
+        enhanced[index + 1] = clampChannel(green);
+        enhanced[index + 2] = clampChannel(blue);
+    }
+
+    return enhanced;
+}
+
+function applyUnsharpMask(
+    pixels: Uint8ClampedArray,
+    width: number,
+    height: number
+): Uint8ClampedArray {
+    if (width < 3 || height < 3) {
+        return pixels;
+    }
+
+    const sharpened = new Uint8ClampedArray(pixels);
+
+    for (let y = 1; y < height - 1; y++) {
+        for (let x = 1; x < width - 1; x++) {
+            const index = (y * width + x) * 4;
+
+            for (let channel = 0; channel < 3; channel++) {
+                const value =
+                    3.0 * pixels[index + channel] -
+                    0.5 * pixels[((y - 1) * width + x) * 4 + channel] -
+                    0.5 * pixels[((y + 1) * width + x) * 4 + channel] -
+                    0.5 * pixels[(y * width + (x - 1)) * 4 + channel] -
+                    0.5 * pixels[(y * width + (x + 1)) * 4 + channel];
+
+                sharpened[index + channel] = clampChannel(value);
+            }
+        }
+    }
+
+    return sharpened;
+}
+
+export function enhanceImagePixels(
+    pixels: Uint8ClampedArray,
+    width: number,
+    height: number
+): Uint8ClampedArray {
+    const saturatedPixels = applySelectiveSaturation(pixels);
+    return applyUnsharpMask(saturatedPixels, width, height);
+}

--- a/apps/web/lib/imageEnhancer.ts
+++ b/apps/web/lib/imageEnhancer.ts
@@ -83,16 +83,16 @@ async function enhancePixelsOffThread(
     height: number
 ): Promise<Uint8ClampedArray> {
     const fallbackPixels = new Uint8ClampedArray(pixels);
-    const worker = ensureEnhancementWorker();
-
-    if (!worker) {
-        return enhanceImagePixels(fallbackPixels, width, height);
-    }
-
-    const transferablePixels = new Uint8ClampedArray(pixels);
-    const requestId = `image-enhancement-${workerRequestSequence++}`;
 
     try {
+        const worker = ensureEnhancementWorker();
+        if (!worker) {
+            return enhanceImagePixels(fallbackPixels, width, height);
+        }
+
+        const transferablePixels = new Uint8ClampedArray(pixels);
+        const requestId = `image-enhancement-${workerRequestSequence++}`;
+
         return await new Promise<Uint8ClampedArray>((resolve, reject) => {
             pendingWorkerRequests.set(requestId, { resolve, reject });
 
@@ -107,7 +107,6 @@ async function enhancePixelsOffThread(
             );
         });
     } catch (error) {
-        pendingWorkerRequests.delete(requestId);
         console.warn(
             "Image enhancement worker failed. Falling back to synchronous processing.",
             error

--- a/apps/web/lib/imageEnhancer.ts
+++ b/apps/web/lib/imageEnhancer.ts
@@ -1,25 +1,128 @@
-/**
- * Adaptive client-side data hygiene and image enhancement feature for sahidawa-india
- */
+import {
+    createImageEnhancementPlan,
+    enhanceImagePixels,
+    WEBP_OUTPUT_QUALITY,
+    WEBP_OUTPUT_TYPE,
+    type ImageEnhancementResponse,
+} from "./imageEnhancer.shared";
+
+type PendingWorkerRequest = {
+    resolve: (pixels: Uint8ClampedArray) => void;
+    reject: (error: Error) => void;
+};
+
+let enhancementWorker: Worker | null = null;
+let workerRequestSequence = 0;
+const pendingWorkerRequests = new Map<string, PendingWorkerRequest>();
+
+function hasCanvasSupport(): boolean {
+    if (typeof window === "undefined") {
+        return false;
+    }
+
+    try {
+        return !!document.createElement("canvas");
+    } catch {
+        return false;
+    }
+}
+
+function resetWorker() {
+    enhancementWorker?.terminate();
+    enhancementWorker = null;
+    pendingWorkerRequests.clear();
+}
+
+function ensureEnhancementWorker(): Worker | null {
+    if (typeof Worker === "undefined") {
+        return null;
+    }
+
+    if (enhancementWorker) {
+        return enhancementWorker;
+    }
+
+    const worker = new Worker("/workers/imageEnhancer.worker.js");
+
+    worker.onmessage = (event: MessageEvent<ImageEnhancementResponse>) => {
+        const { id, pixels, error } = event.data;
+        const pendingRequest = pendingWorkerRequests.get(id);
+        if (!pendingRequest) {
+            return;
+        }
+
+        pendingWorkerRequests.delete(id);
+
+        if (error) {
+            pendingRequest.reject(new Error(error));
+            return;
+        }
+
+        if (!pixels) {
+            pendingRequest.reject(new Error("Image enhancement worker returned no pixel buffer."));
+            return;
+        }
+
+        pendingRequest.resolve(new Uint8ClampedArray(pixels));
+    };
+
+    worker.onerror = () => {
+        for (const pendingRequest of pendingWorkerRequests.values()) {
+            pendingRequest.reject(new Error("Image enhancement worker crashed."));
+        }
+        resetWorker();
+    };
+
+    enhancementWorker = worker;
+    return worker;
+}
+
+async function enhancePixelsOffThread(
+    pixels: Uint8ClampedArray,
+    width: number,
+    height: number
+): Promise<Uint8ClampedArray> {
+    const fallbackPixels = new Uint8ClampedArray(pixels);
+    const worker = ensureEnhancementWorker();
+
+    if (!worker) {
+        return enhanceImagePixels(fallbackPixels, width, height);
+    }
+
+    const transferablePixels = new Uint8ClampedArray(pixels);
+    const requestId = `image-enhancement-${workerRequestSequence++}`;
+
+    try {
+        return await new Promise<Uint8ClampedArray>((resolve, reject) => {
+            pendingWorkerRequests.set(requestId, { resolve, reject });
+
+            worker.postMessage(
+                {
+                    id: requestId,
+                    width,
+                    height,
+                    pixels: transferablePixels,
+                },
+                [transferablePixels.buffer]
+            );
+        });
+    } catch (error) {
+        pendingWorkerRequests.delete(requestId);
+        console.warn(
+            "Image enhancement worker failed. Falling back to synchronous processing.",
+            error
+        );
+        return enhanceImagePixels(fallbackPixels, width, height);
+    }
+}
 
 export async function preprocessMedicineImage(
     input: File | Blob | string
 ): Promise<Blob | File | string> {
-    // 1. Safe Guard for Server-Side Rendering (SSR) environment executions
-    if (
-        typeof window === "undefined" ||
-        !(() => {
-            try {
-                return !!document.createElement("canvas");
-            } catch {
-                return false;
-            }
-        })()
-    ) {
+    if (!hasCanvasSupport()) {
         return input;
     }
 
-    // 2. Input MIME Type and Instance Structural Verification Guardrail
     if (input instanceof File && !input.type.startsWith("image/")) {
         console.warn("Invalid file payload provided. Bypassing enhancement processor pipelines.");
         return input;
@@ -32,25 +135,21 @@ export async function preprocessMedicineImage(
 
             const isString = typeof input === "string";
             const url = isString ? input : URL.createObjectURL(input);
-
-            // Preserve absolute incoming MIME structure to guard alpha channels / transparency
-            const outputMimeType = input instanceof File ? input.type : "image/jpeg";
-
-            // 3. Image Network Loading Timeout Engine Protection Guard (15 Second Limit)
             const executionTimeoutTracker = setTimeout(() => {
                 img.onload = null;
                 img.onerror = null;
-                if (!isString) URL.revokeObjectURL(url);
+                if (!isString) {
+                    URL.revokeObjectURL(url);
+                }
                 console.warn(
                     "Image payload ingestion timed out. Falling back to original resource stream."
                 );
                 resolve(input);
             }, 15000);
 
-            img.onload = () => {
+            img.onload = async () => {
                 clearTimeout(executionTimeoutTracker);
 
-                // 4. Resolution Bounds & Performance Downscaling
                 let width = img.width;
                 let height = img.height;
                 const maxLongEdge = 1200;
@@ -71,205 +170,58 @@ export async function preprocessMedicineImage(
                 const ctx = canvas.getContext("2d");
 
                 if (!ctx) {
-                    if (!isString) URL.revokeObjectURL(url);
-                    return reject(new Error("Canvas 2D context context initialization dropped."));
+                    if (!isString) {
+                        URL.revokeObjectURL(url);
+                    }
+                    reject(new Error("Canvas 2D context initialization dropped."));
+                    return;
                 }
 
-                // Draw standard clean buffer layout onto canvas plane
                 ctx.drawImage(img, 0, 0, width, height);
-                if (!isString) URL.revokeObjectURL(url);
+                if (!isString) {
+                    URL.revokeObjectURL(url);
+                }
 
-                let imageData: ImageData;
+                let sampledImageData: ImageData;
                 try {
-                    imageData = ctx.getImageData(0, 0, width, height);
+                    sampledImageData = ctx.getImageData(0, 0, width, height);
                 } catch (error) {
                     console.warn(
                         "Canvas getImageData locked via cross-origin parameters. Gracefully bypassing manipulation step tracks.",
                         error
                     );
-                    return resolve(input);
+                    resolve(input);
+                    return;
                 }
 
-                const data = imageData.data;
+                const plan = createImageEnhancementPlan(sampledImageData.data);
 
-                // 5. Context Aware Texture Complexity Parsing Check (Digital Graphic Filter Gate)
-                let extremeCount = 0;
-                let sampleCount = 0;
-                let sumLuminance = 0;
-
-                for (let i = 0; i < data.length; i += 16) {
-                    const l = 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
-                    sumLuminance += l;
-                    if (l < 15 || l > 240) {
-                        extremeCount++;
-                    }
-                    sampleCount++;
+                if (plan.filter !== "none") {
+                    ctx.filter = plan.filter;
+                    ctx.drawImage(img, 0, 0, width, height);
+                    ctx.filter = "none";
                 }
 
-                const isDigitalGraphic = extremeCount / sampleCount > 0.1;
-                const avgLuminance = sumLuminance / sampleCount;
+                if (plan.shouldRunWorker) {
+                    try {
+                        const filteredImageData = ctx.getImageData(0, 0, width, height);
+                        const enhancedPixels = await enhancePixelsOffThread(
+                            filteredImageData.data,
+                            width,
+                            height
+                        );
 
-                // 6. Unified Mathematical Adaptation Pipeline (Optimized for Mobile Performance)
-                if (!isDigitalGraphic) {
-                    // Dynamic Gamma Tuning
-                    let gamma = 1.0;
-                    if (avgLuminance < 100) {
-                        gamma = 0.8; // Gently brighten underexposed images
-                    } else if (avgLuminance > 180) {
-                        gamma = 1.15; // Gently darken overexposed glare
-                    }
-
-                    // Mild Contrast Curve Parameters
-                    const contrast = 12;
-                    const contrastFactor = (259 * (contrast + 255)) / (255 * (259 - contrast));
-
-                    const clamp = (val: number) => Math.min(255, Math.max(0, val));
-
-                    // Color Space Helpers
-                    const rgbToHsl = (r: number, g: number, b: number) => {
-                        r /= 255;
-                        g /= 255;
-                        b /= 255;
-                        const max = Math.max(r, g, b),
-                            min = Math.min(r, g, b);
-                        let h = 0,
-                            s = 0,
-                            l = (max + min) / 2;
-                        if (max !== min) {
-                            const d = max - min;
-                            s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
-                            switch (max) {
-                                case r:
-                                    h = (g - b) / d + (g < b ? 6 : 0);
-                                    break;
-                                case g:
-                                    h = (b - r) / d + 2;
-                                    break;
-                                case b:
-                                    h = (r - g) / d + 4;
-                                    break;
-                            }
-                            h /= 6;
-                        }
-                        return [h, s, l];
-                    };
-
-                    const hslToRgb = (h: number, s: number, l: number) => {
-                        let r, g, b;
-                        if (s === 0) {
-                            r = g = b = l;
-                        } else {
-                            const hue2rgb = (p: number, q: number, t: number) => {
-                                if (t < 0) t += 1;
-                                if (t > 1) t -= 1;
-                                if (t < 1 / 6) return p + (q - p) * 6 * t;
-                                if (t < 1 / 2) return q;
-                                if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
-                                return p;
-                            };
-                            const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-                            const p = 2 * l - q;
-                            r = hue2rgb(p, q, h + 1 / 3);
-                            g = hue2rgb(p, q, h);
-                            b = hue2rgb(p, q, h - 1 / 3);
-                        }
-                        return [r * 255, g * 255, b * 255];
-                    };
-
-                    // Single-Pass Pixel Loop for Gamma, Contrast, and Smart Saturation
-                    for (let i = 0; i < data.length; i += 4) {
-                        let r = data[i],
-                            g = data[i + 1],
-                            b = data[i + 2];
-
-                        // A. Gamma Correction
-                        if (gamma !== 1.0) {
-                            r = 255 * Math.pow(r / 255, gamma);
-                            g = 255 * Math.pow(g / 255, gamma);
-                            b = 255 * Math.pow(b / 255, gamma);
-                        }
-
-                        // B. Mild Contrast Application
-                        r = clamp(contrastFactor * (r - 128) + 128);
-                        g = clamp(contrastFactor * (g - 128) + 128);
-                        b = clamp(contrastFactor * (b - 128) + 128);
-
-                        // C. Smart Saturation (Luminance Masked to prevent neon noise artifacts)
-                        const [h, s, l] = rgbToHsl(r, g, b);
-
-                        // Protect dark shadows (<0.15), bright glares (>0.85), and true grays (s<0.05)
-                        if (l > 0.15 && l < 0.85 && s > 0.05) {
-                            // The mask peaks at 1.0 for mid-tones and drops to 0 at the boundaries
-                            const lumMask = 1.0 - Math.abs(l - 0.5) * 2.0;
-                            let newS = s + s * (1.0 - s) * 0.3 * lumMask;
-                            newS = Math.min(1.0, Math.max(0.0, newS));
-
-                            const [nR, nG, nB] = hslToRgb(h, newS, l);
-                            r = nR;
-                            g = nG;
-                            b = nB;
-                        }
-
-                        data[i] = r;
-                        data[i + 1] = g;
-                        data[i + 2] = b;
+                        filteredImageData.data.set(enhancedPixels);
+                        ctx.putImageData(filteredImageData, 0, 0);
+                    } catch (error) {
+                        console.warn(
+                            "Image enhancement worker pipeline failed. Continuing with filtered canvas output.",
+                            error
+                        );
                     }
                 }
 
-                ctx.putImageData(imageData, 0, 0);
-                let finalCanvasToBlob = canvas;
-
-                // 7. Sharpness Optimization Segment: Softened Unsharp Mask
-                if (!isDigitalGraphic) {
-                    const sharpCanvas = document.createElement("canvas");
-                    sharpCanvas.width = width;
-                    sharpCanvas.height = height;
-                    const sharpCtx = sharpCanvas.getContext("2d")!;
-                    sharpCtx.drawImage(canvas, 0, 0);
-
-                    const sourceData = sharpCtx.getImageData(0, 0, width, height);
-                    const destData = sharpCtx.createImageData(width, height);
-
-                    const src = sourceData.data;
-                    const dst = destData.data;
-                    const w = width;
-                    const h = height;
-
-                    // Safe, dampened sharpening kernel to boost text without crunching boundaries
-                    for (let y = 1; y < h - 1; y++) {
-                        for (let x = 1; x < w - 1; x++) {
-                            const idx = (y * w + x) * 4;
-                            for (let c = 0; c < 3; c++) {
-                                const val =
-                                    3.0 * src[idx + c] -
-                                    0.5 * src[((y - 1) * w + x) * 4 + c] -
-                                    0.5 * src[((y + 1) * w + x) * 4 + c] -
-                                    0.5 * src[(y * w + (x - 1)) * 4 + c] -
-                                    0.5 * src[(y * w + (x + 1)) * 4 + c];
-                                dst[idx + c] = Math.min(255, Math.max(0, val));
-                            }
-                            dst[idx + 3] = src[idx + 3]; // Preserve alpha
-                        }
-                    }
-
-                    // Frame Boundary Padding Sync
-                    for (let y = 0; y < h; y++) {
-                        for (let x = 0; x < w; x++) {
-                            if (y === 0 || y === h - 1 || x === 0 || x === w - 1) {
-                                const idx = (y * w + x) * 4;
-                                dst[idx] = src[idx];
-                                dst[idx + 1] = src[idx + 1];
-                                dst[idx + 2] = src[idx + 2];
-                                dst[idx + 3] = src[idx + 3];
-                            }
-                        }
-                    }
-                    sharpCtx.putImageData(destData, 0, 0);
-                    finalCanvasToBlob = sharpCanvas;
-                }
-
-                // 8. Output Serialization
-                finalCanvasToBlob.toBlob(
+                canvas.toBlob(
                     (blob) => {
                         if (blob) {
                             resolve(blob);
@@ -277,14 +229,16 @@ export async function preprocessMedicineImage(
                             resolve(input);
                         }
                     },
-                    outputMimeType,
-                    outputMimeType === "image/png" ? undefined : 0.8
+                    WEBP_OUTPUT_TYPE,
+                    WEBP_OUTPUT_QUALITY
                 );
             };
 
             img.onerror = () => {
                 clearTimeout(executionTimeoutTracker);
-                if (!isString) URL.revokeObjectURL(url);
+                if (!isString) {
+                    URL.revokeObjectURL(url);
+                }
                 console.warn("Source resource parsing failed. Dropping compression parameters.");
                 resolve(input);
             };

--- a/apps/web/public/workers/imageEnhancer.worker.js
+++ b/apps/web/public/workers/imageEnhancer.worker.js
@@ -1,0 +1,134 @@
+function clampChannel(value) {
+    return Math.min(255, Math.max(0, value));
+}
+
+function rgbToHsl(red, green, blue) {
+    const normalizedRed = red / 255;
+    const normalizedGreen = green / 255;
+    const normalizedBlue = blue / 255;
+    const max = Math.max(normalizedRed, normalizedGreen, normalizedBlue);
+    const min = Math.min(normalizedRed, normalizedGreen, normalizedBlue);
+    const lightness = (max + min) / 2;
+
+    if (max === min) {
+        return [0, 0, lightness];
+    }
+
+    const delta = max - min;
+    const saturation = lightness > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+
+    let hue = 0;
+    switch (max) {
+        case normalizedRed:
+            hue =
+                (normalizedGreen - normalizedBlue) / delta +
+                (normalizedGreen < normalizedBlue ? 6 : 0);
+            break;
+        case normalizedGreen:
+            hue = (normalizedBlue - normalizedRed) / delta + 2;
+            break;
+        default:
+            hue = (normalizedRed - normalizedGreen) / delta + 4;
+            break;
+    }
+
+    return [hue / 6, saturation, lightness];
+}
+
+function hslToRgb(hue, saturation, lightness) {
+    if (saturation === 0) {
+        const channel = lightness * 255;
+        return [channel, channel, channel];
+    }
+
+    const q =
+        lightness < 0.5
+            ? lightness * (1 + saturation)
+            : lightness + saturation - lightness * saturation;
+    const p = 2 * lightness - q;
+    const hueToChannel = (offset) => {
+        let channelHue = offset;
+        if (channelHue < 0) channelHue += 1;
+        if (channelHue > 1) channelHue -= 1;
+        if (channelHue < 1 / 6) return p + (q - p) * 6 * channelHue;
+        if (channelHue < 1 / 2) return q;
+        if (channelHue < 2 / 3) return p + (q - p) * (2 / 3 - channelHue) * 6;
+        return p;
+    };
+
+    return [
+        hueToChannel(hue + 1 / 3) * 255,
+        hueToChannel(hue) * 255,
+        hueToChannel(hue - 1 / 3) * 255,
+    ];
+}
+
+function applySelectiveSaturation(pixels) {
+    const enhanced = new Uint8ClampedArray(pixels);
+
+    for (let index = 0; index < enhanced.length; index += 4) {
+        const [hue, saturation, lightness] = rgbToHsl(
+            enhanced[index],
+            enhanced[index + 1],
+            enhanced[index + 2]
+        );
+
+        if (lightness <= 0.15 || lightness >= 0.85 || saturation <= 0.05) {
+            continue;
+        }
+
+        const luminanceMask = 1 - Math.abs(lightness - 0.5) * 2;
+        const nextSaturation = Math.min(
+            1,
+            Math.max(0, saturation + saturation * (1 - saturation) * 0.3 * luminanceMask)
+        );
+        const [red, green, blue] = hslToRgb(hue, nextSaturation, lightness);
+
+        enhanced[index] = clampChannel(red);
+        enhanced[index + 1] = clampChannel(green);
+        enhanced[index + 2] = clampChannel(blue);
+    }
+
+    return enhanced;
+}
+
+function applyUnsharpMask(pixels, width, height) {
+    if (width < 3 || height < 3) {
+        return pixels;
+    }
+
+    const sharpened = new Uint8ClampedArray(pixels);
+
+    for (let y = 1; y < height - 1; y++) {
+        for (let x = 1; x < width - 1; x++) {
+            const index = (y * width + x) * 4;
+
+            for (let channel = 0; channel < 3; channel++) {
+                const value =
+                    3.0 * pixels[index + channel] -
+                    0.5 * pixels[((y - 1) * width + x) * 4 + channel] -
+                    0.5 * pixels[((y + 1) * width + x) * 4 + channel] -
+                    0.5 * pixels[(y * width + (x - 1)) * 4 + channel] -
+                    0.5 * pixels[(y * width + (x + 1)) * 4 + channel];
+
+                sharpened[index + channel] = clampChannel(value);
+            }
+        }
+    }
+
+    return sharpened;
+}
+
+self.onmessage = (event) => {
+    const { id, pixels, width, height } = event.data;
+
+    try {
+        const enhancedPixels = applyUnsharpMask(applySelectiveSaturation(pixels), width, height);
+        self.postMessage({ id, pixels: enhancedPixels }, [enhancedPixels.buffer]);
+    } catch (error) {
+        self.postMessage({
+            id,
+            error: error instanceof Error ? error.message : "Image enhancement worker failed.",
+        });
+    }
+};

--- a/apps/web/tests/image-enhancer.test.ts
+++ b/apps/web/tests/image-enhancer.test.ts
@@ -110,8 +110,8 @@ describe("preprocessMedicineImage", () => {
         class MockImage {
             onload: null | (() => void) = null;
             onerror: null | (() => void) = null;
-            width = 2400;
-            height = 1200;
+            width = 2;
+            height = 2;
             crossOrigin = "";
 
             set src(_value: string) {
@@ -151,6 +151,68 @@ describe("preprocessMedicineImage", () => {
         expect(workerInstances).toHaveLength(1);
         expect(workerInstances[0].postMessage).toHaveBeenCalledTimes(1);
         expect(drawFilters).toContain("contrast(1.06) brightness(1.08)");
+        expect(toBlobCalls).toEqual([["image/webp", 0.8]]);
+    });
+
+    it("falls back to synchronous enhancement when worker construction throws", async () => {
+        const toBlobCalls: Array<[string, number | undefined]> = [];
+        const imagePixels = createPixelBuffer([
+            40, 42, 44, 255, 70, 72, 74, 255, 110, 112, 114, 255, 150, 152, 154, 255,
+        ]);
+        const canvases: CanvasMock[] = [];
+
+        globalThis.window = {} as Window & typeof globalThis;
+        globalThis.document = {
+            createElement: jest.fn((tagName: string) => {
+                if (tagName !== "canvas") {
+                    throw new Error(`Unexpected element request: ${tagName}`);
+                }
+
+                const canvas = createCanvas(imagePixels, toBlobCalls);
+                canvases.push(canvas);
+                return {
+                    width: canvas.width,
+                    height: canvas.height,
+                    getContext: jest.fn(() => canvas.context),
+                    toBlob: canvas.toBlob,
+                };
+            }),
+        } as unknown as Document;
+
+        URL.createObjectURL = jest.fn(() => "blob:mock-url");
+        URL.revokeObjectURL = jest.fn();
+
+        class MockImage {
+            onload: null | (() => void) = null;
+            onerror: null | (() => void) = null;
+            width = 2;
+            height = 2;
+            crossOrigin = "";
+
+            set src(_value: string) {
+                this.onload?.();
+            }
+        }
+
+        class ThrowingWorker {
+            constructor() {
+                throw new Error("worker init failed");
+            }
+        }
+
+        globalThis.Image = MockImage as unknown as typeof Image;
+        globalThis.Worker = ThrowingWorker as unknown as typeof Worker;
+
+        const input = new File(["photo"], "medicine.jpg", { type: "image/jpeg" });
+        const result = await preprocessMedicineImage(input);
+        const putImageDataCalls = canvases.reduce(
+            (count, canvas) => count + canvas.context.putImageData.mock.calls.length,
+            0
+        );
+
+        expect(result).toBeInstanceOf(Blob);
+        expect((result as Blob).type).toBe("image/webp");
+        expect(putImageDataCalls).toBe(1);
         expect(toBlobCalls).toEqual([["image/webp", 0.8]]);
     });
 });

--- a/apps/web/tests/image-enhancer.test.ts
+++ b/apps/web/tests/image-enhancer.test.ts
@@ -1,0 +1,156 @@
+import { preprocessMedicineImage } from "../lib/imageEnhancer";
+
+type CanvasMock = {
+    width: number;
+    height: number;
+    drawFilters: string[];
+    context: {
+        filter: string;
+        drawImage: jest.Mock;
+        getImageData: jest.Mock;
+        putImageData: jest.Mock;
+        createImageData: jest.Mock;
+    };
+    toBlob: jest.Mock;
+};
+
+function createPixelBuffer(values: number[]): Uint8ClampedArray {
+    return new Uint8ClampedArray(values);
+}
+
+function createCanvas(
+    imageData: Uint8ClampedArray,
+    toBlobCalls: Array<[string, number | undefined]>
+) {
+    const context = {
+        filter: "none",
+        drawImage: jest.fn(),
+        getImageData: jest.fn(() => ({
+            data: new Uint8ClampedArray(imageData),
+            width: 2,
+            height: 2,
+        })),
+        putImageData: jest.fn(),
+        createImageData: jest.fn((width: number, height: number) => ({
+            data: new Uint8ClampedArray(width * height * 4),
+            width,
+            height,
+        })),
+    };
+
+    const canvas: CanvasMock = {
+        width: 0,
+        height: 0,
+        drawFilters: [],
+        context,
+        toBlob: jest.fn(
+            (callback: (blob: Blob | null) => void, type?: string, quality?: number) => {
+                toBlobCalls.push([type ?? "", quality]);
+                callback(new Blob(["optimized"], { type: type ?? "image/webp" }));
+            }
+        ),
+    };
+
+    return canvas;
+}
+
+describe("preprocessMedicineImage", () => {
+    const realWindow = globalThis.window;
+    const realDocument = globalThis.document;
+    const realImage = globalThis.Image;
+    const realWorker = globalThis.Worker;
+    const realCreateObjectURL = URL.createObjectURL;
+    const realRevokeObjectURL = URL.revokeObjectURL;
+
+    beforeEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        globalThis.window = realWindow;
+        globalThis.document = realDocument;
+        globalThis.Image = realImage;
+        globalThis.Worker = realWorker;
+        URL.createObjectURL = realCreateObjectURL;
+        URL.revokeObjectURL = realRevokeObjectURL;
+    });
+
+    it("offloads photo enhancement to a worker, uses canvas filters, and serializes as WebP", async () => {
+        const toBlobCalls: Array<[string, number | undefined]> = [];
+        const imagePixels = createPixelBuffer([
+            40, 42, 44, 255, 70, 72, 74, 255, 110, 112, 114, 255, 150, 152, 154, 255,
+        ]);
+        const canvases: CanvasMock[] = [];
+        const workerInstances: Array<{ postMessage: jest.Mock }> = [];
+
+        globalThis.window = {} as Window & typeof globalThis;
+        globalThis.document = {
+            createElement: jest.fn((tagName: string) => {
+                if (tagName !== "canvas") {
+                    throw new Error(`Unexpected element request: ${tagName}`);
+                }
+
+                const canvas = createCanvas(imagePixels, toBlobCalls);
+                canvas.context.drawImage = jest.fn(() => {
+                    canvas.drawFilters.push(canvas.context.filter);
+                });
+                canvases.push(canvas);
+                return {
+                    width: canvas.width,
+                    height: canvas.height,
+                    getContext: jest.fn(() => canvas.context),
+                    toBlob: canvas.toBlob,
+                };
+            }),
+        } as unknown as Document;
+
+        URL.createObjectURL = jest.fn(() => "blob:mock-url");
+        URL.revokeObjectURL = jest.fn();
+
+        class MockImage {
+            onload: null | (() => void) = null;
+            onerror: null | (() => void) = null;
+            width = 2400;
+            height = 1200;
+            crossOrigin = "";
+
+            set src(_value: string) {
+                this.onload?.();
+            }
+        }
+
+        class MockWorker {
+            onmessage:
+                | null
+                | ((event: { data: { id: string; pixels: Uint8ClampedArray } }) => void) = null;
+            onerror: null | ((error: unknown) => void) = null;
+            postMessage = jest.fn((message: { id: string; pixels: Uint8ClampedArray }) => {
+                this.onmessage?.({
+                    data: {
+                        id: message.id,
+                        pixels: message.pixels,
+                    },
+                });
+            });
+            terminate = jest.fn();
+
+            constructor() {
+                workerInstances.push(this);
+            }
+        }
+
+        globalThis.Image = MockImage as unknown as typeof Image;
+        globalThis.Worker = MockWorker as unknown as typeof Worker;
+
+        const input = new File(["photo"], "medicine.jpg", { type: "image/jpeg" });
+        const result = await preprocessMedicineImage(input);
+        const drawFilters = canvases.flatMap((canvas) => canvas.drawFilters);
+
+        expect(result).toBeInstanceOf(Blob);
+        expect((result as Blob).type).toBe("image/webp");
+        expect(workerInstances).toHaveLength(1);
+        expect(workerInstances[0].postMessage).toHaveBeenCalledTimes(1);
+        expect(drawFilters).toContain("contrast(1.06) brightness(1.08)");
+        expect(toBlobCalls).toEqual([["image/webp", 0.8]]);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._

## 📋 PR Summary

This PR moves the heavy image-enhancement work in the report flow off the main thread so multi-image uploads stay responsive on slower devices. It also forces optimized uploads to `image/webp` at `0.8` quality and uses a simple `ctx.filter` pass for contrast and brightness before the worker handles the more expensive saturation and sharpening work.

---

## 🔗 Related Issue

Closes #524

---

## 🏷️ PR Type

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [x] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Moved the report-image enhancement path into a worker-backed pipeline, with a synchronous fallback if `Worker` is unavailable or fails.
- Added a canvas `filter` pass for the simple contrast/brightness adjustments before the worker applies selective saturation and sharpening.
- Forced report-image serialization to `image/webp` with `0.8` quality before upload.
- Updated the upload flow to keep enhanced filenames consistent with the new `.webp` MIME type.
- Added a focused regression test that covers worker usage, filter orchestration, and WebP serialization.

## 📸 Screenshots / Proof of Work (REQUIRED)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
> - **Backend/API/ML changes:** You MUST attach terminal logs, curl/Postman outputs, or test run outputs proving the changes work.
>
> _Please drag & drop your screenshots/GIFs here, or paste terminal/console logs below:_

<img width="1648" height="1712" alt="issue524-report-upload" src="https://github.com/user-attachments/assets/51902b7c-9c32-4a97-9399-56cb2d7dc939" />

Terminal verification:

```bash
npm test -w web -- --runTestsByPath tests/image-enhancer.test.ts --runInBand
npm run build -w web
```

Observed results:

- `tests/image-enhancer.test.ts` passed.
- `npm run build -w web` completed successfully.

Browser verification:

- Started the app locally with `npm run dev -w web -- --port 3010 --webpack`.
- Opened `http://localhost:3010/en/report`.
- Filled step 1, moved to the photo upload step, mocked `/api/upload` in-browser to avoid missing Cloudinary credentials, and injected two local image files into the real file input.
- Confirmed both previews rendered successfully (`icon-192.png` and `icon-512.png`) and no JavaScript errors appeared in the browser console.
- Local screenshot captured for attachment: `/tmp/issue524-report-upload.png`

Note:

- A full `npm test -w web -- --runInBand` run on current `upstream/main` still shows unrelated pre-existing failures in `tests/voice-accessibility.test.tsx`, `tests/pharmacy-panels.test.tsx`, and `tests/pharmacy-map-layout.test.tsx`.

---

## ✅ Contributor Checklist

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [ ] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [x] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change / N/A here)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant
