### PR TITLE
feat: add locale aware AI chat responses

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -149,7 +149,7 @@ export async function POST(req: Request) {
 
         const formattedContents = mapMessagesToGeminiContents(messages || []);
 
-        const supportedLocales = ["en", "gu", "hi", "bn", "te", "ta", "mr"];
+        const supportedLocales = ["en", "gu", "bn", "te", "ta", "mr", "ur", "kn"];
         const finalLocale = supportedLocales.includes(locale) ? locale : "en";
         const localeMap = {
             en: "English",

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI } from "@google/genai";
 import { NextResponse } from "next/server";
 import { detectEmergencyKeywords } from "@/lib/voice/emergency";
+import { BASE_PROMPT } from "@/lib/chatPrompts";
 
 const DEFAULT_DISCLAIMER =
     "This guidance is for informational use only and is not a diagnosis. Consult a doctor or pharmacist, especially for severe or persistent symptoms.";
@@ -115,7 +116,7 @@ function getAiClient() {
 export async function POST(req: Request) {
     try {
         const ai = getAiClient();
-        const { messages, mode, responseLanguage } = await req.json();
+        const { messages, mode, responseLanguage, locale } = await req.json();
         const latestMessageText = getLatestMessageText(messages);
 
         if (!latestMessageText) {
@@ -148,12 +149,26 @@ export async function POST(req: Request) {
 
         const formattedContents = mapMessagesToGeminiContents(messages || []);
 
+        const supportedLocales = ["en", "gu", "hi", "bn", "te", "ta", "mr"];
+        const finalLocale = supportedLocales.includes(locale) ? locale : "en";
+        const localeMap = {
+            en: "English",
+            bn: "Bengali",
+            gu: "Gujarati",
+            kn: "Kannada",
+            mr: "Marathi",
+            ta: "Tamil",
+            te: "Telugu",
+            ur: "Urdu",
+        };
+        const language = localeMap[finalLocale as keyof typeof localeMap];
+        const systemPrompt = BASE_PROMPT.replace("{language}", language);
+
         const response = await ai.models.generateContent({
             model: "gemini-2.5-flash",
             contents: formattedContents,
             config: {
-                systemInstruction:
-                    "You are the SahiDawa AI Assistant. SahiDawa is India's First Open-Source Citizen Medicine Verifier & Rural Health Bridge. You help users verify medicine information, understand their prescriptions, and navigate the app. Be concise, empathetic, and highly accurate in your medical guidance, but always remind users to consult a doctor for serious concerns.",
+                systemInstruction: systemPrompt,
             },
         });
 

--- a/apps/web/app/components/health/ChatUI.tsx
+++ b/apps/web/app/components/health/ChatUI.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
+import { useParams } from "next/navigation";
 import { ChatBubble, type Message } from "./components/ChatBubble";
 import { ActionCard } from "./components/ActionCard";
 import { TypingIndicator } from "./components/TypingIndicator";
@@ -9,19 +10,22 @@ import { Camera, Pill, MapPin } from "lucide-react";
 
 const genId = () => Math.random().toString(36).slice(2, 10);
 
-const SYSTEM_PROMPT = `You are SahiDawa, India's trusted open-source health assistant and medicine verifier.
-Help citizens verify medicines, understand symptoms, find appropriate care, and make informed health decisions.
-Respond warmly, empathetically, and clearly. Keep responses concise (2–4 sentences) and actionable.
-Understand Hindi/Hinglish but respond in simple English unless asked otherwise.
-Never diagnose. Help people understand when to seek professional care.
-For medicine queries, describe common use and always recommend a doctor or pharmacist.`;
+const INITIAL_MESSAGES = {
+    en: "Namaste, I'm SahiDawa, your trusted health companion. I can help you verify medicines, understand symptoms, or find nearby care. What would you like help with today?",
 
-const INITIAL_MESSAGE: Message = {
-    id: "init",
-    role: "assistant",
-    content:
-        "Namaste, I'm SahiDawa, your trusted health companion. I can help you verify medicines, understand symptoms, or find nearby care. What would you like help with today?",
-    timestamp: new Date(),
+    bn: "নমস্কার, আমি SahiDawa। আমি ওষুধ যাচাই, উপসর্গ বোঝা এবং নিকটবর্তী স্বাস্থ্যসেবা খুঁজে পেতে সাহায্য করতে পারি। আজ আপনাকে কীভাবে সাহায্য করতে পারি?",
+
+    te: "నమస్కారం, నేను SahiDawa. మందులను ధృవీకరించడం, లక్షణాలను అర్థం చేసుకోవడం మరియు సమీప వైద్య సేవలను కనుగొనడంలో నేను సహాయం చేయగలను. ఈ రోజు మీకు ఎలా సహాయం చేయగలను?",
+
+    ta: "வணக்கம், நான் SahiDawa. மருந்துகளை சரிபார்க்கவும், அறிகுறிகளை புரிந்துகொள்ளவும் மற்றும் அருகிலுள்ள சிகிச்சை சேவைகளை கண்டறியவும் உதவ முடியும். இன்று உங்களுக்கு என்ன உதவி வேண்டும்?",
+
+    mr: "नमस्कार, मी SahiDawa आहे. मी औषध पडताळणी, लक्षणे समजून घेणे आणि जवळील आरोग्यसेवा शोधण्यात मदत करू शकतो. आज मी तुम्हाला कशी मदत करू?",
+
+    gu: "નમસ્તે, હું SahiDawa છું. હું તમને દવાઓ ચકાસવામાં, લક્ષણો સમજવામાં અને નજીકની આરોગ્ય સેવાઓ શોધવામાં મદદ કરી શકું છું. આજે હું તમારી કેવી રીતે મદદ કરી શકું?",
+
+    kn: "ನಮಸ್ಕಾರ, ನಾನು SahiDawa. ಔಷಧಿಗಳನ್ನು ಪರಿಶೀಲಿಸಲು, ಲಕ್ಷಣಗಳನ್ನು ಅರ್ಥಮಾಡಿಕೊಳ್ಳಲು ಮತ್ತು ಸಮೀಪದ ಆರೋಗ್ಯ ಸೇವೆಗಳನ್ನು ಹುಡುಕಲು ನಾನು ಸಹಾಯ ಮಾಡಬಹುದು. ಇಂದು ನಿಮಗೆ ಹೇಗೆ ಸಹಾಯ ಮಾಡಲಿ?",
+
+    ur: "السلام علیکم، میں SahiDawa ہوں۔ میں ادویات کی تصدیق، علامات کو سمجھنے اور قریبی صحت کی سہولیات تلاش کرنے میں مدد کر سکتا ہوں۔ آج میں آپ کی کیسے مدد کر سکتا ہوں؟",
 };
 
 // Icons
@@ -94,7 +98,15 @@ const ACTIONS = [
 ];
 
 export default function ChatUI() {
-    const [messages, setMessages] = useState<Message[]>([INITIAL_MESSAGE]);
+    const params = useParams();
+    const locale = (params.locale as string) || "en";
+    const initialMessage: Message = {
+        id: "init",
+        role: "assistant",
+        content: INITIAL_MESSAGES[locale as keyof typeof INITIAL_MESSAGES] || INITIAL_MESSAGES.en,
+        timestamp: new Date(),
+    };
+    const [messages, setMessages] = useState<Message[]>([initialMessage]);
     const [input, setInput] = useState("");
     const [isTyping, setIsTyping] = useState(false);
     const [isListening, setIsListening] = useState(false);
@@ -145,7 +157,7 @@ export default function ChatUI() {
                 const res = await fetch("/api/chat", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ messages: history }),
+                    body: JSON.stringify({ messages: history, locale }),
                 });
                 if (!res.ok) throw new Error();
                 const data = await res.json();
@@ -192,7 +204,18 @@ export default function ChatUI() {
         }
         const SR = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
         const r = new SR();
-        r.lang = "en-IN";
+        const speechLocales = {
+            en: "en-IN",
+            hi: "hi-IN",
+            bn: "bn-IN",
+            gu: "gu-IN",
+            te: "te-IN",
+            ta: "ta-IN",
+            kn: "kn-IN",
+            ur: "ur-IN",
+            mr: "mr-IN",
+        };
+        r.lang = speechLocales[locale as keyof typeof speechLocales] || "en-IN";
         r.interimResults = false;
         r.onresult = (e: any) => {
             setInput(e.results[0][0].transcript);

--- a/apps/web/lib/chatPrompts.ts
+++ b/apps/web/lib/chatPrompts.ts
@@ -1,0 +1,18 @@
+export const BASE_PROMPT = `
+You are SahiDawa, India's trusted open-source health assistant and medicine verifier.
+
+Help citizens verify medicines, understand symptoms, find appropriate care, and make informed health decisions.
+
+Respond warmly, empathetically, and clearly.
+
+Keep responses concise (2–4 sentences) and actionable.
+
+Never diagnose.
+
+Help people understand when to seek professional care.
+
+For medicine queries, describe common use and always recommend a doctor or pharmacist.
+
+IMPORTANT:
+Respond in {language}.
+`;


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._

## 📋 PR Summary

<!-- Provide a brief summary of the changes introduced by this PR. -->

This PR adds locale-aware support to the AI chat assistant so responses automatically follow the application's selected language instead of defaulting to English.

The chat system was refactored by moving the system prompt from `ChatUI.tsx` into a dedicated `chatPrompts.ts` file under `lib/`, making prompt management centralized and easier to maintain.

The original SahiDawa assistant prompt behavior was preserved while adding dynamic language support

## 🔗 Related Issue

<!-- Link the issue this PR resolves. For example: Closes 123 -->

Closes #552 

---

## 🏷️ PR Type

<!-- Select the type of changes. Replace [ ] with [x] for matching items. -->

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [x] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [x] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [x] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

<!-- Select the areas that have been modified by this PR. Replace [ ] with [x] for matching items. -->

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

<!-- Provide a bulleted list of the exact changes made in this PR. -->

- Moved AI system prompt from `ChatUI.tsx` to `lib/chatPrompts.ts`
- Preserved the existing SahiDawa assistant prompt behavior
- Added locale-aware AI responses
- Passed active locale from frontend chat request to `/api/chat`
- Added dynamic language injection based on selected locale
- Added localized initial welcome messages which could be done in a better way in later prs
- Added support for:
  - English (`en`)
  - Bengali (`bn`)
  - Gujarati (`gu`)
  - Kannada (`kn`)
  - Marathi (`mr`)
  - Tamil (`ta`)
  - Telugu (`te`)
  - Urdu (`ur`)
- Updated voice locale handling for multilingual support
- Refactored prompt handling for easier future maintenance

## 📸 Screenshots / Proof of Work (REQUIRED)

- Different languages with different initial messages and chat support and proper response from the server

<img width="1771" height="744" alt="Screenshot 2026-05-26 005005" src="https://github.com/user-attachments/assets/3f611f0f-ec14-41ee-b9a1-84d3a26ddb9d" />
<img width="1702" height="838" alt="Screenshot 2026-05-26 005017" src="https://github.com/user-attachments/assets/34e746be-07ff-495d-8902-be080c6d08f0" />
<img width="1678" height="713" alt="Screenshot 2026-05-26 005030" src="https://github.com/user-attachments/assets/f9e2e195-89da-423a-9c5c-797edbd01cd5" />
<img width="1720" height="850" alt="Screenshot 2026-05-26 005253" src="https://github.com/user-attachments/assets/3a23ca47-9bef-4ab9-8ca6-468eb2eca22b" />
<img width="960" height="210" alt="Screenshot 2026-05-26 005724" src="https://github.com/user-attachments/assets/39349d76-5935-4dde-9481-3e7bb5c4792e" />

---

## ✅ Contributor Checklist

<!-- Ensure you have completed the following steps before requesting a review. Replace [ ] with [x]. -->

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [x] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant
