### PR TITLE
fix(reports): reject private/loopback addresses in report image URLs

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -10,11 +10,45 @@ import {
 
 const reportsRouter = Router();
 
+// Blocked hostname patterns for image URL SSRF protection.
+// z.string().url() only validates URL format, not destination.
+// An attacker could supply cloud metadata or internal service URLs that may be
+// fetched server-side when the image is processed.
+const BLOCKED_IMAGE_URL_PATTERNS = [
+  /^localhost$/i,
+  /^127\./,
+  /^10\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^::1$/,
+  /^fc00:/i,
+  /^fe80:/i,
+];
+
+function isPublicImageUrl(rawUrl: string): boolean {
+  try {
+    const { protocol, hostname } = new URL(rawUrl);
+    if (protocol !== 'https:' && protocol !== 'http:') return false;
+    return !BLOCKED_IMAGE_URL_PATTERNS.some((p) => p.test(hostname));
+  } catch {
+    return false;
+  }
+}
+
+const safeImageUrl = z
+  .string()
+  .url()
+  .refine(isPublicImageUrl, {
+    message:
+      'Image URL must use http(s) and must not point to a private, loopback, or link-local address',
+  });
+
 const createReportSchema = z.object({
   medicineName: z.string().min(2),
   manufacturer: z.string().min(2),
   description: z.string().min(20),
-  images: z.array(z.string().url()).min(1),
+  images: z.array(safeImageUrl).min(1),
   pharmacyName: z.string().min(2),
   address: z.string().min(5),
   city: z.string().min(2),


### PR DESCRIPTION
## Summary

The `images` field in `createReportSchema` used `z.string().url()` which only validates URL syntax, not destination. An attacker could supply cloud metadata endpoints or internal service URLs that may be fetched server-side when the image is processed, potentially leaking instance credentials or reaching internal APIs.

Closes #952

## Root Cause

```typescript
// Before — format only, no destination check
images: z.array(z.string().url()).min(1),
```

## Fix

Added `isPublicImageUrl()` which parses the URL and rejects any hostname matching RFC-1918 private ranges (10.x, 172.16-31.x, 192.168.x), loopback (127.x, localhost, ::1), and link-local (169.254.x) addresses. Wrapped it in a `safeImageUrl` Zod refinement applied to the images array.

```typescript
const safeImageUrl = z
  .string()
  .url()
  .refine(isPublicImageUrl, {
    message: 'Image URL must use http(s) and must not point to a private, loopback, or link-local address',
  });

images: z.array(safeImageUrl).min(1),
```

Invalid image URLs now produce a descriptive 400 error at schema parse time rather than reaching the database or any downstream fetch.

## Files Changed

- `apps/api/src/routes/reports.ts`: added `BLOCKED_IMAGE_URL_PATTERNS`, `isPublicImageUrl()`, `safeImageUrl`, updated `images` field in schema.

## Checklist

- [x] Public HTTPS image URLs (CDN, Supabase Storage, S3) pass validation unchanged.
- [x] No new dependencies.
- [x] Consistent with the same pattern in `mlService.ts` (PR #1026).