### PR TITLE
[Critical] fix: replace py_compile syntax check with real pytest run in ML CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,8 @@ jobs:
                   python -m pip install --upgrade pip
                   if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-            - name: 🔍 Check ML Syntax
+            - name: 🧪 Run ML Tests
               working-directory: ./apps/ml
-              run: python -m py_compile main.py
+              run: python -m pytest tests/ -v --timeout=60
+              env:
+                  WHISPER_MODEL_SIZE: base

--- a/apps/ml/requirements.txt
+++ b/apps/ml/requirements.txt
@@ -31,5 +31,9 @@ soundfile>=0.12.1
 noisereduce>=3.0.0
 numpy>=1.26.0
 
+# Testing
+pytest>=8.0
+pytest-timeout>=2.3.0
+
 # Load testing
 locust>=2.31.8


### PR DESCRIPTION
## What issue does this fix?

Closes #1245 — The ML service CI job (\.github/workflows/test.yml:35-55\) only ran \python -m py_compile main.py\ which checks syntax only, not runtime behavior. The ML service has 10+ existing pytest test files that were never executed in CI.

## What caused it

The \	est-ml-service\ job was configured to run \python -m py_compile main.py\ (line 55), a syntax-only check that cannot detect:
- Runtime import errors or missing dependencies
- Logic bugs in OCR matching, ASR transcription, or API endpoints
- Regressions introduced by code changes

## What the fix does

1. **\pps/ml/requirements.txt\**: Adds \pytest>=8.0\ and \pytest-timeout>=2.3.0\
2. **\.github/workflows/test.yml\**: Replaces the \py_compile\ step with \python -m pytest tests/ -v --timeout=60\
3. Sets \WHISPER_MODEL_SIZE: base\ environment variable so ASR tests don't download large Whisper models

## Additional context

The ML service is a critical path for medicine verification via OCR and ASR. The existing test files at \pps/ml/tests/\ cover API endpoints, ASR transcription, matcher logic, and telemetry — all of which were previously unverified in CI.

## Testing

- [ ] CI run should execute all existing pytest tests
- [ ] Verify tests with \@pytest.mark.skipif\ for missing audio fixtures are gracefully skipped
- [ ] Confirm \	est_matcher.py\ (standalone script) is not picked up by pytest discovery