### PR TITLE
fix: persist theme preference across page reloads and navigation (Fixes #1024)

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -61,7 +61,23 @@ export default async function LocaleLayout({
 
     return (
         <html lang={locale} suppressHydrationWarning>
-            {/* REPLACE YOUR OLD BODY TAG WITH THIS ONE: */}
+            <head>
+                {/* Prevent flash of incorrect theme on page load */}
+                <script
+                    dangerouslySetInnerHTML={{
+                        __html: `
+                            (function() {
+                                try {
+                                    var theme = localStorage.getItem('theme');
+                                    if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+                                        document.documentElement.classList.add('dark');
+                                    }
+                                } catch (e) {}
+                            })();
+                        `,
+                    }}
+                />
+            </head>
             <body className="bg-(--color-surface-page) text-(--color-text-primary) transition-colors duration-300">
                 <ServiceWorkerProvider>
                     <ThemeProvider>


### PR DESCRIPTION
## Summary
Fixes theme resetting to light mode on page reload/navigation by adding a blocking script in `<head>` that reads the stored theme preference before first paint.

## Changes
- Add inline script in `<head>` that reads theme from `localStorage` before React hydration
- Applies `dark` class to `<html>` element immediately on page load when dark theme is stored
- Falls back to system preference (`prefers-color-scheme: dark`) when no stored theme exists
- Prevents flash of incorrect theme (FICT) during navigation

## Root Cause
The `next-themes` library (`ThemeProvider`) only applies the theme class after React hydration, which causes a brief flash of light mode on every page load/navigation. The stored preference is correctly read by `next-themes`, but the visual application happens too late.

## Testing
1. Switch to dark mode using the theme toggle
2. Reload the page — dark mode should persist immediately without flash
3. Navigate to different pages — theme should remain consistent
4. Clear localStorage and reload — should fall back to system preference

## Related Issues
Fixes #1024