### PR TITLE
[Critical] test: implement offline component tests for useOfflineStatus, OfflineBanner, OfflineErrorBoundary

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,8 @@
     },
     "devDependencies": {
         "@tailwindcss/postcss": "^4.3.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
         "@types/leaflet": "^1.9.21",
         "@types/node": "^25.9.1",

--- a/apps/web/tests/offline.test.ts
+++ b/apps/web/tests/offline.test.ts
@@ -1,10 +1,24 @@
 /**
+ * @jest-environment jsdom
+ */
+/**
  * Tests for offline support functionality
  * Run with: npm test apps/web -- offline.test.ts
  */
 
 import { join } from "path";
+import React, { act } from "react";
+import { renderHook, render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
 import { fetchWithRetry, offlineRequestQueue } from "@/lib/apiWithRetry";
+import { useOfflineStatus } from "@/hooks/useOfflineStatus";
+import { OfflineBanner } from "@/components/OfflineBanner";
+import { OfflineErrorBoundary } from "@/components/OfflineErrorBoundary";
+
+// Mock next-intl for OfflineBanner translations
+jest.mock("next-intl", () => ({
+    useTranslations: () => (key: string) => key,
+}));
 
 describe("Offline Support", () => {
     describe("fetchWithRetry", () => {
@@ -172,27 +186,219 @@ describe("Offline Support", () => {
     });
 
     describe("useOfflineStatus", () => {
-        // These would need to be tested with React Testing Library
-        // Tests for:
-        // 1. isOffline state updates on online/offline events
-        // 2. registerRetryCallback registration
-        // 3. Callback execution on reconnect
+        it("should initialize isOffline to false when navigator.onLine is true", () => {
+            const { result } = renderHook(() => useOfflineStatus());
+            expect(result.current.isOffline).toBe(false);
+        });
+
+        it("should set isOffline to true on offline event", () => {
+            const { result } = renderHook(() => useOfflineStatus());
+            act(() => {
+                window.dispatchEvent(new Event("offline"));
+            });
+            expect(result.current.isOffline).toBe(true);
+        });
+
+        it("should set isOffline to false on online event", () => {
+            const { result } = renderHook(() => useOfflineStatus());
+            act(() => {
+                window.dispatchEvent(new Event("offline"));
+            });
+            expect(result.current.isOffline).toBe(true);
+
+            act(() => {
+                window.dispatchEvent(new Event("online"));
+            });
+            expect(result.current.isOffline).toBe(false);
+        });
+
+        it("should register and execute retry callbacks on reconnect", () => {
+            const { result } = renderHook(() => useOfflineStatus());
+            const callback = jest.fn();
+
+            act(() => {
+                result.current.registerRetryCallback(callback);
+            });
+
+            // Go offline then online — callbacks should fire on reconnect
+            act(() => {
+                window.dispatchEvent(new Event("offline"));
+            });
+            act(() => {
+                window.dispatchEvent(new Event("online"));
+            });
+
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+
+        it("should clear retry callbacks after execution", () => {
+            const { result } = renderHook(() => useOfflineStatus());
+            const callback = jest.fn();
+
+            act(() => {
+                result.current.registerRetryCallback(callback);
+            });
+
+            act(() => {
+                window.dispatchEvent(new Event("offline"));
+            });
+            act(() => {
+                window.dispatchEvent(new Event("online"));
+            });
+
+            expect(callback).toHaveBeenCalledTimes(1);
+
+            // Go offline and back online again — callback should not fire again
+            act(() => {
+                window.dispatchEvent(new Event("offline"));
+            });
+            act(() => {
+                window.dispatchEvent(new Event("online"));
+            });
+
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe("OfflineBanner", () => {
-        // Tests using React Testing Library:
-        // 1. Renders when offline
-        // 2. Hides when online
-        // 3. Shows correct messages from i18n
-        // 4. Dismiss button works
+        it("should not render when online", () => {
+            render(<OfflineBanner />);
+            expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+        });
+
+        it("should render offline message when offline", () => {
+            render(<OfflineBanner />);
+            act(() => {
+                window.dispatchEvent(new Event("offline"));
+            });
+            expect(screen.getByRole("alert")).toBeInTheDocument();
+            expect(screen.getByText("bannerOffline")).toBeInTheDocument();
+        });
+
+        it("should show back-online message when reconnecting", () => {
+            jest.useFakeTimers();
+            render(<OfflineBanner />);
+
+            act(() => {
+                window.dispatchEvent(new Event("offline"));
+            });
+            expect(screen.getByText("bannerOffline")).toBeInTheDocument();
+
+            act(() => {
+                window.dispatchEvent(new Event("online"));
+            });
+            expect(screen.getByText("bannerOnline")).toBeInTheDocument();
+
+            act(() => {
+                jest.advanceTimersByTime(3000);
+            });
+            expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+            jest.useRealTimers();
+        });
+
+        it("should dismiss when dismiss button is clicked", () => {
+            render(<OfflineBanner />);
+            act(() => {
+                window.dispatchEvent(new Event("offline"));
+            });
+            expect(screen.getByRole("alert")).toBeInTheDocument();
+
+            fireEvent.click(screen.getByLabelText("dismiss"));
+            expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+        });
     });
 
     describe("OfflineErrorBoundary", () => {
-        // Tests using React Testing Library:
-        // 1. Catches errors
-        // 2. Displays fallback UI
-        // 3. Retry button works
-        // 4. Distinguishes network errors
+        beforeEach(() => {
+            jest.spyOn(console, "error").mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        function ThrowComponent({ message = "Something went wrong" }: { message?: string }) {
+            throw new Error(message);
+        }
+
+        it("should catch errors and display fallback UI", () => {
+            render(
+                <OfflineErrorBoundary>
+                    <ThrowComponent />
+                </OfflineErrorBoundary>
+            );
+            expect(screen.getByText("Something Went Wrong")).toBeInTheDocument();
+        });
+
+        it("should display Connection Lost message for network errors", () => {
+            function NetworkThrowComponent() {
+                throw new TypeError("Failed to fetch");
+            }
+
+            render(
+                <OfflineErrorBoundary>
+                    <NetworkThrowComponent />
+                </OfflineErrorBoundary>
+            );
+            expect(screen.getByText("Connection Lost")).toBeInTheDocument();
+        });
+
+        it("should display generic message for non-network errors", () => {
+            function NonNetworkThrowComponent() {
+                throw new Error("Random error");
+            }
+
+            render(
+                <OfflineErrorBoundary>
+                    <NonNetworkThrowComponent />
+                </OfflineErrorBoundary>
+            );
+            expect(screen.getByText("Something Went Wrong")).toBeInTheDocument();
+        });
+
+        it("should reset and render children when retry is clicked and error is resolved", () => {
+            let shouldThrow = true;
+
+            function ConditionalThrow() {
+                if (shouldThrow) {
+                    throw new Error("fetch failed");
+                }
+                return <div>Content loaded successfully</div>;
+            }
+
+            render(
+                <OfflineErrorBoundary>
+                    <ConditionalThrow />
+                </OfflineErrorBoundary>
+            );
+            expect(screen.getByText("Connection Lost")).toBeInTheDocument();
+
+            shouldThrow = false;
+
+            fireEvent.click(screen.getByText("Try Again"));
+            expect(screen.getByText("Content loaded successfully")).toBeInTheDocument();
+        });
+
+        it("should show checking state when retry is clicked while offline", () => {
+            jest.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+
+            function NetworkThrowComponent() {
+                throw new TypeError("Failed to fetch");
+            }
+
+            render(
+                <OfflineErrorBoundary>
+                    <NetworkThrowComponent />
+                </OfflineErrorBoundary>
+            );
+            expect(screen.getByText("Connection Lost")).toBeInTheDocument();
+
+            fireEvent.click(screen.getByText("Try Again"));
+            expect(screen.getByText("Checking...")).toBeInTheDocument();
+
+            jest.restoreAllMocks();
+        });
     });
 
     describe("Service Worker", () => {


### PR DESCRIPTION
## What issue does this fix?

Closes #1246 — Three \describe\ blocks in \pps/web/tests/offline.test.ts\ (lines 174-196) contained only comments listing what should be tested with zero actual test code.

## What caused it

The test stubs for \useOfflineStatus\, \OfflineBanner\, and \OfflineErrorBoundary\ were left as TODO placeholders during initial development. The comments documented the expected test cases but no \it()\ blocks were ever written.

## What the fix does

### Changes to \pps/web/tests/offline.test.ts\:
1. Added \@jest-environment jsdom\ to enable DOM APIs (window, navigator, events)
2. Added mocks for \
ext-intl\ (useTranslations) used by OfflineBanner
3. **\useOfflineStatus\ (5 tests)**: Initial online state detection, offline/online event handling, retry callback registration/execution, callback cleanup after reconnection
4. **\OfflineBanner\ (4 tests)**: Hidden when online, renders offline message, transitions to back-online message with auto-dismiss after 3s, manual dismiss button
5. **\OfflineErrorBoundary\ (5 tests)**: Error catching with fallback UI, network vs. generic error distinction, retry reset when error is resolved, checking state when retrying while offline

### Changes to \pps/web/package.json\:
- Added \@testing-library/react\ and \@testing-library/jest-dom\ as devDependencies

## Additional context

The existing test file had 272 lines with only test shells for the React components. After this change, the file now has 14 new real test cases covering all the scenarios documented in the original stubs. The \@jest-environment jsdom\ directive enables DOM-dependent testing without affecting other test files.

## Testing

- [ ] \
pm test\ from apps/web directory passes all existing + new tests
- [ ] Verify jest-environment-jsdom properly handles jsdom-specific behavior
- [ ] Confirm all 14 new tests provide meaningful coverage of the offline components