### PR TITLE
Feat/push notifications rate limiting

### DIFF
--- a/apps/api/src/services/notifications.ts
+++ b/apps/api/src/services/notifications.ts
@@ -173,16 +173,29 @@ export async function triggerRecallAlert(alert: RecallAlert) {
         };
     }
 
-    const results = await Promise.allSettled(
-        subscriptions.map((item) =>
-            webPush.sendNotification(item.subscription, JSON.stringify(payload))
-        )
-    );
+    const BATCH_SIZE = 50;
+    const results: PromiseSettledResult<any>[] = [];
+    const failedEndpoints: string[] = [];
 
-    const failedEndpoints = results
-        .map((result, index) => ({ result, endpoint: subscriptions[index].endpoint }))
-        .filter(({ result }) => result.status === "rejected")
-        .map(({ endpoint }) => endpoint);
+    for (let i = 0; i < subscriptions.length; i += BATCH_SIZE) {
+        const chunk = subscriptions.slice(i, i + BATCH_SIZE);
+        const chunkResults = await Promise.allSettled(
+            chunk.map((item) =>
+                webPush.sendNotification(item.subscription, JSON.stringify(payload))
+            )
+        );
+
+        chunkResults.forEach((result, index) => {
+            results.push(result);
+            if (result.status === "rejected") {
+                failedEndpoints.push(chunk[index].endpoint);
+            }
+        });
+
+        if (i + BATCH_SIZE < subscriptions.length) {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+    }
 
     await Promise.all(failedEndpoints.map(removePushSubscription));
 


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

## 📋 PR Summary

This PR introduces performance and scalability enhancements to the CDSCO Alerts push notifications dispatcher in `apps/api/src/services/notifications.ts`. Rather than broadcasting alerts to all subscriptions concurrently (which causes Node.js socket pool exhaustion and rate-limits at high volumes), this update chunks subscription dispatches into batches and introduces a small delay between them to clean up socket handles.

---

## 🔗 Related Issue

Closes #1205

---

## 🏷️ PR Type

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [ ] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [x] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [ ] `apps/web` — Next.js Frontend
- [x] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Refactored `triggerRecallAlert` in [notifications.ts](file:///C:/Users/ravic/OneDrive/Desktop/sarvam/apps/api/src/services/notifications.ts) to slice subscriptions into batches of `BATCH_SIZE = 50`.
- Processed each batch concurrently using `Promise.allSettled` to optimize sending speed within the batch.
- Introduced a `100ms` delay (`await new Promise((resolve) => setTimeout(resolve, 100))`) between batches to permit Node's outbound socket connection pool to clean up finished sockets.
- Gathered and merged results across all batches to identify and delete failed subscription endpoints from the database at the end of the dispatch.

---

## 📸 Screenshots / Proof of Work (REQUIRED)

### Jest Backend Test Logs:
```text
PASS tests/verify.test.ts
PASS tests/pharmacies.test.ts
PASS tests/alertsPagination.test.ts
...
Test Suites: 8 passed, 8 total
Tests:       62 passed, 62 total
Snapshots:   0 total
Time:        2.931 s, estimated 3 s
Ran all test suites.
