### PR TITLE
fix(web): enable Kannada and Punjabi locales

### DIFF
--- a/apps/web/app/[locale]/LanguageSwitcher.tsx
+++ b/apps/web/app/[locale]/LanguageSwitcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useLocale, useTranslations } from "next-intl";
+import { useLocale } from "next-intl";
 import { useRouter, usePathname } from "@/i18n/routing";
 import { Globe, ChevronDown } from "lucide-react";
 import { useState, useRef, useEffect } from "react";
@@ -14,7 +14,9 @@ const languages = [
   { code: "mr", label: "Marathi", native: "मराठी" },
   { code: "gu", label: "Gujarati", native: "ગુજરાતી" },
   { code: "ur", label: "Urdu", native: "اردو" },
-  { code: "od", label: "Odia", native: "ଓଡ଼ିଆ" }
+  { code: "od", label: "Odia", native: "ଓଡ଼ିଆ" },
+  { code: "kn", label: "Kannada", native: "ಕನ್ನಡ" },
+  { code: "pa", label: "Punjabi", native: "ਪੰਜਾਬੀ" }
 ];
 
 export default function LanguageSwitcher() {

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -171,7 +171,7 @@ export async function POST(req: Request) {
 
         const formattedContents = mapMessagesToGeminiContents(messages || []);
 
-        const supportedLocales = ["en", "gu", "bn", "te", "ta", "mr", "ur", "kn"];
+        const supportedLocales = ["en", "gu", "bn", "te", "ta", "mr", "ur", "kn", "pa"];
         const finalLocale = supportedLocales.includes(locale) ? locale : "en";
         const localeMap = {
             en: "English",
@@ -180,6 +180,7 @@ export async function POST(req: Request) {
             gu: "Gujarati",
             kn: "Kannada",
             mr: "Marathi",
+            pa: "Punjabi",
             ta: "Tamil",
             te: "Telugu",
             ur: "Urdu",

--- a/apps/web/i18n/routing.ts
+++ b/apps/web/i18n/routing.ts
@@ -2,7 +2,7 @@ import {defineRouting} from 'next-intl/routing';
 import {createNavigation} from 'next-intl/navigation';
 
 export const routing = defineRouting({
-  locales: ['en', 'ta', 'bn', 'te', 'mr', 'gu', 'ur', 'od', 'hi'],
+  locales: ['en', 'ta', 'bn', 'te', 'mr', 'gu', 'ur', 'od', 'hi', 'kn', 'pa'],
   defaultLocale: 'en'
 });
 

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -5,5 +5,5 @@ export default createMiddleware(routing);
  
 export const config = {
   // Match only internationalized pathnames
-  matcher: ['/', '/(ta|en|bn|te|mr|gu|ur|od|hi)/:path*']
+  matcher: ['/', '/(ta|en|bn|te|mr|gu|ur|od|hi|kn|pa)/:path*']
 };

--- a/apps/web/tests/chat-route.test.ts
+++ b/apps/web/tests/chat-route.test.ts
@@ -126,4 +126,30 @@ describe("POST /api/chat", () => {
             config: expect.any(Object),
         });
     });
+
+    it("uses Punjabi in the standard chat system prompt when locale is pa", async () => {
+        generateContentMock.mockResolvedValue({
+            text: "ਮੈਂ ਮਦਦ ਕਰ ਸਕਦਾ ਹਾਂ।",
+        });
+
+        const response = await POST(
+            new Request("http://localhost/api/chat", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    locale: "pa",
+                    messages: [{ role: "user", content: "What is paracetamol?" }],
+                }),
+            })
+        );
+
+        expect(response.status).toBe(200);
+        expect(generateContentMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                config: expect.objectContaining({
+                    systemInstruction: expect.stringContaining("Punjabi"),
+                }),
+            })
+        );
+    });
 });

