### PR TITLE
fix(db): sync push_subscriptions schema with migration

### DIFF
--- a/apps/api/src/db/schema.sql
+++ b/apps/api/src/db/schema.sql
@@ -159,6 +159,7 @@ CREATE TABLE IF NOT EXISTS push_subscriptions (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     endpoint TEXT NOT NULL UNIQUE,
     subscription JSONB NOT NULL,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );


### PR DESCRIPTION
Fixes #1203

## Changes
- Added missing user_id column to push_subscriptions table
- Added foreign key reference to auth.users(id)
- Synchronized schema.sql with migration state

This prevents schema drift for fresh installations and ensures push subscription inserts remain compatible with the latest migration.