### PR TITLE
fix(config): validate ML_SERVICE_URL hostname to prevent SSRF

### DIFF
--- a/apps/api/src/config/mlService.ts
+++ b/apps/api/src/config/mlService.ts
@@ -3,9 +3,76 @@ import logger from "../utils/logger";
 const MISSING_ML_SERVICE_URL_MESSAGE =
     "ML_SERVICE_URL is not configured. Set it to the ML service origin before using ML-backed routes.";
 
+// RFC-1918 private address ranges, loopback, and link-local prefixes that must
+// never be used as ML service endpoints. A misconfigured or injected value
+// pointing at these addresses would allow the API server to reach cloud instance
+// metadata services or internal network resources (SSRF).
+const BLOCKED_HOSTNAME_PATTERNS = [
+    /^localhost$/i,
+    /^127\./,
+    /^10\./,
+    /^172\.(1[6-9]|2\d|3[01])\./,
+    /^192\.168\./,
+    /^169\.254\./,
+    /^::1$/,
+    /^fc00:/i,
+    /^fe80:/i,
+];
+
+/**
+ * Returns true when the hostname is a safe external address, false for any
+ * private, loopback, or link-local hostname.
+ */
+function isAllowedHostname(hostname: string): boolean {
+    return !BLOCKED_HOSTNAME_PATTERNS.some((pattern) => pattern.test(hostname));
+}
+
+/**
+ * Validates that the supplied URL string is a well-formed absolute URL and that
+ * its hostname is not an internal network address. Returns a validation result
+ * so callers can surface a descriptive error rather than silently failing.
+ */
+export function validateMlServiceUrl(rawUrl: string): { valid: boolean; reason?: string } {
+    let parsed: URL;
+    try {
+        parsed = new URL(rawUrl);
+    } catch {
+        return { valid: false, reason: "ML_SERVICE_URL is not a valid URL" };
+    }
+
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+        return {
+            valid: false,
+            reason: `ML_SERVICE_URL uses disallowed scheme '${parsed.protocol}'. Only http: and https: are permitted.`,
+        };
+    }
+
+    if (!isAllowedHostname(parsed.hostname)) {
+        return {
+            valid: false,
+            reason: `ML_SERVICE_URL hostname '${parsed.hostname}' resolves to a private or loopback address and is not permitted.`,
+        };
+    }
+
+    return { valid: true };
+}
+
 export function getMlServiceUrl(): string | null {
     const configuredUrl = process.env.ML_SERVICE_URL?.trim();
-    return configuredUrl ? configuredUrl.replace(/\/+$/, "") : null;
+    if (!configuredUrl) return null;
+
+    const trimmed = configuredUrl.replace(/\/+$/, "");
+    const { valid, reason } = validateMlServiceUrl(trimmed);
+
+    if (!valid) {
+        logger.error(`Invalid ML_SERVICE_URL: ${reason}`, {
+            url: trimmed,
+            environment: process.env.NODE_ENV || "development",
+        });
+        return null;
+    }
+
+    return trimmed;
 }
 
 export function validateMlServiceConfig(): void {


### PR DESCRIPTION
## Summary

`getMlServiceUrl()` in `apps/api/src/config/mlService.ts` returned any configured URL string without checking whether the hostname was a private, loopback, or link-local address. A misconfigured or injected `ML_SERVICE_URL` pointing at `http://169.254.169.254/latest/meta-data/` would cause the API server to expose cloud instance metadata to an attacker. Internal services on RFC-1918 ranges were also reachable this way.

Closes #955

## Root Cause

```typescript
// Before — no hostname validation
export function getMlServiceUrl(): string | null {
    const configuredUrl = process.env.ML_SERVICE_URL?.trim();
    return configuredUrl ? configuredUrl.replace(/\/+$/, "") : null;
}
```

## Fix

Added `validateMlServiceUrl()` which:
- Parses the URL and rejects non-parseable strings
- Rejects any scheme other than `http:` or `https:`
- Rejects hostnames matching RFC-1918 private ranges (10.x, 172.16-31.x, 192.168.x), loopback (127.x, localhost, ::1), and link-local (169.254.x, fe80::, fc00::)

`getMlServiceUrl()` now calls `validateMlServiceUrl()` and returns null with an error log when the URL fails validation. Existing callers that check for null will return a clean `ML_SERVICE_URL_MISSING` error response rather than forwarding the request to an internal endpoint.

## Files Changed

- `apps/api/src/config/mlService.ts`: added `BLOCKED_HOSTNAME_PATTERNS`, `isAllowedHostname()`, `validateMlServiceUrl()`, updated `getMlServiceUrl()`.

## Checklist

- [x] Correctly configured production URLs (public HTTPS hostname) pass validation unchanged.
- [x] No new runtime dependencies.
- [x] `validateMlServiceUrl` is exported for use in tests.