### PR TITLE
feat(dark-mode): add EaseMotion CSS variable dark mode demo and docs

### DIFF
--- a/submissions/README.md
+++ b/submissions/README.md
@@ -1,0 +1,9 @@
+# Submissions
+
+This folder contains project submissions for issues and improvements.
+
+## Dark Mode Submission
+
+- `dark-mode-easemotion/README.md` — documentation for implementing dark mode with EaseMotion CSS variables
+- `dark-mode-easemotion/dark-mode-demo.html` — live demo page
+- `dark-mode-easemotion/dark-mode.css` — theme variable definitions and manual toggle styles

--- a/submissions/dark-mode-easemotion/README.md
+++ b/submissions/dark-mode-easemotion/README.md
@@ -1,0 +1,123 @@
+# EaseMotion Dark Mode
+
+This submission demonstrates how to implement dark mode using EaseMotion's CSS variable system.
+
+## What this includes
+
+- `dark-mode-demo.html` — self-contained demo page with theme toggle
+- `dark-mode.css` — CSS variables, light/dark theme overrides, and manual toggle styles
+- `README.md` — documentation for implementing dark mode with EaseMotion
+
+## How it works
+
+EaseMotion's token system is built on global CSS variables such as `--ease-background`, `--ease-foreground`, `--ease-primary`, and more.
+
+### 1. Default theme
+Define your default color palette in `:root`.
+
+```css
+:root {
+  --ease-background: #ffffff;
+  --ease-surface: #f8fafc;
+  --ease-surface-strong: #f1f5f9;
+  --ease-foreground: #0f172a;
+  --ease-muted: #64748b;
+  --ease-border: #cbd5e1;
+  --ease-border-muted: #e2e8f0;
+  --ease-primary: #2563eb;
+  --ease-primary-contrast: #ffffff;
+  --ease-secondary: #7c3aed;
+  --ease-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+```
+
+### 2. Automatic dark mode with `prefers-color-scheme`
+Use `@media (prefers-color-scheme: dark)` to override the same variables for users who prefer dark mode.
+
+```css
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-background: #020617;
+    --ease-surface: #111827;
+    --ease-surface-strong: #1f2937;
+    --ease-foreground: #f8fafc;
+    --ease-muted: #94a3b8;
+    --ease-border: #334155;
+    --ease-border-muted: #334155;
+    --ease-primary: #60a5fa;
+    --ease-primary-contrast: #0f172a;
+    --ease-secondary: #8b5cf6;
+    --ease-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+  }
+}
+```
+
+### 3. Manual toggle using `data-theme`
+A manual theme toggle gives users control independent of system settings.
+
+```css
+:root[data-theme="dark"] {
+  --ease-background: #020617;
+  --ease-surface: #111827;
+  --ease-surface-strong: #1f2937;
+  --ease-foreground: #f8fafc;
+  --ease-muted: #94a3b8;
+  --ease-border: #334155;
+  --ease-border-muted: #334155;
+  --ease-primary: #60a5fa;
+  --ease-primary-contrast: #0f172a;
+  --ease-secondary: #8b5cf6;
+  --ease-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+}
+
+:root[data-theme="light"] {
+  --ease-background: #ffffff;
+  --ease-surface: #f8fafc;
+  --ease-surface-strong: #f1f5f9;
+  --ease-foreground: #0f172a;
+  --ease-muted: #64748b;
+  --ease-border: #cbd5e1;
+  --ease-border-muted: #e2e8f0;
+  --ease-primary: #2563eb;
+  --ease-primary-contrast: #ffffff;
+  --ease-secondary: #7c3aed;
+  --ease-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+```
+
+## Variable reference
+
+Override these common `--ease-*` tokens to enable dark mode across your UI:
+
+- `--ease-background`
+- `--ease-surface`
+- `--ease-surface-strong`
+- `--ease-foreground`
+- `--ease-muted`
+- `--ease-border`
+- `--ease-border-muted`
+- `--ease-primary`
+- `--ease-primary-contrast`
+- `--ease-secondary`
+- `--ease-shadow`
+- `--ease-ring`
+- `--ease-code-bg`
+- `--ease-link`
+- `--ease-link-hover`
+
+> Tip: only override the variables your theme needs. Components built with the EaseMotion token system will automatically adapt when the shared variables change.
+
+## Demo
+
+Open `dark-mode-demo.html` in a browser to preview:
+
+- automatic dark mode through `prefers-color-scheme`
+- manual toggle using the theme button
+- accessible keyboard and local storage support
+
+## Why this approach
+
+- `@media (prefers-color-scheme: dark)` respects user system preferences
+- `:root[data-theme]` makes manual toggling explicit and easy to override
+- CSS variables keep theme values centralized and reusable
+- The demo shows how to build UI components that depend on the same global tokens

