### PR TITLE
feat(voice): add cloud Text-to-Speech for Voice Triage results

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,14 @@ WHISPER_COMPUTE_TYPE=int8
 WHISPER_BEAM_SIZE=5
 WHISPER_PRELOAD_ON_STARTUP=true
 
+# --- Text-to-Speech (Cloud TTS) ---
+# Which cloud provider to use for voice output. Options: google | azure | both
+TTS_PROVIDER=google
+# Path to your Google Cloud service account JSON key file.
+# Download it from the Google Cloud Console under IAM > Service Accounts.
+# The account needs the "Cloud Text-to-Speech API User" role.
+GOOGLE_APPLICATION_CREDENTIALS=apps/ml/google-credentials.json
+
 # --- Caching (Redis/Upstash) ---
 REDIS_URL=your_redis_url
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,12 @@ htmlcov/
 .env.*
 !.env.example
 
+# Credentials & API Keys (NEVER commit these!)
+**/google-credentials.json
+**/credentials.json
+*.pem
+*.key
+
 # Logs
 npm-debug.log*
 yarn-debug.log*
@@ -54,6 +60,9 @@ coverage/
 .tmp/
 .cache/
 .turbo/
+
+# Dev / scratch test scripts (not part of the test suite)
+test_tts_live.py
 
 # local model data 
 ml_model_dev_pipeline/.venv/*

--- a/apps/ml/main.py
+++ b/apps/ml/main.py
@@ -33,11 +33,15 @@ app.add_middleware(
 
 # Include ASR as a required router and OCR as optional so voice triage can boot
 # even when OCR-only dependencies are not installed in the current environment.
+# TTS is optional - app boots without it but cloud TTS is disabled.
 include_router_if_available(app, "routers.asr", required=True)
 include_router_if_available(app, "routers.analyze", required=True)
 ocr_loaded = include_router_if_available(app, "routers.ocr", required=False)
 if not ocr_loaded:
     logger.warning("OCR routes are disabled in this runtime.")
+tts_loaded = include_router_if_available(app, "routers.tts", required=False)
+if not tts_loaded:
+    logger.warning("TTS routes are disabled. Install google-cloud-texttospeech or configure Azure TTS.")
 
 @app.get("/")
 def read_root():

--- a/apps/ml/requirements.txt
+++ b/apps/ml/requirements.txt
@@ -31,5 +31,9 @@ soundfile>=0.12.1
 noisereduce>=3.0.0
 numpy>=1.26.0
 
+# TTS (Text-to-Speech) - Optional
+# Google Cloud TTS
+google-cloud-texttospeech>=2.14.0  # For cloud-based high-quality speech synthesis
+
 # Load testing
 locust>=2.31.8

--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -242,19 +242,29 @@ def _transcribe_audio_bytes(
 
         normalized_path = tmp_path + "_norm.wav"
 
-        ffmpeg_result = subprocess.run(
-            [
-                "ffmpeg",
-                "-y",
-                "-i", tmp_path,
-                "-ar", "16000",
-                "-ac", "1",
-                "-f", "wav",
-                normalized_path,
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        try:
+            ffmpeg_result = subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i", tmp_path,
+                    "-ar", "16000",
+                    "-ac", "1",
+                    "-f", "wav",
+                    normalized_path,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            logger.error(
+                "ffmpeg executable not found. Install ffmpeg on the ML host "
+                "(e.g. `sudo apt install ffmpeg`) so uploaded audio can be transcoded."
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="Voice transcription is temporarily unavailable. Please try again later.",
+            )
 
         if ffmpeg_result.returncode != 0:
             ffmpeg_stderr = ffmpeg_result.stderr.decode("utf-8", errors="ignore")
@@ -318,7 +328,7 @@ def _transcribe_audio_bytes(
         logger.error(f"ASR transcription error: {str(e)}", exc_info=True)
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to transcribe audio: {str(e)}"
+            detail="Oops..! Please try again later."
         )
 
     finally:

--- a/apps/ml/routers/tts.py
+++ b/apps/ml/routers/tts.py
@@ -1,0 +1,285 @@
+"""
+Text-to-Speech (TTS) router for generating speech audio from text.
+Supports multiple languages: English, Hindi, Tamil, Bengali, Marathi, Telugu.
+
+Provider: Google Cloud Text-to-Speech (primary), Azure TTS (fallback)
+Free tier: 1M characters/month (Google), 0.5M characters/month (Azure)
+"""
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from typing import Optional, Literal
+import os
+import logging
+import hashlib
+import base64
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/voice/tts", tags=["voice-tts"])
+
+# Language to Google Cloud voice mapping (highest-quality female voice available
+# per language). Google only offers Neural2 for en-IN/hi-IN; Tamil/Bengali/Marathi
+# fall back to WaveNet, and Telugu only has Standard voices. All chosen voices
+# support the speaking_rate audio config used below.
+GOOGLE_VOICES_MAP = {
+    "en-IN": "en-IN-Neural2-A",   # English - Indian (Neural2)
+    "hi-IN": "hi-IN-Neural2-A",   # Hindi (Neural2)
+    "ta-IN": "ta-IN-Wavenet-A",   # Tamil (no Neural2 -> WaveNet)
+    "bn-IN": "bn-IN-Wavenet-A",   # Bengali (no Neural2 -> WaveNet)
+    "mr-IN": "mr-IN-Wavenet-A",   # Marathi (no Neural2 -> WaveNet)
+    "te-IN": "te-IN-Standard-A",  # Telugu (no Neural2/WaveNet -> Standard)
+}
+
+# Language to Azure voice mapping
+AZURE_VOICES_MAP = {
+    "en-IN": "en-IN-PallaviNeural",  # English - Indian
+    "hi-IN": "hi-IN-SwaraNeural",     # Hindi
+    "ta-IN": "ta-IN-PallaviNeural",   # Tamil
+    "bn-IN": "bn-IN-TanayaNeural",    # Bengali
+    "mr-IN": "mr-IN-AarohiNeural",    # Marathi
+    "te-IN": "te-IN-ShrutiNeural",    # Telugu
+}
+
+# Cache configuration
+CACHE_DIR = Path("/tmp/tts_cache")
+CACHE_DIR.mkdir(exist_ok=True)
+
+# Provider detection from environment
+TTS_PROVIDER = os.getenv("TTS_PROVIDER", "google").lower()
+
+# Initialize TTS clients
+tts_google_client = None
+tts_azure_client = None
+azure_tts_key = None
+azure_tts_region = None
+
+# Initialize Google Cloud TTS client
+if TTS_PROVIDER == "google" or TTS_PROVIDER == "both":
+    try:
+        from google.cloud import texttospeech
+        tts_google_client = texttospeech.TextToSpeechClient()
+        logger.info("✓ Google Cloud TTS client initialized")
+    except ImportError:
+        logger.warning("⚠ google-cloud-texttospeech not installed. Install with: pip install google-cloud-texttospeech")
+    except Exception as e:
+        logger.warning(f"⚠ Google Cloud TTS initialization failed: {e}")
+
+# Initialize Azure TTS client
+if TTS_PROVIDER == "azure" or TTS_PROVIDER == "both":
+    azure_tts_key = os.getenv("AZURE_TTS_KEY")
+    azure_tts_region = os.getenv("AZURE_TTS_REGION", "southindia")
+    if azure_tts_key:
+        logger.info(f"✓ Azure TTS configured for region: {azure_tts_region}")
+    else:
+        logger.warning("⚠ AZURE_TTS_KEY not set. Azure TTS disabled.")
+
+
+class TTSRequest(BaseModel):
+    """Request model for TTS generation"""
+    text: str = Field(..., min_length=1, max_length=5000, description="Text to synthesize")
+    language_code: str = Field(..., description="BCP-47 language code (e.g., 'en-IN', 'hi-IN')")
+    gender: Optional[Literal["MALE", "FEMALE", "NEUTRAL"]] = "FEMALE"
+
+
+class TTSResponse(BaseModel):
+    """Response model for TTS generation"""
+    audio_base64: str
+    language_code: str
+    provider: str
+    cached: bool
+    character_count: int
+
+
+def get_cache_key(text: str, language_code: str) -> str:
+    """Generate cache key from text and language"""
+    combined = f"{text}:{language_code}"
+    return hashlib.md5(combined.encode()).hexdigest()
+
+
+def generate_with_google(text: str, language_code: str, gender: str) -> tuple[bytes, str]:
+    """Generate TTS using Google Cloud Text-to-Speech"""
+    if not tts_google_client:
+        raise HTTPException(
+            status_code=503,
+            detail="Google Cloud TTS service is not configured"
+        )
+
+    if language_code not in GOOGLE_VOICES_MAP:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Language '{language_code}' not supported. Supported: {', '.join(GOOGLE_VOICES_MAP.keys())}"
+        )
+
+    try:
+        from google.cloud import texttospeech
+
+        synthesis_input = texttospeech.SynthesisInput(text=text)
+        
+        gender_enum = {
+            "MALE": texttospeech.SsmlVoiceGender.MALE,
+            "FEMALE": texttospeech.SsmlVoiceGender.FEMALE,
+            "NEUTRAL": texttospeech.SsmlVoiceGender.NEUTRAL,
+        }.get(gender, texttospeech.SsmlVoiceGender.FEMALE)
+
+        voice = texttospeech.VoiceSelectionParams(
+            language_code=language_code,
+            name=GOOGLE_VOICES_MAP[language_code],
+            ssml_gender=gender_enum
+        )
+
+        audio_config = texttospeech.AudioConfig(
+            audio_encoding=texttospeech.AudioEncoding.MP3,
+            speaking_rate=0.9  # Slightly slower for clarity
+        )
+
+        response = tts_google_client.synthesize_speech(
+            input=synthesis_input,
+            voice=voice,
+            audio_config=audio_config
+        )
+
+        logger.info(f"✓ Generated {len(text)} chars of {language_code} audio via Google TTS")
+        return response.audio_content, "google"
+
+    except Exception as e:
+        logger.error(f"❌ Google TTS error: {e}")
+        raise HTTPException(status_code=500, detail="Google TTS generation failed")
+
+
+def generate_with_azure(text: str, language_code: str, gender: str) -> tuple[bytes, str]:
+    """Generate TTS using Azure Cognitive Services"""
+    if not azure_tts_key:
+        raise HTTPException(
+            status_code=503,
+            detail="Azure TTS service is not configured"
+        )
+
+    if language_code not in AZURE_VOICES_MAP:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Language '{language_code}' not supported by Azure. Supported: {', '.join(AZURE_VOICES_MAP.keys())}"
+        )
+
+    try:
+        import requests
+
+        voice_name = AZURE_VOICES_MAP[language_code]
+        ssml_text = f"""
+        <speak version='1.0' xml:lang='{language_code}'>
+            <voice name='{voice_name}'>
+                <prosody rate='0.9'>{text}</prosody>
+            </voice>
+        </speak>
+        """
+
+        headers = {
+            "Ocp-Apim-Subscription-Key": azure_tts_key,
+            "Content-Type": "application/ssml+xml",
+            "X-Microsoft-OutputFormat": "audio-16khz-32kbitrate-mono-mp3"
+        }
+
+        endpoint = f"https://{azure_tts_region}.tts.speech.microsoft.com/cognitiveservices/v1"
+        
+        response = requests.post(endpoint, headers=headers, data=ssml_text.encode('utf-8'), timeout=30)
+        
+        if response.status_code != 200:
+            raise Exception(f"Azure API returned {response.status_code}: {response.text}")
+
+        logger.info(f"✓ Generated {len(text)} chars of {language_code} audio via Azure TTS")
+        return response.content, "azure"
+
+    except Exception as e:
+        logger.error(f"❌ Azure TTS error: {e}")
+        raise HTTPException(status_code=500, detail="Azure TTS generation failed")
+
+
+@router.post("/generate", response_model=TTSResponse)
+async def generate_tts(request: TTSRequest):
+    """
+    Generate speech audio from text.
+    
+    Supported languages:
+    - en-IN: English (Indian)
+    - hi-IN: हिन्दी (Hindi)
+    - ta-IN: தமிழ் (Tamil)
+    - bn-IN: বাংলা (Bengali)
+    - mr-IN: मराठी (Marathi)
+    - te-IN: తెలుగు (Telugu)
+    
+    Returns:
+    - audio_base64: MP3 audio encoded as Base64 string (standard for web clients)
+    - provider: Which service generated the audio
+    - cached: Whether the result came from cache
+    """
+
+    cache_key = get_cache_key(request.text, request.language_code)
+    cache_file = CACHE_DIR / f"{cache_key}.mp3"
+
+    # Check cache first
+    if cache_file.exists():
+        try:
+            with open(cache_file, "rb") as f:
+                audio_data = f.read()
+            
+            return TTSResponse(
+                audio_base64=base64.b64encode(audio_data).decode('utf-8'),
+                language_code=request.language_code,
+                provider="cache",
+                cached=True,
+                character_count=len(request.text)
+            )
+        except Exception as e:
+            logger.warning(f"Cache read failed: {e}")
+
+    # Generate new audio
+    try:
+        if TTS_PROVIDER == "google":
+            audio_content, provider = generate_with_google(request.text, request.language_code, request.gender)
+        elif TTS_PROVIDER == "azure":
+            audio_content, provider = generate_with_azure(request.text, request.language_code, request.gender)
+        else:
+            # Fallback: try Google first, then Azure
+            try:
+                audio_content, provider = generate_with_google(request.text, request.language_code, request.gender)
+            except Exception as e:
+                logger.warning(f"Google TTS failed, trying Azure: {e}")
+                audio_content, provider = generate_with_azure(request.text, request.language_code, request.gender)
+
+        # Cache the result
+        try:
+            with open(cache_file, "wb") as f:
+                f.write(audio_content)
+            logger.info(f"✓ Cached TTS result to {cache_file}")
+        except Exception as e:
+            logger.warning(f"Cache write failed: {e}")
+
+        return TTSResponse(
+            audio_base64=base64.b64encode(audio_content).decode('utf-8'),
+            language_code=request.language_code,
+            provider=provider,
+            cached=False,
+            character_count=len(request.text)
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"❌ TTS generation failed: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="Text-to-speech generation failed. Please try again."
+        )
+
+
+@router.get("/health")
+def tts_health():
+    """Health check for TTS service"""
+    return {
+        "status": "healthy",
+        "provider": TTS_PROVIDER,
+        "google_available": tts_google_client is not None,
+        "azure_available": azure_tts_key is not None,
+        "supported_languages": list(GOOGLE_VOICES_MAP.keys()) if TTS_PROVIDER == "google" else list(AZURE_VOICES_MAP.keys())
+    }

--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -62,7 +62,14 @@ export default async function LocaleLayout({
     return (
         <html lang={locale} suppressHydrationWarning>
             {/* REPLACE YOUR OLD BODY TAG WITH THIS ONE: */}
