### PR TITLE
fix: add max-height and scroll to language dropdown

### DIFF
--- a/apps/web/app/[locale]/LanguageSwitcher.tsx
+++ b/apps/web/app/[locale]/LanguageSwitcher.tsx
@@ -79,7 +79,7 @@ export default function LanguageSwitcher() {
                 <div
                     id="language-dropdown"
                     role="listbox"
-                    className="absolute right-0 z-50 mt-2 w-44 overflow-hidden rounded-2xl border border-(--color-border-muted) bg-(--color-surface-page) shadow-lg"
+                    className="absolute right-0 z-50 mt-2 w-44 rounded-2xl border border-(--color-border-muted) bg-(--color-surface-page) shadow-lg max-h-60 overflow-y-auto"
                 >
                     {languages.map((lang) => {
                         const isActive = locale === lang.code;


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.


## 📋 PR Summary

The language dropdown in the navbar was overflowing the entire 
viewport height because it had no height constraint. This fix 
adds a max-height and enables vertical scrolling so the dropdown 
stays compact and usable.
---

## 🔗 Related Issue

<!-- Link the issue this PR resolves. For example: Closes 123 -->

Closes #942 

---

## 🏷️ PR Type

<!-- Select the type of changes. Replace [ ] with [x] for matching items. -->

- [x] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [x] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

<!-- Select the areas that have been modified by this PR. Replace [ ] with [x] for matching items. -->

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

<!-- Provide a bulleted list of the exact changes made in this PR. -->
- Added `max-h-60` to constrain dropdown height to 240px
- Added `overflow-y-auto` to enable vertical scrolling
- Removed `overflow-hidden` which was blocking scroll behavior
- ***

## 📸 Screenshots / Proof of Work (REQUIRED)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
> - **Backend/API/ML changes:** You MUST attach terminal logs, curl/Postman outputs, or test run outputs proving the changes work.
>
> _Please drag & drop your screenshots/GIFs here, or paste terminal/console logs below:_
<img width="1915" height="947" alt="image" src="https://github.com/user-attachments/assets/01288589-5580-4170-8473-950c8edaaffa" />

---

## ✅ Contributor Checklist

<!-- Ensure you have completed the following steps before requesting a review. Replace [ ] with [x]. -->

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [ ] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant
