### PR TITLE
fix: reduce navbar icon sizes and gaps for 320px mobile screens (Fixes #1002)

### DIFF
--- a/apps/web/app/[locale]/components/Navbar.tsx
+++ b/apps/web/app/[locale]/components/Navbar.tsx
@@ -36,24 +36,24 @@ export default function Navbar() {
         <>
             {/* ── Top Navigation ── */}
             <header className="sticky top-0 z-50 w-full border-b border-white/30 bg-white/60 shadow-sm shadow-black/5 backdrop-blur-md dark:border-white/10 dark:bg-slate-900/60">
-                <div className="container mx-auto flex h-16 items-center gap-2 px-3 sm:gap-3 sm:px-4 md:px-6">
+                <div className="container mx-auto flex h-16 items-center gap-1.5 px-2.5 sm:gap-3 sm:px-4 md:px-6">
                     {/* Left — Logo */}
-                    <div className="flex min-w-0 flex-1 items-center gap-2">
-                        <Link href="/" className="flex min-w-0 items-center gap-2">
+                    <div className="flex min-w-0 flex-1 items-center gap-1.5 sm:gap-2">
+                        <Link href="/" className="flex min-w-0 items-center gap-1.5 sm:gap-2">
                             <div
-                                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-emerald-100 text-emerald-600 shadow-sm sm:h-10 sm:w-10 dark:bg-emerald-950/30 dark:text-emerald-400"
+                                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-xl bg-emerald-100 text-emerald-600 shadow-sm sm:h-10 sm:w-10 dark:bg-emerald-950/30 dark:text-emerald-400"
                                 aria-label="SahiDawa Logo"
                             >
                                 <Image
                                     src="/favicon.ico"
                                     alt=""
                                     aria-hidden="true"
-                                    className="h-6 w-6 object-contain sm:h-7 sm:w-7"
+                                    className="h-5 w-5 object-contain sm:h-7 sm:w-7"
                                     width={28}
                                     height={28}
                                 />
                             </div>
-                            <h1 className="truncate text-lg font-extrabold tracking-tight text-(--color-text-primary) sm:text-xl md:text-2xl">
+                            <h1 className="truncate text-base font-extrabold tracking-tight text-(--color-text-primary) sm:text-xl md:text-2xl">
                                 SahiDawa
                             </h1>
                         </Link>
@@ -82,13 +82,14 @@ export default function Navbar() {
                     </nav>
 
                     {/* Right — Action Buttons */}
-                    <div className="ml-auto flex shrink-0 items-center justify-end gap-1.5 sm:gap-3">
+                    <div className="ml-auto flex shrink-0 items-center justify-end gap-1 sm:gap-3">
                         <button
                             onClick={() => handleNavigation("health")}
-                            className="flex h-9 w-9 items-center justify-center rounded-full bg-linear-to-r from-blue-500 to-purple-500 text-white transition-all duration-200 hover:scale-105 hover:shadow-lg hover:shadow-purple-500/25 sm:h-10 sm:w-10"
+                            className="flex h-8 w-8 items-center justify-center rounded-full bg-linear-to-r from-blue-500 to-purple-500 text-white transition-all duration-200 hover:scale-105 hover:shadow-lg hover:shadow-purple-500/25 sm:h-10 sm:w-10"
                             aria-label={tHome("open_ai_health_assistant")}
                         >
-                            <MessageCircle size={17} />
+                            <MessageCircle size={15} className="sm:hidden" />
+                            <MessageCircle size={17} className="hidden sm:block" />
                         </button>
 
                         <LanguageSwitcher />
@@ -96,11 +97,11 @@ export default function Navbar() {
 
                         <button
                             onClick={() => handleNavigation("login")}
-                            className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-500/30 bg-emerald-50/70 text-emerald-700 transition-all duration-200 hover:scale-105 hover:border-emerald-500/50 hover:bg-emerald-100 sm:hidden dark:bg-emerald-500/10 dark:text-emerald-400 dark:hover:bg-emerald-500/20"
+                            className="flex h-8 w-8 items-center justify-center rounded-full border border-emerald-500/30 bg-emerald-50/70 text-emerald-700 transition-all duration-200 hover:scale-105 hover:border-emerald-500/50 hover:bg-emerald-100 sm:hidden dark:bg-emerald-500/10 dark:text-emerald-400 dark:hover:bg-emerald-500/20"
                             aria-label={tHome("sign_in")}
                             title={tHome("sign_in")}
                         >
-                            <User size={17} />
+                            <User size={15} />
                             <span className="sr-only">{tHome("sign_in")}</span>
                         </button>
 


### PR DESCRIPTION
Fixes #1002

## Summary
Fixes navbar text and action icons overlapping on mobile screens ≤ 320px width by reducing element sizes and gaps.

## Changes
- **Logo container**: Reduced from h-8/w-8 to h-7/w-7 on mobile (sm:h-10/w-10 stays)
- **Logo image**: Reduced from h-6/w-6 to h-5/w-5 on mobile
- **Brand title**: Reduced from text-lg to text-base on mobile
- **Container gap**: Reduced from gap-2 to gap-1.5 on mobile
- **Action button gap**: Reduced from gap-1.5 to gap-1 on mobile
- **Action buttons**: Reduced from h-9/w-9 to h-8/w-8 on mobile
- **Icon sizes**: Using 15px on mobile, 17px on sm+ breakpoint
- **Sign-in button**: Reduced from h-9/w-9 to h-8/w-8 on mobile

## Testing
- Open DevTools → Device toolbar → Mobile S (320px)
- Verify navbar text does not overlap with action icons
- Verify all icons are visible and clickable
- Verify no layout shift on larger screens (sm/md/lg breakpoints)