--- a/apps/web/tests/i18n-locales.test.tsx
+++ b/apps/web/tests/i18n-locales.test.tsx
@@ -1,0 +1,38 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import LanguageSwitcher from "../app/[locale]/LanguageSwitcher";
+import { routing } from "../i18n/routing";
+import { config as proxyConfig } from "../proxy";
+
+let activeLocale = "en";
+
+jest.mock("next-intl/middleware", () => jest.fn(() => () => undefined));
+
+jest.mock("next-intl", () => ({
+    useLocale: () => activeLocale,
+    useTranslations: () => (key: string) => key,
+}));
+
+describe("i18n locale availability", () => {
+    it.each(["kn", "pa"])("enables %s in the routing config", (locale) => {
+        expect(routing.locales).toContain(locale);
+    });
+
+    it("matches every routing locale in the proxy config", () => {
+        const localeMatcher = proxyConfig.matcher.find((matcher) => matcher.endsWith("/:path*"));
+        const matchedLocales = localeMatcher?.match(/\(([^)]+)\)/)?.[1].split("|");
+
+        expect(matchedLocales).toEqual(expect.arrayContaining(routing.locales));
+    });
+
+    it.each([
+        ["kn", "ಕನ್ನಡ"],
+        ["pa", "ਪੰਜਾਬੀ"],
+    ])("shows the native language label for %s", (locale, nativeLabel) => {
+        activeLocale = locale;
+
+        const markup = renderToStaticMarkup(<LanguageSwitcher />);
+
+        expect(markup).toContain(nativeLabel);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._

## 📋 PR Summary

Enables the existing Kannada (`kn`) and Punjabi (`pa`) message files in the web app locale routing, language switcher, and proxy matcher.

---

## 🔗 Related Issue

Closes #755

---

## 🏷️ PR Type

- [x] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [x] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [x] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Added `kn` and `pa` to the next-intl routing locales.
- Added Kannada and Punjabi to the language switcher options.
- Updated the proxy matcher so direct `/kn` and `/pa` routes are handled.
- Added a Jest regression test for routing, proxy matching, and switcher labels.
- Removed one unused import from the language switcher while touching the file.

## 📸 Screenshots / Proof of Work (REQUIRED)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
> - **Backend/API/ML changes:** You MUST attach terminal logs, curl/Postman outputs, or test run outputs proving the changes work.
>
> _Please drag & drop your screenshots/GIFs here, or paste terminal/console logs below:_

<img width="1610" height="741" alt="issue-755-language-dropdown" src="https://github.com/user-attachments/assets/40706e99-4352-4829-b62a-85140ca8f2d3" />
<img width="1610" height="741" alt="issue-755-pa" src="https://github.com/user-attachments/assets/d4564711-cad6-4aed-8040-bda11d4e4f01" />



Local browser check:

- Opened `http://localhost:3001/en`
- Opened the language switcher and confirmed `ಕನ್ನಡ` and `ਪੰਜਾਬੀ` are listed
- Selected Kannada and confirmed the app routed to `/kn` with Kannada hero/nav text
- Selected Punjabi and confirmed the app routed to `/pa` with Punjabi hero/nav text
- Direct route check returned `kn 200` and `pa 200`

Terminal checks:

```bash
npm run test -w web -- --runInBand
# Test Suites: 17 passed, 17 total
# Tests:       107 passed, 107 total

cd apps/web && npx eslint app/'[locale]'/LanguageSwitcher.tsx i18n/routing.ts proxy.ts tests/i18n-locales.test.tsx
# passed with no output

npm run build -w web
# ✓ Compiled successfully
# ✓ Generating static pages using 3 workers (6/6)
```

Note: full `npm run lint -w web` still fails on unrelated existing app-wide lint issues, including `apps/web/components/ui/Skeleton.tsx` (`no-empty-object-type`). I kept this PR scoped to the locale bug.

---

## ✅ Contributor Checklist

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [x] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant
