### PR TITLE
feat(chat): stream Gemini health assistant responses

### DIFF
--- a/apps/web/app/[locale]/components/Chatbot.tsx
+++ b/apps/web/app/[locale]/components/Chatbot.tsx
@@ -5,12 +5,21 @@ import { useTranslations } from "next-intl";
 import { usePathname } from "next/navigation";
 import { MessageSquare, X, Send, Bot } from "lucide-react";
 import { getChatbotPanelClasses, getChatbotPositionClasses } from "./chatbotPosition";
+import { ChatMarkdown } from "@/app/components/ChatMarkdown";
+import { isAbortError, readChatErrorMessage, readTextResponseStream } from "@/lib/chatStream";
 
 type Message = {
     text: string;
     isBot: boolean;
     isTyping?: boolean;
 };
+
+const MessageContent = ({ msg }: { msg: Message }) =>
+    msg.isBot ? (
+        <ChatMarkdown content={msg.text} />
+    ) : (
+        <span className="text-sm leading-relaxed whitespace-pre-wrap">{msg.text}</span>
+    );
 
 export default function Chatbot() {
     const pathname = usePathname();
@@ -19,6 +28,7 @@ export default function Chatbot() {
     const [messages, setMessages] = useState<Message[]>([{ text: t("welcome"), isBot: true }]);
     const [input, setInput] = useState("");
     const messagesEndRef = useRef<HTMLDivElement>(null);
+    const activeRequestRef = useRef<AbortController | null>(null);
 
     const scrollToBottom = () => {
         messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -28,14 +38,23 @@ export default function Chatbot() {
         scrollToBottom();
     }, [messages]);
 
+    useEffect(() => {
+        return () => {
+            activeRequestRef.current?.abort();
+        };
+    }, []);
+
     // Securely check route-based visibility after hook declarations to satisfy React Rules of Hooks
     if (pathname && pathname.includes("/health")) {
         return null;
     }
 
     const handleSend = async () => {
-        if (!input.trim()) return;
+        if (!input.trim() || messages.some((message) => message.isTyping)) return;
 
+        activeRequestRef.current?.abort();
+        const requestController = new AbortController();
+        activeRequestRef.current = requestController;
         const userMessage = { text: input, isBot: false };
         const currentMessages = [...messages, userMessage];
         setMessages(currentMessages);
@@ -48,22 +67,34 @@ export default function Chatbot() {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ messages: currentMessages }),
+                signal: requestController.signal,
             });
-
-            const data = await response.json();
 
             if (!response.ok) {
-                throw new Error(data.error || "Failed to fetch response");
+                throw new Error(await readChatErrorMessage(response, "Failed to fetch response"));
             }
 
+            let streamedReply = "";
+            const reply = await readTextResponseStream(
+                response,
+                (chunk) => {
+                    streamedReply += chunk;
+                    setMessages((prev) =>
+                        prev.map((msg) =>
+                            msg.isTyping ? { ...msg, text: streamedReply || "Thinking..." } : msg
+                        )
+                    );
+                },
+                { signal: requestController.signal }
+            );
+
             setMessages((prev) => {
-                const withoutTyping = prev.filter((msg) => !msg.isTyping);
-                return [
-                    ...withoutTyping,
-                    { text: data.text || "Sorry, I received an empty response.", isBot: true },
-                ];
+                const finalText = reply || "Sorry, I received an empty response.";
+                return prev.map((msg) => (msg.isTyping ? { text: finalText, isBot: true } : msg));
             });
         } catch (error: any) {
+            if (isAbortError(error)) return;
+
             console.error("Chatbot API Error:", error);
             setMessages((prev) => {
                 const withoutTyping = prev.filter((msg) => !msg.isTyping);
@@ -77,6 +108,10 @@ export default function Chatbot() {
                     },
                 ];
             });
+        } finally {
+            if (activeRequestRef.current === requestController) {
+                activeRequestRef.current = null;
+            }
         }
     };
 
@@ -115,7 +150,7 @@ export default function Chatbot() {
                                         : "self-end rounded-tr-sm bg-green-600 text-white dark:bg-green-700"
                                 }`}
                             >
-                                <p className="text-sm leading-relaxed">{msg.text}</p>
+                                <MessageContent msg={msg} />
                             </div>
                         ))}
                         <div ref={messagesEndRef} />

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -197,13 +197,15 @@ export async function POST(req: Request) {
         const language = localeMap[finalLocale as keyof typeof localeMap] || "English";
         const systemPrompt = BASE_PROMPT.replace("{language}", language);
 
-        const responseStream = await ai.models.generateContentStream({
+        const responseStream = (await ai.models.generateContentStream({
             model: "gemini-2.5-flash",
             contents: formattedContents,
             config: {
                 systemInstruction: systemPrompt,
             },
-        });
+        })) as AsyncIterable<TextStreamChunk>;
+        const responseIterator = responseStream[Symbol.asyncIterator]();
+        const firstStreamResult = await responseIterator.next();
 
         const encoder = new TextEncoder();
         const stream = new ReadableStream<Uint8Array>({
@@ -211,12 +213,24 @@ export async function POST(req: Request) {
                 let usageMetadata: TextStreamChunk["usageMetadata"];
 
                 try {
-                    for await (const chunk of responseStream as AsyncIterable<TextStreamChunk>) {
+                    const enqueueChunk = (chunk: TextStreamChunk) => {
                         usageMetadata = chunk.usageMetadata ?? usageMetadata;
 
                         if (chunk.text) {
                             controller.enqueue(encoder.encode(chunk.text));
                         }
+                    };
+
+                    if (!firstStreamResult.done) {
+                        enqueueChunk(firstStreamResult.value);
+                    }
+
+                    while (true) {
+                        const chunkResult = await responseIterator.next();
+                        if (chunkResult.done) {
+                            break;
+                        }
+                        enqueueChunk(chunkResult.value);
                     }
 
                     const latency_ms = Date.now() - startTime;
@@ -247,6 +261,9 @@ export async function POST(req: Request) {
                     });
                     controller.error(streamError);
                 }
+            },
+            async cancel() {
+                await responseIterator.return?.();
             },
         });
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -22,6 +22,14 @@ type VoiceTriageResponse = {
     emergency: boolean;
 };
 
+type TextStreamChunk = {
+    text?: string;
+    usageMetadata?: {
+        promptTokenCount?: number;
+        candidatesTokenCount?: number;
+    };
+};
+
 function getLatestMessageText(messages: ChatMessage[] | undefined) {
     if (!Array.isArray(messages) || messages.length === 0) {
         return "";
@@ -189,7 +197,7 @@ export async function POST(req: Request) {
         const language = localeMap[finalLocale as keyof typeof localeMap] || "English";
         const systemPrompt = BASE_PROMPT.replace("{language}", language);
 
-        const response = await ai.models.generateContent({
+        const responseStream = await ai.models.generateContentStream({
             model: "gemini-2.5-flash",
             contents: formattedContents,
             config: {
@@ -197,19 +205,57 @@ export async function POST(req: Request) {
             },
         });
 
-        const latency_ms = Date.now() - startTime;
-        structuredLog({
-            log_level: "info",
-            route: ROUTE,
-            latency_ms,
-            metrics: {
-                input_tokens: response.usageMetadata?.promptTokenCount,
-                output_tokens: response.usageMetadata?.candidatesTokenCount,
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream<Uint8Array>({
+            async start(controller) {
+                let usageMetadata: TextStreamChunk["usageMetadata"];
+
+                try {
+                    for await (const chunk of responseStream as AsyncIterable<TextStreamChunk>) {
+                        usageMetadata = chunk.usageMetadata ?? usageMetadata;
+
+                        if (chunk.text) {
+                            controller.enqueue(encoder.encode(chunk.text));
+                        }
+                    }
+
+                    const latency_ms = Date.now() - startTime;
+                    structuredLog({
+                        log_level: "info",
+                        route: ROUTE,
+                        latency_ms,
+                        metrics: {
+                            input_tokens: usageMetadata?.promptTokenCount,
+                            output_tokens: usageMetadata?.candidatesTokenCount,
+                        },
+                        meta: { mode: "chat", messageCount: (messages || []).length },
+                    });
+                    controller.close();
+                } catch (streamError) {
+                    const latency_ms = Date.now() - startTime;
+                    structuredLog({
+                        log_level: "error",
+                        route: ROUTE,
+                        latency_ms,
+                        error: {
+                            message: "AI chat stream failed",
+                            code: 500,
+                            stack:
+                                streamError instanceof Error ? streamError.stack : undefined,
+                        },
+                        meta: { mode: "chat", messageCount: (messages || []).length },
+                    });
+                    controller.error(streamError);
+                }
             },
-            meta: { mode: "chat", messageCount: (messages || []).length },
         });
 
-        return NextResponse.json({ text: response.text });
+        return new Response(stream, {
+            headers: {
+                "Content-Type": "text/plain; charset=utf-8",
+                "Cache-Control": "no-cache, no-transform",
+            },
+        });
     } catch (error: any) {
         const latency_ms = Date.now() - startTime;
         const statusCode: number = error?.status || 500;

--- a/apps/web/app/components/ChatMarkdown.tsx
+++ b/apps/web/app/components/ChatMarkdown.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import type { AnchorHTMLAttributes, ComponentPropsWithoutRef } from "react";
+import Markdown, { type MarkdownToJSX } from "markdown-to-jsx";
+import { normalizeChatMarkdown } from "@/lib/chatFormatting";
+
+type ChatMarkdownProps = {
+    content: string;
+    tone?: "assistant" | "user";
+};
+
+const MarkdownLink = ({ children, href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a
+        {...props}
+        href={href}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="font-medium underline decoration-emerald-500/60 underline-offset-2 hover:decoration-emerald-600"
+    >
+        {children}
+    </a>
+);
+
+const MarkdownBlockquote = ({ children }: ComponentPropsWithoutRef<"blockquote">) => (
+    <blockquote className="border-l-2 border-emerald-500/50 pl-3 text-slate-600 dark:text-slate-300">
+        {children}
+    </blockquote>
+);
+
+const MarkdownPre = ({ children }: ComponentPropsWithoutRef<"pre">) => (
+    <pre className="overflow-x-auto rounded-lg bg-slate-950 p-3 text-xs leading-relaxed text-slate-50">
+        {children}
+    </pre>
+);
+
+const MarkdownTable = ({ children }: ComponentPropsWithoutRef<"table">) => (
+    <div className="overflow-x-auto">
+        <table className="min-w-full border-collapse text-xs">{children}</table>
+    </div>
+);
+
+const markdownOptions: MarkdownToJSX.Options = {
+    disableParsingRawHTML: true,
+    overrides: {
+        h1: {
+            component: "h3",
+            props: { className: "text-base leading-snug font-semibold" },
+        },
+        h2: {
+            component: "h3",
+            props: { className: "text-base leading-snug font-semibold" },
+        },
+        h3: {
+            component: "h3",
+            props: { className: "text-sm leading-snug font-semibold" },
+        },
+        h4: {
+            component: "h4",
+            props: { className: "text-sm leading-snug font-semibold" },
+        },
+        p: {
+            component: "p",
+            props: { className: "my-0" },
+        },
+        ul: {
+            component: "ul",
+            props: { className: "list-disc space-y-1.5 pl-5" },
+        },
+        ol: {
+            component: "ol",
+            props: { className: "list-decimal space-y-1.5 pl-5" },
+        },
+        li: {
+            component: "li",
+            props: { className: "pl-1" },
+        },
+        strong: {
+            component: "strong",
+            props: { className: "font-semibold" },
+        },
+        em: {
+            component: "em",
+            props: { className: "italic" },
+        },
+        blockquote: MarkdownBlockquote,
+        a: MarkdownLink,
+        code: {
+            component: "code",
+            props: {
+                className: "rounded bg-slate-900/10 px-1 py-0.5 text-[0.92em] dark:bg-white/10",
+            },
+        },
+        pre: MarkdownPre,
+        table: MarkdownTable,
+        th: {
+            component: "th",
+            props: {
+                className:
+                    "border border-slate-300 px-2 py-1 text-left font-semibold dark:border-slate-600",
+            },
+        },
+        td: {
+            component: "td",
+            props: {
+                className: "border border-slate-300 px-2 py-1 align-top dark:border-slate-600",
+            },
+        },
+        hr: {
+            component: "hr",
+            props: { className: "border-slate-300 dark:border-slate-600" },
+        },
+        input: {
+            component: "input",
+            props: { disabled: true, className: "mr-1 align-middle" },
+        },
+        img: () => null,
+    },
+};
+
+export function ChatMarkdown({ content, tone = "assistant" }: ChatMarkdownProps) {
+    const toneClasses =
+        tone === "user"
+            ? "[&_a]:text-white [&_code]:bg-white/20"
+            : "[&_a]:text-emerald-700 dark:[&_a]:text-emerald-300";
+
+    return (
+        <div className={`space-y-2 text-sm leading-relaxed ${toneClasses}`}>
+            <Markdown options={markdownOptions}>{normalizeChatMarkdown(content)}</Markdown>
+        </div>
+    );
+}

--- a/apps/web/app/components/health/ChatUI.tsx
+++ b/apps/web/app/components/health/ChatUI.tsx
@@ -2,14 +2,15 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
-import { useTranslations } from "next-intl";
 import { ChatBubble, type Message } from "./components/ChatBubble";
 import { ActionCard } from "./components/ActionCard";
 import { TypingIndicator } from "./components/TypingIndicator";
 import { TrustBar } from "./components/TrustBar";
 import { Camera, Pill, MapPin } from "lucide-react";
+import { isAbortError, readChatErrorMessage, readTextResponseStream } from "@/lib/chatStream";
 
 const genId = () => Math.random().toString(36).slice(2, 10);
+const EMPTY_ASSISTANT_REPLY = "I'm here to help! Could you rephrase that?";
 
 const INITIAL_MESSAGES = {
     en: "Namaste, I'm SahiDawa, your trusted health companion. I can help you verify medicines, understand symptoms, or find nearby care. What would you like help with today?",
@@ -104,6 +105,38 @@ const ACTIONS = [
     },
 ];
 
+function upsertAssistantMessage(
+    messages: Message[],
+    id: string,
+    content: string,
+    options: { isError?: boolean } = {}
+) {
+    const existingMessage = messages.find((message) => message.id === id);
+
+    if (!existingMessage) {
+        return [
+            ...messages,
+            {
+                id,
+                role: "assistant" as const,
+                content,
+                timestamp: new Date(),
+                isError: options.isError || undefined,
+            },
+        ];
+    }
+
+    return messages.map((message) =>
+        message.id === id
+            ? {
+                  ...message,
+                  content,
+                  isError: options.isError || undefined,
+              }
+            : message
+    );
+}
+
 export default function ChatUI() {
     const params = useParams();
     const locale = (params.locale as string) || "en";
@@ -118,11 +151,23 @@ export default function ChatUI() {
     const [isTyping, setIsTyping] = useState(false);
     const [isListening, setIsListening] = useState(false);
     const [showWelcome, setShowWelcome] = useState(true);
+    const [streamingAssistantId, setStreamingAssistantId] = useState<string | null>(null);
     const lastUserText = useRef("");
     const messagesContainerRef = useRef<HTMLElement>(null);
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const recRef = useRef<any>(null);
-    const t = useTranslations("chat");
+    const activeRequestRef = useRef<AbortController | null>(null);
+    const isMountedRef = useRef(true);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+
+        return () => {
+            isMountedRef.current = false;
+            activeRequestRef.current?.abort();
+            recRef.current?.stop?.();
+        };
+    }, []);
 
     useEffect(() => {
         const container = messagesContainerRef.current;
@@ -157,6 +202,17 @@ export default function ChatUI() {
             setInput("");
             setIsTyping(true);
 
+            activeRequestRef.current?.abort();
+            const requestController = new AbortController();
+            activeRequestRef.current = requestController;
+            const isActiveRequest = () =>
+                isMountedRef.current &&
+                activeRequestRef.current === requestController &&
+                !requestController.signal.aborted;
+
+            let assistantMessageId: string | null = null;
+            let streamedReply = "";
+
             try {
                 const history = [...messages, userMsg]
                     .filter((m) => !m.isError)
@@ -165,33 +221,71 @@ export default function ChatUI() {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({ messages: history, locale }),
+                    signal: requestController.signal,
                 });
                 if (res.status === 429) {
                     throw new Error("Too many requests. Please try again in a few moments.");
                 }
-                if (!res.ok) throw new Error();
-                const data = await res.json();
-                const reply = data.text || "I'm here to help! Could you rephrase that?";
-                setMessages((prev) => [
-                    ...prev,
-                    { id: genId(), role: "assistant", content: reply, timestamp: new Date() },
-                ]);
-            } catch (err: any) {
-                setMessages((prev) => [
-                    ...prev,
-                    {
-                        id: genId(),
-                        role: "assistant",
-                        content: err.message || "Something went wrong",
-                        timestamp: new Date(),
-                        isError: true,
+                if (!res.ok) {
+                    throw new Error(
+                        await readChatErrorMessage(res, "Failed to generate AI response")
+                    );
+                }
+
+                const reply = await readTextResponseStream(
+                    res,
+                    (chunk) => {
+                        if (!isActiveRequest()) return;
+
+                        streamedReply += chunk;
+
+                        if (!assistantMessageId) {
+                            assistantMessageId = genId();
+                            setStreamingAssistantId(assistantMessageId);
+                        }
+
+                        setMessages((prev) =>
+                            upsertAssistantMessage(
+                                prev,
+                                assistantMessageId as string,
+                                streamedReply
+                            )
+                        );
                     },
-                ]);
+                    { signal: requestController.signal }
+                );
+
+                if (!isActiveRequest()) return;
+
+                const finalReply = reply || EMPTY_ASSISTANT_REPLY;
+                if (!assistantMessageId) {
+                    assistantMessageId = genId();
+                }
+
+                setMessages((prev) =>
+                    upsertAssistantMessage(prev, assistantMessageId as string, finalReply)
+                );
+            } catch (err: any) {
+                if (isAbortError(err)) return;
+                if (!isActiveRequest()) return;
+
+                const errorMessage = err.message || "Something went wrong";
+                const messageId = assistantMessageId || genId();
+
+                setMessages((prev) =>
+                    upsertAssistantMessage(prev, messageId, errorMessage, { isError: true })
+                );
             } finally {
-                setIsTyping(false);
+                if (activeRequestRef.current === requestController) {
+                    activeRequestRef.current = null;
+                    if (isMountedRef.current) {
+                        setIsTyping(false);
+                        setStreamingAssistantId(null);
+                    }
+                }
             }
         },
-        [messages, isTyping]
+        [messages, isTyping, locale]
     );
 
     const handleRetry = useCallback(
@@ -230,10 +324,15 @@ export default function ChatUI() {
         r.lang = speechLocales[locale as keyof typeof speechLocales] || "en-IN";
         r.interimResults = false;
         r.onresult = (e: any) => {
+            if (!isMountedRef.current) return;
             setInput(e.results[0][0].transcript);
             setIsListening(false);
         };
-        r.onerror = r.onend = () => setIsListening(false);
+        r.onerror = r.onend = () => {
+            if (isMountedRef.current) {
+                setIsListening(false);
+            }
+        };
         recRef.current = r;
         r.start();
         setIsListening(true);
@@ -280,7 +379,7 @@ export default function ChatUI() {
                         <ChatBubble key={msg.id} msg={msg} onRetry={handleRetry} />
                     ))}
 
-                    {isTyping && <TypingIndicator />}
+                    {isTyping && !streamingAssistantId && <TypingIndicator />}
 
                     {showWelcome && !isTyping && messages.length === 1 && (
                         <div>

--- a/apps/web/app/components/health/components/ChatBubble.tsx
+++ b/apps/web/app/components/health/components/ChatBubble.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { ChatMarkdown } from "@/app/components/ChatMarkdown";
+
 // ─── ChatBubble ────────────────────────────────────────────────────────────────
 // Single chat message: avatar · bubble · timestamp · optional error state.
 
@@ -81,6 +83,10 @@ const ErrorContent = ({ onRetry, msgId }: { onRetry?: (id: string) => void; msgI
     </div>
 );
 
+const PlainMessageContent = ({ content }: { content: string }) => (
+    <span className="whitespace-pre-wrap">{content}</span>
+);
+
 export function ChatBubble({ msg, onRetry }: ChatBubbleProps) {
     const isUser = msg.role === "user";
 
@@ -105,7 +111,13 @@ export function ChatBubble({ msg, onRetry }: ChatBubbleProps) {
                               : "rounded-bl-sm border border-white/40 bg-white/50 text-slate-800 backdrop-blur-xl dark:border-white/10 dark:bg-slate-800/50 dark:text-slate-200"
                     }`}
                 >
-                    {msg.isError ? <ErrorContent onRetry={onRetry} msgId={msg.id} /> : msg.content}
+                    {msg.isError ? (
+                        <ErrorContent onRetry={onRetry} msgId={msg.id} />
+                    ) : isUser ? (
+                        <PlainMessageContent content={msg.content} />
+                    ) : (
+                        <ChatMarkdown content={msg.content} />
+                    )}
                 </div>
 
                 <time

--- a/apps/web/lib/chatFormatting.ts
+++ b/apps/web/lib/chatFormatting.ts
@@ -1,0 +1,45 @@
+const orderedListMarkerPattern = /(^|\s)(\d{1,2})\.\s+(?=(?:\*\*)?[A-Za-z0-9])/g;
+
+function normalizeInlineOrderedList(line: string): string {
+    const markers = Array.from(line.matchAll(orderedListMarkerPattern)).map((match) => ({
+        markerStart: (match.index ?? 0) + match[1].length,
+        contentStart: (match.index ?? 0) + match[0].length,
+        number: match[2],
+    }));
+
+    if (markers.length < 2) return line;
+
+    const intro = line.slice(0, markers[0].markerStart).trim();
+    const listItems = markers
+        .map((marker, index) => {
+            const nextMarker = markers[index + 1];
+            const text = line
+                .slice(marker.contentStart, nextMarker?.markerStart ?? line.length)
+                .trim();
+            return text ? `${marker.number}. ${text}` : "";
+        })
+        .filter(Boolean);
+
+    if (listItems.length < 2) return line;
+
+    return intro ? `${intro}\n\n${listItems.join("\n")}` : listItems.join("\n");
+}
+
+export function normalizeChatMarkdown(content: string): string {
+    const lines = content.replace(/\r\n/g, "\n").trim().split("\n");
+    let fenceMarker: string | null = null;
+
+    return lines
+        .map((line) => {
+            const fenceMatch = line.match(/^\s*(```|~~~)/);
+            if (fenceMatch) {
+                fenceMarker = fenceMarker === fenceMatch[1] ? null : fenceMatch[1];
+                return line;
+            }
+
+            if (fenceMarker) return line;
+
+            return normalizeInlineOrderedList(line);
+        })
+        .join("\n");
+}

--- a/apps/web/lib/chatStream.ts
+++ b/apps/web/lib/chatStream.ts
@@ -1,0 +1,86 @@
+type ReadTextResponseStreamOptions = {
+    signal?: AbortSignal;
+};
+
+function createAbortError() {
+    if (typeof DOMException !== "undefined") {
+        return new DOMException("The operation was aborted.", "AbortError");
+    }
+
+    const error = new Error("The operation was aborted.");
+    error.name = "AbortError";
+    return error;
+}
+
+function throwIfAborted(signal?: AbortSignal) {
+    if (signal?.aborted) {
+        throw createAbortError();
+    }
+}
+
+export function isAbortError(error: unknown) {
+    return error instanceof Error && error.name === "AbortError";
+}
+
+export async function readTextResponseStream(
+    response: Response,
+    onChunk: (chunk: string) => void,
+    options: ReadTextResponseStreamOptions = {}
+) {
+    throwIfAborted(options.signal);
+
+    const reader = response.body?.getReader();
+
+    if (!reader) {
+        throw new Error("AI response stream is unavailable.");
+    }
+
+    const decoder = new TextDecoder();
+    let text = "";
+
+    try {
+        while (true) {
+            throwIfAborted(options.signal);
+
+            const { done, value } = await reader.read();
+
+            throwIfAborted(options.signal);
+
+            if (done) {
+                break;
+            }
+
+            const chunk = decoder.decode(value, { stream: true });
+            if (chunk) {
+                text += chunk;
+                onChunk(chunk);
+            }
+        }
+
+        const finalChunk = decoder.decode();
+        if (finalChunk) {
+            throwIfAborted(options.signal);
+            text += finalChunk;
+            onChunk(finalChunk);
+        }
+
+        return text;
+    } finally {
+        if (options.signal?.aborted) {
+            await reader.cancel().catch(() => undefined);
+        }
+
+        reader.releaseLock();
+    }
+}
+
+export async function readChatErrorMessage(response: Response, fallback: string) {
+    try {
+        const data = await response.json();
+        return typeof data.error === "string" && data.error.trim().length > 0
+            ? data.error
+            : fallback;
+    } catch {
+        return fallback;
+    }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
         "framer-motion": "^12.39.0",
         "leaflet": "^1.9.4",
         "lucide-react": "^1.16.0",
+        "markdown-to-jsx": "^9.8.1",
         "next": "^16.2.6",
         "next-intl": "^4.12.0",
         "next-themes": "^0.4.6",

--- a/apps/web/tests/chat-route.test.ts
+++ b/apps/web/tests/chat-route.test.ts
@@ -20,6 +20,12 @@ function createTextStream(chunks: string[]) {
     })();
 }
 
+function createFailingTextStream(error: unknown) {
+    return (async function* () {
+        throw error;
+    })();
+}
+
 describe("POST /api/chat", () => {
     beforeEach(() => {
         generateContentMock.mockReset();
@@ -136,6 +142,26 @@ describe("POST /api/chat", () => {
             config: expect.any(Object),
         });
         expect(generateContentMock).not.toHaveBeenCalled();
+    });
+
+    it("returns the existing JSON error response when Gemini stream fails before first chunk", async () => {
+        generateContentStreamMock.mockResolvedValue(createFailingTextStream({ status: 503 }));
+
+        const response = await POST(
+            new Request("http://localhost/api/chat", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    messages: [{ role: "user", content: "What is paracetamol?" }],
+                }),
+            })
+        );
+
+        expect(response.status).toBe(503);
+        expect(response.headers.get("content-type")).toContain("application/json");
+        await expect(response.json()).resolves.toEqual({
+            error: "Google AI is currently experiencing high demand. Please try again in a few moments.",
+        });
     });
 
     it("uses Punjabi in the standard chat system prompt when locale is pa", async () => {

--- a/apps/web/tests/chat-route.test.ts
+++ b/apps/web/tests/chat-route.test.ts
@@ -1,18 +1,29 @@
 const generateContentMock = jest.fn();
+const generateContentStreamMock = jest.fn();
 
 jest.mock("@google/genai", () => ({
     GoogleGenAI: jest.fn().mockImplementation(() => ({
         models: {
             generateContent: generateContentMock,
+            generateContentStream: generateContentStreamMock,
         },
     })),
 }));
 
 import { POST } from "../app/api/chat/route";
 
+function createTextStream(chunks: string[]) {
+    return (async function* () {
+        for (const chunk of chunks) {
+            yield { text: chunk };
+        }
+    })();
+}
+
 describe("POST /api/chat", () => {
     beforeEach(() => {
         generateContentMock.mockReset();
+        generateContentStreamMock.mockReset();
     });
 
     it("forces emergency true when deterministic detection matches", async () => {
@@ -42,6 +53,7 @@ describe("POST /api/chat", () => {
         await expect(response.json()).resolves.toMatchObject({
             emergency: true,
         });
+        expect(generateContentStreamMock).not.toHaveBeenCalled();
     });
 
     it("keeps non-emergency responses false when neither detector signals danger", async () => {
@@ -71,6 +83,7 @@ describe("POST /api/chat", () => {
         await expect(response.json()).resolves.toMatchObject({
             emergency: false,
         });
+        expect(generateContentStreamMock).not.toHaveBeenCalled();
     });
 
     it("returns 400 when message text is missing", async () => {
@@ -92,10 +105,8 @@ describe("POST /api/chat", () => {
         });
     });
 
-    it("correctly formats and forwards chat history to standard chat", async () => {
-        generateContentMock.mockResolvedValue({
-            text: "Hello! I can help you with that.",
-        });
+    it("streams standard chat chunks as plain text", async () => {
+        generateContentStreamMock.mockResolvedValue(createTextStream(["Hello! ", "I can help."]));
 
         const response = await POST(
             new Request("http://localhost/api/chat", {
@@ -112,11 +123,10 @@ describe("POST /api/chat", () => {
         );
 
         expect(response.status).toBe(200);
-        await expect(response.json()).resolves.toMatchObject({
-            text: "Hello! I can help you with that.",
-        });
+        expect(response.headers.get("content-type")).toContain("text/plain");
+        await expect(response.text()).resolves.toBe("Hello! I can help.");
 
-        expect(generateContentMock).toHaveBeenCalledWith({
+        expect(generateContentStreamMock).toHaveBeenCalledWith({
             model: "gemini-2.5-flash",
             contents: [
                 { role: "user", parts: [{ text: "Hello" }] },
@@ -125,12 +135,11 @@ describe("POST /api/chat", () => {
             ],
             config: expect.any(Object),
         });
+        expect(generateContentMock).not.toHaveBeenCalled();
     });
 
     it("uses Punjabi in the standard chat system prompt when locale is pa", async () => {
-        generateContentMock.mockResolvedValue({
-            text: "ਮੈਂ ਮਦਦ ਕਰ ਸਕਦਾ ਹਾਂ।",
-        });
+        generateContentStreamMock.mockResolvedValue(createTextStream(["ਮੈਂ ਮਦਦ ਕਰ ਸਕਦਾ ਹਾਂ।"]));
 
         const response = await POST(
             new Request("http://localhost/api/chat", {
@@ -144,7 +153,8 @@ describe("POST /api/chat", () => {
         );
 
         expect(response.status).toBe(200);
-        expect(generateContentMock).toHaveBeenCalledWith(
+        await expect(response.text()).resolves.toBe("ਮੈਂ ਮਦਦ ਕਰ ਸਕਦਾ ਹਾਂ।");
+        expect(generateContentStreamMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 config: expect.objectContaining({
                     systemInstruction: expect.stringContaining("Punjabi"),

--- a/apps/web/tests/chatBubble-render.test.tsx
+++ b/apps/web/tests/chatBubble-render.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { ChatBubble, type Message } from "../app/components/health/components/ChatBubble";
+
+function message(overrides: Partial<Message>): Message {
+    return {
+        id: "msg",
+        role: "assistant",
+        content: "",
+        timestamp: new Date("2026-06-04T00:00:00.000Z"),
+        ...overrides,
+    };
+}
+
+describe("ChatBubble", () => {
+    it("renders assistant messages as markdown", () => {
+        const html = renderToStaticMarkup(
+            <ChatBubble
+                msg={message({ role: "assistant", content: "**Hydrate:** Drink water." })}
+            />
+        );
+
+        expect(html).toContain("<strong");
+        expect(html).not.toContain("**Hydrate:**");
+    });
+
+    it("keeps user messages as plain text", () => {
+        const html = renderToStaticMarkup(
+            <ChatBubble msg={message({ role: "user", content: "**not assistant markdown**" })} />
+        );
+
+        expect(html).not.toContain("<strong");
+        expect(html).toContain("**not assistant markdown**");
+    });
+});

--- a/apps/web/tests/chatFormatting.test.ts
+++ b/apps/web/tests/chatFormatting.test.ts
@@ -1,0 +1,32 @@
+import { normalizeChatMarkdown } from "../lib/chatFormatting";
+
+describe("normalizeChatMarkdown", () => {
+    it("keeps regular markdown blocks intact for the renderer", () => {
+        const content = [
+            "## Fever care",
+            "",
+            "- **Hydrate:** Drink water.",
+            "- Rest in a cool room.",
+            "",
+            "Use `paracetamol` only as directed.",
+            "",
+            "[Read more](https://example.com)",
+        ].join("\n");
+
+        expect(normalizeChatMarkdown(content)).toBe(content);
+    });
+
+    it("turns inline numbered Gemini output into markdown ordered-list lines", () => {
+        expect(
+            normalizeChatMarkdown(
+                "Here are tips: 1. **Hydrate:** Drink water. 2. **Rest:** Sleep well."
+            )
+        ).toBe("Here are tips:\n\n1. **Hydrate:** Drink water.\n2. **Rest:** Sleep well.");
+    });
+
+    it("does not rewrite ordered-list markers inside fenced code blocks", () => {
+        expect(
+            normalizeChatMarkdown("Try this:\n```txt\n1. Keep this code line. 2. Same line.\n```")
+        ).toBe("Try this:\n```txt\n1. Keep this code line. 2. Same line.\n```");
+    });
+});

--- a/apps/web/tests/chatMarkdown-render.test.tsx
+++ b/apps/web/tests/chatMarkdown-render.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { ChatMarkdown } from "../app/components/ChatMarkdown";
+
+describe("ChatMarkdown", () => {
+    it("renders common Gemini markdown as structured HTML", () => {
+        const html = renderToStaticMarkup(
+            <ChatMarkdown
+                content={[
+                    "### Fever care",
+                    "",
+                    "- **Hydrate:** Drink water.",
+                    "- Rest in a cool room.",
+                    "",
+                    "Use `paracetamol` only as directed.",
+                    "",
+                    "[Read more](https://example.com)",
+                ].join("\n")}
+            />
+        );
+
+        expect(html).toContain("<h3");
+        expect(html).toContain("<ul");
+        expect(html).toContain("<strong");
+        expect(html).toContain("<code");
+        expect(html).toContain('href="https://example.com"');
+        expect(html).not.toContain("**Hydrate:**");
+    });
+
+    it("renders inline numbered Gemini output as an ordered list", () => {
+        const html = renderToStaticMarkup(
+            <ChatMarkdown content="Here are tips: 1. **Hydrate:** Drink water. 2. **Rest:** Sleep well." />
+        );
+
+        expect(html).toContain("<ol");
+        expect(html).toContain("<li");
+        expect(html).toContain("<strong");
+        expect(html).not.toContain("1. **Hydrate:**");
+    });
+
+    it("does not render raw HTML, images, or unsafe link protocols", () => {
+        const html = renderToStaticMarkup(
+            <ChatMarkdown
+                content={
+                    '<script>alert("x")</script>\n\n![x](https://example.com/x.png)\n\n[bad](javascript:alert("x"))'
+                }
+            />
+        );
+
+        expect(html).not.toContain("<script");
+        expect(html).not.toContain("<img");
+        expect(html).not.toContain("javascript:");
+        expect(html).toContain("&lt;script&gt;");
+    });
+});

--- a/apps/web/tests/chatStream.test.ts
+++ b/apps/web/tests/chatStream.test.ts
@@ -1,0 +1,65 @@
+import { readChatErrorMessage, readTextResponseStream } from "../lib/chatStream";
+
+function streamFrom(chunks: string[]) {
+    const encoder = new TextEncoder();
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            for (const chunk of chunks) {
+                controller.enqueue(encoder.encode(chunk));
+            }
+            controller.close();
+        },
+    });
+}
+
+describe("readTextResponseStream", () => {
+    it("appends decoded response chunks as they arrive", async () => {
+        const onChunk = jest.fn();
+
+        const result = await readTextResponseStream(
+            new Response(streamFrom(["Hello", " streaming", " chat"])),
+            onChunk
+        );
+
+        expect(result).toBe("Hello streaming chat");
+        expect(onChunk).toHaveBeenNthCalledWith(1, "Hello");
+        expect(onChunk).toHaveBeenNthCalledWith(2, " streaming");
+        expect(onChunk).toHaveBeenNthCalledWith(3, " chat");
+    });
+
+    it("throws a useful error when a response has no readable body", async () => {
+        await expect(readTextResponseStream(new Response(null), jest.fn())).rejects.toThrow(
+            "AI response stream is unavailable."
+        );
+    });
+
+    it("stops without appending chunks when the stream is already aborted", async () => {
+        const controller = new AbortController();
+        controller.abort();
+        const onChunk = jest.fn();
+
+        await expect(
+            readTextResponseStream(new Response(streamFrom(["late chunk"])), onChunk, {
+                signal: controller.signal,
+            })
+        ).rejects.toMatchObject({ name: "AbortError" });
+        expect(onChunk).not.toHaveBeenCalled();
+    });
+});
+
+describe("readChatErrorMessage", () => {
+    it("uses an API error message from a JSON response", async () => {
+        await expect(
+            readChatErrorMessage(
+                Response.json({ error: "Too many requests. Please wait." }, { status: 429 }),
+                "Fallback error"
+            )
+        ).resolves.toBe("Too many requests. Please wait.");
+    });
+
+    it("falls back when the error body is not JSON", async () => {
+        await expect(
+            readChatErrorMessage(new Response("not json", { status: 500 }), "Fallback error")
+        ).resolves.toBe("Fallback error");
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,7 @@
                 "framer-motion": "^12.39.0",
                 "leaflet": "^1.9.4",
                 "lucide-react": "^1.16.0",
+                "markdown-to-jsx": "^9.8.1",
                 "next": "^16.2.6",
                 "next-intl": "^4.12.0",
                 "next-themes": "^0.4.6",
@@ -4540,6 +4541,17 @@
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/react": {
+            "version": "19.2.16",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+            "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "csstype": "^3.2.2"
+            }
         },
         "node_modules/@types/react-dom": {
             "version": "19.2.3",
@@ -11625,6 +11637,34 @@
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tmpl": "1.0.5"
+            }
+        },
+        "node_modules/markdown-to-jsx": {
+            "version": "9.8.1",
+            "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-9.8.1.tgz",
+            "integrity": "sha512-yq70dLPkBnE2LYFtGTLfRes4qyBDS+a4wDttAA/b/BzVGrbs2e0TfCeSFrMkapCg1lsxYi+42BowuBDxLP9k4Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "react": ">= 16.0.0",
+                "solid-js": ">=1.0.0",
+                "vue": ">=3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "react": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                },
+                "solid-js": {
+                    "optional": true
+                },
+                "vue": {
+                    "optional": true
+                }
             }
         },
         "node_modules/math-intrinsics": {


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

_(Warning: If you are not assigned, this PR will be immediately closed without review to prevent duplicate work)._

## 📋 PR Summary

This PR makes the AI Health Assistant feel responsive by streaming Gemini output as it is generated instead of waiting for the whole response before rendering it.

It also updates the other `/api/chat` consumer so the endpoint response change does not break the floating chatbot, and renders Gemini Markdown cleanly in assistant messages.

---

## 🔗 Related Issue

Closes #1206

---

## 🏷️ PR Type

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [x] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [x] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [x] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [x] Root config (package.json, etc.)

---

## 📝 What Was Done

- Switched standard health chat responses from `ai.models.generateContent` to `ai.models.generateContentStream`.
- Streamed Gemini chunks from `/api/chat` as `text/plain; charset=utf-8`.
- Updated the health chat UI to read `res.body.getReader()` and append chunks into one assistant bubble.
- Kept the voice triage path on the existing JSON/non-streaming flow.
- Updated the floating chatbot consumer so the `/api/chat` response change does not break it.
- Added shared stream/error helpers for both chat consumers.
- Added assistant-only Markdown rendering for Gemini output, including headings, lists, bold text, links, code, and tables.
- Kept user messages plain text so user-entered Markdown is not rendered.
- Disabled raw HTML parsing and image rendering in assistant Markdown output.
- Added abort handling for in-flight chat streams and unmount cleanup.
- Added tests for streaming, route behavior, Markdown rendering, formatter normalization, and abort handling.

---

## 📸 Screenshots / Proof of Work (REQUIRED)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
> - **Backend/API/ML changes:** You MUST attach terminal logs, curl/Postman outputs, or test run outputs proving the changes work.
>
> _Please drag & drop your screenshots/GIFs here, or paste terminal/console logs below:_

Live local Gemini proof:

![issue-1206-final-complete-chat-proof.png](https://github.com/user-attachments/assets/e147e29b-ab76-4352-a969-068b3a114bc9)

Browser verification:

- Opened `http://localhost:3000/en/health`.
- Cleared service worker/cache before the run.
- Sent a real Gemini prompt asking for Markdown with heading, bullet list, numbered list, bold labels, and inline code.
- Verified `/api/chat => 200 OK`.
- Verified the user message stayed plain text.
- Verified the assistant message rendered Markdown as structured UI and did not show raw `**` markers.

Local verification:

```txt
/home/user/sahidawa-india/node_modules/.bin/jest --config jest.config.cjs --runInBand
Test Suites: 32 passed, 32 total
Tests:       168 passed, 168 total
```

```txt
/home/user/sahidawa-india/node_modules/.bin/tsc --noEmit
exit 0
```

```txt
Changed-file ESLint
exit 0
```

```txt
git diff --check
exit 0
```

```txt
npm run build -w web
exit 0
```

---

## ✅ Contributor Checklist

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the patterns and conventions in `docs/code-guide.md`
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [x] Response format reviewed: voice triage still returns structured JSON, while standard health chat intentionally streams `text/plain` for #1206
- [x] I have performed a self-review of my own code

Note: the changed `/api/chat` route is a Next.js web route. Standard chat intentionally returns `text/plain` for streaming; voice triage still returns JSON.

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant
