### PR TITLE
fix: restrict verification rate limiter to verification routes only

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -28,7 +28,7 @@ import helmet from "helmet";
 import morgan from "morgan";
 import adminRoutes from "./routes/admin.routes";
 import { requireAuth, requireRole } from "./middleware/auth";
-import { verifyLimiter } from "./middleware/rateLimit";
+
 import reportsRouter from "./routes/reports";
 import pharmaciesRouter from "./routes/pharmacies";
 import verifyRouter from "./routes/verify";
@@ -59,7 +59,7 @@ app.use(
 app.use(cors(createCorsOptions()));
 
 app.use(express.json({ limit: "1mb" }));
-app.use(verifyLimiter);
+
 
 app.use(
     morgan((tokens, req: Request, res: Response) => {


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

---

## 📋 PR Summary

This PR restricts the verification rate limiter (`verifyLimiter`) to verification routes only. Previously, it was registered globally in `app.ts` using `app.use(verifyLimiter);`, causing all API endpoints in the application to be rate-limited under the same verification route constraints.

---

## 🔗 Related Issue

Closes #

---

## 🏷️ PR Type

- [x] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [ ] `apps/web` — Next.js Frontend
- [x] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Removed `app.use(verifyLimiter);` from `apps/api/src/app.ts` to prevent global rate-limiting across all routes.
- Removed the unused import of `verifyLimiter` from `apps/api/src/app.ts`.
- Verified that `verifyLimiter` is already correctly applied at the route level in `apps/api/src/routes/verify.ts` for verification POST requests, maintaining security where intended.

---

## 📸 Screenshots / Proof of Work (REQUIRED)
My PR has a linked issue (see above)
I have pulled the latest main and rebased/merged before opening this PR
My code follows the patterns and conventions in docs/code-guide.md
I ran the project locally and verified there are no compile/build errors
I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
My backend responses return structured JSON { success: boolean, data ?: any, error ?: { message: string } } (if backend change)
I have performed a self-review of my own code

GSSoC 2026

I am a GSSoC 2026 participant