### PR TITLE
fix: preserve locale on profile and alerts links

### DIFF
--- a/apps/web/app/[locale]/alerts/page.tsx
+++ b/apps/web/app/[locale]/alerts/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
-import { Activity, ArrowLeft, Filter, AlertTriangle, AlertCircle, Search } from "lucide-react";
-import Link from "next/link";
+import { Activity, ArrowLeft, Filter, AlertTriangle, Search } from "lucide-react";
+import { Link } from "@/i18n/routing";
 import { Globe } from "lucide-react";
 import RecallPushSubscriber from "@/components/alerts/RecallPushSubscriber";
 import { LiveMessage } from "@/components/ui/LiveMessage";

--- a/apps/web/app/[locale]/profile/page.tsx
+++ b/apps/web/app/[locale]/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import { Link } from "@/i18n/routing";
 import { User, ShieldCheck, Bell, ChevronRight, ArrowLeft } from "lucide-react";
 
 export default function ProfilePage() {


### PR DESCRIPTION
## Summary
- switch Profile page home navigation to SahiDawa's locale-aware `Link`
- switch Alerts page home navigation to the same i18n routing wrapper
- remove an unused `AlertCircle` icon import from the touched Alerts page

## Related Issue
Closes #1199

## Validation
- `NODE_PATH="$PWD/node_modules" ./node_modules/.bin/eslint 'app/[locale]/profile/page.tsx' 'app/[locale]/alerts/page.tsx' --max-warnings=0` ✅
- `git diff --check HEAD~1..HEAD` ✅
- Pre-commit `prettier --write` ran on the two staged TSX files ✅

## Notes
The local web install exposes `eslint` but not a `tsc` binary, so I used focused ESLint plus diff checks for this two-import routing fix.
