### PR TITLE
feat(web): improve OfflineErrorBoundary with dev stack trace and bett…

### DIFF
--- a/apps/web/components/OfflineErrorBoundary.tsx
+++ b/apps/web/components/OfflineErrorBoundary.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { ReactNode } from "react";
-import { AlertTriangle, Wifi, Home } from "lucide-react";
+import { AlertTriangle, Wifi } from "lucide-react";
 
 interface OfflineErrorBoundaryProps {
     children: ReactNode;
@@ -11,6 +11,8 @@ interface OfflineErrorBoundaryState {
     hasError: boolean;
     isOfflineError: boolean;
     isChecking: boolean;
+    errorStack?: string;
+    componentStack?: string;
 }
 
 /**
@@ -27,6 +29,8 @@ export class OfflineErrorBoundary extends React.Component<
             hasError: false,
             isOfflineError: false,
             isChecking: false,
+            errorStack: "",
+            componentStack: "",
         };
     }
 
@@ -45,6 +49,19 @@ export class OfflineErrorBoundary extends React.Component<
 
     componentDidCatch(error: Error, info: React.ErrorInfo) {
         console.error("OfflineErrorBoundary caught error:", error, info);
+
+        if (process.env.NODE_ENV === "development") {
+            console.group("🔴 OfflineErrorBoundary Dev Trace");
+            console.error("Error:", error);
+            console.error("Stack:", error.stack);
+            console.error("Component Stack:", info.componentStack);
+            console.groupEnd();
+
+            this.setState({
+                errorStack: error.stack || "",
+                componentStack: info.componentStack || "",
+            });
+        }
     }
 
     handleRetry = () => {
@@ -67,51 +84,66 @@ export class OfflineErrorBoundary extends React.Component<
     render() {
         if (this.state.hasError) {
             return (
-                <div className="flex min-h-[400px] items-center justify-center p-4">
-                    <div className="max-w-md text-center">
-                        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/20">
-                            {this.state.isOfflineError ? (
-                                <Wifi size={32} className="text-amber-600 dark:text-amber-400" />
-                            ) : (
-                                <AlertTriangle
-                                    size={32}
-                                    className="text-red-600 dark:text-red-400"
-                                />
-                            )}
-                        </div>
+                <>
+                    <div className="flex min-h-[400px] items-center justify-center p-4">
+                        <div className="max-w-md rounded-2xl border border-slate-200 bg-white p-8 text-center shadow-lg dark:border-slate-700 dark:bg-slate-900">
+                            <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-amber-100 ring-4 ring-amber-50 dark:bg-amber-900/20 dark:ring-amber-900/10">
+                                {this.state.isOfflineError ? (
+                                    <Wifi size={32} className="text-amber-600 dark:text-amber-400" />
+                                ) : (
+                                    <AlertTriangle
+                                        size={32}
+                                        className="text-red-600 dark:text-red-400"
+                                    />
+                                )}
+                            </div>
 
-                        <h2 className="mb-2 text-lg font-bold text-slate-900 dark:text-white">
-                            {this.state.isOfflineError ? "Connection Lost" : "Something Went Wrong"}
-                        </h2>
+                            <h2 className="mb-2 text-lg font-bold text-slate-900 dark:text-white">
+                                {this.state.isOfflineError ? "Connection Lost" : "Something Went Wrong"}
+                            </h2>
 
-                        <p
-                            aria-live="polite"
-                            className="mb-6 text-sm text-slate-600 dark:text-slate-400"
-                        >
-                            {this.state.isOfflineError
-                                ? "Please check your internet connection and try again. Cached data may still be available."
-                                : "An unexpected error occurred. Please try again or go back."}
-                        </p>
-
-                        <div className="flex flex-col gap-3 sm:flex-row">
-                            <button
-                                type="button"
-                                onClick={this.handleRetry}
-                                disabled={this.state.isChecking}
-                                className="flex-1 rounded-lg bg-emerald-600 px-4 py-2 font-semibold text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+                            <p
+                                aria-live="polite"
+                                className="mb-6 text-sm text-slate-600 dark:text-slate-400"
                             >
-                                {this.state.isChecking ? "Checking..." : "Try Again"}
-                            </button>
+                                {this.state.isOfflineError
+                                    ? "Please check your internet connection and try again. Cached data may still be available."
+                                    : "An unexpected error occurred. Please try again or go back."}
+                            </p>
 
-                            <a
-                                href="/"
-                                className="flex-1 rounded-lg bg-slate-200 px-4 py-2 text-center font-semibold text-slate-900 transition-colors hover:bg-slate-300 dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600"
-                            >
-                                Go Home
-                            </a>
+                            <div className="flex flex-col gap-3 sm:flex-row">
+                                <button
+                                    type="button"
+                                    onClick={this.handleRetry}
+                                    disabled={this.state.isChecking}
+                                    className="flex-1 rounded-lg bg-emerald-600 px-4 py-2 font-semibold text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
+                                >
+                                    {this.state.isChecking ? "Checking..." : "Try Again"}
+                                </button>
+
+                                <a
+                                    href="/"
+                                    className="flex-1 rounded-lg bg-slate-200 px-4 py-2 text-center font-semibold text-slate-900 transition-colors hover:bg-slate-300 dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600"
+                                >
+                                    Go Home
+                                </a>
+                            </div>
                         </div>
                     </div>
-                </div>
+
+                    {process.env.NODE_ENV === "development" &&
+                        this.state.componentStack && (
+                            <details className="mt-6 text-left">
+                                <summary className="cursor-pointer text-sm font-semibold text-slate-700 dark:text-slate-300">
+                                    Developer Error Details
+                                </summary>
+
+                                <pre className="mt-2 max-h-40 overflow-auto rounded bg-slate-100 p-3 text-xs dark:bg-slate-800">
+                                    {this.state.componentStack}
+                                </pre>
+                            </details>
+                    )}
+                </>
             );
         }
 


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

* [x] I am officially assigned to the issue this PR fixes.

## 📋 PR Summary

Improved the `OfflineErrorBoundary` developer experience by adding development-only stack trace visibility and enhancing the fallback UI while preserving existing functionality and dark-mode support.

## 🔗 Related Issue

Closes #929

## 🏷️ PR Type

* [x] ✨ New Feature / Enhancement
* [x] 🎨 UI / UX Improvement

## 🗂️ Area Changed

* [x] `apps/web` — Next.js Frontend

## 📝 What Was Done

* Added development-only error diagnostics inside `componentDidCatch()`
* Logged error stack trace and React component stack when `NODE_ENV === "development"`
* Stored stack trace information in component state for debugging
* Improved fallback error card UI with:

  * Rounded card container
  * Border and shadow styling
  * Enhanced icon container with ring accent
  * Better spacing and visual hierarchy
* Preserved existing dark mode support
* Preserved existing offline detection and retry behavior
* Removed unused `Home` icon import
* Added collapsible "Developer Error Details" section visible only in development mode

## 📸 Screenshots / Proof of Work (REQUIRED)

Frontend UI updated successfully.

Attached:

* Screenshot of improved fallback UI
* Screenshot showing developer error details section in development mode

## ✅ Contributor Checklist

* [x] My PR has a linked issue (see above)
* [x] I have pulled the latest `main` and rebased/merged before opening this PR
* [x] My code follows the patterns and conventions in `docs/code-guide.md`
* [x] I ran the project locally and verified there are no compile/build errors
* [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
* [ ] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (not applicable)
* [x] I have performed a self-review of my own code

## 🎓 GSSoC 2026

* [x] I am a GSSoC 2026 participant
