### PR TITLE
fix: add batch number input & display in Expiry Tracker, fix timezone day-off

### DIFF
--- a/apps/web/app/[locale]/expiry-tracker/page.tsx
+++ b/apps/web/app/[locale]/expiry-tracker/page.tsx
@@ -66,8 +66,13 @@ export default function ExpiryTrackerPage() {
         saveToLocalStorage(updated);
     };
 
+    const parseLocalDate = (dateStr: string) => {
+        const [year, month, day] = dateStr.split("-").map(Number);
+        return new Date(year, month - 1, day);
+    };
+
     const getExpiryStatus = (dateStr: string) => {
-        const expiry = new Date(dateStr);
+        const expiry = parseLocalDate(dateStr);
         const today = new Date();
         today.setHours(0, 0, 0, 0);
         const diffDays = Math.ceil((expiry.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
@@ -132,6 +137,18 @@ export default function ExpiryTrackerPage() {
                                     className="w-full rounded-xl border border-(--color-border-muted) bg-(--color-surface-page) p-3 text-(--color-text-primary) [color-scheme:light] transition outline-none focus:ring-2 focus:ring-emerald-500 dark:[color-scheme:dark]"
                                 />
                             </div>
+                            <div>
+                                <label className="mb-1 block text-xs font-bold tracking-wider uppercase opacity-60">
+                                    Batch Number (Optional)
+                                </label>
+                                <input
+                                    type="text"
+                                    value={batchNumber}
+                                    onChange={(e) => setBatchNumber(e.target.value)}
+                                    className="w-full rounded-xl border border-(--color-border-muted) bg-(--color-surface-page) p-3 text-(--color-text-primary) transition outline-none focus:ring-2 focus:ring-emerald-500"
+                                    placeholder="e.g. B12345"
+                                />
+                            </div>
                             <button
                                 type="submit"
                                 className="w-full rounded-xl bg-emerald-600 py-3 font-bold text-white shadow-lg shadow-emerald-900/20 transition-all hover:bg-emerald-700 active:scale-95"
@@ -174,10 +191,16 @@ export default function ExpiryTrackerPage() {
                                                 <div className="flex items-center gap-3 text-sm opacity-70">
                                                     <span className="flex items-center gap-1">
                                                         <Calendar size={14} />{" "}
-                                                        {new Date(
+                                                        {parseLocalDate(
                                                             med.expiryDate
                                                         ).toLocaleDateString()}
                                                     </span>
+                                                    {med.batchNumber && (
+                                                        <span className="flex items-center gap-1">
+                                                            <Package size={14} />{" "}
+                                                            {med.batchNumber}
+                                                        </span>
+                                                    )}
                                                 </div>
                                             </div>
                                             <div className="flex items-center gap-4">


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

## 📋 PR Summary

The Medicine Expiry Tracker already managed a `batchNumber` field in state and wrote it into the saved medicine object, but never exposed it in the UI — there was no input to enter it and the tracked list never displayed it. This PR wires the field through the form and the list cards, and fixes a timezone normalization bug in the expiry-day calculation.

---

## 🔗 Related Issue

Closes #1149

---

## 🏷️ PR Type

- [x] 🐛 Bug Fix
- [ ] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [x] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

All changes are scoped to `apps/web/app/[locale]/expiry-tracker/page.tsx`:

- **Added a "Batch Number (Optional)" text input** to the Add Medicine form, wired to the pre-existing `batchNumber` / `setBatchNumber` state. Reuses the exact label and input styling of the surrounding Name/Expiry Date fields.
- **Displayed the batch number in the Tracked Medicines cards**, next to the expiry date, rendered conditionally (`med.batchNumber && …`) with the already-imported `Package` icon and matching `gap` / `text-sm opacity-70` hierarchy.
- **Fixed the timezone day-off bug** by adding a `parseLocalDate` helper that builds a `Date` from the `YYYY-MM-DD` parts as **local midnight**, and using it in both `getExpiryStatus` and the displayed date. Previously `new Date("YYYY-MM-DD")` parsed as **UTC** midnight while `today` was local midnight, causing off-by-one expiry-day counts and a displayed date that could disagree with the status.

No other behavior was touched — Name/Expiry inputs, localStorage logic, delete handler, status thresholds, and styling are unchanged.


## ✅ Contributor Checklist

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [ ] I have attached screenshots, screen recordings, or terminal logs as pro