### PR TITLE
fix: enable trust proxy to fix rate limiter IP detection behind Nginx

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -53,6 +53,8 @@ import { errorHandler } from "./middleware/errorHandler";
 
 // ── Application Initialization ─────────────────────────────────────────────
 const app: Express = express();
+app.set("trust proxy", 1); // Trust first proxy (Nginx) — fixes req.ip for rate limiters
+
 
 app.use(compression());
 


### PR DESCRIPTION
### 🛑 STOP: Assignment Check
- [x] I am officially assigned to the issue this PR fixes.

## 📋 PR Summary
Enable `trust proxy` in Express so rate limiters correctly identify individual client IPs when the API runs behind an Nginx reverse proxy.

## 🔗 Related Issue
Closes #1146

## 🏷️ PR Type
- [ ] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [x] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

## 🗂️ Area Changed
- [ ] `apps/web` - Next.js Frontend
- [x] `apps/api` - Node.js / Express Backend
- [ ] `apps/ml` - Python / FastAPI ML Service
- [ ] `data/` - Database seeds / migrations
- [ ] `docs/` - Documentation
- [ ] `.github/` - GitHub config, workflows
- [ ] Root config (package.json, etc.)

## 📝 What Was Done
- Added `app.set("trust proxy", 1)` in `apps/api/src/app.ts` immediately after Express app initialization
- This tells Express to trust the `X-Forwarded-For` header passed by Nginx, so `req.ip` resolves to the real client IP instead of `127.0.0.1`
- Fixes the DoS vulnerability where one user hitting a rate limit would block all users sharing the same proxy IP

## 📸 Screenshots / Proof of Work
<img width="890" height="349" alt="image" src="https://github.com/user-attachments/assets/b5de1207-c782-4900-8f42-2aa91eefe6db" />


## ✅ Contributor Checklist
- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [x] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

## 🎓 GSSoC 2026
- [x] I am a GSSoC 2026 participant