### PR TITLE
Redact sensitive error details from health endpoint

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -167,18 +167,24 @@ app.get("/health", async (_req: Request, res: Response) => {
         };
 
         if (error) {
+            logger.error("Health check database failure", { error });
             return res.status(503).json({
                 ...healthData,
-                database: { status: "unreachable", error: error.message },
+                database: {
+                    status: "unreachable",
+                    error: "Database connection failed",
+                },
             });
         }
 
         return res.status(200).json(healthData);
     } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : "Unknown error";
+        logger.error("Health check error", { error: err, errorMessage });
         return res.status(500).json({
             status: "error",
             service: "sahidawa-api",
-            error: err instanceof Error ? err.message : "Unknown error",
+            error: "Service health check failed",
             timestamp: new Date().toISOString(),
         });
     }


### PR DESCRIPTION
## Summary
The health check endpoint was exposing raw database error messages to clients, leaking sensitive information about infrastructure and internal error paths. This could be exploited by attackers.

## Changes
- Log full error details server-side for operational debugging
- Return generic redacted messages to clients instead of raw error.message
- Maintain error context in server logs while keeping API responses non-revealing
- Covers both database error and exception handler paths

## Testing
- Health check with working database — returns status: 'ok' with no error field
- Health check with database down — returns status: 'degraded' with generic "Database connection failed" message (not raw Supabase error)
- Health check with exception — returns status: 'error' with generic "Service health check failed" message (not stack trace)
- Server logs contain full error context for debugging

Closes #1183

Generated with Claude Code