### PR TITLE
fix(web): prevent mobile floating button overlap

### DIFF
--- a/apps/web/app/[locale]/components/BackToTopButton.tsx
+++ b/apps/web/app/[locale]/components/BackToTopButton.tsx
@@ -32,7 +32,7 @@ export default function BackToTopButton() {
             title={label}
             onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
             className={clsx(
-                "fixed bottom-24 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full border border-emerald-400/30 bg-emerald-600 text-white shadow-[0_10px_25px_rgba(16,185,129,0.28)] transition-all duration-300 hover:-translate-y-1 hover:bg-emerald-500 focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
+                "fixed bottom-36 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full border border-emerald-400/30 bg-emerald-600 text-white shadow-[0_10px_25px_rgba(16,185,129,0.28)] transition-all duration-300 hover:-translate-y-1 hover:bg-emerald-500 focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 md:bottom-24",
                 isVisible
                     ? "opacity-100 translate-y-0"
                     : "pointer-events-none opacity-0 translate-y-4"

--- a/apps/web/tests/back-to-top-button.test.tsx
+++ b/apps/web/tests/back-to-top-button.test.tsx
@@ -1,0 +1,17 @@
+import { renderToStaticMarkup } from "react-dom/server";
+
+import BackToTopButton from "../app/[locale]/components/BackToTopButton";
+
+jest.mock("next-intl", () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+describe("BackToTopButton", () => {
+    it("keeps the mobile button high enough to stay visible above the chat launcher", () => {
+        const markup = renderToStaticMarkup(<BackToTopButton />);
+
+        expect(markup).toContain("bottom-36");
+        expect(markup).toContain("md:bottom-24");
+        expect(markup).toContain("right-6");
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x ] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._

## 📋 PR Summary

This PR prevents the mobile back-to-top button from overlapping the floating chat button by moving it higher on small screens while keeping the desktop position unchanged. It also adds a regression test to lock in the mobile spacing behavior in

---

## 🔗 Related Issue

Closes #813 

---

## 🏷️ PR Type

<!-- Select the type of changes. Replace [ ] with [x] for matching items. -->

- [ x] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [x ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

<!-- Select the areas that have been modified by this PR. Replace [ ] with [x] for matching items. -->

- [x ] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

1. Updated apps/web/app/locale to move the back-to-top button higher on mobile so it no longer overlaps the floating chat button, while keeping the desktop offset unchanged.
2. Added back-to-top-button.test.tsx to lock in the mobile spacing behavior and prevent the overlap regression from coming back.
3. Verified the change with the focused Jest run for back-to-top-button.test.tsx and chatbot-position.test.ts
- ***

## 📸 Screenshots / Proof of Work (REQUIRED)

<img width="214" height="458" alt="Screenshot 2026-05-28 224816" src="https://github.com/user-attachments/assets/373c20ba-5585-42b1-8097-b8e5a44a12ca" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e55470a3-97de-4dbc-a6b3-2cd24cf3deb7" />

---

## ✅ Contributor Checklist

<!-- Ensure you have completed the following steps before requesting a review. Replace [ ] with [x]. -->

- [x ] My PR has a linked issue (see above)
- [ x] I have pulled the latest `main` and rebased/merged before opening this PR
- [ x] My code follows the patterns and conventions in `docs/code-guide.md`
- [ x] I ran the project locally and verified there are no compile/build errors
- [ x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [ x] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [ x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [ x] I am a GSSoC 2026 participant