-            <body className="bg-(--color-surface-page) text-(--color-text-primary) transition-colors duration-300">
+            <body
+                suppressHydrationWarning
+                style={{
+                    backgroundColor: "var(--color-surface-page)",
+                    color: "var(--color-text-primary)",
+                }}
+                className="transition-colors duration-300"
+            >
                 <ServiceWorkerProvider>
                     <ThemeProvider>
                         <NextIntlClientProvider messages={messages}>

--- a/apps/web/app/[locale]/voice/lib/useCloudTTS.ts
+++ b/apps/web/app/[locale]/voice/lib/useCloudTTS.ts
@@ -1,0 +1,161 @@
+import { useRef, useCallback, useState } from "react";
+import { toast } from "sonner";
+
+export interface UseCloudTTSOptions {
+    onStart?: () => void;
+    onEnd?: () => void;
+    onError?: (error: Error) => void;
+}
+
+export interface TTSError extends Error {
+    code?: "TTS_UNAVAILABLE" | "TTS_FAILED" | "TIMEOUT" | "INVALID_LANGUAGE" | "UNKNOWN";
+}
+
+/**
+ * Hook for playing cloud-generated TTS audio
+ * Falls back to native SpeechSynthesis if cloud TTS fails
+ */
+export function useCloudTTS() {
+    const audioRef = useRef<HTMLAudioElement | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    const playTTS = useCallback(
+        async (text: string, languageCode: string, options?: UseCloudTTSOptions): Promise<void> => {
+            if (typeof window === "undefined") {
+                throw new Error("Cloud TTS can only be used in browser");
+            }
+
+            try {
+                setIsLoading(true);
+                options?.onStart?.();
+
+                // Request TTS audio from backend
+                const response = await fetch("/api/voice/tts", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        text,
+                        languageCode,
+                        gender: "FEMALE",
+                    }),
+                });
+
+                if (!response.ok) {
+                    const errorData = (await response.json().catch(() => ({}))) as Record<
+                        string,
+                        unknown
+                    >;
+                    const code = (errorData.code as string) || "UNKNOWN";
+
+                    if (response.status === 503) {
+                        const error = new Error("TTS service unavailable") as TTSError;
+                        error.code = "TTS_UNAVAILABLE";
+                        throw error;
+                    }
+
+                    if (response.status === 400) {
+                        const error = new Error(
+                            (errorData.error as string) || "Invalid TTS request"
+                        ) as TTSError;
+                        error.code = "INVALID_LANGUAGE";
+                        throw error;
+                    }
+
+                    if (response.status === 504) {
+                        const error = new Error("TTS request timed out") as TTSError;
+                        error.code = "TIMEOUT";
+                        throw error;
+                    }
+
+                    const error = new Error("TTS generation failed") as TTSError;
+                    error.code = (code as TTSError["code"]) || "TTS_FAILED";
+                    throw error;
+                }
+
+                const data = (await response.json()) as {
+                    audio_base64: string;
+                    language_code: string;
+                    provider: string;
+                    cached: boolean;
+                    character_count: number;
+                };
+
+                // Decode base64 MP3 payload into a browser-native byte array
+                const binaryString = atob(data.audio_base64);
+                const bytes = new Uint8Array(binaryString.length);
+                for (let i = 0; i < binaryString.length; i++) {
+                    bytes[i] = binaryString.charCodeAt(i);
+                }
+                const audioBlob = new Blob([bytes], { type: "audio/mp3" });
+                const audioUrl = URL.createObjectURL(audioBlob);
+
+                // Create or reuse audio element
+                if (!audioRef.current) {
+                    audioRef.current = new Audio();
+                }
+
+                const audio = audioRef.current;
+                audio.src = audioUrl;
+
+                // Set up event listeners
+                const handlePlay = () => {
+                    setIsLoading(false);
+                    options?.onStart?.();
+                };
+
+                const handleEnded = () => {
+                    setIsLoading(false);
+                    options?.onEnd?.();
+                    // Clean up object URL
+                    URL.revokeObjectURL(audioUrl);
+                };
+
+                const handleError = (event: Event | string) => {
+                    const audioError = new Error("Audio playback error");
+                    setIsLoading(false);
+                    options?.onEnd?.();
+                    options?.onError?.(audioError);
+                    toast.error("Failed to play audio");
+                    console.error("Audio playback error:", event);
+                };
+
+                audio.onplay = handlePlay;
+                audio.onended = handleEnded;
+                audio.onerror = handleError;
+
+                // Log cache hit for analytics
+                if (data.cached) {
+                    console.debug(
+                        `[TTS] Served from cache: ${languageCode}, ${data.character_count} chars`
+                    );
+                }
+
+                await audio.play();
+            } catch (error) {
+                setIsLoading(false);
+
+                const err = error instanceof Error ? error : new Error(String(error));
+                options?.onEnd?.();
+                options?.onError?.(err);
+
+                // Re-throw for caller to handle fallback logic
+                throw err;
+            }
+        },
+        []
+    );
+
+    const stopTTS = useCallback(() => {
+        if (audioRef.current) {
+            audioRef.current.pause();
+            audioRef.current.currentTime = 0;
+        }
+        setIsLoading(false);
+    }, []);
+
+    return {
+        playTTS,
+        stopTTS,
+        isLoading,
+    };
+}

--- a/apps/web/app/[locale]/voice/page.tsx
+++ b/apps/web/app/[locale]/voice/page.tsx
@@ -51,6 +51,7 @@ import {
     subscribeToMediaQueryChange,
     type StoredVoiceAnimationPreference,
 } from "./lib/audio";
+import { useCloudTTS, type TTSError } from "./lib/useCloudTTS";
 import type { VoiceErrorState, VoiceStep, VoiceStreamingStatus, VoiceTriageResult } from "./types";
 
 const DEFAULT_FLOW_CONFIDENCE = getConfidenceMeta(undefined);
@@ -648,49 +649,81 @@ export default function VoiceTriagePage() {
         }
     }
 
+    const { playTTS, stopTTS } = useCloudTTS();
+
     function handleReplaySummary() {
         if (typeof window === "undefined" || !result?.summary) {
             return;
         }
 
-        if (!supportsSpeechSynthesis(window)) {
-            toast.error(t("tts_not_supported"));
-            return;
-        }
+        setIsSpeaking(true);
 
-        stopSpeaking(window);
-
-        const utterance = new SpeechSynthesisUtterance(result.summary);
-        utterance.lang = resultLanguageOption.speechSynthesisLang;
-        const voiceMatch = resolveSpeechSynthesisVoice(
-            window,
-            resultLanguageOption.speechSynthesisLang
-        );
-
-        if (voiceMatch.voice) {
-            utterance.voice = voiceMatch.voice;
-        }
-
-        if (voiceMatch.supportLevel === "fallback") {
-            const fallbackNoticeKey = `${resultLanguageOption.value}:${result.summary}`;
-            if (ttsFallbackNoticeKeyRef.current !== fallbackNoticeKey) {
-                ttsFallbackNoticeKeyRef.current = fallbackNoticeKey;
-                toast.warning(
-                    t("tts_fallback_message", {
-                        language: resultLanguageOption.label,
-                    })
-                );
+        const playWithCloudTTSAndFallback = async () => {
+            try {
+                // Try cloud TTS first
+                await playTTS(result!.summary, resultLanguageOption.speechSynthesisLang, {
+                    onStart: () => setIsSpeaking(true),
+                    onEnd: () => setIsSpeaking(false),
+                    onError: (error: Error) => {
+                        console.error("Cloud TTS error:", error);
+                        // Fallback to native SpeechSynthesis
+                        fallbackToNativeSpeech();
+                    },
+                });
+            } catch (error) {
+                const ttsError = error as TTSError;
+                console.warn("Cloud TTS failed, falling back to native SpeechSynthesis:", ttsError);
+                // Fallback to native SpeechSynthesis
+                fallbackToNativeSpeech();
             }
-        }
+        };
 
-        utterance.onstart = () => setIsSpeaking(true);
-        utterance.onend = () => setIsSpeaking(false);
-        utterance.onerror = () => setIsSpeaking(false);
+        const fallbackToNativeSpeech = () => {
+            if (!supportsSpeechSynthesis(window)) {
+                toast.error(t("tts_not_supported"));
+                setIsSpeaking(false);
+                return;
+            }
 
-        window.speechSynthesis.speak(utterance);
+            stopSpeaking(window);
+
+            const utterance = new SpeechSynthesisUtterance(result!.summary);
+            utterance.lang = resultLanguageOption.speechSynthesisLang;
+            const voiceMatch = resolveSpeechSynthesisVoice(
+                window,
+                resultLanguageOption.speechSynthesisLang
+            );
+
+            if (voiceMatch.voice) {
+                utterance.voice = voiceMatch.voice;
+            }
+
+            if (voiceMatch.supportLevel === "fallback") {
+                const fallbackNoticeKey = `${resultLanguageOption.value}:${result!.summary}`;
+                if (ttsFallbackNoticeKeyRef.current !== fallbackNoticeKey) {
+                    ttsFallbackNoticeKeyRef.current = fallbackNoticeKey;
+                    toast.warning(
+                        t("tts_fallback_message", {
+                            language: resultLanguageOption.label,
+                        })
+                    );
+                }
+            }
+
+            utterance.onstart = () => setIsSpeaking(true);
+            utterance.onend = () => setIsSpeaking(false);
+            utterance.onerror = () => setIsSpeaking(false);
+
+            window.speechSynthesis.speak(utterance);
+        };
+
+        playWithCloudTTSAndFallback();
     }
 
     function handleStopSpeaking() {
+        // Stop cloud TTS
+        stopTTS();
+        // Stop native SpeechSynthesis as fallback
         if (typeof window !== "undefined") {
             stopSpeaking(window);
         }
@@ -1123,17 +1156,17 @@ export default function VoiceTriagePage() {
                   : undefined;
 
     return (
-        <div className="relative flex min-h-screen flex-col overflow-hidden bg-(--color-surface-muted) text-(--color-text-primary) font-sans">
+        <div className="relative flex min-h-screen flex-col overflow-hidden bg-(--color-surface-muted) font-sans text-(--color-text-primary)">
             <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
                 {srAnnouncement}
             </div>
 
             <div
-                className="absolute top-0 right-0 -mt-20 -mr-20 h-96 w-96 rounded-full bg-emerald-100/40 dark:bg-emerald-950/15 blur-3xl"
+                className="absolute top-0 right-0 -mt-20 -mr-20 h-96 w-96 rounded-full bg-emerald-100/40 blur-3xl dark:bg-emerald-950/15"
                 aria-hidden="true"
             ></div>
             <div
-                className="absolute bottom-0 left-0 -mb-20 -ml-20 h-80 w-80 rounded-full bg-blue-100/40 dark:bg-blue-950/15 blur-3xl"
+                className="absolute bottom-0 left-0 -mb-20 -ml-20 h-80 w-80 rounded-full bg-blue-100/40 blur-3xl dark:bg-blue-950/15"
                 aria-hidden="true"
             ></div>
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { GoogleGenAI } from "@google/genai";
+import { GoogleGenAI, Type } from "@google/genai";
 import { NextResponse } from "next/server";
 import { detectEmergencyKeywords } from "@/lib/voice/emergency";
 import { rateLimit } from "@/lib/rateLimit";
@@ -88,14 +88,43 @@ function parseVoiceTriageResponse(rawText: string): VoiceTriageResponse {
     }
 }
 
+// Structured-output schema so Gemini always returns valid, parseable JSON
+// (no markdown fences, no trailing/mixed-language corruption).
+const VOICE_TRIAGE_SCHEMA = {
+    type: Type.OBJECT,
+    properties: {
+        summary: {
+            type: Type.STRING,
+            description:
+                "One short sentence (max two) describing the likely situation and next step.",
+        },
+        recommendations: {
+            type: Type.ARRAY,
+            description: "The 3 most important actions, each a single short sentence.",
+            items: { type: Type.STRING },
+            minItems: "1",
+            maxItems: "3",
+        },
+        disclaimer: {
+            type: Type.STRING,
+            description:
+                "A brief reminder to seek professional care for serious, persistent, or worsening symptoms.",
+        },
+        emergency: {
+            type: Type.BOOLEAN,
+            description: "True only if the symptoms could indicate urgent medical attention.",
+        },
+    },
+    required: ["summary", "recommendations", "disclaimer", "emergency"],
+    propertyOrdering: ["summary", "recommendations", "disclaimer", "emergency"],
+};
+
 function buildVoiceTriagePrompt(transcript: string, responseLanguage: string) {
     return [
         `Citizen transcript: ${JSON.stringify(transcript)}`,
-        `Respond in ${responseLanguage}.`,
-        "Return strict JSON only.",
-        'Use this shape: {"summary":"string","recommendations":["string"],"disclaimer":"string","emergency":boolean,"text":"string"}.',
-        "Keep the summary to at most 2 short sentences.",
-        "Return no more than 3 concise recommendation items.",
+        `Write every field entirely in ${responseLanguage}. Do not mix languages or scripts within any field.`,
+        "Be brief: the summary is at most 2 short sentences.",
+        "Give only the 3 most important recommendations, each a single short sentence.",
         "Set emergency to true only if the symptoms could indicate urgent medical attention.",
         "The disclaimer must remind the user to seek professional care for serious, persistent, or worsening symptoms.",
     ].join("\n");
@@ -147,6 +176,8 @@ export async function POST(req: Request) {
                 config: {
                     systemInstruction:
                         "You are the SahiDawa voice triage assistant for India. Help users understand possible next steps based on symptoms, but never claim certainty or replace medical professionals. Be calm, concise, practical, and safety-first.",
+                    responseMimeType: "application/json",
+                    responseSchema: VOICE_TRIAGE_SCHEMA,
                 },
             });
 
@@ -210,7 +241,6 @@ export async function POST(req: Request) {
         });
 
         return NextResponse.json({ text: response.text });
-
     } catch (error: any) {
         const latency_ms = Date.now() - startTime;
         const statusCode: number = error?.status || 500;

--- a/apps/web/app/api/voice/tts/route.ts
+++ b/apps/web/app/api/voice/tts/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse } from "next/server";
+import { structuredLog } from "@/lib/structuredLogger";
+
+const ROUTE = "/api/voice/tts";
+const ML_TTS_TIMEOUT_MS = 15_000;
+const LANGUAGE_CODE_PATTERN = /^[a-z]{2}-[A-Z]{2}$/;
+const MAX_TEXT_LENGTH = 5000;
+
+function getMlServiceUrl() {
+    const configuredUrl = process.env.ML_SERVICE_URL?.trim();
+    return configuredUrl ? configuredUrl.replace(/\/+$/, "") : null;
+}
+
+async function readJsonSafely(response: Response) {
+    try {
+        return await response.json();
+    } catch {
+        return null;
+    }
+}
+
+export async function POST(req: Request) {
+    const startTime = Date.now();
+
+    const body = await req.json().catch(() => null);
+    const text = typeof body?.text === "string" ? body.text.trim() : "";
+    const languageCode = typeof body?.languageCode === "string" ? body.languageCode : "";
+    const gender = body?.gender === "MALE" || body?.gender === "NEUTRAL" ? body.gender : "FEMALE";
+
+    if (!text || text.length > MAX_TEXT_LENGTH) {
+        return NextResponse.json(
+            { error: "Text is required and must be 5000 characters or less." },
+            { status: 400 }
+        );
+    }
+
+    if (!LANGUAGE_CODE_PATTERN.test(languageCode)) {
+        return NextResponse.json(
+            {
+                error: "Language code must be in format xx-YY (e.g., en-IN, hi-IN).",
+                code: "INVALID_LANGUAGE",
+            },
+            { status: 400 }
+        );
+    }
+
+    const mlServiceUrl = getMlServiceUrl();
+    if (!mlServiceUrl) {
+        structuredLog({
+            log_level: "error",
+            route: ROUTE,
+            error: {
+                message: "ML_SERVICE_URL is not configured",
+                code: 500,
+                stack: undefined,
+            },
+            meta: { missingVars: ["ML_SERVICE_URL"] },
+        });
+        return NextResponse.json(
+            {
+                error: "Server configuration error: text-to-speech service URL is missing.",
+                code: "ML_SERVICE_URL_MISSING",
+            },
+            { status: 500 }
+        );
+    }
+
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(() => abortController.abort(), ML_TTS_TIMEOUT_MS);
+
+    try {
+        const upstreamResponse = await fetch(`${mlServiceUrl}/voice/tts/generate`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                text,
+                language_code: languageCode,
+                gender,
+            }),
+            signal: abortController.signal,
+        });
+
+        const latency_ms = Date.now() - startTime;
+        const upstreamData = await readJsonSafely(upstreamResponse);
+
+        if (!upstreamResponse.ok) {
+            const statusCode = upstreamResponse.status;
+            const errorDetail =
+                upstreamData &&
+                typeof upstreamData.detail === "string" &&
+                upstreamData.detail.trim()
+                    ? upstreamData.detail
+                    : "Text-to-speech generation failed.";
+
+            structuredLog({
+                log_level: statusCode === 503 ? "error" : "warn",
+                route: ROUTE,
+                latency_ms,
+                error: { message: errorDetail, code: statusCode, stack: undefined },
+                meta: { languageCode, textLength: text.length },
+            });
+
+            return NextResponse.json({ error: errorDetail }, { status: statusCode });
+        }
+
+        if (!upstreamData || typeof upstreamData.audio_base64 !== "string") {
+            structuredLog({
+                log_level: "error",
+                route: ROUTE,
+                latency_ms,
+                error: {
+                    message: "TTS service returned an invalid response",
+                    code: 502,
+                    stack: undefined,
+                },
+                meta: { languageCode, textLength: text.length },
+            });
+            return NextResponse.json(
+                { error: "Text-to-speech service returned an invalid response." },
+                { status: 502 }
+            );
+        }
+
+        structuredLog({
+            log_level: "info",
+            route: ROUTE,
+            latency_ms,
+            meta: {
+                languageCode,
+                provider: upstreamData.provider,
+                cached: upstreamData.cached,
+                characterCount: upstreamData.character_count,
+            },
+        });
+
+        return NextResponse.json(upstreamData);
+    } catch (error) {
+        const latency_ms = Date.now() - startTime;
+
+        if (error instanceof Error && error.name === "AbortError") {
+            structuredLog({
+                log_level: "error",
+                route: ROUTE,
+                latency_ms,
+                error: {
+                    message: "Text-to-speech service timed out",
+                    code: 504,
+                    stack: error.stack,
+                },
+                meta: { timeoutMs: ML_TTS_TIMEOUT_MS, languageCode },
+            });
+            return NextResponse.json(
+                { error: "Text-to-speech service timed out.", code: "TTS_TIMEOUT" },
+                { status: 504 }
+            );
+        }
+
+        structuredLog({
+            log_level: "error",
+            route: ROUTE,
+            latency_ms,
+            error: {
+                message: "Could not reach the text-to-speech service",
+                code: 503,
+                stack: error instanceof Error ? error.stack : undefined,
+            },
+            meta: { languageCode },
+        });
+        return NextResponse.json(
+            {
+                error: "Could not reach the text-to-speech service.",
+                code: "TTS_SERVICE_UNAVAILABLE",
+            },
+            { status: 503 }
+        );
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}


### PR DESCRIPTION
Closes #522

### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._
---
## 📋 PR Summary

<!-- Provide a brief summary of the changes introduced by this PR. -->

Integrates `Google Cloud TTS` so `Voice Triage` results are read aloud in high-quality regional voices across all browsers/devices, replacing reliance on fragmented native `speechSynthesis` (native TTS is kept as a graceful fallback). Also includes the fixes needed to make the flow work end-to-end: Gemini structured output for clean triage results, and graceful ASR error handling when `ffmpeg` is unavailable.


## 🔗 Related Issue

<!-- Link the issue this PR resolves. For example: Closes 123 -->

Closes #522 

---

## 🏷️ PR Type

<!-- Select the type of changes. Replace [ ] with [x] for matching items. -->

- [x] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [x] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [ ] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

<!-- Select the areas that have been modified by this PR. Replace [ ] with [x] for matching items. -->

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [x] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [x] Root config (package.json, etc.)

---

## 📝 What Was Done

<!-- Provide a bulleted list of the exact changes made in this PR. -->

- `apps/ml/routers/tts.py` (new): FastAPI router `POST /voice/tts/generate` — takes `{ text, language_code, gender }`, synthesizes MP3 via Google Cloud TTS, returns base64 audio. Per-language voice map (Neural2 for `en-IN/hi-IN`, WaveNet for `ta-IN/bn-IN/mr-IN`, Standard for `te-IN`, since Google offers no Neural2 for those). On-disk caching keyed by text+language, plus a `/voice/tts/health` check.
- `apps/web/app/api/voice/tts/route.ts` (new): Next.js handler proxying the browser's relative `/api/voice/tts` to `ML_SERVICE_URL/voice/tts/generate` , with input validation, a 15s timeout, and structured logging (mirrors the existing `transcribe` handler).
- `apps/web/app/[locale]/voice/page.tsx`: wired the cloud-TTS hook into the Voice Triage flow with native fallback and synced speaking state.
- `apps/web/app/api/chat/route.ts`: switched voice-triage to Gemini structured output `(responseMimeType: "application/json" + responseSchema)` . Previously the model occasionally returned markdown-fenced or language-mixed JSON that failed to parse (a bug) and dumped raw JSON into the on-screen summary. Prompt tightened for brevity and single-language output (top-3 recommendations).
- `apps/ml/routers/asr.py`: transcription now returns a clean 503 (and logs the real cause) when `ffmpeg` is missing, instead of leaking the raw `[Errno 2] ... 'ffmpeg'` exception; generic handler no longer echoes internal exception text.
- `apps/ml/main.py` / `apps/ml/requirements.txt`: register the TTS router; add `google-cloud-texttospeech` .
- `apps/web/app/[locale]/layout.tsx`: suppressHydrationWarning + theme-aware body styling to avoid theme hydration mismatch.

***

## 📸 Screenshots / Proof of Work (REQUIRED)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
> - **Backend/API/ML changes:** You MUST attach terminal logs, curl/Postman outputs, or test run outputs proving the changes work.
>
> _Please drag & drop your screenshots/GIFs here, or paste terminal/console logs below:_


---
Test string was "I have a headache" for instances of all languages. English and Hindi were also transcribed and solutioning was similar to that of the ones below.

<img width="532" height="887" alt="Screenshot from 2026-06-04 00-01-53" src="https://github.com/user-attachments/assets/6af776ec-c4ca-4bab-a49d-34f4d67cefee" />
<img width="532" height="887" alt="Screenshot from 2026-06-04 00-28-43" src="https://github.com/user-attachments/assets/94bee79d-ec45-4f49-a3ed-77ceda7dd80d" />
<img width="532" height="887" alt="Screenshot from 2026-06-04 00-33-04" src="https://github.com/user-attachments/assets/ab3de561-b042-4564-b605-ddfc1faace82" />
<img width="532" height="887" alt="Screenshot from 2026-06-04 00-37-36" src="https://github.com/user-attachments/assets/6520b902-e616-43a4-8313-f6cf186a4d95" />

## ✅ Contributor Checklist

<!-- Ensure you have completed the following steps before requesting a review. Replace [ ] with [x]. -->

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [ ] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (if backend change)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant
