### PR TITLE
feat(scanner): add scan-history duplicate detection for barcode reuse

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -19,11 +19,11 @@
 
 ## Endpoints Overview
 
-| # | Method | Route | Description | Auth Required |
-|---|--------|-------|-------------|---------------|
-| 1 | `POST` | `/api/verify` | Verify a batch by batch number | No |
-| 2 | `POST` | `/api/scan` | Upload an image/document for scanning | No |
-| 3 | `GET` | `/health` | Check system health status | No |
+| #   | Method | Route         | Description                           | Auth Required |
+| --- | ------ | ------------- | ------------------------------------- | ------------- |
+| 1   | `POST` | `/api/verify` | Verify a batch by batch number        | No            |
+| 2   | `POST` | `/api/scan`   | Upload an image/document for scanning | No            |
+| 3   | `GET`  | `/health`     | Check system health status            | No            |
 
 ---
 
@@ -33,23 +33,27 @@ Verifies the authenticity and status of a product batch using its batch number.
 
 ### Request
 
-| Property | Value |
-|----------|-------|
-| **Method** | `POST` |
-| **URL** | `/api/verify` |
+| Property         | Value              |
+| ---------------- | ------------------ |
+| **Method**       | `POST`             |
+| **URL**          | `/api/verify`      |
 | **Content-Type** | `application/json` |
 
 #### Request Body
 
 ```json
 {
-  "batchNumber": "BATCH123"
+    "batchNumber": "BATCH123",
+    "latitude": 23.0355,
+    "longitude": 72.5116
 }
 ```
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `batchNumber` | `string` | ✅ Yes | The unique batch identifier to verify |
+| Field         | Type     | Required | Description                                                    |
+| ------------- | -------- | -------- | -------------------------------------------------------------- |
+| `batchNumber` | `string` | ✅ Yes   | The unique batch identifier to verify                          |
+| `latitude`    | `number` | ❌ No    | Optional scanner latitude for location-aware anomaly analysis  |
+| `longitude`   | `number` | ❌ No    | Optional scanner longitude for location-aware anomaly analysis |
 
 #### Example cURL
 
@@ -67,49 +71,49 @@ curl -X POST https://<your-domain>/api/verify \
 
 ```json
 {
-  "success": true,
-  "status": "verified",
-  "batchNumber": "BATCH123",
-  "product": {
-    "name": "Product Name",
-    "category": "Category",
-    "manufacturingDate": "2024-01-15",
-    "expiryDate": "2026-01-15",
-    "origin": "India"
-  },
-  "manufacturer": {
-    "id": "MFG-001",
-    "name": "Manufacturer Name",
-    "licenseNumber": "LIC-2024-XXXX",
-    "address": "123 Factory Road, City, State - 000000"
-  },
-  "verifiedAt": "2025-05-19T10:30:00.000Z"
+    "success": true,
+    "status": "verified",
+    "batchNumber": "BATCH123",
+    "product": {
+        "name": "Product Name",
+        "category": "Category",
+        "manufacturingDate": "2024-01-15",
+        "expiryDate": "2026-01-15",
+        "origin": "India"
+    },
+    "manufacturer": {
+        "id": "MFG-001",
+        "name": "Manufacturer Name",
+        "licenseNumber": "LIC-2024-XXXX",
+        "address": "123 Factory Road, City, State - 000000"
+    },
+    "verifiedAt": "2025-05-19T10:30:00.000Z"
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `success` | `boolean` | `true` when verification succeeds |
-| `status` | `string` | `"verified"` \| `"unverified"` \| `"expired"` |
-| `batchNumber` | `string` | Echo of the queried batch number |
-| `product.name` | `string` | Product display name |
-| `product.category` | `string` | Product category/type |
-| `product.manufacturingDate` | `string` (ISO 8601) | Date of manufacture |
-| `product.expiryDate` | `string` (ISO 8601) | Expiry/best-before date |
-| `product.origin` | `string` | Country or region of origin |
-| `manufacturer.id` | `string` | Internal manufacturer identifier |
-| `manufacturer.name` | `string` | Registered manufacturer name |
-| `manufacturer.licenseNumber` | `string` | Government-issued license number |
-| `manufacturer.address` | `string` | Registered address |
-| `verifiedAt` | `string` (ISO 8601) | Timestamp of the verification check |
+| Field                        | Type                | Description                                   |
+| ---------------------------- | ------------------- | --------------------------------------------- |
+| `success`                    | `boolean`           | `true` when verification succeeds             |
+| `status`                     | `string`            | `"verified"` \| `"unverified"` \| `"expired"` |
+| `batchNumber`                | `string`            | Echo of the queried batch number              |
+| `product.name`               | `string`            | Product display name                          |
+| `product.category`           | `string`            | Product category/type                         |
+| `product.manufacturingDate`  | `string` (ISO 8601) | Date of manufacture                           |
+| `product.expiryDate`         | `string` (ISO 8601) | Expiry/best-before date                       |
+| `product.origin`             | `string`            | Country or region of origin                   |
+| `manufacturer.id`            | `string`            | Internal manufacturer identifier              |
+| `manufacturer.name`          | `string`            | Registered manufacturer name                  |
+| `manufacturer.licenseNumber` | `string`            | Government-issued license number              |
+| `manufacturer.address`       | `string`            | Registered address                            |
+| `verifiedAt`                 | `string` (ISO 8601) | Timestamp of the verification check           |
 
 #### `404 Not Found` — Batch Not Found
 
 ```json
 {
-  "success": false,
-  "status": "not_found",
-  "message": "No batch found with number: BATCH123"
+    "success": false,
+    "status": "not_found",
+    "message": "No batch found with number: BATCH123"
 }
 ```
 
@@ -117,9 +121,9 @@ curl -X POST https://<your-domain>/api/verify \
 
 ```json
 {
-  "success": false,
-  "status": "validation_error",
-  "message": "batchNumber is required and must be a non-empty string"
+    "success": false,
+    "status": "validation_error",
+    "message": "batchNumber is required and must be a non-empty string"
 }
 ```
 
@@ -131,27 +135,27 @@ Accepts a multipart form-data upload (image or document) and returns extracted/p
 
 ### Request
 
-| Property | Value |
-|----------|-------|
-| **Method** | `POST` |
-| **URL** | `/api/scan` |
+| Property         | Value                 |
+| ---------------- | --------------------- |
+| **Method**       | `POST`                |
+| **URL**          | `/api/scan`           |
 | **Content-Type** | `multipart/form-data` |
 
 #### Form Fields
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `file` | `File` (binary) | ✅ Yes | The image or document to scan (JPEG, PNG, PDF, WEBP) |
-| `scanType` | `string` | No | Hint for scan mode: `"barcode"` \| `"qr"` \| `"label"` \| `"auto"` (default: `"auto"`) |
+| Field      | Type            | Required | Description                                                                            |
+| ---------- | --------------- | -------- | -------------------------------------------------------------------------------------- |
+| `file`     | `File` (binary) | ✅ Yes   | The image or document to scan (JPEG, PNG, PDF, WEBP)                                   |
+| `scanType` | `string`        | No       | Hint for scan mode: `"barcode"` \| `"qr"` \| `"label"` \| `"auto"` (default: `"auto"`) |
 
 #### Accepted File Types
 
-| MIME Type | Extension | Max Size |
-|-----------|-----------|----------|
-| `image/jpeg` | `.jpg`, `.jpeg` | 10 MB |
-| `image/png` | `.png` | 10 MB |
-| `image/webp` | `.webp` | 10 MB |
-| `application/pdf` | `.pdf` | 10 MB |
+| MIME Type         | Extension       | Max Size |
+| ----------------- | --------------- | -------- |
+| `image/jpeg`      | `.jpg`, `.jpeg` | 10 MB    |
+| `image/png`       | `.png`          | 10 MB    |
+| `image/webp`      | `.webp`         | 10 MB    |
+| `application/pdf` | `.pdf`          | 10 MB    |
 
 #### Example cURL
 
@@ -165,12 +169,12 @@ curl -X POST https://<your-domain>/api/scan \
 
 ```javascript
 const formData = new FormData();
