### PR TITLE
fix(#916): name Cloudinary report uploads as sahidawa/reports/{batch_number}_{timestamp}

### DIFF
--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -38,8 +38,14 @@ export async function POST(req: NextRequest) {
         const timestamp = Math.round(new Date().getTime() / 1000).toString();
         const folder = "sahidawa/reports";
 
+        // Store each report image at cloud_name/sahidawa/reports/{batch_number}_{timestamp}.
+        // Sanitise the batch number so it cannot inject extra folder paths into the public_id.
+        const rawBatchNumber = (formData.get("batch_number") as string | null) ?? "";
+        const batchNumber = rawBatchNumber.replace(/[^A-Za-z0-9._-]/g, "") || "report";
+        const publicId = `${batchNumber}_${timestamp}`;
+
         // correct signature format — sorted params + secret appended at end
-        const paramsToSign = `folder=${folder}&signature_algorithm=sha256&timestamp=${timestamp}${apiSecret}`;
+        const paramsToSign = `folder=${folder}&public_id=${publicId}&signature_algorithm=sha256&timestamp=${timestamp}${apiSecret}`;
         const signature = crypto.createHash("sha256").update(paramsToSign).digest("hex");
 
         const cloudinaryFormData = new FormData();
@@ -49,6 +55,7 @@ export async function POST(req: NextRequest) {
         cloudinaryFormData.append("signature_algorithm", "sha256");
         cloudinaryFormData.append("signature", signature);
         cloudinaryFormData.append("folder", folder);
+        cloudinaryFormData.append("public_id", publicId);
 
         const res = await fetch(`https://api.cloudinary.com/v1_1/${cloudName}/image/upload`, {
             method: "POST",

--- a/apps/web/tests/upload-route.test.ts
+++ b/apps/web/tests/upload-route.test.ts
@@ -1,0 +1,89 @@
+import crypto from "crypto";
+
+import { POST } from "../app/api/upload/route";
+
+const CLOUD_NAME = "test-cloud";
+const API_KEY = "test-key";
+const API_SECRET = "test-secret";
+
+function buildRequest(fields: Record<string, string> = {}) {
+    const formData = new FormData();
+    formData.append("file", new Blob(["fake-image-bytes"], { type: "image/jpeg" }), "photo.jpg");
+    for (const [key, value] of Object.entries(fields)) {
+        formData.append(key, value);
+    }
+    return new Request("http://localhost/api/upload", {
+        method: "POST",
+        body: formData,
+    });
+}
+
+function captureCloudinaryFormData(fetchMock: jest.Mock): FormData {
+    const [, init] = fetchMock.mock.calls[0];
+    return init.body as FormData;
+}
+
+describe("POST /api/upload", () => {
+    let fetchMock: jest.Mock;
+
+    beforeEach(() => {
+        process.env.CLOUDINARY_CLOUD_NAME = CLOUD_NAME;
+        process.env.CLOUDINARY_API_KEY = API_KEY;
+        process.env.CLOUDINARY_API_SECRET = API_SECRET;
+
+        fetchMock = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                secure_url: "https://res.cloudinary.com/test-cloud/image/upload/v1/sample.jpg",
+            }),
+        });
+        global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+        delete process.env.CLOUDINARY_CLOUD_NAME;
+        delete process.env.CLOUDINARY_API_KEY;
+        delete process.env.CLOUDINARY_API_SECRET;
+        jest.restoreAllMocks();
+    });
+
+    it("stores the image under sahidawa/reports with a {batch_number}_{timestamp} public_id", async () => {
+        const response = await POST(buildRequest({ batch_number: "BATCH123" }));
+
+        expect(response.status).toBe(200);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        const sent = captureCloudinaryFormData(fetchMock);
+        const timestamp = sent.get("timestamp") as string;
+
+        expect(sent.get("folder")).toBe("sahidawa/reports");
+        expect(sent.get("public_id")).toBe(`BATCH123_${timestamp}`);
+    });
+
+    it("falls back to a 'report' prefix when no batch number is supplied", async () => {
+        await POST(buildRequest());
+
+        const sent = captureCloudinaryFormData(fetchMock);
+        const timestamp = sent.get("timestamp") as string;
+
+        expect(sent.get("public_id")).toBe(`report_${timestamp}`);
+    });
+
+    it("signs the request over the sorted params including public_id", async () => {
+        await POST(buildRequest({ batch_number: "BATCH123" }));
+
+        const sent = captureCloudinaryFormData(fetchMock);
+        const timestamp = sent.get("timestamp") as string;
+        const publicId = sent.get("public_id") as string;
+
+        const expectedSignature = crypto
+            .createHash("sha256")
+            .update(
+                `folder=sahidawa/reports&public_id=${publicId}&signature_algorithm=sha256&timestamp=${timestamp}${API_SECRET}`
+            )
+            .digest("hex");
+
+        expect(sent.get("signature")).toBe(expectedSignature);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #916.

Report photos already upload to Cloudinary through the server-signed
`/api/upload` route and land in the `sahidawa/reports` folder, but Cloudinary
was assigning a **random auto-generated `public_id`**. The issue asks for the
storage route `cloud_name/sahidawa/reports/{batch_number}_{timestamp}`, so the
missing piece was the deterministic `{batch_number}_{timestamp}` file naming.

## What changed

**`apps/web/app/api/upload/route.ts`**
- Sets `public_id = {batch_number}_{timestamp}`, so each image is stored at
  `sahidawa/reports/{batch_number}_{timestamp}`.
- Reads an optional `batch_number` from the upload request and sanitises it
  (`[^A-Za-z0-9._-]` stripped) so it can't inject extra folder segments into the
  `public_id`. Falls back to a stable `report` prefix when none is supplied.
- Adds `public_id` to the signed params (kept alphabetically sorted:
  `folder`, `public_id`, `signature_algorithm`, `timestamp`) and to the
  Cloudinary form data, keeping the signed upload valid.

**`apps/web/tests/upload-route.test.ts`** (new)
- Regression test (mirrors the existing route-test pattern) verifying the
  `sahidawa/reports` folder, the `{batch_number}_{timestamp}` public_id, the
  `report` fallback, and that the signature is computed over the sorted params
  including `public_id`.

## Out of scope

The report wizard does not collect a batch number, so uploads currently use the
`report_{timestamp}` fallback. The route now *supports* a `batch_number` for any
caller that provides one — wiring a batch-number field into the form would be a
separate feature and is intentionally not included here.

## Testing

- `npx jest` (web) — 155 tests / 28 suites pass, no regressions.
- `npx tsc --noEmit` — clean.
- `npx prettier --check` on both files — clean.
