### PR TITLE
style: update batch input styling to support light and dark mode themes

### DIFF
--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -1142,7 +1142,7 @@ export default function ScanPage() {
                         value={batchInput}
                         onChange={(e) => setBatchInput(e.target.value)}
                         placeholder="Enter batch number"
-                        className="flex-1 rounded-full border border-white/20 bg-white/10 px-4 py-3 text-center text-sm font-medium text-white placeholder-white/40 focus:border-transparent focus:ring-2 focus:ring-emerald-500 focus:outline-none"
+                        className="flex-1 rounded-full border border-gray-300 bg-white px-4 py-3 text-center text-sm font-medium text-gray-900 placeholder-gray-500 focus:border-transparent focus:ring-2 focus:ring-emerald-500 focus:outline-none dark:border-white/20 dark:bg-white/10 dark:text-white dark:placeholder-white/40"
                     />
                     <button
                         type="submit"


### PR DESCRIPTION
# 🚀 PR: Fix Medicine Batch Number Input Visibility & Contrast (Light Mode)

### Closes #1005

## 📝 Description

This PR resolves a visibility and contrast bug where the medicine batch number input field was completely invisible on initial load in Light Mode. Both the typed characters and the placeholder text were styled white on a white background, making the input unusable in light mode.

This fix updates the Tailwind CSS classes on the `<input>` element in the medicine scanning view to provide high-contrast, fully accessible styling for both light and dark modes.

---

## 🛠️ Key Changes

In [apps/web/app/\[locale\]/scan/page.tsx](file:///Users/tanushreeharika/Downloads/Gssoc26%20%28sahidawa%29/sahidawa-india/apps/web/app/%5Blocale%5D/scan/page.tsx#L1202-L1208):
- 📦 **Visible Border**: Added `border-gray-300` as the default border, falling back to `dark:border-white/20` in Dark Mode.
- 🎨 **Solid Background**: Set `bg-white` as the default background, falling back to `dark:bg-white/10` in Dark Mode.
- ✏️ **Dark Text Color**: Updated typed text color to `text-gray-900` (`dark:text-white` in Dark Mode).
- 🏷️ **Accessible Placeholder**: Improved the contrast of the placeholder text with `placeholder-gray-500` (`dark:placeholder-white/40` in Dark Mode).

###before
<img width="833" height="389" alt="Screenshot 2026-05-31 at 9 46 20 PM" src="https://github.com/user-attachments/assets/b8cb32d7-6ef4-4f61-ab65-c7fd65ae6f26" />

<img width="1440" height="900" alt="Screenshot 2026-05-31 at 9 46 11 PM" src="https://github.com/user-attachments/assets/c910b62d-bfff-438d-9825-4878e426821c" />

###After
<img width="1075" height="479" alt="Screenshot 2026-05-31 at 11 24 05 PM" src="https://github.com/user-attachments/assets/26caec50-49fe-49d1-93cf-5904594bb345" />
<img width="1013" height="410" alt="Screenshot 2026-05-31 at 11 24 31 PM" src="https://github.com/user-attachments/assets/2cdd8b63-c2ef-402f-8edc-45b3406950ef" />
#darkmode
<img width="1231" height="342" alt="Screenshot 2026-05-31 at 11 24 45 PM" src="https://github.com/user-attachments/assets/2615775b-f1aa-4749-a5f1-b1c6bb265423" />




### Code Comparison

**Before:**
```tsx
className="flex-1 rounded-full border border-white/20 bg-white/10 px-4 py-3 text-center text-sm font-medium text-white placeholder-white/40 focus:border-transparent focus:ring-2 focus:ring-emerald-500 focus:outline-none"
