### PR TITLE
refactor: remove pharmacy env revalidation

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -134,28 +134,6 @@ function formatPharmacy(p: PharmacyRow, distanceKm: number): FormattedPharmacy {
 }
 
 /**
- * Validates that the required Supabase environment variables are set.
- * Returns false and sends a 500 response if credentials are missing.
- */
-function validateSupabaseConfig(res: Response): boolean {
-    const hasUrl = !!process.env.SUPABASE_URL;
-    const hasKey = !!(process.env.SUPABASE_ANON_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY);
-
-    if (!hasUrl || !hasKey) {
-        logger.error("Missing Supabase credentials in pharmacies route", {
-            missingVars: { SUPABASE_URL: !hasUrl, SUPABASE_KEY: !hasKey },
-        });
-        res.status(500).json({
-            error: "Server Configuration Error",
-            message: "The backend is missing database credentials.",
-            hint: "Please ensure SUPABASE_URL and SUPABASE_ANON_KEY are set in your root .env file.",
-        });
-        return false;
-    }
-    return true;
-}
-
-/**
  * Handles database fetch errors with descriptive error messages and hints.
  */
 function handleFetchError(
@@ -296,8 +274,6 @@ router.get("/nearest", async (req: Request, res: Response, next: NextFunction) =
         }
 
         const { lat, lng, radius } = result.data;
-
-        if (!validateSupabaseConfig(res)) return;
 
         // Primary path: PostGIS RPC with server-side radius filtering
         const { data: rpcData, error: rpcError } = await supabase.rpc("get_nearest_pharmacies", {
@@ -467,8 +443,6 @@ router.get("/in-bounds", async (req: Request, res: Response, next: NextFunction)
         }
 
         const { south, west, north, east } = result.data;
-
-        if (!validateSupabaseConfig(res)) return;
 
         const centerLat = (south + north) / 2;
         const centerLng = (west + east) / 2;

--- a/apps/api/tests/setup.ts
+++ b/apps/api/tests/setup.ts
@@ -1,5 +1,6 @@
 process.env.SUPABASE_URL = "http://localhost:54321";
 process.env.SUPABASE_ANON_KEY = "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
 process.env.API_SECRET_KEY = "test-secret-key";
 
 // Register a dummy WebSocket implementation to bypass Node 20 Supabase initialization crash


### PR DESCRIPTION
## Summary
- remove the unreachable `validateSupabaseConfig` helper from the pharmacies route
- rely on the existing startup-time Supabase environment validation path
- keep nearest and in-bounds pharmacy handlers behavior unchanged after request validation

## Validation
- `SUPABASE_SERVICE_ROLE_KEY=test-service-role-key npm run test --workspace apps/api -- pharmacies.test.ts --runInBand --forceExit`
- `npm run build --workspace apps/api`
- `git diff --check HEAD^ HEAD`

Closes #939
