### PR TITLE
[Critical] fix: replace mock analytics heatmap with real Supabase scan_history query

### DIFF
--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -1,29 +1,63 @@
-// @ts-ignore
-import { Router } from 'express';
+import { Router, Request, Response } from 'express';
 import { z } from 'zod';
+import { supabase } from '../db/client';
+import logger from '../utils/logger';
 
 const router = Router();
 const QuerySchema = z.object({
   days: z.coerce.number().min(1).default(30),
 });
 
-router.get('/heatmap', async (req, res) => {
+router.get('/heatmap', async (req: Request, res: Response) => {
   try {
     const { days } = QuerySchema.parse(req.query);
-    // Placeholder for actual DB data
-    const mockData = [{ lat: 21.25, lng: 81.63, created_at: new Date().toISOString() }];
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+    const { data: scans, error } = await supabase
+      .from('scan_history')
+      .select('latitude, longitude, created_at')
+      .not('latitude', 'is', null)
+      .not('longitude', 'is', null)
+      .gte('created_at', since);
+
+    if (error) {
+      logger.error({ message: 'Failed to fetch scan history for heatmap', error, days });
+      res.status(500).json({ error: 'Failed to fetch heatmap data' });
+      return;
+    }
+
+    const grouped = new Map<string, { lat: number; lng: number; intensity: number }>();
+    for (const scan of scans || []) {
+      const lat = Math.round(parseFloat(scan.latitude as string) * 100) / 100;
+      const lng = Math.round(parseFloat(scan.longitude as string) * 100) / 100;
+      const key = `${lat},${lng}`;
+      const entry = grouped.get(key) || { lat, lng, intensity: 0 };
+      entry.intensity++;
+      grouped.set(key, entry);
+    }
+
+    const features = Array.from(grouped.values()).map((point) => ({
+      type: 'Feature' as const,
+      geometry: {
+        type: 'Point' as const,
+        coordinates: [point.lng, point.lat],
+      },
+      properties: { intensity: point.intensity },
+    }));
 
     const geoJson = {
-      type: "FeatureCollection",
-      features: mockData.map(d => ({
-        type: "Feature",
-        geometry: { type: "Point", coordinates: [d.lng, d.lat] },
-        properties: { intensity: 1 }
-      }))
+      type: 'FeatureCollection',
+      features,
     };
+
     res.json(geoJson);
   } catch (e) {
-    res.status(400).json({ error: "Invalid query" });
+    if (e instanceof z.ZodError) {
+      res.status(400).json({ error: 'Invalid query parameters', details: e.errors });
+      return;
+    }
+    logger.error({ message: 'Unexpected error in analytics heatmap', error: e });
+    res.status(500).json({ error: 'Internal server error' });
   }
 });
 


### PR DESCRIPTION
## What issue does this fix?

Closes #1244 — The \GET /api/analytics/heatmap\ endpoint returned hardcoded mock GeoJSON data (single point in Raipur) regardless of the \days\ query parameter, making the analytics map feature non-functional.

## What caused it

The original handler at \pps/api/src/routes/analytics.ts:10-28\:
- Used \// @ts-ignore\ to suppress a TypeScript error instead of proper type imports
- Defined \mockData\ with a single hardcoded coordinate
- Never actually queried the database
- Had a bare \catch (e)\ that only returned 400 without logging errors

## What the fix does

1. Removes \// @ts-ignore\ and adds proper \Request\ / \Response\ type imports
2. Imports \supabase\ client and queries \scan_history\ for records with coordinates in the requested time window
3. Groups results by rounded lat/lng (2 decimal places) and computes \intensity\ as the count per cluster
4. Returns a proper GeoJSON FeatureCollection
5. Handles \ZodError\ validation errors with detailed messages
6. Uses the structured \logger\ for error reporting instead of bare \console.log\

## Additional context

The \scan_history\ table was chosen because it has plain numeric \latitude\ / \longitude\ columns (no PostGIS dependency) and records every medicine verification scan with location data. The grouping at 2-decimal precision (~1.1km at the equator) provides a natural heatmap clustering suitable for the frontend map view.

## Testing

- [ ] Verified the endpoint returns valid GeoJSON with proper FeatureCollection structure
- [ ] Verify error responses for invalid \days\ parameter (negative, zero, non-numeric)
- [ ] Verify graceful handling of empty results (no scans in range)
- [ ] Confirm structured logger captures DB errors