--- a/submissions/dark-mode-easemotion/dark-mode-demo.html
+++ b/submissions/dark-mode-easemotion/dark-mode-demo.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EaseMotion Dark Mode Demo</title>
+    <link rel="stylesheet" href="dark-mode.css" />
+  </head>
+  <body>
+    <div class="page">
+      <section class="card">
+        <div style="display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap;">
+          <div>
+            <h1>EaseMotion Dark Mode</h1>
+            <p>Demo showing automatic `prefers-color-scheme` and manual theme switching with CSS variables.</p>
+          </div>
+          <button id="theme-toggle" type="button" aria-pressed="false">Enable dark mode</button>
+        </div>
+      </section>
+
+      <section class="card strong">
+        <h2>How it works</h2>
+        <ul>
+          <li><strong>Light mode:</strong> default `:root` values</li>
+          <li><strong>Auto dark mode:</strong> `@media (prefers-color-scheme: dark)` overrides root values</li>
+          <li><strong>Manual theme:</strong> `:root[data-theme="dark"]` / `:root[data-theme="light"]`</li>
+        </ul>
+      </section>
+
+      <section class="card theme-summary">
+        <div class="theme-swatch">
+          <strong>Background</strong>
+          <span>var(--ease-background)</span>
+        </div>
+        <div class="theme-swatch">
+          <strong>Surface</strong>
+          <span>var(--ease-surface)</span>
+        </div>
+        <div class="theme-swatch">
+          <strong>Foreground</strong>
+          <span>var(--ease-foreground)</span>
+        </div>
+        <div class="theme-swatch">
+          <strong>Primary</strong>
+          <span>var(--ease-primary)</span>
+        </div>
+      </section>
+
+      <section class="card">
+        <h2>Example CSS</h2>
+        <pre class="code-block">@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-background: #020617;
+    --ease-surface: #111827;
+    --ease-foreground: #f8fafc;
+    --ease-primary: #60a5fa;
+  }
+}
+
+:root[data-theme="dark"] {
+  --ease-background: #020617;
+  --ease-surface: #111827;
+  --ease-foreground: #f8fafc;
+  --ease-primary: #60a5fa;
+}
+</pre>
+      </section>
+
+      <section class="card">
+        <h2>Theme variables to override</h2>
+        <p class="demo-notice">These are the most important tokens for dark mode in an EaseMotion-like system.</p>
+        <ul>
+          <li>--ease-background</li>
+          <li>--ease-surface</li>
+          <li>--ease-surface-strong</li>
+          <li>--ease-foreground</li>
+          <li>--ease-muted</li>
+          <li>--ease-border</li>
+          <li>--ease-border-muted</li>
+          <li>--ease-primary</li>
+          <li>--ease-primary-contrast</li>
+          <li>--ease-secondary</li>
+          <li>--ease-shadow</li>
+          <li>--ease-link</li>
+        </ul>
+      </section>
+    </div>
+
+    <script>
+      const root = document.documentElement;
+      const toggle = document.getElementById('theme-toggle');
+      const savedTheme = localStorage.getItem('easeTheme');
+
+      function applyTheme(theme) {
+        if (theme) {
+          root.dataset.theme = theme;
+          toggle.textContent = theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode';
+          toggle.setAttribute('aria-pressed', theme === 'dark');
+        } else {
+          root.removeAttribute('data-theme');
+          toggle.textContent = 'Enable dark mode';
+          toggle.setAttribute('aria-pressed', 'false');
+        }
+      }
+
+      function getNextTheme() {
+        const current = root.dataset.theme || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        return current === 'dark' ? 'light' : 'dark';
+      }
+
+      function refreshToggleLabel() {
+        const current = root.dataset.theme;
+        if (current === 'dark') {
+          toggle.textContent = 'Switch to light mode';
+          toggle.setAttribute('aria-pressed', 'true');
+        } else if (current === 'light') {
+          toggle.textContent = 'Switch to dark mode';
+          toggle.setAttribute('aria-pressed', 'false');
+        } else {
+          toggle.textContent = 'Use system theme or enable dark mode';
+          toggle.setAttribute('aria-pressed', 'false');
+        }
+      }
+
+      if (savedTheme === 'dark' || savedTheme === 'light') {
+        applyTheme(savedTheme);
+      } else {
+        refreshToggleLabel();
+      }
+
+      toggle.addEventListener('click', () => {
+        const theme = getNextTheme();
+        applyTheme(theme);
+        localStorage.setItem('easeTheme', theme);
+      });
+    </script>
+  </body>
+</html>

