### PR TITLE
fix: validate geographic bounds to prevent inverted values

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -65,12 +65,21 @@ const nearestQuerySchema = z.object({
     radius: z.coerce.number().min(1).max(200).default(50),
 });
 
-const boundsQuerySchema = z.object({
-    south: z.coerce.number().min(-90).max(90),
-    west: z.coerce.number().min(-180).max(180),
-    north: z.coerce.number().min(-90).max(90),
-    east: z.coerce.number().min(-180).max(180),
-});
+const boundsQuerySchema = z
+    .object({
+        south: z.coerce.number().min(-90).max(90),
+        west: z.coerce.number().min(-180).max(180),
+        north: z.coerce.number().min(-90).max(90),
+        east: z.coerce.number().min(-180).max(180),
+    })
+    .refine((data) => data.south < data.north, {
+        message: "South boundary must be less than North boundary",
+        path: ["south"],
+    })
+    .refine((data) => data.west < data.east, {
+        message: "West boundary must be less than East boundary",
+        path: ["west"],
+    });
 
 // ── Helper functions ─────────────────────────────────────────────────────────
 

--- a/apps/api/tests/pharmacies.test.ts
+++ b/apps/api/tests/pharmacies.test.ts
@@ -275,6 +275,17 @@ describe("GET /api/pharmacies/in-bounds", () => {
         expect(response.body.details).toHaveProperty("south");
     });
 
+    it("returns 400 when south >= north or west >= east", async () => {
+        const response = await request(app).get(
+            "/api/pharmacies/in-bounds?south=30&west=80&north=20&east=70"
+        );
+
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe("Invalid bounds");
+        expect(response.body.details).toHaveProperty("south");
+        expect(response.body.details).toHaveProperty("west");
+    });
+
     it("returns pharmacies from PostGIS bounds RPC when available", async () => {
         mockedSupabase.rpc.mockResolvedValueOnce({
             data: [


### PR DESCRIPTION
## 📋 PR Summary
This PR introduces geo-coordinate relationship validation for the pharmacy bounding-box search endpoint (`/api/pharmacies/in-bounds`). It ensures that incoming query bounds are valid by verifying that `south < north` and `west < east`, preventing inverted coordinates from returning incorrect results or causing unexpected system/PostGIS behavior.
---
## 🔗 Related Issue
Closes [922] #
---
## 🏷️ PR Type
- [x] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality
---
## 🗂️ Area Changed
- [ ] `apps/web` — Next.js Frontend
- [x] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)
---
## 📝 What Was Done
- Added `.refine()` validations to `boundsQuerySchema` in `apps/api/src/routes/pharmacies.ts` to enforce `south < north` and `west < east`.
- Added test coverage in `apps/api/tests/pharmacies.test.ts` to assert that inverted bounds return a `400 Bad Request` with appropriate validation field errors.
- Verified that all 14 tests in `pharmacies.test.ts` compile and pass cleanly.
---
## 📸 Screenshots / Proof of Work (REQUIRED)
<img width="1095" height="586" alt="image" src="https://github.com/user-attachments/assets/5262c8be-ee2f-4eeb-835e-0d843825728d" />


### Test Suite Output:
GET /api/pharmacies/in-bounds √ returns 400 when bounds are missing (8 ms) √ returns 400 for out-of-range bounds (9 ms) √ returns 400 when south >= north or west >= east (8 ms) √ returns pharmacies from PostGIS bounds RPC when available (9 ms) √ falls back to in-memory filter when bounds RPC is unavailable (7 ms)

Test Suites: 1 passed, 1 total Tests: 14 passed, 14 total

### Code Diff:

✅ Contributor Checklist
 My PR has a linked issue (see above)
 I have pulled the latest main and rebased/merged before opening this PR
 My code follows the patterns and conventions in docs/code-guide.md
 I ran the project locally and verified there are no compile/build errors
 I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
 My backend responses return structured JSON { success: boolean, data?: any, error?: { message: string } } (if backend change)
 I have performed a self-review of my own code
🎓 GSSoC 2026
 I am a GSSoC 2026 participant