### PR TITLE
fix(lasa): add TTL cache with in-flight deduplication to prevent TOCTOU race

### DIFF
--- a/apps/api/src/services/lasa.service.ts
+++ b/apps/api/src/services/lasa.service.ts
@@ -8,22 +8,88 @@ export interface LasaMatch {
     score?: number;
 }
 
+// ── In-process TTL cache ────────────────────────────────────────────────────
+//
+// The find_lasa_conflicts RPC performs string-distance comparisons across the
+// full medicines table. Calling it on every request without a cache exhausts
+// the Supabase connection pool under concurrent load.
+//
+// Caching strategy:
+// - Cache key: normalized (trimmed, lower-cased) medicine name.
+// - Cache value: the resolved LasaMatch[] result.
+// - TTL: 5 minutes. LASA conflict lists change only when the medicines
+//   dataset is updated, so a short TTL is safe.
+// - Race condition prevention: inflight requests for the same key share a
+//   single Promise stored in `inFlight`. When two concurrent requests for
+//   the same name arrive before the first resolves, the second awaits the
+//   same Promise rather than issuing a second RPC call. This eliminates the
+//   TOCTOU window where two requests both miss the cache and both hit the DB.
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CacheEntry {
+    value: LasaMatch[];
+    expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inFlight = new Map<string, Promise<LasaMatch[]>>();
+
+function getCached(key: string): LasaMatch[] | null {
+    const entry = cache.get(key);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+        cache.delete(key);
+        return null;
+    }
+    return entry.value;
+}
+
+function setCached(key: string, value: LasaMatch[]): void {
+    cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+// ── Service ─────────────────────────────────────────────────────────────────
+
 export const detectLasaConflicts = async (medicineName: string): Promise<LasaMatch[]> => {
     const targetName = medicineName.trim();
 
     if (!targetName) return [];
 
-    const { data, error } = await supabase.rpc("find_lasa_conflicts", {
-        target_name: targetName,
-    });
+    const cacheKey = targetName.toLowerCase();
 
-    if (error) {
-        throw new Error(`Failed to check LASA conflicts: ${error.message}`);
-    }
+    // Return immediately if a valid cached result exists.
+    const cached = getCached(cacheKey);
+    if (cached) return cached;
 
-    return (data || []).map((row: any) => ({
-        name: row.name,
-        type: row.match_type as LasaMatchType,
-        score: row.match_type === "sound-alike" ? 1.0 : 0.85,
-    }));
+    // If another request for the same name is already in progress, await its
+    // result instead of issuing a duplicate RPC call (prevents TOCTOU race).
+    const existing = inFlight.get(cacheKey);
+    if (existing) return existing;
+
+    const promise = (async (): Promise<LasaMatch[]> => {
+        try {
+            const { data, error } = await supabase.rpc("find_lasa_conflicts", {
+                target_name: targetName,
+            });
+
+            if (error) {
+                throw new Error(`Failed to check LASA conflicts: ${error.message}`);
+            }
+
+            const result: LasaMatch[] = (data || []).map((row: any) => ({
+                name: row.name,
+                type: row.match_type as LasaMatchType,
+                score: row.match_type === "sound-alike" ? 1.0 : 0.85,
+            }));
+
+            setCached(cacheKey, result);
+            return result;
+        } finally {
+            inFlight.delete(cacheKey);
+        }
+    })();
+
+    inFlight.set(cacheKey, promise);
+    return promise;
 };


### PR DESCRIPTION
## Description

detectLasaConflicts called supabase.rpc on every request without any caching. The RPC performs string-distance comparisons across the full medicines table. Under concurrent load, two requests for the same medicine name would both call the RPC simultaneously, wasting connections and creating a TOCTOU window where cache-check and cache-read could be interleaved by another request.

## Root Cause

No caching layer existed. Every call issued a fresh RPC regardless of whether an identical query was already in progress or recently resolved.

## Related Issue

Closes #1181

## Type of Change

- [x] Bug fix (performance)

## Changes Made

- apps/api/src/services/lasa.service.ts: Added a 5-minute TTL in-process cache and an in-flight deduplication map. A cache hit returns the stored result immediately. If a request for the same normalized key is already in progress, the second caller awaits the same Promise instead of issuing a duplicate RPC call. The Promise is removed in the finally block so failures do not permanently block future requests.

## Testing Done

1. First request for a medicine name: RPC is called, result cached.
2. Second request within 5 minutes: cache hit, no RPC.
3. Two concurrent requests for the same name: second awaits the first's Promise, only one RPC issued.
4. RPC failure: cache not populated, next request issues a fresh RPC.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue