### PR TITLE
fix(api): handle fatal errors with graceful shutdown

### DIFF
--- a/apps/api/src/gracefulShutdown.ts
+++ b/apps/api/src/gracefulShutdown.ts
@@ -1,0 +1,97 @@
+import type { Server } from "http";
+import { supabase } from "./db/client";
+import logger from "./utils/logger";
+
+type ShutdownReason = "uncaughtException" | "unhandledRejection";
+
+type ShutdownOptions = {
+    exitProcess?: (code: number) => never | void;
+    timeoutMs?: number;
+};
+
+type SupabaseResourceClient = typeof supabase & {
+    removeAllChannels?: () => Promise<unknown> | unknown;
+    auth?: {
+        stopAutoRefresh?: () => void;
+    };
+};
+
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
+
+function getErrorDetails(error: unknown) {
+    if (error instanceof Error) {
+        return {
+            name: error.name,
+            message: error.message,
+            stack: error.stack,
+        };
+    }
+
+    return {
+        message: String(error),
+    };
+}
+
+function closeServer(server: Server): Promise<void> {
+    return new Promise((resolve, reject) => {
+        server.close((error?: Error) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+
+            resolve();
+        });
+    });
+}
+
+async function releaseDatabaseResources(): Promise<void> {
+    const client = supabase as SupabaseResourceClient;
+
+    await Promise.resolve(client.removeAllChannels?.());
+    client.auth?.stopAutoRefresh?.();
+}
+
+export function createGracefulShutdown(server: Server, options: ShutdownOptions = {}) {
+    const exitProcess = options.exitProcess ?? process.exit;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+    let isShuttingDown = false;
+
+    return async (reason: ShutdownReason, error: unknown): Promise<void> => {
+        if (isShuttingDown) {
+            logger.warn("Graceful shutdown already in progress", { reason });
+            return;
+        }
+
+        isShuttingDown = true;
+        logger.error(`${reason} detected. Starting graceful shutdown.`, {
+            reason,
+            error: getErrorDetails(error),
+        });
+
+        const timeout = setTimeout(() => {
+            logger.error("Graceful shutdown timed out. Forcing process exit.", {
+                reason,
+                timeoutMs,
+            });
+            exitProcess(1);
+        }, timeoutMs);
+        timeout.unref();
+
+        try {
+            await closeServer(server);
+            logger.info("HTTP server closed during graceful shutdown", { reason });
+
+            await releaseDatabaseResources();
+            logger.info("Database resources released during graceful shutdown", { reason });
+        } catch (shutdownError) {
+            logger.error("Error during graceful shutdown", {
+                reason,
+                error: getErrorDetails(shutdownError),
+            });
+        } finally {
+            clearTimeout(timeout);
+            exitProcess(1);
+        }
+    };
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,10 +1,21 @@
 import app from "./app";
+import { createGracefulShutdown } from "./gracefulShutdown";
 import logger from "./utils/logger";
 
 const port = process.env.PORT || 4000;
 
 if (process.env.NODE_ENV !== "test") {
-    app.listen(port, () => {
+    const server = app.listen(port, () => {
         logger.info(`SahiDawa API is running at http://localhost:${port}`);
+    });
+
+    const gracefulShutdown = createGracefulShutdown(server);
+
+    process.on("uncaughtException", (error) => {
+        void gracefulShutdown("uncaughtException", error);
+    });
+
+    process.on("unhandledRejection", (reason) => {
+        void gracefulShutdown("unhandledRejection", reason);
     });
 }

--- a/apps/api/tests/gracefulShutdown.test.ts
+++ b/apps/api/tests/gracefulShutdown.test.ts
@@ -1,0 +1,70 @@
+import type { Server } from "http";
+import { createGracefulShutdown } from "../src/gracefulShutdown";
+import { supabase } from "../src/db/client";
+import logger from "../src/utils/logger";
+
+jest.mock("../src/db/client", () => ({
+    supabase: {
+        removeAllChannels: jest.fn().mockResolvedValue(undefined),
+        auth: {
+            stopAutoRefresh: jest.fn(),
+        },
+    },
+}));
+
+jest.mock("../src/utils/logger", () => ({
+    __esModule: true,
+    default: {
+        error: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+
+describe("createGracefulShutdown", () => {
+    const exitProcess = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    function createServerMock(): Server {
+        return {
+            close: jest.fn((callback: (error?: Error) => void) => callback()),
+        } as unknown as Server;
+    }
+
+    it("closes the server, releases database resources, and exits for uncaught exceptions", async () => {
+        const server = createServerMock();
+        const shutdown = createGracefulShutdown(server, { exitProcess, timeoutMs: 1000 });
+
+        await shutdown("uncaughtException", new Error("boom"));
+
+        expect(server.close).toHaveBeenCalledTimes(1);
+        expect(supabase.removeAllChannels).toHaveBeenCalledTimes(1);
+        expect(supabase.auth.stopAutoRefresh).toHaveBeenCalledTimes(1);
+        expect(logger.error).toHaveBeenCalledWith(
+            "uncaughtException detected. Starting graceful shutdown.",
+            expect.objectContaining({ reason: "uncaughtException" })
+        );
+        expect(exitProcess).toHaveBeenCalledWith(1);
+    });
+
+    it("handles unhandled rejections with non-error reasons", async () => {
+        const server = createServerMock();
+        const shutdown = createGracefulShutdown(server, { exitProcess, timeoutMs: 1000 });
+
+        await shutdown("unhandledRejection", "rejected");
+
+        expect(server.close).toHaveBeenCalledTimes(1);
+        expect(supabase.removeAllChannels).toHaveBeenCalledTimes(1);
+        expect(logger.error).toHaveBeenCalledWith(
+            "unhandledRejection detected. Starting graceful shutdown.",
+            expect.objectContaining({
+                reason: "unhandledRejection",
+                error: { message: "rejected" },
+            })
+        );
+        expect(exitProcess).toHaveBeenCalledWith(1);
+    });
+});

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "ES2022",
         "module": "CommonJS",
         "moduleResolution": "node",
+        "ignoreDeprecations": "6.0",
         "rootDir": "./src",
         "outDir": "./dist",
 


### PR DESCRIPTION
## 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._

## 📋 PR Summary

Implemented graceful shutdown handling for fatal API runtime errors so the Express server logs the error, stops accepting requests, releases Supabase resources, and exits with status code 1.

---

## 🔗 Related Issue

Closes #277

---

## 🏷️ PR Type

- [x] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [ ] `apps/web` — Next.js Frontend
- [x] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Added process-level graceful shutdown handling for `uncaughtException`.
- Added process-level graceful shutdown handling for `unhandledRejection`.
- Closed the Express HTTP server during shutdown.
- Released Supabase client resources during shutdown.
- Logged fatal error details using the existing Winston logger.
- Added tests covering both fatal error shutdown paths.
- Fixed the API TypeScript build config by silencing the TypeScript 6 `moduleResolution=node10` deprecation warning.

## 📸 Screenshots / Proof of Work (REQUIRED)

```powershell
> npm test -w apps/api

> sahidawa-api@1.0.0 test
> jest

Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Ran all test suites.