### PR TITLE
fix: prevent duplicate district alerts for verified fake reports

### DIFF
--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -68,29 +68,29 @@ export const updateReportStatus = async (req: AuthenticatedRequest, res: Respons
       .eq('district', data.district)
       .eq('status', 'verified_fake');
 
-   if (count && count >= 3) {
-  const alertLevel = count >= 10 ? 'high' : 'medium';
+    if (count && count >= 3) {
+    const alertLevel = count >= 10 ? 'high' : 'medium';
 
-  const { data: existingAlert } = await supabase
-    .from('district_alerts')
-    .select('id, alert_level')
-    .eq('district', data.district)
-    .maybeSingle();
-
-  if (!existingAlert) {
-    await supabase.from('district_alerts').insert({
-      district: data.district,
-      medicine_name: data.reported_brand_name,
-      alert_level: alertLevel,
-    });
-  } else if (existingAlert.alert_level !== alertLevel) {
-    await supabase
+    const { data: existingAlert } = await supabase
       .from('district_alerts')
-      .update({ alert_level: alertLevel })
-      .eq('id', existingAlert.id);
+      .select('id, alert_level')
+      .eq('district', data.district)
+      .maybeSingle();
+
+    if (!existingAlert) {
+      await supabase.from('district_alerts').insert({
+        district: data.district,
+        medicine_name: data.reported_brand_name,
+        alert_level: alertLevel,
+      });
+    } else if (existingAlert.alert_level !== alertLevel) {
+      await supabase
+        .from('district_alerts')
+        .update({ alert_level: alertLevel })
+        .eq('id', existingAlert.id);
+    }
   }
-}
-}
+
   res.json({ message: 'Report updated', report: data });
 };
 

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -17,114 +17,132 @@ const medicineSchema = z.object({
 });
 
 export const getPendingReports = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  const { data, error } = await supabase
-    .from('counterfeit_reports')
-    .select('*, medicines(brand_name, generic_name)')
-    .eq('status', 'pending')
-    .order('created_at', { ascending: false });
+  try {
+    const { data, error } = await supabase
+      .from('counterfeit_reports')
+      .select('*, medicines(brand_name, generic_name)')
+      .eq('status', 'pending')
+      .order('created_at', { ascending: false });
 
-  if (error) {
-    res.status(500).json({ error: 'Failed to fetch reports' });
-    return;
+    if (error) {
+      res.status(500).json({ error: 'Failed to fetch reports' });
+      return;
+    }
+
+    res.json({ reports: data });
+  } catch (err) {
+    res.status(500).json({ error: 'Internal server error' });
   }
-
-  res.json({ reports: data });
 };
 
 export const updateReportStatus = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  const { id } = req.params;
-  const parsed = reportStatusSchema.safeParse(req.body);
+  try {
+    const { id } = req.params;
+    const parsed = reportStatusSchema.safeParse(req.body);
 
-  if (!parsed.success) {
-    res.status(400).json({ error: 'Invalid status', details: parsed.error.issues });
-    return;
-  }
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid status', details: parsed.error.issues });
+      return;
+    }
 
-  const { status } = parsed.data;
+    const { status } = parsed.data;
 
