### PR TITLE
chore: add .editorconfig for consistent editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

Adds a root \.editorconfig\ file to enforce consistent formatting across all editors and IDEs.

## Settings

| Rule | Value |
|------|-------|
| indent_style | space |
| indent_size | 4 (code), 2 (JSON/YAML) |
| end_of_line | LF |
| charset | UTF-8 |
| trim_trailing_whitespace | true |
| insert_final_newline | true |

\indent_size: 4\ matches the project's existing \.prettierrc\ \	abWidth\ setting and the actual code style (4-space indentation visible throughout the codebase).

Closes #726