### PR TITLE
fix: prevent role escalation via client-controlled metadata

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -32,7 +32,7 @@ const getBearerToken = (authorization?: string): string | null => {
 };
 
 const getUserRole = (user: User): AuthRole => {
-    const metadataRole = user.app_metadata?.role || user.user_metadata?.role;
+const metadataRole = user.app_metadata?.role;
     return metadataRole === "admin" ? "admin" : "user";
 };
 


### PR DESCRIPTION
## Summary

Fixed a privilege escalation vulnerability in the authentication middleware where user roles were being read from both `app_metadata` and client-controlled `user_metadata`.

## Changes Made

* Removed role fallback to `user_metadata`
* Restricted authorization checks to server-controlled `app_metadata`
* Preserved safe fallback behavior for non-admin users

## Security Impact

Prevents authenticated users from self-assigning elevated roles such as `admin` through the Supabase client SDK.

Closes #740
