### PR TITLE
fix(lasa): add lasaLimiter and cap medicineName length on /check endpoint

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -43,3 +43,22 @@ export const limiter = rateLimit({
         });
     },
 });
+
+// LASA check limiter
+// find_lasa_conflicts performs string-distance comparisons across the full
+// medicines table, making each request more expensive than a simple key lookup.
+// Without throttling a single IP can exhaust the Supabase connection pool
+// with a rapid stream of POST /api/v1/lasa/check requests.
+// 30 requests per 15 minutes matches the verifyLimiter budget (20/15 min)
+// while allowing a few extra attempts for legitimate batch UI workflows.
+export const lasaLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    handler: (_req, res) => {
+        res.status(429).json({
+            error: "Too many LASA check requests. Please try again later.",
+        });
+    },
+});

--- a/apps/api/src/routes/lasa.ts
+++ b/apps/api/src/routes/lasa.ts
@@ -1,15 +1,29 @@
 import { Router, Request, Response } from "express";
 import { detectLasaConflicts } from "../services/lasa.service";
+import { lasaLimiter } from "../middleware/rateLimit";
 import logger from "../utils/logger";
+
+// Maximum length for a medicine name search string.
+// Real medicine names are at most 100 characters. Accepting unbounded strings
+// allows callers to send kilobyte-scale payloads to a full-text similarity RPC,
+// amplifying database CPU cost per request.
+const MAX_MEDICINE_NAME_LENGTH = 200;
 
 const router = Router();
 
-router.post("/check", async (req: Request, res: Response): Promise<void> => {
+router.post("/check", lasaLimiter, async (req: Request, res: Response): Promise<void> => {
     try {
         const { medicineName } = req.body;
 
         if (!medicineName || typeof medicineName !== "string") {
             res.status(400).json({ error: "medicineName is required" });
+            return;
+        }
+
+        if (medicineName.length > MAX_MEDICINE_NAME_LENGTH) {
+            res.status(400).json({
+                error: `medicineName must not exceed ${MAX_MEDICINE_NAME_LENGTH} characters`,
+            });
             return;
         }
 


### PR DESCRIPTION
## Summary

- Adds `lasaLimiter` to `rateLimit.ts` (30 req per 15 min per IP)
- Applies `lasaLimiter` as middleware on `POST /check` in `lasa.ts`
- Rejects `medicineName` strings longer than 200 characters with 400
- Adds `MAX_MEDICINE_NAME_LENGTH = 200` constant with an explanatory comment

## Root Cause

`POST /api/v1/lasa/check` was the only endpoint in the API that triggered a resource-intensive database operation (`find_lasa_conflicts` performs full-text string-distance comparisons across the medicines table) without any rate limiting or input length cap.

Every other expensive endpoint already had a dedicated limiter:
- `/verify` uses `verifyLimiter` (20 req/15 min)
- `/batch` uses `batchLimiter` (100 req/hr)

A single unauthenticated IP could send a continuous stream of requests with arbitrarily long `medicineName` strings, saturating the Supabase connection pool and degrading the entire API.

## Changes

**`apps/api/src/middleware/rateLimit.ts`**
```ts
export const lasaLimiter = rateLimit({
    windowMs: 15 * 60 * 1000,
    max: 30,
    ...
});
```

**`apps/api/src/routes/lasa.ts`**
```ts
const MAX_MEDICINE_NAME_LENGTH = 200;

router.post("/check", lasaLimiter, async (req, res) => {
    ...
    if (medicineName.length > MAX_MEDICINE_NAME_LENGTH) {
        res.status(400).json({ error: "medicineName must not exceed 200 characters" });
        return;
    }
    ...
});
```

## Testing

- Requests within the rate limit: pass through as before.
- 31st request within 15 minutes from same IP: 429.
- `medicineName` with 200 characters: accepted.
- `medicineName` with 201 characters: 400.
- Missing or non-string `medicineName`: still 400 as before.

Closes #1105