--- a/submissions/dark-mode-easemotion/dark-mode.css
+++ b/submissions/dark-mode-easemotion/dark-mode.css
@@ -1,0 +1,219 @@
+:root {
+  color-scheme: light dark;
+
+  --ease-background: #ffffff;
+  --ease-surface: #f8fafc;
+  --ease-surface-strong: #f1f5f9;
+  --ease-foreground: #0f172a;
+  --ease-muted: #64748b;
+
+  --ease-border: #cbd5e1;
+  --ease-border-muted: #e2e8f0;
+
+  --ease-primary: #2563eb;
+  --ease-primary-contrast: #ffffff;
+  --ease-secondary: #7c3aed;
+
+  --ease-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  --ease-ring: rgba(37, 99, 235, 0.35);
+  --ease-code-bg: #e2e8f0;
+  --ease-link: #2563eb;
+  --ease-link-hover: #1d4ed8;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ease-background: #020617;
+    --ease-surface: #111827;
+    --ease-surface-strong: #1f2937;
+    --ease-foreground: #f8fafc;
+    --ease-muted: #94a3b8;
+
+    --ease-border: #334155;
+    --ease-border-muted: #334155;
+
+    --ease-primary: #60a5fa;
+    --ease-primary-contrast: #0f172a;
+    --ease-secondary: #8b5cf6;
+
+    --ease-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+    --ease-ring: rgba(96, 165, 250, 0.28);
+    --ease-code-bg: #0f172a;
+    --ease-link: #93c5fd;
+    --ease-link-hover: #bfdbfe;
+  }
+}
+
+:root[data-theme="dark"] {
+  --ease-background: #020617;
+  --ease-surface: #111827;
+  --ease-surface-strong: #1f2937;
+  --ease-foreground: #f8fafc;
+  --ease-muted: #94a3b8;
+
+  --ease-border: #334155;
+  --ease-border-muted: #334155;
+
+  --ease-primary: #60a5fa;
+  --ease-primary-contrast: #0f172a;
+  --ease-secondary: #8b5cf6;
+
+  --ease-shadow: 0 10px 30px rgba(15, 23, 42, 0.45);
+  --ease-ring: rgba(96, 165, 250, 0.28);
+  --ease-code-bg: #0f172a;
+  --ease-link: #93c5fd;
+  --ease-link-hover: #bfdbfe;
+}
+
+:root[data-theme="light"] {
+  --ease-background: #ffffff;
+  --ease-surface: #f8fafc;
+  --ease-surface-strong: #f1f5f9;
+  --ease-foreground: #0f172a;
+  --ease-muted: #64748b;
+
+  --ease-border: #cbd5e1;
+  --ease-border-muted: #e2e8f0;
+
+  --ease-primary: #2563eb;
+  --ease-primary-contrast: #ffffff;
+  --ease-secondary: #7c3aed;
+
+  --ease-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  --ease-ring: rgba(37, 99, 235, 0.35);
+  --ease-code-bg: #e2e8f0;
+  --ease-link: #2563eb;
+  --ease-link-hover: #1d4ed8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--ease-background);
+  color: var(--ease-foreground);
+}
+
+body {
+  padding: 2rem;
+  transition: background-color 220ms ease, color 220ms ease;
+}
+
+.page {
+  max-width: 900px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  padding: 1.75rem;
+  border-radius: 1rem;
+  border: 1px solid var(--ease-border);
+  background: var(--ease-surface);
+  box-shadow: var(--ease-shadow);
+}
+
+.card.strong {
+  background: var(--ease-surface-strong);
+}
+
+h1,
+h2 {
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 2.5vw, 2.75rem);
+}
+
+h2 {
+  font-size: 1.25rem;
+}
+
+p,
+ul {
+  margin: 0;
+  color: var(--ease-muted);
+  line-height: 1.75;
+}
+
+ul {
+  padding-left: 1.25rem;
+}
+
+li {
+  margin-bottom: 0.75rem;
+}
+
+a {
+  color: var(--ease-link);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--ease-link-hover);
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.25rem;
+  font-size: 1rem;
+  font-weight: 700;
+  background: var(--ease-primary);
+  color: var(--ease-primary-contrast);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.15);
+  transition: transform 180ms ease, background-color 180ms ease;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-1px);
+  outline: 2px solid var(--ease-ring);
+  outline-offset: 3px;
+}
+
+.code-block {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background: var(--ease-code-bg);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  overflow-x: auto;
+  color: var(--ease-foreground);
+}
+
+.theme-summary {
+  display: grid;
+  gap: 1rem;
+}
+
+.theme-swatch {
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--ease-border-muted);
+  background: var(--ease-surface-strong);
+}
+
+.theme-swatch span {
+  display: block;
+  font-size: 0.875rem;
+  color: var(--ease-muted);
+}
+
+.theme-swatch strong {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--ease-foreground);
+}
+
+.demo-notice {
+  color: var(--ease-foreground);
+}


### PR DESCRIPTION
### Summary
Add a demo and documentation for implementing dark mode with EaseMotion CSS variables.

### What changed
- Added `submissions/dark-mode-easemotion/dark-mode-demo.html`
- Added `submissions/dark-mode-easemotion/dark-mode.css`
- Added `submissions/dark-mode-easemotion/README.md`
- Added top-level `submissions/README.md`

### Why
This documents how to use `@media (prefers-color-scheme: dark)` plus manual theme switching with `:root[data-theme="dark"]` and overrides common `--ease-*` variables.

### Notes
- Demo includes keyboard-accessible toggle
- Uses localStorage for theme persistence
- Compatible with EaseMotion token-based styling
closes #603