### PR TITLE
fix: localize alerts log and compare grid

### DIFF
--- a/apps/web/app/[locale]/alerts/page.tsx
+++ b/apps/web/app/[locale]/alerts/page.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import { Activity, ArrowLeft, Filter, AlertTriangle, AlertCircle, Search } from "lucide-react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { Globe } from "lucide-react";
 import RecallPushSubscriber from "@/components/alerts/RecallPushSubscriber";
 import { LiveMessage } from "@/components/ui/LiveMessage";
@@ -31,6 +32,7 @@ function formatRelativeTime(dateString: string | null): string {
 }
 
 export default function FullAlertsLogPage() {
+    const t = useTranslations("Alerts");
     const [allAlerts, setAllAlerts] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
@@ -84,7 +86,7 @@ export default function FullAlertsLogPage() {
                     className="inline-flex items-center gap-2 text-sm font-semibold text-(--color-text-secondary) transition-colors hover:text-(--color-text-primary)"
                 >
                     <ArrowLeft size={16} />
-                    Back to Home Page
+                    {t("backHome")}
                 </Link>
 
                 <div className="animate-in fade-in slide-in-from-bottom-4 inline-flex items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-4 py-2 text-sm font-bold text-emerald-700 duration-700 dark:border-emerald-900/30 dark:bg-emerald-950/20 dark:text-emerald-400">
@@ -92,7 +94,7 @@ export default function FullAlertsLogPage() {
                         <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75"></span>
                         <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500"></span>
                     </span>
-                    Live Alerts
+                    {t("badge")}
                 </div>
             </div>
 
@@ -100,19 +102,18 @@ export default function FullAlertsLogPage() {
                 <div>
                     <h1 className="flex items-center gap-3 text-3xl font-extrabold tracking-tight text-(--color-text-primary)">
                         <Activity className="text-red-500" size={28} />
-                        Live CDSCO Alerts
+                        {t("title")}
                     </h1>
                     <p className="mt-1 font-medium text-(--color-text-secondary)">
-                        Complete historical safety logging stream directly mapped to the master
-                        CDSCO registry.
+                        {t("subtitle")}
                     </p>
                 </div>
                 <span className="hidden rounded-full bg-red-100 px-2.5 py-1 text-xs font-bold tracking-wider text-red-600 uppercase sm:block dark:bg-red-950/30 dark:text-red-400">
-                    India Region
+                    {t("regionBadge")}
                 </span>
                 <div className="inline-flex items-center gap-2 self-start rounded-xl border border-(--color-border-muted) bg-(--color-surface-page) px-4 py-2 text-sm font-bold text-(--color-text-primary) shadow-sm md:self-auto">
                     <Filter size={16} />
-                    Total Count: {totalCount}
+                    {t("totalCount", { count: totalCount })}
                 </div>
             </div>
 
@@ -126,7 +127,7 @@ export default function FullAlertsLogPage() {
                     </div>
                     <input
                         type="text"
-                        placeholder="Search by Brand Name..."
+                        placeholder={t("brandPlaceholder")}
                         value={brandSearch}
                         onChange={(e) => setBrandSearch(e.target.value)}
                         className="block w-full rounded-xl border border-(--color-border-muted) bg-(--color-surface-muted) p-3 pl-10 text-sm text-(--color-text-primary) placeholder-(--color-text-muted) shadow-sm focus:border-emerald-500 focus:ring-emerald-500 focus:outline-hidden"
@@ -138,7 +139,7 @@ export default function FullAlertsLogPage() {
                     </div>
                     <input
                         type="text"
-                        placeholder="Filter by State/District..."
+                        placeholder={t("regionPlaceholder")}
                         value={regionSearch}
                         onChange={(e) => setRegionSearch(e.target.value)}
                         className="block w-full rounded-xl border border-(--color-border-muted) bg-(--color-surface-muted) p-3 pl-10 text-sm text-(--color-text-primary) placeholder-(--color-text-muted) shadow-sm focus:border-emerald-500 focus:ring-emerald-500 focus:outline-hidden"
@@ -151,14 +152,14 @@ export default function FullAlertsLogPage() {
                     tone="critical"
                     className="mb-6 rounded-xl border border-red-200 bg-red-50 p-4 text-sm font-medium text-red-800 dark:border-red-900 dark:bg-red-950/20 dark:text-red-400"
                 >
-                    Database synchronization error encountered while fetching active logs.
+                    {t("error")}
                 </LiveMessage>
             )}
 
             <div role="feed" aria-busy={loading} className="space-y-4">
                 {loading ? (
                     <div className="rounded-2xl border border-(--color-border-muted) bg-(--color-surface-page) py-16 text-center font-medium text-(--color-text-muted)">
-                        Loading alerts...
+                        {t("loading")}
                     </div>
                 ) : allAlerts.length > 0 ? (
                     allAlerts.map((alert) => {
@@ -211,7 +212,7 @@ export default function FullAlertsLogPage() {
                                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                                             <h4 className="leading-tight font-bold text-(--color-text-primary)">
                                                 {isSystem
-                                                    ? "System Update"
+                                                    ? t("systemUpdate")
                                                     : alert.reported_brand_name ||
                                                       alert.brand_name ||
                                                       alert.brand}
@@ -239,22 +240,22 @@ export default function FullAlertsLogPage() {
 
                                     <p className="mt-1 text-sm leading-snug font-medium text-(--color-text-secondary)">
                                         {alert.alert_type
-                                            ? `Alert: ${alert.alert_type}`
-                                            : alert.composition || "No details available"}
+                                            ? t("alertType", { type: alert.alert_type })
+                                            : alert.composition || t("noDetails")}
                                     </p>
 
                                     {/* Render metadata bottom line layout only if it's not a system update card */}
                                     {!isSystem && (
                                         <div className="mt-2 flex flex-wrap items-center gap-3 text-[11px] font-semibold text-(--color-text-muted)">
                                             <span>
-                                                Batch:{" "}
+                                                {t("batchLabel")}{" "}
                                                 <span className="font-bold text-(--color-text-primary)">
                                                     {alert.batch_number}
                                                 </span>
                                             </span>
                                             <span>•</span>
                                             <span>
-                                                Manufacturer:{" "}
+                                                {t("manufacturerLabel")}{" "}
                                                 <span className="font-bold text-(--color-text-primary)">
                                                     {alert.manufacturer}
                                                 </span>
@@ -263,7 +264,7 @@ export default function FullAlertsLogPage() {
                                                 <>
                                                     <span>•</span>
                                                     <span>
-                                                        Region:{" "}
+                                                        {t("regionLabel")}{" "}
                                                         <span className="font-bold text-(--color-text-primary)">
                                                             {[alert.state, alert.district]
                                                                 .filter(Boolean)
@@ -280,7 +281,7 @@ export default function FullAlertsLogPage() {
                     })
                 ) : (
                     <div className="rounded-2xl border border-(--color-border-muted) bg-(--color-surface-page) py-16 text-center font-medium text-(--color-text-muted)">
-                        No health alerts matching your criteria were found.
+                        {t("empty")}
                     </div>
                 )}
             </div>
@@ -291,14 +292,14 @@ export default function FullAlertsLogPage() {
                     onClick={() => setPage((p) => p - 1)}
                     className="rounded-xl border border-slate-300 px-4 py-2 text-sm font-bold disabled:opacity-50"
                 >
-                    Previous
+                    {t("previous")}
                 </button>
                 <button
                     disabled={page * 50 >= totalCount}
                     onClick={() => setPage((p) => p + 1)}
                     className="rounded-xl border border-slate-300 px-4 py-2 text-sm font-bold disabled:cursor-not-allowed disabled:opacity-50"
                 >
-                    Next
+                    {t("next")}
                 </button>
             </div>
         </div>

--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -4,7 +4,10 @@ import { useCallback, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/routing";
 import { PageHeader } from "../components/PageHeader";
-import ComparisonGrid, { type Medicine } from "@/src/components/ComparisonGrid";
+import ComparisonGrid, {
+    type ComparisonGridLabels,
+    type Medicine,
+} from "@/src/components/ComparisonGrid";
 import MedicineSearchSelect from "@/src/components/MedicineSearchSelect";
 import { COMPARE_SELECT_FIELDS } from "@/src/lib/compareSelectFields";
 import { supabase } from "@/lib/supabase";
@@ -33,6 +36,36 @@ export default function ComparePage() {
     const [medicine1, setMedicine1] = useState<Medicine | null>(null);
     const [medicine2, setMedicine2] = useState<Medicine | null>(null);
     const handleSearch = useCallback((q: string) => searchMedicines(q), []);
+    const comparisonLabels: ComparisonGridLabels = {
+        emptyComparison: t("emptyComparison"),
+        fieldHeader: t("fieldHeader"),
+        medicineA: t("medicineA"),
+        medicineB: t("medicineB"),
+        priceUnavailable: t("priceUnavailable"),
+        noSavings: t("noSavings"),
+        saveAmount: (amount, percent) => t("saveAmount", { amount, percent }),
+        rows: {
+            brandName: t("rows.brandName"),
+            genericName: t("rows.genericName"),
+            composition: t("rows.composition"),
+            manufacturer: t("rows.manufacturer"),
+            type: t("rows.type"),
+            cdscoStatus: t("rows.cdscoStatus"),
+            expiryDate: t("rows.expiryDate"),
+            marketPrice: t("rows.marketPrice"),
+            janAushadhiPrice: t("rows.janAushadhiPrice"),
+            savings: t("rows.savings"),
+        },
+        medicineTypes: {
+            brand: t("medicineTypes.brand"),
+            generic: t("medicineTypes.generic"),
+        },
+        status: {
+            approved: t("status.approved"),
+            recalled: t("status.recalled"),
+            banned: t("status.banned"),
+        },
+    };
 
     return (
         <div className="min-h-screen bg-(--color-surface-muted) text-(--color-text-primary)">
@@ -61,7 +94,11 @@ export default function ComparePage() {
                         />
                     </div>
                 </section>
-                <ComparisonGrid medicine1={medicine1} medicine2={medicine2} />
+                <ComparisonGrid
+                    medicine1={medicine1}
+                    medicine2={medicine2}
+                    labels={comparisonLabels}
+                />
                 <p className="text-center text-sm text-(--color-text-secondary)">
                     <Link
                         href="/map"

--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/routing";
 import { PageHeader } from "../components/PageHeader";
 import ComparisonGrid, { type Medicine } from "@/src/components/ComparisonGrid";
@@ -28,6 +29,7 @@ async function searchMedicines(query: string): Promise<Medicine[]> {
 }
 
 export default function ComparePage() {
+    const t = useTranslations("Compare");
     const [medicine1, setMedicine1] = useState<Medicine | null>(null);
     const [medicine2, setMedicine2] = useState<Medicine | null>(null);
     const handleSearch = useCallback((q: string) => searchMedicines(q), []);
@@ -35,8 +37,8 @@ export default function ComparePage() {
     return (
         <div className="min-h-screen bg-(--color-surface-muted) text-(--color-text-primary)">
             <PageHeader
-                title="Compare medicines"
-                subtitle="Brand vs generic side by side"
+                title={t("pageTitle")}
+                subtitle={t("pageSubtitle")}
                 backHref="/"
                 variant="light"
             />
@@ -44,16 +46,18 @@ export default function ComparePage() {
                 <section className="rounded-xl border border-(--color-border-muted) bg-(--color-surface-page) p-5 transition-all duration-300 hover:border-emerald-500/20 hover:shadow-md">
                     <div className="grid gap-4 sm:grid-cols-2">
                         <MedicineSearchSelect
-                            label="First medicine"
+                            label={t("firstMedicine")}
                             value={medicine1}
                             onChange={setMedicine1}
                             onSearch={handleSearch}
+                            placeholder={t("searchPlaceholder")}
                         />
                         <MedicineSearchSelect
-                            label="Second medicine"
+                            label={t("secondMedicine")}
                             value={medicine2}
                             onChange={setMedicine2}
                             onSearch={handleSearch}
+                            placeholder={t("searchPlaceholder")}
                         />
                     </div>
                 </section>
@@ -63,7 +67,7 @@ export default function ComparePage() {
                         href="/map"
                         className="text-emerald-700 hover:underline dark:text-emerald-400"
                     >
-                        Find pharmacies
+                        {t("findPharmacies")}
                     </Link>
                 </p>
             </main>

--- a/apps/web/messages/bn.json
+++ b/apps/web/messages/bn.json
@@ -366,5 +366,62 @@
         "status": "Online",
         "title": "SahiDawa AI",
         "welcome": "Hi! I am the SahiDawa AI Assistant. How can I help you with your medicines today?"
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -353,9 +353,18 @@
         "quick_actions": "Quick actions",
         "footer": "For informational use only • Consult a doctor",
         "actions": {
-            "scan": { "label": "Scan Medicine", "description": "Verify authenticity" },
-            "symptoms": { "label": "Check Symptoms", "description": "AI-assisted guidance" },
-            "pharmacy": { "label": "Find Pharmacy", "description": "Locate verified stores" }
+            "scan": {
+                "label": "Scan Medicine",
+                "description": "Verify authenticity"
+            },
+            "symptoms": {
+                "label": "Check Symptoms",
+                "description": "AI-assisted guidance"
+            },
+            "pharmacy": {
+                "label": "Find Pharmacy",
+                "description": "Locate verified stores"
+            }
         }
     },
     "chatbot": {
@@ -363,5 +372,62 @@
         "status": "Online",
         "welcome": "Hi! I am the SahiDawa AI Assistant. How can I help you with your medicines today?",
         "placeholder": "Ask me about a medicine..."
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/gu.json
+++ b/apps/web/messages/gu.json
@@ -366,5 +366,62 @@
         "status": "Online",
         "title": "SahiDawa AI",
         "welcome": "Hi! I am the SahiDawa AI Assistant. How can I help you with your medicines today?"
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -372,5 +372,62 @@
         "status": "Online",
         "title": "SahiDawa AI",
         "welcome": "Hi! I am the SahiDawa AI Assistant. How can I help you with your medicines today?"
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/kn.json
+++ b/apps/web/messages/kn.json
@@ -366,5 +366,62 @@
         "status": "Online",
         "title": "SahiDawa AI",
         "welcome": "Hi! I am the SahiDawa AI Assistant. How can I help you with your medicines today?"
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/ks.json
+++ b/apps/web/messages/ks.json
@@ -353,9 +353,18 @@
         "quick_actions": "فcurrent کٲم",
         "footer": "صِرَف مَعلوٗمات خٲطرِ • ڈاکٹرَس سٲتؠ مَشورہِ کَریو",
         "actions": {
-            "scan": { "label": "دَوا سکین کَریو", "description": "اَصلیَت تصدیق کَریو" },
-            "symptoms": { "label": "علامت چیک کَریو", "description": "اے آئی مَدَدگار رَہنُمٲیی" },
-            "pharmacy": { "label": "میڈیکل سٹور لَبِیو", "description": "تصدیق شُدہ دُکان" }
+            "scan": {
+                "label": "دَوا سکین کَریو",
+                "description": "اَصلیَت تصدیق کَریو"
+            },
+            "symptoms": {
+                "label": "علامت چیک کَریو",
+                "description": "اے آئی مَدَدگار رَہنُمٲیی"
+            },
+            "pharmacy": {
+                "label": "میڈیکل سٹور لَبِیو",
+                "description": "تصدیق شُدہ دُکان"
+            }
         }
     },
     "chatbot": {
@@ -363,5 +372,62 @@
         "status": "آن لائن",
         "welcome": "خوش آمدید! بِہ چُھس صحیح دَوا اے آئی مَدَدگار۔ اَز کیا دَواہَن مُتلِق مَدَد کَرو؟",
         "placeholder": "دَوا مُتلِق پُچھِیو..."
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/ml.json
+++ b/apps/web/messages/ml.json
@@ -372,5 +372,62 @@
             "title": "Get In Touch",
             "subtitle": "Have questions, ideas, or want to contribute? We'd love to hear from you."
         }
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/mr.json
+++ b/apps/web/messages/mr.json
@@ -366,5 +366,62 @@
         "status": "Online",
         "title": "SahiDawa AI",
         "welcome": "Hi! I am the SahiDawa AI Assistant. How can I help you with your medicines today?"
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/or.json
+++ b/apps/web/messages/or.json
@@ -366,5 +366,62 @@
         "status": "Online",
         "title": "SahiDawa AI",
         "welcome": "Hi! I am the SahiDawa AI Assistant. How can I help you with your medicines today?"
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/pa.json
+++ b/apps/web/messages/pa.json
@@ -366,5 +366,62 @@
     },
     "BackToTopButton": {
         "label": "Back to top"
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/sa.json
+++ b/apps/web/messages/sa.json
@@ -366,5 +366,62 @@
     },
     "BackToTopButton": {
         "label": "Back to top"
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/ta.json
+++ b/apps/web/messages/ta.json
@@ -366,5 +366,62 @@
         "status": "Online",
         "title": "SahiDawa AI",
         "welcome": "Hi! I am the SahiDawa AI Assistant. How can I help you with your medicines today?"
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/te.json
+++ b/apps/web/messages/te.json
@@ -366,5 +366,62 @@
         "status": "Online",
         "title": "SahiDawa AI",
         "welcome": "Hi! I am the SahiDawa AI Assistant. How can I help you with your medicines today?"
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/messages/ur.json
+++ b/apps/web/messages/ur.json
@@ -366,5 +366,62 @@
         "status": "Online",
         "title": "SahiDawa AI",
         "welcome": "Hi! I am the SahiDawa AI Assistant. How can I help you with your medicines today?"
+    },
+    "Alerts": {
+        "backHome": "Back to Home Page",
+        "badge": "Live Alerts",
+        "title": "Live CDSCO Alerts",
+        "subtitle": "Complete historical safety logging stream directly mapped to the master CDSCO registry.",
+        "regionBadge": "India Region",
+        "totalCount": "Total Count: {count}",
+        "brandPlaceholder": "Search by Brand Name...",
+        "regionPlaceholder": "Filter by State/District...",
+        "error": "Database synchronization error encountered while fetching active logs.",
+        "loading": "Loading alerts...",
+        "systemUpdate": "System Update",
+        "alertType": "Alert: {type}",
+        "noDetails": "No details available",
+        "batchLabel": "Batch:",
+        "manufacturerLabel": "Manufacturer:",
+        "regionLabel": "Region:",
+        "empty": "No health alerts matching your criteria were found.",
+        "previous": "Previous",
+        "next": "Next"
+    },
+    "Compare": {
+        "pageTitle": "Compare medicines",
+        "pageSubtitle": "Brand vs generic side by side",
+        "firstMedicine": "First medicine",
+        "secondMedicine": "Second medicine",
+        "searchPlaceholder": "Search brand or generic name",
+        "findPharmacies": "Find pharmacies",
+        "emptyComparison": "Select two medicines above to see the comparison.",
+        "fieldHeader": "Field",
+        "medicineA": "Medicine A",
+        "medicineB": "Medicine B",
+        "priceUnavailable": "Price unavailable",
+        "noSavings": "No savings",
+        "saveAmount": "Save ₹{amount} ({percent}%)",
+        "rows": {
+            "brandName": "Brand name",
+            "genericName": "Generic name",
+            "composition": "Composition",
+            "manufacturer": "Manufacturer",
+            "type": "Type",
+            "cdscoStatus": "CDSCO status",
+            "expiryDate": "Expiry date",
+            "marketPrice": "Market price (MRP)",
+            "janAushadhiPrice": "Jan Aushadhi price",
+            "savings": "Savings vs MRP"
+        },
+        "medicineTypes": {
+            "brand": "Brand",
+            "generic": "Generic"
+        },
+        "status": {
+            "approved": "Approved",
+            "recalled": "Recalled",
+            "banned": "Banned"
+        }
     }
 }

--- a/apps/web/src/components/ComparisonGrid.tsx
+++ b/apps/web/src/components/ComparisonGrid.tsx
@@ -1,5 +1,3 @@
-import { useTranslations } from "next-intl";
-
 export interface Medicine {
     id: string;
     brand_name: string | null;
@@ -12,6 +10,68 @@ export interface Medicine {
     medicine_type?: "brand" | "generic";
     cdsco_approval_status: string;
 }
+
+export interface ComparisonGridLabels {
+    emptyComparison: string;
+    fieldHeader: string;
+    medicineA: string;
+    medicineB: string;
+    priceUnavailable: string;
+    noSavings: string;
+    saveAmount: (amount: string, percent: string) => string;
+    rows: {
+        brandName: string;
+        genericName: string;
+        composition: string;
+        manufacturer: string;
+        type: string;
+        cdscoStatus: string;
+        expiryDate: string;
+        marketPrice: string;
+        janAushadhiPrice: string;
+        savings: string;
+    };
+    medicineTypes: {
+        brand: string;
+        generic: string;
+    };
+    status: {
+        approved: string;
+        recalled: string;
+        banned: string;
+    };
+}
+
+const defaultLabels: ComparisonGridLabels = {
+    emptyComparison: "Select two medicines above to see the comparison.",
+    fieldHeader: "Field",
+    medicineA: "Medicine A",
+    medicineB: "Medicine B",
+    priceUnavailable: "Price unavailable",
+    noSavings: "No savings",
+    saveAmount: (amount, percent) => `Save ₹${amount} (${percent}%)`,
+    rows: {
+        brandName: "Brand name",
+        genericName: "Generic name",
+        composition: "Composition",
+        manufacturer: "Manufacturer",
+        type: "Type",
+        cdscoStatus: "CDSCO status",
+        expiryDate: "Expiry date",
+        marketPrice: "Market price (MRP)",
+        janAushadhiPrice: "Jan Aushadhi price",
+        savings: "Savings vs MRP",
+    },
+    medicineTypes: {
+        brand: "brand",
+        generic: "generic",
+    },
+    status: {
+        approved: "Approved",
+        recalled: "Recalled",
+        banned: "Banned",
+    },
+};
 
 function hasValidMrp(m: Medicine | null | undefined): m is Medicine & { mrp: number } {
     return m != null && m.mrp != null && Number.isFinite(m.mrp) && m.mrp >= 0;
@@ -32,11 +92,11 @@ function displayName(m: Medicine): string {
     return m.brand_name?.trim() || m.generic_name;
 }
 
-function formatStatus(status: string, t: ReturnType<typeof useTranslations>): string {
+function formatStatus(status: string, labels: ComparisonGridLabels): string {
     const map: Record<string, string> = {
-        approved: t("status.approved"),
-        recalled: t("status.recalled"),
-        banned: t("status.banned"),
+        approved: labels.status.approved,
+        recalled: labels.status.recalled,
+        banned: labels.status.banned,
     };
     return map[status.toLowerCase()] ?? status;
 }
@@ -61,62 +121,62 @@ function formatPrice(value: number | null | undefined, unavailableText: string):
     return value != null ? `₹${value.toFixed(2)}` : unavailableText;
 }
 
-function getSavingsText(medicine: Medicine | null, t: ReturnType<typeof useTranslations>): string {
+function getSavingsText(medicine: Medicine | null, labels: ComparisonGridLabels): string {
     if (!medicine || !hasValidMrp(medicine) || !hasValidJanAushadhiPrice(medicine)) {
-        return t("priceUnavailable");
+        return labels.priceUnavailable;
     }
 
     if (medicine.mrp <= medicine.jan_aushadhi_price) {
-        return t("noSavings");
+        return labels.noSavings;
     }
 
     const amount = medicine.mrp - medicine.jan_aushadhi_price;
     const percent = computeSavingsPercent(medicine.mrp, medicine.jan_aushadhi_price);
-    return t("saveAmount", { amount: amount.toFixed(2), percent: percent.toFixed(1) });
+    return labels.saveAmount(amount.toFixed(2), percent.toFixed(1));
 }
 
 export default function ComparisonGrid({
     medicine1,
     medicine2,
+    labels = defaultLabels,
 }: {
     medicine1: Medicine | null;
     medicine2: Medicine | null;
+    labels?: ComparisonGridLabels;
 }) {
-    const t = useTranslations("Compare");
-
     if (!medicine1 && !medicine2) {
         return (
             <div className="rounded-xl border border-dashed border-slate-200 bg-white py-14 text-center text-slate-500">
-                {t("emptyComparison")}
+                {labels.emptyComparison}
             </div>
         );
     }
 
     const rows: { label: string; getValue: (m: Medicine) => string }[] = [
-        { label: t("rows.brandName"), getValue: (m) => m.brand_name?.trim() || "—" },
-        { label: t("rows.genericName"), getValue: (m) => m.generic_name },
-        { label: t("rows.composition"), getValue: (m) => m.composition?.trim() || "—" },
-        { label: t("rows.manufacturer"), getValue: (m) => m.manufacturer },
+        { label: labels.rows.brandName, getValue: (m) => m.brand_name?.trim() || "—" },
+        { label: labels.rows.genericName, getValue: (m) => m.generic_name },
+        { label: labels.rows.composition, getValue: (m) => m.composition?.trim() || "—" },
+        { label: labels.rows.manufacturer, getValue: (m) => m.manufacturer },
         {
-            label: t("rows.type"),
+            label: labels.rows.type,
             getValue: (m) =>
                 m.medicine_type ??
-                (m.brand_name?.trim() ? t("medicineTypes.brand") : t("medicineTypes.generic")),
+                (m.brand_name?.trim() ? labels.medicineTypes.brand : labels.medicineTypes.generic),
         },
         {
-            label: t("rows.cdscoStatus"),
-            getValue: (m) => formatStatus(m.cdsco_approval_status, t),
+            label: labels.rows.cdscoStatus,
+            getValue: (m) => formatStatus(m.cdsco_approval_status, labels),
         },
-        { label: t("rows.expiryDate"), getValue: (m) => formatExpiry(m.expiry_date) },
+        { label: labels.rows.expiryDate, getValue: (m) => formatExpiry(m.expiry_date) },
         {
-            label: t("rows.marketPrice"),
-            getValue: (m) => formatPrice(m.mrp, t("priceUnavailable")),
+            label: labels.rows.marketPrice,
+            getValue: (m) => formatPrice(m.mrp, labels.priceUnavailable),
         },
         {
-            label: t("rows.janAushadhiPrice"),
-            getValue: (m) => formatPrice(m.jan_aushadhi_price, t("priceUnavailable")),
+            label: labels.rows.janAushadhiPrice,
+            getValue: (m) => formatPrice(m.jan_aushadhi_price, labels.priceUnavailable),
         },
-        { label: t("rows.savings"), getValue: (m) => getSavingsText(m, t) },
+        { label: labels.rows.savings, getValue: (m) => getSavingsText(m, labels) },
     ];
 
     return (
@@ -125,13 +185,13 @@ export default function ComparisonGrid({
                 <thead>
                     <tr className="border-b border-slate-200 bg-slate-50">
                         <th className="w-1/4 px-5 py-3 text-left text-xs font-semibold tracking-wide text-slate-500 uppercase">
-                            {t("fieldHeader")}
+                            {labels.fieldHeader}
                         </th>
                         <th className="px-5 py-3 text-center text-sm font-semibold text-slate-800">
-                            {medicine1 ? displayName(medicine1) : t("medicineA")}
+                            {medicine1 ? displayName(medicine1) : labels.medicineA}
                         </th>
                         <th className="px-5 py-3 text-center text-sm font-semibold text-slate-800">
-                            {medicine2 ? displayName(medicine2) : t("medicineB")}
+                            {medicine2 ? displayName(medicine2) : labels.medicineB}
                         </th>
                     </tr>
                 </thead>

--- a/apps/web/src/components/ComparisonGrid.tsx
+++ b/apps/web/src/components/ComparisonGrid.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from "next-intl";
+
 export interface Medicine {
     id: string;
     brand_name: string | null;
@@ -30,11 +32,11 @@ function displayName(m: Medicine): string {
     return m.brand_name?.trim() || m.generic_name;
 }
 
-function formatStatus(status: string): string {
+function formatStatus(status: string, t: ReturnType<typeof useTranslations>): string {
     const map: Record<string, string> = {
-        approved: "Approved",
-        recalled: "Recalled",
-        banned: "Banned",
+        approved: t("status.approved"),
+        recalled: t("status.recalled"),
+        banned: t("status.banned"),
     };
     return map[status.toLowerCase()] ?? status;
 }
@@ -55,22 +57,22 @@ function computeSavingsPercent(higher: number, lower: number): number {
     return ((higher - lower) / higher) * 100;
 }
 
-function formatPrice(value: number | null | undefined): string {
-    return value != null ? `₹${value.toFixed(2)}` : "Price unavailable";
+function formatPrice(value: number | null | undefined, unavailableText: string): string {
+    return value != null ? `₹${value.toFixed(2)}` : unavailableText;
 }
 
-function getSavingsText(medicine: Medicine | null): string {
+function getSavingsText(medicine: Medicine | null, t: ReturnType<typeof useTranslations>): string {
     if (!medicine || !hasValidMrp(medicine) || !hasValidJanAushadhiPrice(medicine)) {
-        return "Price unavailable";
+        return t("priceUnavailable");
     }
 
     if (medicine.mrp <= medicine.jan_aushadhi_price) {
-        return "No savings";
+        return t("noSavings");
     }
 
     const amount = medicine.mrp - medicine.jan_aushadhi_price;
     const percent = computeSavingsPercent(medicine.mrp, medicine.jan_aushadhi_price);
-    return `Save ₹${amount.toFixed(2)} (${percent.toFixed(1)}%)`;
+    return t("saveAmount", { amount: amount.toFixed(2), percent: percent.toFixed(1) });
 }
 
 export default function ComparisonGrid({
@@ -80,34 +82,41 @@ export default function ComparisonGrid({
     medicine1: Medicine | null;
     medicine2: Medicine | null;
 }) {
+    const t = useTranslations("Compare");
+
     if (!medicine1 && !medicine2) {
         return (
             <div className="rounded-xl border border-dashed border-slate-200 bg-white py-14 text-center text-slate-500">
-                Select two medicines above to see the comparison.
+                {t("emptyComparison")}
             </div>
         );
     }
 
     const rows: { label: string; getValue: (m: Medicine) => string }[] = [
-        { label: "Brand name", getValue: (m) => m.brand_name?.trim() || "—" },
-        { label: "Generic name", getValue: (m) => m.generic_name },
-        { label: "Composition", getValue: (m) => m.composition?.trim() || "—" },
-        { label: "Manufacturer", getValue: (m) => m.manufacturer },
+        { label: t("rows.brandName"), getValue: (m) => m.brand_name?.trim() || "—" },
+        { label: t("rows.genericName"), getValue: (m) => m.generic_name },
+        { label: t("rows.composition"), getValue: (m) => m.composition?.trim() || "—" },
+        { label: t("rows.manufacturer"), getValue: (m) => m.manufacturer },
         {
-            label: "Type",
-            getValue: (m) => m.medicine_type ?? (m.brand_name?.trim() ? "Brand" : "Generic"),
+            label: t("rows.type"),
+            getValue: (m) =>
+                m.medicine_type ??
+                (m.brand_name?.trim() ? t("medicineTypes.brand") : t("medicineTypes.generic")),
         },
         {
-            label: "CDSCO status",
-            getValue: (m) => formatStatus(m.cdsco_approval_status),
+            label: t("rows.cdscoStatus"),
+            getValue: (m) => formatStatus(m.cdsco_approval_status, t),
         },
-        { label: "Expiry date", getValue: (m) => formatExpiry(m.expiry_date) },
-        { label: "Market price (MRP)", getValue: (m) => formatPrice(m.mrp) },
+        { label: t("rows.expiryDate"), getValue: (m) => formatExpiry(m.expiry_date) },
         {
-            label: "Jan Aushadhi price",
-            getValue: (m) => formatPrice(m.jan_aushadhi_price),
+            label: t("rows.marketPrice"),
+            getValue: (m) => formatPrice(m.mrp, t("priceUnavailable")),
         },
-        { label: "Savings vs MRP", getValue: (m) => getSavingsText(m) },
+        {
+            label: t("rows.janAushadhiPrice"),
+            getValue: (m) => formatPrice(m.jan_aushadhi_price, t("priceUnavailable")),
+        },
+        { label: t("rows.savings"), getValue: (m) => getSavingsText(m, t) },
     ];
 
     return (
@@ -116,13 +125,13 @@ export default function ComparisonGrid({
                 <thead>
                     <tr className="border-b border-slate-200 bg-slate-50">
                         <th className="w-1/4 px-5 py-3 text-left text-xs font-semibold tracking-wide text-slate-500 uppercase">
-                            Field
+                            {t("fieldHeader")}
                         </th>
                         <th className="px-5 py-3 text-center text-sm font-semibold text-slate-800">
-                            {medicine1 ? displayName(medicine1) : "Medicine A"}
+                            {medicine1 ? displayName(medicine1) : t("medicineA")}
                         </th>
                         <th className="px-5 py-3 text-center text-sm font-semibold text-slate-800">
-                            {medicine2 ? displayName(medicine2) : "Medicine B"}
+                            {medicine2 ? displayName(medicine2) : t("medicineB")}
                         </th>
                     </tr>
                 </thead>


### PR DESCRIPTION
## Summary
- localize the CDSCO alerts log page with a dedicated `Alerts` message namespace
- localize compare page labels and the comparison grid with a `Compare` namespace
- add matching fallback keys across all 14 locale bundles so next-intl lookups stay complete

Closes #1201

## Validation
- `node` locale parity check for Alerts/Compare keys across 14 bundles
- `npx tsc -p apps/web/tsconfig.json --noEmit`
- `npm test -w web -- --runTestsByPath tests/i18n-locales.test.tsx --runInBand`
- `npx prettier --check ...changed files...`
- `git diff --check`

## Note
- `npm run lint -w web` is blocked in this checkout because the workspace-level Next/TypeScript ESLint config resolves `eslint` from root `node_modules`, while `eslint` is installed under `apps/web/node_modules`. The failure happens before linting project files: `Cannot find module 'eslint'` from `node_modules/@typescript-eslint/utils/...`.