### PR TITLE
[I18N] Localize offline page and banner using next-intl

### DIFF
--- a/apps/web/app/[locale]/offline/page.tsx
+++ b/apps/web/app/[locale]/offline/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { WifiOff, Home, RefreshCw, Wifi, Pill, MapPin, ShieldCheck, PartyPopper } from "lucide-react";
 
 /**
@@ -8,6 +9,7 @@ import { WifiOff, Home, RefreshCw, Wifi, Pill, MapPin, ShieldCheck, PartyPopper 
  * Automatically redirects to home when the connection is restored.
  */
 export default function OfflinePage() {
+    const t = useTranslations("offline");
     const [isOnline, setIsOnline] = useState(false);
     const [isRetrying, setIsRetrying] = useState(false);
     const [retryCount, setRetryCount] = useState(0);
@@ -68,9 +70,9 @@ export default function OfflinePage() {
                     </div>
 
                     <h1 className="mb-3 flex items-center justify-center gap-2 text-3xl font-bold text-white">
-                        Back Online! <PartyPopper className="h-8 w-8 text-emerald-400" />
+                        {t("bannerOnline")} <PartyPopper className="h-8 w-8 text-emerald-400" />
                     </h1>
-                    <p className="mb-2 text-lg text-emerald-400">Connection restored</p>
+                    <p className="mb-2 text-lg text-emerald-400">`{t("descriptionOnline")}</p>
                     <p className="text-sm text-slate-400">Redirecting you to SahiDawa…</p>
 
                     {/* Progress bar */}
@@ -100,13 +102,13 @@ export default function OfflinePage() {
 
                 {/* Headline */}
                 <h1 className="mb-3 text-4xl font-bold tracking-tight text-white">
-                    You're Offline
+                    {t("title")}
                 </h1>
                 <p className="mb-2 text-lg leading-relaxed text-slate-400">
-                    SahiDawa needs an internet connection to verify medicines and locate pharmacies.
+                    {t("description")}
                 </p>
                 <p className="mb-10 text-sm leading-relaxed text-slate-500">
-                    Please check your Wi-Fi or mobile data and try again.
+                    {t("subtitle")}
                     {retryCount > 0 && (
                         <span className="ml-1 text-amber-400">(Attempt {retryCount})</span>
                     )}
@@ -121,7 +123,7 @@ export default function OfflinePage() {
                         className="inline-flex w-full items-center justify-center gap-2.5 rounded-xl bg-gradient-to-r from-emerald-600 to-emerald-500 px-6 py-3.5 font-semibold text-white shadow-lg shadow-emerald-500/25 transition-all duration-200 hover:-translate-y-0.5 hover:from-emerald-500 hover:to-emerald-400 hover:shadow-emerald-500/40 active:translate-y-0 disabled:cursor-not-allowed disabled:opacity-60"
                     >
                         <RefreshCw size={18} className={isRetrying ? "animate-spin" : ""} />
-                        {isRetrying ? "Checking connection…" : "Try Again"}
+                        {isRetrying ? "Checking connection…" : t("tryAgain")}
                     </button>
 
                     <a
@@ -131,7 +133,7 @@ export default function OfflinePage() {
                     >
                         <span className="inline-flex items-center justify-center gap-2.5">
                             <Home size={18} />
-                            Go to Home
+                            {t("goHome")}
                         </span>
                     </a>
                 </div>
@@ -160,7 +162,7 @@ export default function OfflinePage() {
 
                 {/* Brand footer */}
                 <p className="mt-8 text-xs text-slate-600">
-                    SahiDawa will automatically sync when your connection returns.
+                    {t("footer")}
                 </p>
             </div>
 

--- a/apps/web/components/OfflineBanner.tsx
+++ b/apps/web/components/OfflineBanner.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { WifiOff, Wifi, X } from "lucide-react";
 import { useOfflineStatus } from "@/hooks/useOfflineStatus";
+import { useTranslations } from "next-intl";
 
 /**
  * OfflineBanner — Sticky connectivity status banner.
@@ -15,6 +16,7 @@ import { useOfflineStatus } from "@/hooks/useOfflineStatus";
  * - Reappears automatically on subsequent disconnections.
  */
 export function OfflineBanner() {
+    const t = useTranslations("offline");
     const { isOffline, isStatusDirty, isTestMode } = useOfflineStatus();
     const [isDismissed, setIsDismissed] = useState(false);
     const [isVisible, setIsVisible] = useState(false);
@@ -84,13 +86,13 @@ export function OfflineBanner() {
 
                         <div className="min-w-0">
                             <p className="truncate text-sm font-bold text-white drop-shadow-sm">
-                                {isCurrentlyOffline ? "You are offline" : "Back online"}
+                                {isCurrentlyOffline ? t("bannerOffline") : t("bannerOnline")}
                             </p>
                             <p className="truncate text-xs text-white/85">
                                 {isCurrentlyOffline
-                                    ? "Medicine search and AI chat are unavailable" +
+                                    ? t("descriptionOffline") +
                                       (isTestMode ? " · Test mode" : "")
-                                    : "Your connection has been restored — syncing…"}
+                                    : t("descriptionOnline")}
                             </p>
                         </div>
                     </div>
@@ -100,7 +102,7 @@ export function OfflineBanner() {
                         <button
                             id="offline-banner-dismiss"
                             onClick={handleDismiss}
-                            aria-label="Dismiss offline notification"
+                            aria-label={t("dismiss")}
                             className="flex-shrink-0 rounded-md p-1.5 text-white/80 transition-colors hover:bg-white/20 hover:text-white"
                         >
                             <X size={18} />


### PR DESCRIPTION
🛑 STOP: Assignment Check
✅ I am officially assigned to the issue this PR fixes.

📋 PR Summary
This PR localizes the offline fallback page and global offline banner using `next-intl` translation keys from the existing `offline` section.

🔗 Related Issue
Closes #753 

🏷️ PR Type
✅ 🌏 Translation (i18n)

🗂️ Area Changed
✅ apps/web — Next.js Frontend

📝 What Was Done

* Refactored `apps/web/app/[locale]/offline/page.tsx` to use `useTranslations("offline")`
* Refactored `apps/web/components/OfflineBanner.tsx` to use `useTranslations("offline")`
* Replaced hardcoded English strings with translation keys
* Verified multilingual behavior and offline simulation locally

📸 Screenshots / Proof of Work (REQUIRED)
Added screenshots showing:

* Offline page localization
* Offline simulation in browser (Network → Offline)
* Translation behavior for localized routes

✅ Contributor Checklist
✅ My PR has a linked issue
✅ I ran the project locally and verified changes
✅ I attached screenshots/proof of testing
✅ I performed a self-review of my code

🎓 GSSoC 2026
✅ I am a GSSoC 2026 participant