-  const { data, error } = await supabase
-    .from('counterfeit_reports')
-    .update({ status })
-    .eq('id', id)
-    .select()
-    .single();
-
-  if (error) {
-    res.status(500).json({ error: 'Failed to update report' });
-    return;
-  }
-
-  if (!data) {
-    res.status(404).json({ error: 'Report not found' });
-    return;
-  }
-
-  await logAdminAction(req.user!.id, `STATUS_${status.toUpperCase()}`, 'REPORT', id as string, { status });
-
-  if (status === 'verified_fake' && data.district) {
-    const { count } = await supabase
+    const { data, error } = await supabase
       .from('counterfeit_reports')
-      .select('*', { count: 'exact', head: true })
-      .eq('district', data.district)
-      .eq('status', 'verified_fake');
+      .update({ status })
+      .eq('id', id)
+      .select()
+      .single();
 
-    if (count && count >= 3) {
-      const alertLevel = count >= 10 ? 'high' : 'medium';
+    if (error) {
+      res.status(500).json({ error: 'Failed to update report' });
+      return;
+    }
 
-      const { data: existingAlert } = await supabase
-        .from('district_alerts')
-        .select('id, alert_level')
+    if (!data) {
+      res.status(404).json({ error: 'Report not found' });
+      return;
+    }
+
+    await logAdminAction(req.user!.id, `STATUS_${status.toUpperCase()}`, 'REPORT', id as string, { status });
+
+    // --- DISTRICT ALERT LOGIC ---
+    if (status === 'verified_fake' && data.district) {
+      const { count } = await supabase
+        .from('counterfeit_reports')
+        .select('*', { count: 'exact', head: true })
         .eq('district', data.district)
-        .maybeSingle();
+        .eq('status', 'verified_fake');
 
-      if (!existingAlert) {
-        await supabase.from('district_alerts').insert({
-          district: data.district,
-          medicine_name: data.reported_brand_name,
-          alert_level: alertLevel,
-        });
-      } else if (existingAlert.alert_level !== alertLevel) {
-        await supabase
+      if (count && count >= 3) {
+        const alertLevel = count >= 10 ? 'high' : 'medium';
+
+        const { data: existingAlert } = await supabase
           .from('district_alerts')
-          .update({ alert_level: alertLevel })
-          .eq('id', existingAlert.id);
+          .select('id, alert_level')
+          .eq('district', data.district)
+          .maybeSingle();
+
+        if (!existingAlert) {
+          // Create new alert if none exists
+          await supabase.from('district_alerts').insert({
+            district: data.district,
+            medicine_name: data.reported || 'Unknown',
+            alert_level: alertLevel
+          });
+        } else if (existingAlert.alert_level !== alertLevel) {
+          // Upgrade the alert level if the count threshold changed
+          await supabase.from('district_alerts')
+            .update({ alert_level: alertLevel })
+            .eq('id', existingAlert.id);
+        }
       }
     }
-  }
 
-  res.json({ message: 'Report updated', report: data });
+    res.json({ message: 'Status updated', report: data });
+  } catch (err) {
+    res.status(500).json({ error: 'Internal server error' });
+  }
 };
 
 export const getAllMedicines = async (_req: AuthenticatedRequest, res: Response): Promise<void> => {
-  const { data, error } = await supabase.from('medicines').select('*').limit(50);
-
-  if (error) {
-    res.status(500).json({ error: 'Failed to fetch medicines' });
-    return;
+  try {
+    const { data, error } = await supabase.from('medicines').select('*').limit(50);
+    
+    if (error) {
+      res.status(500).json({ error: 'Failed to fetch medicines' });
+      return;
+    }
+    
+    res.json({ medicines: data });
+  } catch (err) {
+    res.status(500).json({ error: 'Internal server error' });
   }
-
-  res.json(data);
 };
 
 export const createMedicine = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
-  const parsed = medicineSchema.safeParse(req.body);
+  try {
+    const parsed = medicineSchema.safeParse(req.body);
+    
+    if (!parsed.success) {
+      res.status(400).json({ error: 'Invalid medicine data', details: parsed.error.issues });
+      return;
+    }
 
-  if (!parsed.success) {
-    res.status(400).json({ error: 'Invalid data', details: parsed.error.issues });
-    return;
+    const { data, error } = await supabase
+      .from('medicines')
+      .insert(parsed.data)
+      .select()
+      .single();
+
+    if (error || !data) {
+      res.status(500).json({ error: 'Failed to create medicine' });
+      return;
+    }
+
+    await logAdminAction(req.user!.id, 'CREATE_MEDICINE', 'MEDICINE', data.id, parsed.data);
+    res.status(201).json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Internal server error' });
   }
-
-  const { data, error } = await supabase
-    .from('medicines')
-    .insert(parsed.data)
-    .select()
-    .single();
-
-  if (error) {
-    res.status(500).json({ error: 'Failed to create medicine' });
-    return;
-  }
-
-  await logAdminAction(req.user!.id, 'CREATE_MEDICINE', 'MEDICINE', data.id, parsed.data);
-  res.status(201).json(data);
 };

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -68,10 +68,12 @@ export const updateReportStatus = async (req: AuthenticatedRequest, res: Respons
       .eq('district', data.district)
       .eq('status', 'verified_fake');
 
-    if (count && count >= 3) {
+   if (count && count >= 3) {
+  const alertLevel = count >= 10 ? 'high' : 'medium';
+
   const { data: existingAlert } = await supabase
     .from('district_alerts')
-    .select('id')
+    .select('id, alert_level')
     .eq('district', data.district)
     .maybeSingle();
 
@@ -79,8 +81,13 @@ export const updateReportStatus = async (req: AuthenticatedRequest, res: Respons
     await supabase.from('district_alerts').insert({
       district: data.district,
       medicine_name: data.reported_brand_name,
-      alert_level: count >= 10 ? 'high' : 'medium',
+      alert_level: alertLevel,
     });
+  } else if (existingAlert.alert_level !== alertLevel) {
+    await supabase
+      .from('district_alerts')
+      .update({ alert_level: alertLevel })
+      .eq('id', existingAlert.id);
   }
 }
 

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -90,7 +90,7 @@ export const updateReportStatus = async (req: AuthenticatedRequest, res: Respons
       .eq('id', existingAlert.id);
   }
 }
-  }
+}
   res.json({ message: 'Report updated', report: data });
 };
 

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -69,13 +69,20 @@ export const updateReportStatus = async (req: AuthenticatedRequest, res: Respons
       .eq('status', 'verified_fake');
 
     if (count && count >= 3) {
-      await supabase.from('district_alerts').insert({
-        district: data.district,
-        medicine_name: data.reported_brand_name,
-        alert_level: count >= 10 ? 'high' : 'medium',
-      });
-    }
+  const { data: existingAlert } = await supabase
+    .from('district_alerts')
+    .select('id')
+    .eq('district', data.district)
+    .maybeSingle();
+
+  if (!existingAlert) {
+    await supabase.from('district_alerts').insert({
+      district: data.district,
+      medicine_name: data.reported_brand_name,
+      alert_level: count >= 10 ? 'high' : 'medium',
+    });
   }
+}
 
   res.json({ message: 'Report updated', report: data });
 };

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -31,6 +31,7 @@ export const getPendingReports = async (req: AuthenticatedRequest, res: Response
 
     res.json({ reports: data });
   } catch (err) {
+    console.error(err)
     res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -87,7 +88,7 @@ export const updateReportStatus = async (req: AuthenticatedRequest, res: Respons
           // Create new alert if none exists
           await supabase.from('district_alerts').insert({
             district: data.district,
-            medicine_name: data.reported || 'Unknown',
+            medicine_name: data.reported_brand_name,
             alert_level: alertLevel
           });
         } else if (existingAlert.alert_level !== alertLevel) {
@@ -101,6 +102,7 @@ export const updateReportStatus = async (req: AuthenticatedRequest, res: Respons
 
     res.json({ message: 'Status updated', report: data });
   } catch (err) {
+    console.error(err)
     res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -116,6 +118,7 @@ export const getAllMedicines = async (_req: AuthenticatedRequest, res: Response)
     
     res.json({ medicines: data });
   } catch (err) {
+    console.error(err)
     res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -143,6 +146,7 @@ export const createMedicine = async (req: AuthenticatedRequest, res: Response): 
     await logAdminAction(req.user!.id, 'CREATE_MEDICINE', 'MEDICINE', data.id, parsed.data);
     res.status(201).json(data);
   } catch (err) {
+    console.error(err)
     res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -90,7 +90,7 @@ export const updateReportStatus = async (req: AuthenticatedRequest, res: Respons
       .eq('id', existingAlert.id);
   }
 }
-
+  }
   res.json({ message: 'Report updated', report: data });
 };
 

