### PR TITLE
fix(auth): read role from app_metadata only to prevent privilege escalation

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -32,7 +32,11 @@ const getBearerToken = (authorization?: string): string | null => {
 };
 
 const getUserRole = (user: User): AuthRole => {
-    const metadataRole = user.app_metadata?.role || user.user_metadata?.role;
+    // Read the role exclusively from app_metadata, which is server-controlled
+    // and cannot be modified by the user via supabase.auth.updateUser().
+    // user_metadata is user-writable and must not be trusted for authorization
+    // decisions; reading it here would allow any user to self-promote to admin.
+    const metadataRole = user.app_metadata?.role;
     if (metadataRole === "admin") return "admin";
     if (metadataRole === "moderator") return "moderator";
     return "user";


### PR DESCRIPTION
## Summary

`getUserRole` in `apps/api/src/middleware/auth.ts` read the user role from `user.app_metadata?.role || user.user_metadata?.role`. The `user_metadata` field is writable by any authenticated user via `supabase.auth.updateUser({ data: { role: 'admin' } })`. Any user could call that SDK method to self-assign the admin role and bypass every `requireRole('admin')` guard across all admin routes.

Closes #951

## Root Cause

```typescript
// Before — user_metadata is user-writable
const metadataRole = user.app_metadata?.role || user.user_metadata?.role;
```

## Fix

```typescript
// After — app_metadata is server-controlled only
const metadataRole = user.app_metadata?.role;
```

Removed the `user_metadata` fallback entirely. Role is now read exclusively from `app_metadata`, which Supabase only allows server-side service-role keys to modify.

## Files Changed

- `apps/api/src/middleware/auth.ts`: one-line change in `getUserRole`.

## Checklist

- [x] No functional change for correctly provisioned users (admin role set via service key in app_metadata).
- [x] No new dependencies.
- [x] Covers all callers of getUserRole (both createAuthMiddleware overloads).