### PR TITLE
feat(a11y): add global focus-visible outline for interactive elements

### DIFF
--- a/apps/web/app/[locale]/globals.css
+++ b/apps/web/app/[locale]/globals.css
@@ -281,3 +281,15 @@
 .dark ::-webkit-scrollbar-thumb:hover {
     background: var(--color-text-secondary);
 }
+
+/* Accessibility: Focus visible states for interactive elements */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid #2563eb !important;
+  outline-offset: 2px !important;
+}
+


### PR DESCRIPTION
Fixes #670. This PR adds a global \:focus-visible\ CSS outline to all interactive elements to ensure accessibility for keyboard users.