### PR TITLE
chore: add .gitattributes to normalize line endings (LF) across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Normalize line endings to LF for cross-platform consistency.
+# Git stores text files with LF in the repository and checks them out as LF,
+# preventing CRLF/LF differences from showing up as spurious diffs.
+* text=auto eol=lf
+
+# Explicitly mark binary files so Git never alters their contents.
+*.png binary
+*.ico binary
+*.wav binary
+*.tflite binary
+*.keras binary


### PR DESCRIPTION
## Description

Closes #727

Adds a `.gitattributes` file to the project root to enforce consistent line endings across all platforms. Without it, line endings depend on each contributor's OS and local git config (CRLF on Windows, LF on Unix/Linux/macOS), which can produce spurious whitespace-only diffs and noisy git history.

## Problem

Inconsistent line ending formats (LF vs CRLF) between Windows and Unix/Linux users cause git to track unnecessary line modifications in diffs, polluting blame and review.

## Solution

Added `.gitattributes` with:

- `* text=auto eol=lf` — git auto-detects text files, stores them with LF in the repository, and checks them out as LF on every platform. This aligns with the existing `.editorconfig` (`end_of_line = lf`).
- Explicit `binary` markers for binary assets present in the repo (`*.png`, `*.ico`, `*.wav`, `*.tflite`, `*.keras`) so git never alters their contents.

## Changes

- **Added** `.gitattributes` (new file, project root) — only file added; no existing files modified.

## Verification

- `git check-attr text eol -- <file>` resolves text files to `text: auto, eol: lf`.
- `git check-attr binary -- <file>` resolves binary assets to `binary: set` (text unset).
- `git status --short` shows only the new untracked file.

> Note: I intentionally did **not** run `git add --renormalize`, as that would rewrite line endings across many existing tracked files and create a large out-of-scope diff. Normalization now applies automatically as files are added or modified going forward.

## Type of change

- [x] Chore / tooling
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change