### PR TITLE
feat(web): add MedicinePhotoUpload component with Cloudinary integration (WCAG AA + memory safe)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,9 +37,8 @@ VAPID_PRIVATE_KEY=your_vapid_private_key
 VAPID_SUBJECT=mailto:security@sahidawa.local
 
 # --- Cloudinary (Medicine Photo Storage) ---
-CLOUDINARY_CLOUD_NAME=your_cloud_name
-CLOUDINARY_API_KEY=your_api_key
-CLOUDINARY_API_SECRET=your_api_secret
+NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=cloud_name_here
+NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET=sahidawa_medicines
 
 # --- AI / External APIs ---
 SARVAM_API_KEY=your_sarvam_api_key

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -26,6 +26,7 @@ import LanguageSwitcher from "./LanguageSwitcher";
 import SearchBar from "./components/SearchBar";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
+import MedicinePhotoUpload from "@/components/MedicinePhotoUpload";
 
 function formatRelativeTime(dateString: string | null): string {
     if (!dateString) return "Recent";
@@ -339,6 +340,30 @@ export default function SahiDawaHome() {
                             />
                         </button>
                     </div>
+                </div>
+
+                {/* ── Medicine Photo Upload ── */}
+                <div className="mt-8 overflow-hidden rounded-3xl border border-emerald-200/60 bg-gradient-to-br from-emerald-50 via-white to-teal-50/80 p-6 shadow-md shadow-emerald-100/50 sm:p-8">
+                    <div className="mb-6 flex items-center gap-3">
+                        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-500 to-teal-600 shadow-lg shadow-emerald-500/30">
+                            <Camera size={24} className="text-white" />
+                        </div>
+                        <div>
+                            <h3 className="text-xl font-extrabold tracking-tight text-slate-800">
+                                Verify Medicine Photo
+                            </h3>
+                            <p className="text-sm font-medium text-slate-500">
+                                Upload packaging for AI-powered fake medicine detection
+                            </p>
+                        </div>
+                    </div>
+                    <MedicinePhotoUpload
+                        onUploadSuccess={(url) => {
+                            console.log("Medicine photo uploaded:", url);
+                            // TODO: pass url to ML service
+                        }}
+                        onUploadError={(err) => console.error("Upload error:", err)}
+                    />
                 </div>
 
                 {/* ── Global Search ── */}

--- a/apps/web/app/scan/page.tsx
+++ b/apps/web/app/scan/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import MedicinePhotoUpload from "@/components/MedicinePhotoUpload";
+
+export default function ScanPage() {
+  const handleUploadSuccess = (cloudinaryUrl: string) => {
+    console.log("Image ready for AI processing:", cloudinaryUrl);
+    // TODO: pass cloudinaryUrl to your ML service / API route
+  };
+
+  const handleUploadError = (error: string) => {
+    console.error("Upload failed:", error);
+  };
+
+  return (
+    <main className="min-h-screen p-6 flex flex-col items-center gap-8">
+      <h1 className="text-2xl font-bold text-gray-800">Verify Your Medicine</h1>
+      <p className="text-gray-500 text-sm text-center max-w-sm">
+        Take a photo of the medicine packaging. Our AI will check if it's genuine.
+      </p>
+
+      <MedicinePhotoUpload
+        onUploadSuccess={handleUploadSuccess}
+        onUploadError={handleUploadError}
+      />
+    </main>
+  );
+}

--- a/apps/web/components/MedicinePhotoUpload/index.tsx
+++ b/apps/web/components/MedicinePhotoUpload/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useCallback } from "react";
+import { useRef, useState, useCallback, useEffect } from "react";
 
 const MAX_FILE_SIZE_MB = 5;
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
@@ -23,7 +23,20 @@ export default function MedicinePhotoUpload({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [cloudinaryUrl, setCloudinaryUrl] = useState<string | null>(null);
 
+  // ── Fix 2: Revoke object URL on unmount to prevent memory leaks ──
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
   const resetState = () => {
+    // Revoke before clearing so we don't leak on manual reset
+    if (previewUrl) {
+      URL.revokeObjectURL(previewUrl);
+    }
     setUploadState("idle");
     setProgress(0);
     setPreviewUrl(null);
@@ -60,7 +73,6 @@ export default function MedicinePhotoUpload({
       setProgress(0);
 
       try {
-        // Use XMLHttpRequest so we can track upload progress
         await new Promise<void>((resolve, reject) => {
           const xhr = new XMLHttpRequest();
 
@@ -107,71 +119,93 @@ export default function MedicinePhotoUpload({
 
       setUploadState("validating");
       setErrorMessage(null);
-      setPreviewUrl(null);
 
-      // Validate type
+      // Revoke previous preview URL before creating a new one
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+        setPreviewUrl(null);
+      }
+
       if (!ALLOWED_TYPES.includes(file.type)) {
         handleError("Invalid file type. Please upload a JPG, PNG, or WebP image.");
         return;
       }
 
-      // Validate size
       if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
         handleError(`File too large. Maximum size is ${MAX_FILE_SIZE_MB}MB.`);
         return;
       }
 
-      // Show local preview immediately
       const objectUrl = URL.createObjectURL(file);
       setPreviewUrl(objectUrl);
 
       await uploadToCloudinary(file);
     },
-    [handleError, uploadToCloudinary]
+    [handleError, uploadToCloudinary, previewUrl]
   );
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     handleFileChange(e.target.files?.[0]);
   };
 
-  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+  const handleDrop = (e: React.DragEvent<HTMLButtonElement>) => {
     e.preventDefault();
     handleFileChange(e.dataTransfer.files?.[0]);
   };
 
-  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+  const handleDragOver = (e: React.DragEvent<HTMLButtonElement>) => {
     e.preventDefault();
+  };
+
+  // ── Fix 1: Keyboard support — trigger file input on Space or Enter ──
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === " " || e.key === "Enter") {
+      e.preventDefault();
+      if (!isUploading) fileInputRef.current?.click();
+    }
   };
 
   const isUploading = uploadState === "uploading" || uploadState === "validating";
 
   return (
     <div className="w-full max-w-md mx-auto font-sans">
-      {/* Drop zone / trigger area */}
+      {/* ── Fix 1: button instead of div — keyboard & screen reader accessible ── */}
       {uploadState !== "success" && (
-        <div
+        <button
+          type="button"
           onDrop={handleDrop}
           onDragOver={handleDragOver}
           onClick={() => !isUploading && fileInputRef.current?.click()}
+          onKeyDown={handleKeyDown}
+          disabled={isUploading}
+          aria-label={
+            isUploading
+              ? uploadState === "validating"
+                ? "Checking file"
+                : `Uploading, ${progress} percent complete`
+              : "Select or capture a medicine photo to upload"
+          }
           className={`
-            relative flex flex-col items-center justify-center gap-3
-            rounded-2xl border-2 border-dashed p-8 text-center transition-colors cursor-pointer
+            relative flex w-full flex-col items-center justify-center gap-3
+            rounded-2xl border-2 border-dashed p-8 text-center transition-colors
+            outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2
             ${isUploading
-              ? "border-blue-300 bg-blue-50 cursor-not-allowed"
+              ? "cursor-not-allowed border-blue-300 bg-blue-50"
               : uploadState === "error"
-              ? "border-red-300 bg-red-50 hover:bg-red-100"
-              : "border-gray-300 bg-gray-50 hover:bg-gray-100 hover:border-blue-400"
+              ? "cursor-pointer border-red-300 bg-red-50 hover:bg-red-100"
+              : "cursor-pointer border-gray-300 bg-gray-50 hover:border-blue-400 hover:bg-gray-100"
             }
           `}
         >
-          {/* Camera icon */}
-          <div className="text-4xl select-none">
+          <div className="text-4xl select-none" aria-hidden="true">
             {isUploading ? "⏳" : uploadState === "error" ? "⚠️" : "📷"}
           </div>
 
           {isUploading ? (
-            <p className="text-sm text-blue-700 font-medium">
-              {uploadState === "validating" ? "Checking file…" : `Uploading… ${progress}%`}
+            <p className="text-sm font-medium text-blue-700">
+              {uploadState === "validating"
+                ? "Checking file…"
+                : `Uploading… ${progress}%`}
             </p>
           ) : (
             <>
@@ -184,7 +218,6 @@ export default function MedicinePhotoUpload({
             </>
           )}
 
-          {/* Hidden file input — accepts camera on mobile */}
           <input
             ref={fileInputRef}
             type="file"
@@ -193,21 +226,25 @@ export default function MedicinePhotoUpload({
             className="hidden"
             onChange={handleInputChange}
             disabled={isUploading}
-            aria-label="Upload medicine photo"
+            aria-hidden="true"
+            tabIndex={-1}
           />
-        </div>
+        </button>
       )}
 
       {/* Progress bar */}
       {uploadState === "uploading" && (
-        <div className="mt-3 w-full bg-gray-200 rounded-full h-2 overflow-hidden">
+        <div
+          className="mt-3 w-full bg-gray-200 rounded-full h-2 overflow-hidden"
+          role="progressbar"
+          aria-valuenow={progress}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`Upload progress: ${progress}%`}
+        >
           <div
             className="h-2 bg-blue-500 rounded-full transition-all duration-200"
             style={{ width: `${progress}%` }}
-            role="progressbar"
-            aria-valuenow={progress}
-            aria-valuemin={0}
-            aria-valuemax={100}
           />
         </div>
       )}
@@ -223,20 +260,21 @@ export default function MedicinePhotoUpload({
 
           {uploadState === "success" && (
             <div className="mt-3 flex flex-col gap-2">
-              <div className="flex items-center gap-2 text-green-700 bg-green-50 border border-green-200 rounded-lg px-4 py-2 text-sm font-medium">
-                <span>✅</span>
+              <div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 px-4 py-2 text-sm font-medium text-green-700">
+                <span aria-hidden="true">✅</span>
                 <span>Photo uploaded successfully</span>
               </div>
 
               {cloudinaryUrl && (
-                <p className="text-xs text-gray-400 break-all px-1">
+                <p className="break-all px-1 text-xs text-gray-400">
                   {cloudinaryUrl}
                 </p>
               )}
 
               <button
+                type="button"
                 onClick={resetState}
-                className="mt-1 text-sm text-blue-600 underline hover:text-blue-800 text-left"
+                className="mt-1 text-left text-sm text-blue-600 underline hover:text-blue-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
               >
                 Upload a different photo
               </button>
@@ -247,13 +285,17 @@ export default function MedicinePhotoUpload({
 
       {/* Error message */}
       {uploadState === "error" && errorMessage && (
-        <div className="mt-3 flex items-start gap-2 bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-sm text-red-700">
-          <span className="mt-0.5">❌</span>
+        <div
+          role="alert"
+          className="mt-3 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+        >
+          <span aria-hidden="true" className="mt-0.5">❌</span>
           <div className="flex-1">
             <p className="font-medium">{errorMessage}</p>
             <button
+              type="button"
               onClick={resetState}
-              className="mt-1 text-red-600 underline hover:text-red-800 text-xs"
+              className="mt-1 text-xs text-red-600 underline hover:text-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
             >
               Try again
             </button>

--- a/apps/web/components/MedicinePhotoUpload/index.tsx
+++ b/apps/web/components/MedicinePhotoUpload/index.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useRef, useState, useCallback } from "react";
+
+const MAX_FILE_SIZE_MB = 5;
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+interface MedicinePhotoUploadProps {
+  onUploadSuccess: (cloudinaryUrl: string) => void;
+  onUploadError?: (error: string) => void;
+}
+
+type UploadState = "idle" | "validating" | "uploading" | "success" | "error";
+
+export default function MedicinePhotoUpload({
+  onUploadSuccess,
+  onUploadError,
+}: MedicinePhotoUploadProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadState, setUploadState] = useState<UploadState>("idle");
+  const [progress, setProgress] = useState(0);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [cloudinaryUrl, setCloudinaryUrl] = useState<string | null>(null);
+
+  const resetState = () => {
+    setUploadState("idle");
+    setProgress(0);
+    setPreviewUrl(null);
+    setErrorMessage(null);
+    setCloudinaryUrl(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleError = useCallback(
+    (message: string) => {
+      setUploadState("error");
+      setErrorMessage(message);
+      onUploadError?.(message);
+    },
+    [onUploadError]
+  );
+
+  const uploadToCloudinary = useCallback(
+    async (file: File) => {
+      const cloudName = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
+      const uploadPreset = process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET;
+
+      if (!cloudName || !uploadPreset) {
+        handleError("Cloudinary is not configured. Check your .env.local file.");
+        return;
+      }
+
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("upload_preset", uploadPreset);
+      formData.append("folder", "sahidawa/medicines");
+
+      setUploadState("uploading");
+      setProgress(0);
+
+      try {
+        // Use XMLHttpRequest so we can track upload progress
+        await new Promise<void>((resolve, reject) => {
+          const xhr = new XMLHttpRequest();
+
+          xhr.upload.addEventListener("progress", (e) => {
+            if (e.lengthComputable) {
+              setProgress(Math.round((e.loaded / e.total) * 100));
+            }
+          });
+
+          xhr.addEventListener("load", () => {
+            if (xhr.status >= 200 && xhr.status < 300) {
+              const data = JSON.parse(xhr.responseText);
+              setCloudinaryUrl(data.secure_url);
+              setUploadState("success");
+              onUploadSuccess(data.secure_url);
+              resolve();
+            } else {
+              reject(new Error("Upload failed — server returned " + xhr.status));
+            }
+          });
+
+          xhr.addEventListener("error", () =>
+            reject(new Error("Network error during upload."))
+          );
+
+          xhr.open(
+            "POST",
+            `https://api.cloudinary.com/v1_1/${cloudName}/image/upload`
+          );
+          xhr.send(formData);
+        });
+      } catch (err: unknown) {
+        handleError(
+          err instanceof Error ? err.message : "Upload failed. Please try again."
+        );
+      }
+    },
+    [onUploadSuccess, handleError]
+  );
+
+  const handleFileChange = useCallback(
+    async (file: File | null | undefined) => {
+      if (!file) return;
+
+      setUploadState("validating");
+      setErrorMessage(null);
+      setPreviewUrl(null);
+
+      // Validate type
+      if (!ALLOWED_TYPES.includes(file.type)) {
+        handleError("Invalid file type. Please upload a JPG, PNG, or WebP image.");
+        return;
+      }
+
+      // Validate size
+      if (file.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+        handleError(`File too large. Maximum size is ${MAX_FILE_SIZE_MB}MB.`);
+        return;
+      }
+
+      // Show local preview immediately
+      const objectUrl = URL.createObjectURL(file);
+      setPreviewUrl(objectUrl);
+
+      await uploadToCloudinary(file);
+    },
+    [handleError, uploadToCloudinary]
+  );
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    handleFileChange(e.target.files?.[0]);
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    handleFileChange(e.dataTransfer.files?.[0]);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+  };
+
+  const isUploading = uploadState === "uploading" || uploadState === "validating";
+
+  return (
+    <div className="w-full max-w-md mx-auto font-sans">
+      {/* Drop zone / trigger area */}
+      {uploadState !== "success" && (
+        <div
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onClick={() => !isUploading && fileInputRef.current?.click()}
+          className={`
+            relative flex flex-col items-center justify-center gap-3
+            rounded-2xl border-2 border-dashed p-8 text-center transition-colors cursor-pointer
+            ${isUploading
+              ? "border-blue-300 bg-blue-50 cursor-not-allowed"
+              : uploadState === "error"
+              ? "border-red-300 bg-red-50 hover:bg-red-100"
+              : "border-gray-300 bg-gray-50 hover:bg-gray-100 hover:border-blue-400"
+            }
+          `}
+        >
+          {/* Camera icon */}
+          <div className="text-4xl select-none">
+            {isUploading ? "⏳" : uploadState === "error" ? "⚠️" : "📷"}
+          </div>
+
+          {isUploading ? (
+            <p className="text-sm text-blue-700 font-medium">
+              {uploadState === "validating" ? "Checking file…" : `Uploading… ${progress}%`}
+            </p>
+          ) : (
+            <>
+              <p className="text-sm font-semibold text-gray-700">
+                Tap to photograph or upload medicine packaging
+              </p>
+              <p className="text-xs text-gray-500">
+                JPG, PNG, or WebP — max {MAX_FILE_SIZE_MB}MB
+              </p>
+            </>
+          )}
+
+          {/* Hidden file input — accepts camera on mobile */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            capture="environment"
+            className="hidden"
+            onChange={handleInputChange}
+            disabled={isUploading}
+            aria-label="Upload medicine photo"
+          />
+        </div>
+      )}
+
+      {/* Progress bar */}
+      {uploadState === "uploading" && (
+        <div className="mt-3 w-full bg-gray-200 rounded-full h-2 overflow-hidden">
+          <div
+            className="h-2 bg-blue-500 rounded-full transition-all duration-200"
+            style={{ width: `${progress}%` }}
+            role="progressbar"
+            aria-valuenow={progress}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          />
+        </div>
+      )}
+
+      {/* Preview + success */}
+      {previewUrl && (
+        <div className="mt-4">
+          <img
+            src={previewUrl}
+            alt="Medicine packaging preview"
+            className="w-full rounded-xl object-cover max-h-64 border border-gray-200 shadow-sm"
+          />
+
+          {uploadState === "success" && (
+            <div className="mt-3 flex flex-col gap-2">
+              <div className="flex items-center gap-2 text-green-700 bg-green-50 border border-green-200 rounded-lg px-4 py-2 text-sm font-medium">
+                <span>✅</span>
+                <span>Photo uploaded successfully</span>
+              </div>
+
+              {cloudinaryUrl && (
+                <p className="text-xs text-gray-400 break-all px-1">
+                  {cloudinaryUrl}
+                </p>
+              )}
+
+              <button
+                onClick={resetState}
+                className="mt-1 text-sm text-blue-600 underline hover:text-blue-800 text-left"
+              >
+                Upload a different photo
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Error message */}
+      {uploadState === "error" && errorMessage && (
+        <div className="mt-3 flex items-start gap-2 bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-sm text-red-700">
+          <span className="mt-0.5">❌</span>
+          <div className="flex-1">
+            <p className="font-medium">{errorMessage}</p>
+            <button
+              onClick={resetState}
+              className="mt-1 text-red-600 underline hover:text-red-800 text-xs"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._

## 📋 PR Summary

Implements the `MedicinePhotoUpload` component with Cloudinary Media API 
integration within `apps/web`. Users can now photograph or upload medicine 
packaging directly from the landing page (below the AI Health Assistant 
banner), with real-time upload progress, image preview, and the Cloudinary 
URL returned to the parent component for future ML pipeline integration.

This PR also addresses all production-grade review feedback — WCAG AA 
keyboard accessibility compliance and memory leak fixes critical for 
low-RAM rural devices.
---

## 🔗 Related Issue

<!-- Link the issue this PR resolves. For example: Closes 123 -->

Closes #424 

---

## 🏷️ PR Type

<!-- Select the type of changes. Replace [ ] with [x] for matching items. -->

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [x] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [x] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

<!-- Select the areas that have been modified by this PR. Replace [ ] with [x] for matching items. -->

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done


## 📝 What Was Done

- Created `apps/web/components/MedicinePhotoUpload/index.tsx` — reusable 
  upload component built with Cloudinary Media API
- Integrated component into `apps/web/app/[locale]/page.tsx` on the 
  landing page, positioned after the AI Health Assistant banner
- Added `NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME` and 
  `NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET` to `.env.example`
- Implemented real-time upload progress tracking via `XMLHttpRequest`
- Implemented mobile camera capture via `capture="environment"` on file input
- Added client-side file type validation (JPG, PNG, WebP only)
- Added client-side file size validation (max 5MB)
- Returns Cloudinary `secure_url` to parent via `onUploadSuccess` callback
- Added graceful error handling with user-friendly messages
- **Accessibility fix:** Converted dropzone `<div>` to `<button type="button">` 
  with `onKeyDown` handler for Space/Enter key support and 
  `focus-visible:ring-2 focus-visible:ring-emerald-500` focus ring
- **Accessibility fix:** Added `role="progressbar"` with full ARIA attributes 
  on progress bar and `role="alert"` on error container
- **Accessibility fix:** Hidden file input marked `aria-hidden="true"` and 
  `tabIndex={-1}` to prevent screen reader double-announcement
- **Memory fix:** `URL.revokeObjectURL()` called in all three required places — 
  on unmount via `useEffect` cleanup, on manual reset, and before new 
  preview replaces old one

- ***

## 📸 Screenshots / Proof of Work (REQUIRED)

PR 585 for the screenshots

https://github.com/user-attachments/assets/1e61df58-88e8-46fa-9d91-a3f16306d971


---

## ✅ Contributor Checklist

<!-- Ensure you have completed the following steps before requesting a review. Replace [ ] with [x]. -->

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [ ] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant
