### PR TITLE
fix(reports): return 404 when report does not exist in status update

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -167,6 +167,21 @@ reportsRouter.patch(
         }
 
         try {
+            // Verify the report exists before updating. Without this check a
+            // caller can submit arbitrary IDs and receive a 500 instead of a
+            // 404, leaking that the endpoint performs blind updates and
+            // enabling IDOR-style enumeration across report IDs.
+            const { data: existing, error: fetchError } = await supabase
+                .from("counterfeit_reports")
+                .select("id")
+                .eq("id", req.params.id)
+                .single();
+
+            if (fetchError || !existing) {
+                res.status(404).json({ error: "Report not found" });
+                return;
+            }
+
             const { data, error } = await supabase
                 .from("counterfeit_reports")
                 .update({ status })


### PR DESCRIPTION
## Description

The admin status update handler performed a blind Supabase update against any caller-supplied report ID without first verifying the record exists. When a non-existent ID was submitted, the Supabase `.single()` call returned an error that was mapped to a generic 500 response. This leaks that the endpoint processes arbitrary IDs and enables IDOR-style enumeration: an attacker who observes that valid IDs return 200 and non-existent IDs return 500 can infer which IDs correspond to real records.

## Root Cause

The PATCH handler jumped straight to `.update({ status }).eq("id", ...)` with no prior existence check. Any Supabase error, including "no rows returned", was treated as a server error.

## Related Issue

Closes #1179

## Type of Change

- [x] Bug fix (security)

## Changes Made

- `apps/api/src/routes/reports.ts`: Added a `.select("id").eq("id", req.params.id).single()` existence check before the update. Non-existent IDs now return 404. The update proceeds only when the record is confirmed to exist.

## Testing Done

1. PATCH with a valid report ID and valid status: returns 200 with updated report.
2. PATCH with a non-existent report ID: returns 404 Report not found.
3. PATCH with an invalid status value: returns 400 as before.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue