### PR TITLE
fix(pharmacies): add POST /api/pharmacies with licenseId uniqueness check

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -59,6 +59,84 @@ interface PharmacyWithRawDistance extends FormattedPharmacy {
 
 // ── Zod validation schemas ───────────────────────────────────────────────────
 
+// Schema for pharmacy registration. licenseId is required and must be unique
+// across all registered pharmacies to prevent duplicate records.
+const registerPharmacySchema = z.object({
+    name: z.string().min(2),
+    licenseId: z.string().min(3),
+    address: z.string().min(5),
+    district: z.string().min(2),
+    state: z.string().min(2),
+    phone_number: z.string().regex(/^\+?[\d\s\-()]{7,15}$/).optional(),
+    lat: z.number().min(-90).max(90).optional(),
+    lng: z.number().min(-180).max(180).optional(),
+});
+
+// ── Pharmacy registration ────────────────────────────────────────────────────
+
+/**
+ * POST /api/pharmacies
+ * Register a new pharmacy. Returns 409 if a pharmacy with the same licenseId
+ * already exists to prevent duplicate entries.
+ */
+router.post("/", async (req: Request, res: Response, next: NextFunction) => {
+    const parsed = registerPharmacySchema.safeParse(req.body);
+    if (!parsed.success) {
+        res.status(400).json({ error: "Invalid pharmacy payload", issues: parsed.error.issues });
+        return;
+    }
+
+    const data = parsed.data;
+
+    try {
+        // Check for an existing pharmacy with the same licenseId before inserting.
+        // Without this check concurrent or repeated requests can create duplicate
+        // records for the same physical location, corrupting search results and
+        // user-facing data.
+        const { data: existing, error: lookupError } = await supabase
+            .from("pharmacies")
+            .select("id")
+            .eq("license_id", data.licenseId)
+            .maybeSingle();
+
+        if (lookupError) {
+            logger.error("Pharmacy duplicate check failed", { error: lookupError });
+            next(lookupError);
+            return;
+        }
+
+        if (existing) {
+            res.status(409).json({ error: "A pharmacy with this license ID is already registered" });
+            return;
+        }
+
+        const { data: pharmacy, error: insertError } = await supabase
+            .from("pharmacies")
+            .insert({
+                name: data.name,
+                license_id: data.licenseId,
+                address: data.address,
+                district: data.district,
+                state: data.state,
+                phone_number: data.phone_number ?? null,
+                lat: data.lat ?? null,
+                lng: data.lng ?? null,
+                is_verified: false,
+            })
+            .select()
+            .single();
+
+        if (insertError) {
+            next(insertError);
+            return;
+        }
+
+        res.status(201).json({ pharmacy });
+    } catch (err) {
+        next(err);
+    }
+});
+
 const nearestQuerySchema = z.object({
     lat: z.coerce.number().min(-90).max(90),
     lng: z.coerce.number().min(-180).max(180),


### PR DESCRIPTION
## Description

The pharmacy model had no registration endpoint. Pharmacies were created directly in the database with no application-level guard against duplicate licenseId values. The same physical location could be registered more than once, polluting nearby search results with duplicate cards and corrupting distance queries.

## Root Cause

No POST /api/pharmacies route existed, so there was no place to enforce the uniqueness invariant at the API layer.

## Related Issue

Closes #1180

## Type of Change

- [x] Bug fix

## Changes Made

- apps/api/src/routes/pharmacies.ts: Added registerPharmacySchema (Zod) and POST /api/pharmacies that checks for an existing record with the same license_id before inserting. Duplicate licenseIds return 409 Conflict. New records are inserted with is_verified=false pending admin review.

## Testing Done

1. POST with a new licenseId: pharmacy created, 201 returned.
2. POST with the same licenseId again: 409 Conflict returned.
3. POST with invalid payload: 400 with validation details.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue