### PR TITLE
Add medicine status validation

### DIFF
--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -8,12 +8,17 @@ const reportStatusSchema = z.object({
     status: z.enum(["pending", "verified_fake", "false_alarm"]),
 });
 
+const medicineStatusSchema = z.object({
+    status: z.enum(["safe", "suspicious", "recalled", "pending_review"]),
+});
+
 const medicineSchema = z.object({
     brand_name: z.string().min(1),
     generic_name: z.string().min(1),
     manufacturer: z.string().min(1),
     barcode_id: z.string().optional(),
     cdsco_approval_status: z.enum(["approved", "recalled", "banned"]).default("approved"),
+    status: z.enum(["safe", "suspicious", "recalled", "pending_review"]).default("safe").optional(),
 });
 
 export const getPendingReports = async (

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import { supabase } from "../db/client";
 import { z } from "zod";
 import { triggerRecallAlert } from "../services/notifications";
+import { validateMedicineStatus, getValidStatusList } from "../validators/medicine.validator";
 
 const AlertSchema = z
     .object({
@@ -130,11 +131,19 @@ alertsRouter.post("/ingest", async (req: Request, res: Response) => {
         }
 
         // 3. Update medicines table based on matched batches
+        const medicineStatus = "recalled";
+        if (!validateMedicineStatus(medicineStatus)) {
+            res.status(400).json({
+                error: `Invalid medicine status. Valid values are: ${getValidStatusList()}`,
+            });
+            return;
+        }
+
         const updatePromises = validatedAlerts.map((alert) => {
             if (alert.batch_number) {
                 let q = supabase
                     .from("medicines")
-                    .update({ status: "recalled", is_counterfeit_alert: true })
+                    .update({ status: medicineStatus, is_counterfeit_alert: true })
                     .eq("batch_number", alert.batch_number);
 
                 if (alert.manufacturer) {

--- a/apps/api/src/validators/medicine.validator.ts
+++ b/apps/api/src/validators/medicine.validator.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const VALID_MEDICINE_STATUSES = ["safe", "suspicious", "recalled", "pending_review"] as const;
+
+export const medicineStatusSchema = z.object({
+  status: z.enum(VALID_MEDICINE_STATUSES),
+});
+
+export const medicineUpdateSchema = z.object({
+  status: z.enum(VALID_MEDICINE_STATUSES).optional(),
+  is_counterfeit_alert: z.boolean().optional(),
+});
+
+export function validateMedicineStatus(status: string): status is (typeof VALID_MEDICINE_STATUSES)[number] {
+  return VALID_MEDICINE_STATUSES.includes(status as any);
+}
+
+export function getValidStatusList(): string {
+  return VALID_MEDICINE_STATUSES.join(", ");
+}


### PR DESCRIPTION
## Summary
The medicine creation endpoint accepts a status field without validation, allowing invalid values to corrupt the database. This fix adds strict enum validation to ensure only valid status values ('safe', 'suspicious', 'recalled', 'pending_review') are accepted.

## Changes
- Added optional status field with enum validation in medicineSchema
- Invalid status values now return 400 with validation details
- Database integrity protected from arbitrary status strings

## Testing
- POST /api/v1/admin/medicines with status: 'safe' — accepted
- POST /api/v1/admin/medicines with status: 'invalid_value' — rejected with 400

Closes #1182

Generated with Claude Code