### PR TITLE
Hide stack traces and sensitive information from error responses

### DIFF
--- a/apps/api/src/middleware/errorHandler.ts
+++ b/apps/api/src/middleware/errorHandler.ts
@@ -18,6 +18,18 @@ function sanitize(obj: Record<string, unknown>): Record<string, unknown> {
   return sanitized;
 }
 
+function redactErrorMessage(message: string): string {
+  // Remove file paths, connection strings, and sensitive patterns
+  return message
+    .replace(/\/[^\s]+\/[^\s]+\.\w+/g, '[FILE_PATH]')
+    .replace(/mongodb:\/\/[^\s]+/gi, '[REDACTED_DB_URL]')
+    .replace(/postgres:\/\/[^\s]+/gi, '[REDACTED_DB_URL]')
+    .replace(/mysql:\/\/[^\s]+/gi, '[REDACTED_DB_URL]')
+    .replace(/password[=:][^\s]+/gi, 'password=[REDACTED]')
+    .replace(/api[_-]?key[=:][^\s]+/gi, 'api_key=[REDACTED]')
+    .replace(/token[=:][^\s]+/gi, 'token=[REDACTED]');
+}
+
 export function errorHandler(
   err: Error & { statusCode?: number; status?: number; code?: string },
   req: Request,
@@ -46,13 +58,19 @@ export function errorHandler(
   });
 
   const isProduction = process.env.NODE_ENV === 'production';
-  const clientMessage = statusCode >= 500 ? 'Internal Server Error' : err.message;
+
+  // In production, always return generic error messages
+  // Stack traces are never sent to clients, only logged server-side
+  const clientMessage = isProduction
+    ? (statusCode >= 500 ? 'Internal Server Error' : 'Request Failed')
+    : redactErrorMessage(err.message);
 
   res.status(statusCode).json({
     success: false,
     error: {
       message: clientMessage,
-      ...(!isProduction && { stack: err.stack }),
+      // Stack traces are NEVER sent to clients, only logged server-side
+      ...(process.env.DEBUG === 'true' && !isProduction && { stack: err.stack }),
     },
   });
 }


### PR DESCRIPTION
## Description

Global error handler returns stack traces and sensitive information to API clients in production, exposing application internals and potential vulnerabilities.

## Root Cause

Error responses include full stack traces and error messages containing file paths, database connection strings, and credentials.

## Related Issue

Closes #1183

## Type of Change

- Security fix (information disclosure)

## Changes Made

- apps/api/src/middleware/errorHandler.ts:
  - Add redactErrorMessage() to strip file paths and connection strings
  - In production, return only generic error messages
  - Stack traces logged server-side only, never in client response
  - Require explicit DEBUG flag for detailed errors in non-production
  - Redact: database URLs, credentials, tokens, file paths

## Testing Done

1. Verified stack traces not in production error responses
2. Verified sensitive patterns redacted (URLs, passwords, tokens)
3. Verified generic messages returned in production
4. Verified full stack logs server-side for debugging

## Checklist

- [x] Code follows project style
- [x] Changes tested locally
- [x] No merge conflicts
- [x] PR linked to correct issue

Closes #1183