### PR TITLE
fix(web): fix dark mode background and remove duplicate theme toggle …

### DIFF
--- a/apps/web/app/[locale]/components/PageHeader.tsx
+++ b/apps/web/app/[locale]/components/PageHeader.tsx
@@ -14,6 +14,7 @@ interface PageHeaderProps {
     variant?: "dark" | "light";
     showLanguage?: boolean;
     languageName?: string;
+    showThemeToggle?: boolean;
     children?: React.ReactNode;
 }
 
@@ -24,6 +25,7 @@ export const PageHeader = ({
     variant = "dark",
     showLanguage = false,
     languageName,
+    showThemeToggle = true,
     children,
 }: PageHeaderProps) => {
     const isDark = variant === "dark";
@@ -66,7 +68,7 @@ export const PageHeader = ({
                 )}
 
                 <div className="flex shrink-0 items-center justify-end gap-2">
-                    <ThemeToggle />
+                    {showThemeToggle && <ThemeToggle />}
                     {showLanguage ? (
                         <div
                             className="flex items-center gap-1.5 rounded-full border border-(--color-border-muted) bg-(--color-surface-page) px-3 py-1.5 shadow-sm"

--- a/apps/web/app/[locale]/contact/page.tsx
+++ b/apps/web/app/[locale]/contact/page.tsx
@@ -15,8 +15,8 @@ export default function ContactPage() {
     const t = useTranslations("contact");
 
     return (
-        <main className="min-h-screen bg-white">
-            <PageHeader backHref="/" variant="light" />
+        <main className="min-h-screen bg-(--color-surface-page) text-(--color-text-primary)">
+            <PageHeader backHref="/" variant="light" showThemeToggle={false} />
             {/* Hero */}
             <section className="border-b border-(--color-border-muted) px-4 py-16 text-center">
                 <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-4 py-1.5 text-sm font-medium text-emerald-700 dark:border-emerald-900/30 dark:bg-emerald-950/20 dark:text-emerald-400">


### PR DESCRIPTION
…on contact page

### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._

## 📋 PR Summary

<!-- Provide a brief summary of the changes introduced by this PR. -->

---

## 🔗 Related Issue

<!-- Link the issue this PR resolves. For example: Closes 123 -->
#982 

Closes #

---

## 🏷️ PR Type

<!-- Select the type of changes. Replace [ ] with [x] for matching items. -->

- [X ] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

<!-- Select the areas that have been modified by this PR. Replace [ ] with [x] for matching items. -->

- [x] `apps/web` — Next.js Frontend
- [] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done
i changed the header section in common header.tsx and  contact pages page background color to match with theme and removed the duplicate toggle of darkmode.

<!-- Provide a bulleted list of the exact changes made in this PR. -->

- ***

## 📸 Screenshots / Proof of Work (REQUIRED)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
> - **Backend/API/ML changes:** You MUST attach terminal logs, curl/Postman outputs, or test run outputs proving the changes work.
>
> _Please drag & drop your screenshots/GIFs here, or paste terminal/console logs below:_
before
<img width="1907" height="1016" alt="image" src="https://github.com/user-attachments/assets/ffda0025-2cd1-4fc2-89dd-43ccdd19a9ee" />
after
<img width="1878" height="982" alt="image" src="https://github.com/user-attachments/assets/690e7236-b165-4690-a4e1-2e70059b1840" />


---

## ✅ Contributor Checklist

<!-- Ensure you have completed the following steps before requesting a review. Replace [ ] with [x]. -->

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [x] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [ X] I am a GSSoC 2026 participant