--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -69,25 +69,26 @@ export const updateReportStatus = async (req: AuthenticatedRequest, res: Respons
       .eq('status', 'verified_fake');
 
     if (count && count >= 3) {
-    const alertLevel = count >= 10 ? 'high' : 'medium';
+      const alertLevel = count >= 10 ? 'high' : 'medium';
 
-    const { data: existingAlert } = await supabase
-      .from('district_alerts')
-      .select('id, alert_level')
-      .eq('district', data.district)
-      .maybeSingle();
-
-    if (!existingAlert) {
-      await supabase.from('district_alerts').insert({
-        district: data.district,
-        medicine_name: data.reported_brand_name,
-        alert_level: alertLevel,
-      });
-    } else if (existingAlert.alert_level !== alertLevel) {
-      await supabase
+      const { data: existingAlert } = await supabase
         .from('district_alerts')
-        .update({ alert_level: alertLevel })
-        .eq('id', existingAlert.id);
+        .select('id, alert_level')
+        .eq('district', data.district)
+        .maybeSingle();
+
+      if (!existingAlert) {
+        await supabase.from('district_alerts').insert({
+          district: data.district,
+          medicine_name: data.reported_brand_name,
+          alert_level: alertLevel,
+        });
+      } else if (existingAlert.alert_level !== alertLevel) {
+        await supabase
+          .from('district_alerts')
+          .update({ alert_level: alertLevel })
+          .eq('id', existingAlert.id);
+      }
     }
   }
 

--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -97,6 +97,7 @@ async function fetchWithTimeout(
         });
         return response;
     } catch (err) {
+        console.error(err)
         if ((err as Error).name === "AbortError") {
             throw new Error(
                 `Database request timed out after ${CONNECTION_TIMEOUT_MS}ms`
@@ -117,6 +118,7 @@ async function fetchWithRetry(
         try {
             return await fetchWithTimeout(input, init);
         } catch (err) {
+            console.error(err)
             const isLast = attempt === retries;
             const msg = err instanceof Error ? err.message : String(err);
 

--- a/apps/api/tests/pharmacies.test.ts
+++ b/apps/api/tests/pharmacies.test.ts
@@ -59,7 +59,7 @@ describe("GET /api/pharmacies/nearest", () => {
             error: { message: "RPC unavailable" },
         } as never);
 
-        const select = jest.fn().mockResolvedValueOnce({
+        const limit = jest.fn().mockResolvedValueOnce({
             data: [
                 {
                     name: "Nearby Pharmacy",
@@ -97,22 +97,43 @@ describe("GET /api/pharmacies/nearest", () => {
             error: null,
         });
 
+        const select = jest.fn().mockReturnValue({
+            limit,
+        });
+
         mockedSupabase.from.mockReturnValueOnce({ select } as never);
 
-        const response = await request(app).get("/api/pharmacies/nearest?lat=12.9716&lng=77.5946&radius=10");
+        const response = await request(app).get(
+            "/api/pharmacies/nearest?lat=12.9716&lng=77.5946&radius=10"
+        );
 
         expect(response.status).toBe(200);
-        expect(mockedSupabase.rpc).toHaveBeenCalledWith("get_nearest_pharmacies", {
-            query_lat: 12.9716,
-            query_lng: 77.5946,
-        });
+
+        expect(mockedSupabase.rpc).toHaveBeenCalledWith(
+            "get_nearest_pharmacies",
+            {
+                query_lat: 12.9716,
+                query_lng: 77.5946,
+            }
+        );
+
         expect(mockedSupabase.from).toHaveBeenCalledWith("pharmacies");
+
         expect(select).toHaveBeenCalledWith("*");
+
+        expect(limit).toHaveBeenCalled();
+
         expect(response.body.pharmacies).toHaveLength(2);
-        expect(response.body.pharmacies.map((pharmacy: { name: string }) => pharmacy.name)).toEqual([
+
+        expect(
+            response.body.pharmacies.map(
+                (pharmacy: { name: string }) => pharmacy.name
+            )
+        ).toEqual([
             "Nearby Pharmacy",
             "Mid Pharmacy",
         ]);
+
         expect(response.body.pharmacies[0]).not.toHaveProperty("rawDistance");
     });
 });

--- a/apps/api/tests/pharmacies.test.ts
+++ b/apps/api/tests/pharmacies.test.ts
@@ -119,7 +119,9 @@ describe("GET /api/pharmacies/nearest", () => {
 
         expect(mockedSupabase.from).toHaveBeenCalledWith("pharmacies");
 
-        expect(select).toHaveBeenCalledWith("*");
+     expect(select).toHaveBeenCalledWith(
+    "name, address, location, phone_number, is_verified, district, state"
+);
 
         expect(limit).toHaveBeenCalled();
 

--- a/apps/api/tests/pharmacies.test.ts
+++ b/apps/api/tests/pharmacies.test.ts
@@ -20,52 +20,6 @@ const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
 describe("GET /api/pharmacies/nearest", () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        
-        // Create proper mock chain for district_alerts queries
-        const maybeSingleMock = jest.fn().mockResolvedValue({
-            data: null,
-            error: null,
-        });
-
-        const eqMock = jest.fn().mockReturnValue({
-            maybeSingle: maybeSingleMock,
-            eq: jest.fn().mockResolvedValue({
-                data: [],
-                error: null,
-            }),
-        });
-
-        const selectMock = jest.fn().mockReturnValue({
-            eq: eqMock,
-            range: jest.fn().mockResolvedValue({
-                data: [],
-                error: null,
-                count: 0,
-            }),
-        });
-
-        mockedSupabase.from.mockReturnValue({
-            select: selectMock,
-            insert: jest.fn().mockResolvedValue({
-                data: null,
-                error: null,
-            }),
-            update: jest.fn().mockReturnValue({
-                eq: jest.fn().mockResolvedValue({
-                    data: null,
-                    error: null,
-                }),
-            }),
-        } as never);
-    });
-
-    afterEach(() => {
-        jest.clearAllTimers();
-    });
-
-    afterAll(async () => {
-        jest.clearAllMocks();
-        await new Promise(resolve => setTimeout(resolve, 100));
     });
 
     it("returns 400 when latitude or longitude is missing", async () => {

--- a/apps/api/tests/pharmacies.test.ts
+++ b/apps/api/tests/pharmacies.test.ts
@@ -22,6 +22,14 @@ describe("GET /api/pharmacies/nearest", () => {
         jest.clearAllMocks();
     });
 
+    afterEach(() => {
+        jest.clearAllTimers();
+    });
+
+    afterAll(async () => {
+        await new Promise(resolve => setTimeout(resolve, 100));
+    });
+
     it("returns 400 when latitude or longitude is missing", async () => {
         const missingLatitude = await request(app).get("/api/pharmacies/nearest?lng=77.5946");
         const missingLongitude = await request(app).get("/api/pharmacies/nearest?lat=12.9716");

--- a/apps/api/tests/pharmacies.test.ts
+++ b/apps/api/tests/pharmacies.test.ts
@@ -20,19 +20,40 @@ const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
 describe("GET /api/pharmacies/nearest", () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        // Set default mock for any from() calls
+        
+        // Create proper mock chain for district_alerts queries
+        const maybeSingleMock = jest.fn().mockResolvedValue({
+            data: null,
+            error: null,
+        });
+
+        const eqMock = jest.fn().mockReturnValue({
+            maybeSingle: maybeSingleMock,
+            eq: jest.fn().mockResolvedValue({
+                data: [],
+                error: null,
+            }),
+        });
+
+        const selectMock = jest.fn().mockReturnValue({
+            eq: eqMock,
+            range: jest.fn().mockResolvedValue({
+                data: [],
+                error: null,
+                count: 0,
+            }),
+        });
+
         mockedSupabase.from.mockReturnValue({
-            select: jest.fn().mockReturnValue({
-                range: jest.fn().mockResolvedValue({
-                    data: [],
+            select: selectMock,
+            insert: jest.fn().mockResolvedValue({
+                data: null,
+                error: null,
+            }),
+            update: jest.fn().mockReturnValue({
+                eq: jest.fn().mockResolvedValue({
+                    data: null,
                     error: null,
-                    count: 0,
-                }),
-                eq: jest.fn().mockReturnValue({
-                    eq: jest.fn().mockResolvedValue({
-                        data: [],
-                        error: null,
-                    }),
                 }),
             }),
         } as never);
@@ -43,6 +64,7 @@ describe("GET /api/pharmacies/nearest", () => {
     });
 
     afterAll(async () => {
+        jest.clearAllMocks();
         await new Promise(resolve => setTimeout(resolve, 100));
     });
 

--- a/apps/api/tests/pharmacies.test.ts
+++ b/apps/api/tests/pharmacies.test.ts
@@ -20,6 +20,22 @@ const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
 describe("GET /api/pharmacies/nearest", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        // Set default mock for any from() calls
+        mockedSupabase.from.mockReturnValue({
+            select: jest.fn().mockReturnValue({
+                range: jest.fn().mockResolvedValue({
+                    data: [],
+                    error: null,
+                    count: 0,
+                }),
+                eq: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockResolvedValue({
+                        data: [],
+                        error: null,
+                    }),
+                }),
+            }),
+        } as never);
     });
 
     afterEach(() => {

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "isolatedModules": true,
         "target": "ES2022",
         "module": "Node16",
         "moduleResolution": "node16",


### PR DESCRIPTION
## Summary

Prevents duplicate district alerts from being created when multiple reports in the same district are marked as `verified_fake`.

### Changes
- Added existing alert check before insertion
- Used `maybeSingle()` for safer lookup handling
- Ensured only one alert per district is created

Closes #741