-formData.append('file', fileInput.files[0]);
-formData.append('scanType', 'auto');
+formData.append("file", fileInput.files[0]);
+formData.append("scanType", "auto");
 
-const response = await fetch('/api/scan', {
-  method: 'POST',
-  body: formData,
+const response = await fetch("/api/scan", {
+    method: "POST",
+    body: formData,
 });
 const result = await response.json();
 ```
@@ -183,40 +187,40 @@ const result = await response.json();
 
 ```json
 {
-  "success": true,
-  "scanType": "qr",
-  "extractedData": {
-    "batchNumber": "BATCH123",
-    "rawValue": "https://sahidawa.in/verify/BATCH123",
-    "confidence": 0.98
-  },
-  "file": {
-    "originalName": "product-label.jpg",
-    "mimeType": "image/jpeg",
-    "sizeBytes": 204800
-  },
-  "scannedAt": "2025-05-19T10:35:00.000Z"
+    "success": true,
+    "scanType": "qr",
+    "extractedData": {
+        "batchNumber": "BATCH123",
+        "rawValue": "https://sahidawa.in/verify/BATCH123",
+        "confidence": 0.98
+    },
+    "file": {
+        "originalName": "product-label.jpg",
+        "mimeType": "image/jpeg",
+        "sizeBytes": 204800
+    },
+    "scannedAt": "2025-05-19T10:35:00.000Z"
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `success` | `boolean` | `true` when scan processing succeeds |
-| `scanType` | `string` | Detected or used scan type (`"barcode"`, `"qr"`, `"label"`, `"auto"`) |
-| `extractedData.batchNumber` | `string` | Batch number extracted from scan (if found) |
-| `extractedData.rawValue` | `string` | Raw decoded string from barcode/QR |
-| `extractedData.confidence` | `number` | Confidence score `0.0–1.0` |
-| `file.originalName` | `string` | Original uploaded filename |
-| `file.mimeType` | `string` | Detected MIME type |
-| `file.sizeBytes` | `integer` | File size in bytes |
-| `scannedAt` | `string` (ISO 8601) | Timestamp of the scan operation |
+| Field                       | Type                | Description                                                           |
+| --------------------------- | ------------------- | --------------------------------------------------------------------- |
+| `success`                   | `boolean`           | `true` when scan processing succeeds                                  |
+| `scanType`                  | `string`            | Detected or used scan type (`"barcode"`, `"qr"`, `"label"`, `"auto"`) |
+| `extractedData.batchNumber` | `string`            | Batch number extracted from scan (if found)                           |
+| `extractedData.rawValue`    | `string`            | Raw decoded string from barcode/QR                                    |
+| `extractedData.confidence`  | `number`            | Confidence score `0.0–1.0`                                            |
+| `file.originalName`         | `string`            | Original uploaded filename                                            |
+| `file.mimeType`             | `string`            | Detected MIME type                                                    |
+| `file.sizeBytes`            | `integer`           | File size in bytes                                                    |
+| `scannedAt`                 | `string` (ISO 8601) | Timestamp of the scan operation                                       |
 
 #### `400 Bad Request` — No File Uploaded
 
 ```json
 {
-  "success": false,
-  "message": "No file was uploaded. Please attach a file using the 'file' field."
+    "success": false,
+    "message": "No file was uploaded. Please attach a file using the 'file' field."
 }
 ```
 
@@ -224,8 +228,8 @@ const result = await response.json();
 
 ```json
 {
-  "success": false,
-  "message": "Unsupported file type: application/zip. Accepted types: image/jpeg, image/png, image/webp, application/pdf"
+    "success": false,
+    "message": "Unsupported file type: application/zip. Accepted types: image/jpeg, image/png, image/webp, application/pdf"
 }
 ```
 
@@ -233,10 +237,10 @@ const result = await response.json();
 
 ```json
 {
-  "success": false,
-  "message": "Scan completed but no readable barcode or QR code was detected.",
-  "scanType": "auto",
-  "extractedData": null
+    "success": false,
+    "message": "Scan completed but no readable barcode or QR code was detected.",
+    "scanType": "auto",
+    "extractedData": null
 }
 ```
 
@@ -248,11 +252,11 @@ Returns the current operational status of the API and its dependent services. Us
 
 ### Request
 
-| Property | Value |
-|----------|-------|
-| **Method** | `GET` |
-| **URL** | `/health` |
-| **Content-Type** | N/A |
+| Property         | Value     |
+| ---------------- | --------- |
+| **Method**       | `GET`     |
+| **URL**          | `/health` |
+| **Content-Type** | N/A       |
 
 #### Example cURL
 
@@ -268,53 +272,53 @@ curl https://<your-domain>/health
 
 ```json
 {
-  "status": "ok",
-  "uptime": 48320.5,
-  "timestamp": "2025-05-19T10:40:00.000Z",
-  "services": {
-    "database": {
-      "status": "ok",
-      "responseTimeMs": 3
+    "status": "ok",
+    "uptime": 48320.5,
+    "timestamp": "2025-05-19T10:40:00.000Z",
+    "services": {
+        "database": {
+            "status": "ok",
+            "responseTimeMs": 3
+        },
+        "storage": {
+            "status": "ok",
+            "responseTimeMs": 12
+        }
     },
-    "storage": {
-      "status": "ok",
-      "responseTimeMs": 12
-    }
-  },
-  "version": "1.0.0"
+    "version": "1.0.0"
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `status` | `string` | Overall status: `"ok"` \| `"degraded"` \| `"down"` |
-| `uptime` | `number` | Server uptime in seconds |
-| `timestamp` | `string` (ISO 8601) | Time of the health check |
-| `services.database.status` | `string` | DB connectivity: `"ok"` \| `"error"` |
-| `services.database.responseTimeMs` | `integer` | DB ping latency in milliseconds |
-| `services.storage.status` | `string` | File storage status: `"ok"` \| `"error"` |
-| `services.storage.responseTimeMs` | `integer` | Storage ping latency in milliseconds |
-| `version` | `string` | Deployed API version |
+| Field                              | Type                | Description                                        |
+| ---------------------------------- | ------------------- | -------------------------------------------------- |
+| `status`                           | `string`            | Overall status: `"ok"` \| `"degraded"` \| `"down"` |
+| `uptime`                           | `number`            | Server uptime in seconds                           |
+| `timestamp`                        | `string` (ISO 8601) | Time of the health check                           |
+| `services.database.status`         | `string`            | DB connectivity: `"ok"` \| `"error"`               |
+| `services.database.responseTimeMs` | `integer`           | DB ping latency in milliseconds                    |
+| `services.storage.status`          | `string`            | File storage status: `"ok"` \| `"error"`           |
+| `services.storage.responseTimeMs`  | `integer`           | Storage ping latency in milliseconds               |
+| `version`                          | `string`            | Deployed API version                               |
 
 #### `503 Service Unavailable` — Degraded or Down
 
 ```json
 {
-  "status": "degraded",
-  "uptime": 48320.5,
-  "timestamp": "2025-05-19T10:40:00.000Z",
-  "services": {
-    "database": {
-      "status": "error",
-      "responseTimeMs": null,
-      "error": "Connection timeout"
+    "status": "degraded",
+    "uptime": 48320.5,
+    "timestamp": "2025-05-19T10:40:00.000Z",
+    "services": {
+        "database": {
+            "status": "error",
+            "responseTimeMs": null,
+            "error": "Connection timeout"
+        },
+        "storage": {
+            "status": "ok",
+            "responseTimeMs": 14
+        }
     },
-    "storage": {
-      "status": "ok",
-      "responseTimeMs": 14
-    }
-  },
-  "version": "1.0.0"
+    "version": "1.0.0"
 }
 ```
 
@@ -326,24 +330,24 @@ All error responses follow a consistent structure:
 
 ```json
 {
-  "success": false,
-  "message": "Human-readable error description",
-  "code": "ERROR_CODE"
+    "success": false,
+    "message": "Human-readable error description",
+    "code": "ERROR_CODE"
 }
 ```
 
 ### Common HTTP Status Codes
 
-| Code | Meaning | When It Occurs |
-|------|---------|----------------|
-| `200` | OK | Request succeeded |
-| `400` | Bad Request | Missing required fields or malformed request body |
-| `404` | Not Found | Resource (e.g., batch number) does not exist |
-| `413` | Payload Too Large | Uploaded file exceeds the 10 MB limit |
-| `415` | Unsupported Media Type | File type not accepted by `/api/scan` |
-| `422` | Unprocessable Entity | Validation failed or scan yielded no result |
-| `500` | Internal Server Error | Unexpected server-side failure |
-| `503` | Service Unavailable | One or more dependent services are down |
+| Code  | Meaning                | When It Occurs                                    |
+| ----- | ---------------------- | ------------------------------------------------- |
+| `200` | OK                     | Request succeeded                                 |
+| `400` | Bad Request            | Missing required fields or malformed request body |
+| `404` | Not Found              | Resource (e.g., batch number) does not exist      |
+| `413` | Payload Too Large      | Uploaded file exceeds the 10 MB limit             |
+| `415` | Unsupported Media Type | File type not accepted by `/api/scan`             |
+| `422` | Unprocessable Entity   | Validation failed or scan yielded no result       |
+| `500` | Internal Server Error  | Unexpected server-side failure                    |
+| `503` | Service Unavailable    | One or more dependent services are down           |
 
 ---
 
@@ -357,4 +361,4 @@ Authorization: Bearer <token>
 
 ---
 
-*Last updated: May 2025 — GSSoC Issue #301*
+_Last updated: May 2025 — GSSoC Issue #301_

--- a/apps/api/src/db/schema.sql
+++ b/apps/api/src/db/schema.sql
@@ -120,7 +120,23 @@ CREATE TABLE IF NOT EXISTS barcode_mappings (
 );
 CREATE INDEX IF NOT EXISTS idx_barcode_mappings_barcode ON barcode_mappings(barcode_id);
 
--- 5. Official Drug Alerts (CDSCO NSQ/Recalls)
+-- 6. Scan History (Duplicate scan and anomaly tracking)
+CREATE TABLE IF NOT EXISTS scan_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_number VARCHAR(100) NOT NULL,
+    medicine_id UUID REFERENCES medicines(id) ON DELETE SET NULL,
+    barcode_id VARCHAR(100),
+    client_ip INET,
+    origin VARCHAR(255),
+    user_agent TEXT,
+    latitude NUMERIC(9,6),
+    longitude NUMERIC(9,6),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_scan_history_batch_number ON scan_history(batch_number);
+CREATE INDEX IF NOT EXISTS idx_scan_history_created_at ON scan_history(created_at);
+
+-- 7. Official Drug Alerts (CDSCO NSQ/Recalls)
 CREATE TABLE IF NOT EXISTS drug_alerts (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     medicine_id UUID REFERENCES medicines(id),

--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -28,6 +28,8 @@ const verifySchema = z.object({
     batchNumber: z
         .string({ message: "batchNumber is required and must be a string" })
         .min(3, "batchNumber must be at least 3 characters long"),
+    latitude: z.number().optional(),
+    longitude: z.number().optional(),
 });
 
 /**
@@ -54,6 +56,16 @@ const verifySchema = z.object({
  *                 minLength: 3
  *                 example: "BN2024001"
  *                 description: The batch number printed on the medicine packaging
+ *               latitude:
+ *                 type: number
+ *                 format: float
+ *                 example: 23.0355
+ *                 description: Optional latitude of the scanner device when available
+ *               longitude:
+ *                 type: number
+ *                 format: float
+ *                 example: 72.5116
+ *                 description: Optional longitude of the scanner device when available
  *     responses:
  *       200:
  *         description: Medicine found and verified
@@ -67,6 +79,24 @@ const verifySchema = z.object({
  *                   example: true
  *                 medicine:
  *                   $ref: '#/components/schemas/Medicine'
+ *                 scanMeta:
+ *                   type: object
+ *                   properties:
+ *                     recentScanCount24h:
+ *                       type: integer
+ *                       example: 3
+ *                     recentScanCount7d:
+ *                       type: integer
+ *                       example: 12
+ *                     suspicious:
+ *                       type: boolean
+ *                       example: true
+ *                     suspicionReasons:
+ *                       type: array
+ *                       items:
+ *                         type: string
+ *                       example:
+ *                         - "This batch has been scanned multiple times in the last 24 hours."
  *       400:
  *         description: Invalid request body
  *         content:
@@ -122,7 +152,7 @@ router.post(
             return;
         }
 
-        const { batchNumber } = parsed.data;
+        const { batchNumber, latitude, longitude } = parsed.data;
 
         const escaped = batchNumber
             .replace(/\\/g, "\\\\")
@@ -133,7 +163,7 @@ router.post(
             const { data, error } = await supabase
                 .from("medicines")
                 .select(
-                    "brand_name, generic_name, manufacturer, batch_number, expiry_date, cdsco_approval_status, is_counterfeit_alert"
+                    "id, barcode_id, brand_name, generic_name, manufacturer, batch_number, expiry_date, cdsco_approval_status, is_counterfeit_alert"
                 )
                 .ilike("batch_number", escaped)
                 .limit(1)
@@ -156,6 +186,62 @@ router.post(
                 return;
             }
 
+            const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+            const since7d = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+            const [{ count: count24h = 0 }, { count: count7d = 0 }] = (await Promise.all([
+                supabase
+                    .from("scan_history")
+                    .select("id", { count: "exact", head: true })
+                    .eq("batch_number", data.batch_number)
+                    .gte("created_at", since24h),
+                supabase
+                    .from("scan_history")
+                    .select("id", { count: "exact", head: true })
+                    .eq("batch_number", data.batch_number)
+                    .gte("created_at", since7d),
+            ])) as Array<{ count: number | null }>;
+
+            const recentScanCount24h = (count24h ?? 0) + 1;
+            const recentScanCount7d = (count7d ?? 0) + 1;
+            const suspicionReasons: string[] = [];
+            let suspicious = false;
+
+            if (data.is_counterfeit_alert) {
+                suspicious = true;
+                suspicionReasons.push(
+                    "This batch is already flagged as a counterfeit alert in the official database."
+                );
+            }
+            if (recentScanCount24h >= 3) {
+                suspicious = true;
+                suspicionReasons.push(
+                    "This batch has been scanned multiple times in the last 24 hours, which may indicate barcode reuse or sticker cloning."
+                );
+            }
+            if (recentScanCount7d >= 10) {
+                suspicious = true;
+                suspicionReasons.push(
+                    "This batch has unusually high scan volume in the last week, increasing the risk of counterfeit reuse."
+                );
+            }
+
+            const { error: insertError } = await supabase.from("scan_history").insert([
+                {
+                    batch_number: data.batch_number,
+                    medicine_id: data.id,
+                    barcode_id: data.barcode_id,
+                    client_ip: req.ip || null,
+                    origin: req.headers.origin ?? null,
+                    user_agent: req.headers["user-agent"] ?? null,
+                    latitude: latitude ?? null,
+                    longitude: longitude ?? null,
+                },
+            ]);
+            if (insertError) {
+                console.error("Failed to record scan history:", insertError);
+            }
+
             res.status(200).json({
                 verified: true,
                 medicine: {
@@ -166,6 +252,12 @@ router.post(
                     expiry_date: data.expiry_date,
                     cdsco_approval_status: data.cdsco_approval_status,
                     is_counterfeit_alert: data.is_counterfeit_alert,
+                },
+                scanMeta: {
+                    recentScanCount24h,
+                    recentScanCount7d,
+                    suspicious,
+                    suspicionReasons,
                 },
             });
         } catch (err) {

--- a/apps/api/tests/verify.test.ts
+++ b/apps/api/tests/verify.test.ts
@@ -1,17 +1,19 @@
 import request from "supertest";
 import app from "../src/app";
 
-// Mocks the supabase client so it doesn't depend on a live database
 jest.mock("../src/db/client", () => {
-    return {
-        supabase: {
-            from: jest.fn().mockReturnThis(),
-            select: jest.fn().mockReturnThis(),
-            ilike: jest.fn().mockReturnThis(),
-            limit: jest.fn().mockReturnThis(),
-            maybeSingle: jest.fn(),
-        },
+    const mock = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        ilike: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn(),
+        eq: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        insert: jest.fn().mockReturnThis(),
     };
+
+    return { supabase: mock };
 });
 
 import { supabase } from "../src/db/client";
@@ -22,9 +24,17 @@ describe("POST /api/verify", () => {
     });
 
     it("should verify a valid batch number", async () => {
+        // Mock scan history counts and insert
+        ((supabase as any).gte as jest.Mock)
+            .mockResolvedValueOnce({ count: 0, error: null })
+            .mockResolvedValueOnce({ count: 0, error: null });
+        ((supabase as any).insert as jest.Mock).mockResolvedValue({ data: null, error: null });
+
         // Mock a successful lookup
         ((supabase as any).maybeSingle as jest.Mock).mockResolvedValue({
             data: {
+                id: "11111111-1111-1111-1111-111111111111",
+                barcode_id: "1234567890123",
                 brand_name: "Test Brand",
                 generic_name: "Test Generic",
                 manufacturer: "Test Mfg",
@@ -41,6 +51,38 @@ describe("POST /api/verify", () => {
         expect(res.status).toBe(200);
         expect(res.body.verified).toBe(true);
         expect(res.body.medicine.batch_number).toBe("AUG625D");
+        expect(res.body.scanMeta).toBeDefined();
+        expect(res.body.scanMeta.recentScanCount24h).toBe(1);
+        expect(res.body.scanMeta.suspicious).toBe(false);
+    });
+
+    it("should flag suspicious duplicate scan volume", async () => {
+        ((supabase as any).gte as jest.Mock)
+            .mockResolvedValueOnce({ count: 2, error: null })
+            .mockResolvedValueOnce({ count: 5, error: null });
+        ((supabase as any).insert as jest.Mock).mockResolvedValue({ data: null, error: null });
+        ((supabase as any).maybeSingle as jest.Mock).mockResolvedValueOnce({
+            data: {
+                id: "11111111-1111-1111-1111-111111111111",
+                barcode_id: "1234567890123",
+                brand_name: "Test Brand",
+                generic_name: "Test Generic",
+                manufacturer: "Test Mfg",
+                batch_number: "AUG625D",
+                expiry_date: "2025-12-31",
+                cdsco_approval_status: "Approved",
+                is_counterfeit_alert: false,
+            },
+            error: null,
+        });
+
+        const res = await request(app).post("/api/verify").send({ batchNumber: "AUG625D" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.scanMeta).toBeDefined();
+        expect(res.body.scanMeta.recentScanCount24h).toBe(3);
+        expect(res.body.scanMeta.suspicious).toBe(true);
+        expect(res.body.scanMeta.suspicionReasons.length).toBeGreaterThan(0);
     });
 
     it("should return 404 for an unknown batch number", async () => {

--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -180,6 +180,7 @@ function LoadingSkeleton({ ocrStatus, ocrProgress }: { ocrStatus: string; ocrPro
 // Result views with dark/light mode surface tokens and variables support
 function VerifiedSafeResult({
     medicine,
+    scanMeta,
     onScanAgain,
     onShare,
     onCopyMedicineDetails,
@@ -187,6 +188,12 @@ function VerifiedSafeResult({
     copied,
 }: {
     medicine: VerifiedMedicine;
+    scanMeta?: {
+        recentScanCount24h: number;
+        recentScanCount7d: number;
+        suspicious: boolean;
+        suspicionReasons: string[];
+    };
     onScanAgain: () => void;
     onShare: () => void;
     onCopyMedicineDetails: () => void;
@@ -208,6 +215,18 @@ function VerifiedSafeResult({
                 </div>
 
                 <CdscoStatusBadge status={medicine.cdsco_approval_status} />
+
+                {scanMeta?.suspicious && (
+                    <div className="border-amber-250 flex w-full items-start gap-3 rounded-2xl border bg-amber-50 p-4 text-left dark:border-amber-900 dark:bg-amber-950/20">
+                        <AlertTriangle
+                            size={18}
+                            className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
+                        />
+                        <p className="text-xs leading-relaxed font-medium text-amber-800 dark:text-amber-400">
+                            {scanMeta.suspicionReasons.join(" ")}
+                        </p>
+                    </div>
+                )}
 
                 <div className="grid w-full grid-cols-2 gap-3 pt-2">
                     <div className="rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) p-3">
@@ -1157,6 +1176,7 @@ export default function ScanPage() {
                                     !verifyResult.medicine.is_counterfeit_alert && (
                                         <VerifiedSafeResult
                                             medicine={verifyResult.medicine}
+                                            scanMeta={verifyResult.scanMeta}
                                             onScanAgain={handleScanAgain}
                                             onShare={handleShare}
                                             onCopyMedicineDetails={handleCopyMedicineDetails}

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -143,9 +143,16 @@ export type VerifiedMedicine = {
     is_counterfeit_alert: boolean;
 };
 
+export type ScanMeta = {
+    recentScanCount24h: number;
+    recentScanCount7d: number;
+    suspicious: boolean;
+    suspicionReasons: string[];
+};
+
 export type VerifyResult =
-    | { verified: true; medicine: VerifiedMedicine }
-    | { verified: false; message: string };
+    | { verified: true; medicine: VerifiedMedicine; scanMeta?: ScanMeta }
+    | { verified: false; message: string; scanMeta?: ScanMeta };
 
 export type VerifiedPharmacy = {
     name: string;

--- a/supabase/migrations/20260602000000_create_scan_history.sql
+++ b/supabase/migrations/20260602000000_create_scan_history.sql
@@ -1,0 +1,17 @@
+-- Create scan history table for duplicate scan anomaly detection
+CREATE TABLE IF NOT EXISTS scan_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_number VARCHAR(100) NOT NULL,
+    medicine_id UUID REFERENCES medicines(id) ON DELETE SET NULL,
+    barcode_id VARCHAR(100),
+    client_ip INET,
+    origin VARCHAR(255),
+    user_agent TEXT,
+    latitude NUMERIC(9,6),
+    longitude NUMERIC(9,6),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_scan_history_batch_number ON scan_history(batch_number);
+CREATE INDEX IF NOT EXISTS idx_scan_history_created_at ON scan_history(created_at);
+CREATE INDEX IF NOT EXISTS idx_scan_history_geo ON scan_history(latitude, longitude);


### PR DESCRIPTION
## 📋 PR Summary

Implemented scan-history based duplicate detection for medicine verification to reduce false trust from reused barcodes/QR codes.

---

## 🔗 Related Issue

Closes #1140 

---

## 🏷️ PR Type

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [x] web — Next.js Frontend
- [x] api — Node.js / Express Backend
- [x] data — Database seeds / migrations
- [ ] docs — Documentation
- [ ] .github — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Added a new `scan_history` migration for tracking medicine verification scans.
- Extended `POST /api/verify` to:
  - record each verified scan
  - accept optional `latitude` and `longitude`
  - return `scanMeta` with recent scan counts
- Added duplicate-scan anomaly detection heuristics:
  - suspicious if `>= 3` scans in 24h
  - suspicious if `>= 10` scans in 7 days
  - suspicious if batch already has `is_counterfeit_alert`
- Updated frontend scan result UI to surface suspicious duplicate-scan warnings.
- Extended shared API result types to include optional scan metadata.
- Added backend tests covering normal verification and duplicate-scan detection.
- Applied Prettier formatting to modified files.

---

## 📸 Screenshots / Proof of Work

Terminal test output:

```bash
npx jest --runInBand verify.test.ts
```

Result:

- `5 passed`

---

## ✅ Contributor Checklist

- [x] My PR has a linked issue
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached terminal logs or test outputs as proof of testing
- [x] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }`
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant

