### PR TITLE
feat(web): integrate profile account session state

### DIFF
--- a/apps/web/app/[locale]/profile/page.tsx
+++ b/apps/web/app/[locale]/profile/page.tsx
@@ -1,9 +1,112 @@
 "use client";
 
-import { Link } from "@/i18n/routing";
-import { User, ShieldCheck, Bell, ChevronRight, ArrowLeft } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Link, useRouter } from "@/i18n/routing";
+import { User, ShieldCheck, Bell, ChevronRight, ArrowLeft, LogIn, LogOut } from "lucide-react";
+
+const ACCESS_TOKEN_KEY = "sb-access-token";
+
+type ProfileSession =
+    | { status: "checking" }
+    | { status: "guest" }
+    | {
+          status: "authenticated";
+          displayName: string;
+      };
+
+type AccessTokenPayload = {
+    email?: unknown;
+    sub?: unknown;
+    exp?: unknown;
+    user_metadata?: Record<string, unknown> | null;
+};
+
+function getString(value: unknown): string | null {
+    return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function decodeBase64Url(value: string): string {
+    const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+    const binary = window.atob(padded);
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+
+    return new TextDecoder().decode(bytes);
+}
+
+function readSessionFromToken(token: string | null): {
+    session: ProfileSession;
+    clearToken: boolean;
+} {
+    if (!token) {
+        return { session: { status: "guest" }, clearToken: false };
+    }
+
+    try {
+        const [, payloadPart] = token.split(".");
+
+        if (!payloadPart) {
+            return { session: { status: "guest" }, clearToken: true };
+        }
+
+        const payload = JSON.parse(decodeBase64Url(payloadPart)) as AccessTokenPayload;
+
+        if (typeof payload.exp === "number" && payload.exp * 1000 <= Date.now()) {
+            return { session: { status: "guest" }, clearToken: true };
+        }
+
+        const displayName =
+            getString(payload.user_metadata?.full_name) ??
+            getString(payload.user_metadata?.name) ??
+            getString(payload.email) ??
+            getString(payload.sub) ??
+            "Signed-in User";
+
+        return {
+            session: {
+                status: "authenticated",
+                displayName,
+            },
+            clearToken: false,
+        };
+    } catch {
+        return { session: { status: "guest" }, clearToken: true };
+    }
+}
 
 export default function ProfilePage() {
+    const router = useRouter();
+    const [session, setSession] = useState<ProfileSession>({ status: "checking" });
+
+    const accountTitle =
+        session.status === "authenticated"
+            ? session.displayName
+            : session.status === "checking"
+              ? "Checking account status"
+              : "Guest User";
+    const accountSubtitle =
+        session.status === "authenticated"
+            ? "Authenticated account"
+            : session.status === "checking"
+              ? "Reading your local session"
+              : "No account connected";
+
+    useEffect(() => {
+        const result = readSessionFromToken(localStorage.getItem(ACCESS_TOKEN_KEY));
+
+        if (result.clearToken) {
+            localStorage.removeItem(ACCESS_TOKEN_KEY);
+        }
+
+        setSession(result.session);
+    }, []);
+
+    const handleSignOut = () => {
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        setSession({ status: "guest" });
+        router.push("/");
+    };
+
     return (
         <div className="flex-grow bg-(--color-surface-muted) px-6 py-8 text-(--color-text-primary)">
             <div className="mx-auto max-w-3xl">
@@ -37,26 +140,61 @@ export default function ProfilePage() {
                 {/* Profile Card */}
                 <div className="overflow-hidden rounded-3xl border border-(--color-border-muted) bg-(--color-surface-page) shadow-sm">
                     {/* User Info */}
-                    <div className="flex items-center justify-between border-b border-(--color-border-muted) p-6">
-                        <div>
-                            <h2 className="font-bold text-(--color-text-primary)">Guest User</h2>
+                    <div className="flex flex-col gap-4 border-b border-(--color-border-muted) p-6 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="flex items-center gap-4">
+                            <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-(--color-surface-muted)">
+                                <ShieldCheck
+                                    className="text-emerald-600 dark:text-emerald-400"
+                                    size={24}
+                                />
+                            </div>
 
-                            <p className="mt-1 text-sm text-(--color-text-secondary)">
-                                No account connected
-                            </p>
+                            <div>
+                                <h2 className="font-bold break-all text-(--color-text-primary)">
+                                    {accountTitle}
+                                </h2>
+
+                                <p className="mt-1 text-sm text-(--color-text-secondary)">
+                                    {accountSubtitle}
+                                </p>
+                            </div>
                         </div>
 
-                        <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-(--color-surface-muted)">
-                            <ShieldCheck
-                                className="text-emerald-600 dark:text-emerald-400"
-                                size={24}
-                            />
-                        </div>
+                        {session.status === "guest" && (
+                            <Link
+                                href="/login"
+                                className="inline-flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:outline-none"
+                            >
+                                <LogIn size={18} />
+                                Sign In / Register
+                            </Link>
+                        )}
                     </div>
 
                     {/* Menu Items */}
                     <div className="divide-y divide-(--color-border-muted)">
-                        <button className="flex w-full items-center justify-between p-5 transition-colors hover:bg-(--color-surface-muted)">
+                        {session.status === "authenticated" && (
+                            <button
+                                type="button"
+                                onClick={handleSignOut}
+                                className="flex w-full items-center justify-between p-5 text-left transition-colors hover:bg-(--color-surface-muted)"
+                            >
+                                <div className="flex items-center gap-3">
+                                    <LogOut size={20} className="text-red-500" />
+
+                                    <span className="font-semibold text-(--color-text-primary)">
+                                        Sign Out
+                                    </span>
+                                </div>
+
+                                <ChevronRight size={18} className="text-(--color-text-muted)" />
+                            </button>
+                        )}
+
+                        <button
+                            type="button"
+                            className="flex w-full items-center justify-between p-5 transition-colors hover:bg-(--color-surface-muted)"
+                        >
                             <div className="flex items-center gap-3">
                                 <Bell size={20} className="text-red-500" />
 
@@ -68,7 +206,10 @@ export default function ProfilePage() {
                             <ChevronRight size={18} className="text-(--color-text-muted)" />
                         </button>
 
-                        <button className="flex w-full items-center justify-between p-5 transition-colors hover:bg-(--color-surface-muted)">
+                        <button
+                            type="button"
+                            className="flex w-full items-center justify-between p-5 transition-colors hover:bg-(--color-surface-muted)"
+                        >
                             <div className="flex items-center gap-3">
                                 <ShieldCheck
                                     size={20}

--- a/apps/web/tests/profile-auth-status.test.tsx
+++ b/apps/web/tests/profile-auth-status.test.tsx
@@ -1,0 +1,136 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { TextDecoder as NodeTextDecoder } from "util";
+
+import ProfilePage from "../app/[locale]/profile/page";
+
+const mockPush = jest.fn();
+
+jest.mock("@/i18n/routing", () => ({
+    Link: ({
+        children,
+        href,
+        ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
+    useRouter: () => ({
+        push: mockPush,
+    }),
+}));
+
+function createAccessToken(payload: Record<string, unknown>) {
+    const encode = (value: Record<string, unknown>) =>
+        Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+
+    return `${encode({ alg: "none", typ: "JWT" })}.${encode(payload)}.signature`;
+}
+
+describe("ProfilePage auth status", () => {
+    beforeEach(() => {
+        if (typeof globalThis.TextDecoder !== "function") {
+            Object.defineProperty(globalThis, "TextDecoder", {
+                configurable: true,
+                value: NodeTextDecoder,
+            });
+        }
+
+        if (typeof window.atob !== "function") {
+            Object.defineProperty(window, "atob", {
+                configurable: true,
+                value: (value: string) => Buffer.from(value, "base64").toString("binary"),
+            });
+        }
+
+        localStorage.clear();
+        mockPush.mockClear();
+    });
+
+    it("renders a guest card with a localized sign-in CTA when no access token exists", async () => {
+        expect(renderToStaticMarkup(<ProfilePage />)).toContain("Checking account status");
+
+        render(<ProfilePage />);
+
+        expect(await screen.findByText("Guest User")).toBeInTheDocument();
+        expect(screen.getByText("No account connected")).toBeInTheDocument();
+
+        const loginLink = screen.getByRole("link", { name: /sign in \/ register/i });
+        expect(loginLink).toHaveAttribute("href", "/login");
+        expect(screen.queryByRole("button", { name: /sign out/i })).not.toBeInTheDocument();
+    });
+
+    it("shows authenticated account details from a valid access token", async () => {
+        const token = createAccessToken({
+            email: "asha@example.com",
+            sub: "user-123",
+            exp: Math.floor(Date.now() / 1000) + 3600,
+            user_metadata: {
+                full_name: "Asha Sharma",
+            },
+        });
+
+        localStorage.setItem("sb-access-token", token);
+        render(<ProfilePage />);
+
+        expect(await screen.findByText("Asha Sharma")).toBeInTheDocument();
+        expect(screen.getByText("Authenticated account")).toBeInTheDocument();
+        expect(screen.queryByText("Guest User")).not.toBeInTheDocument();
+        expect(document.body).not.toHaveTextContent(token);
+    });
+
+    it("clears malformed access tokens instead of rendering them", async () => {
+        localStorage.setItem("sb-access-token", "not-a-valid-jwt");
+
+        render(<ProfilePage />);
+
+        expect(await screen.findByText("Guest User")).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /sign in \/ register/i })).toHaveAttribute(
+            "href",
+            "/login"
+        );
+        expect(localStorage.getItem("sb-access-token")).toBeNull();
+        expect(document.body).not.toHaveTextContent("not-a-valid-jwt");
+    });
+
+    it("treats an expired access token as a guest session", async () => {
+        localStorage.setItem(
+            "sb-access-token",
+            createAccessToken({
+                email: "expired@example.com",
+                exp: Math.floor(Date.now() / 1000) - 60,
+            })
+        );
+
+        render(<ProfilePage />);
+
+        expect(await screen.findByText("Guest User")).toBeInTheDocument();
+        expect(screen.getByText("No account connected")).toBeInTheDocument();
+        expect(localStorage.getItem("sb-access-token")).toBeNull();
+    });
+
+    it("signs out by clearing the local session and redirecting home", async () => {
+        localStorage.setItem(
+            "sb-access-token",
+            createAccessToken({
+                email: "asha@example.com",
+                exp: Math.floor(Date.now() / 1000) + 3600,
+            })
+        );
+
+        render(<ProfilePage />);
+
+        fireEvent.click(await screen.findByRole("button", { name: /sign out/i }));
+
+        expect(localStorage.getItem("sb-access-token")).toBeNull();
+        expect(mockPush).toHaveBeenCalledWith("/");
+
+        await waitFor(() => {
+            expect(screen.getByText("Guest User")).toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment Check

- [x] I am officially assigned to the issue this PR fixes.

## 📋 PR Summary

This makes the profile page reflect the local auth session used elsewhere in the app. It reads `sb-access-token` after mount, shows a short checking state while the client session is read, renders guest vs authenticated account status, and adds a sign-out action that clears the local token and redirects home.

---

## 🔗 Related Issue

Closes #1200

---

## 🏷️ PR Type

- [ ] 🐛 Bug Fix
- [x] ✨ New Feature / Enhancement
- [ ] 📖 Documentation
- [ ] 🌏 Translation (i18n)
- [x] 🎨 UI / UX Improvement
- [ ] ⚙️ DevOps / CI-CD
- [ ] 🤖 ML / AI Feature
- [ ] 🔒 Security Fix
- [x] ♻️ Refactor / Code Quality

---

## 🗂️ Area Changed

- [x] `apps/web` — Next.js Frontend
- [ ] `apps/api` — Node.js / Express Backend
- [ ] `apps/ml` — Python / FastAPI ML Service
- [ ] `data/` — Database seeds / migrations
- [ ] `docs/` — Documentation
- [ ] `.github/` — GitHub config, workflows
- [ ] Root config (package.json, etc.)

---

## 📝 What Was Done

- Read `sb-access-token` from `localStorage` after mount and decode safe JWT payload fields for display.
- Added checking, guest, malformed-token, expired-token, and authenticated account states.
- Added a localized `Sign In / Register` CTA through `@/i18n/routing` and a `Sign Out` action that removes the token and redirects home.
- Added focused Jest coverage for guest state, valid token display, malformed token cleanup, expired token cleanup, and sign-out behavior.

## 📸 Screenshots / Proof of Work (REQUIRED)

Browser proof captured in Codex Browser at 1280x720. These screenshots are hosted from a proof-only branch in my fork and are not part of this PR branch or PR diff.

**Guest profile**
![Guest profile](https://raw.githubusercontent.com/shashank03-dev/sahidawa-india/proof-issue-1200-profile-auth-images/proof/issue-1200/sahidawa-issue-1200-pr-guest-profile.png)

**Login destination**
![Login destination](https://raw.githubusercontent.com/shashank03-dev/sahidawa-india/proof-issue-1200-profile-auth-images/proof/issue-1200/sahidawa-issue-1200-pr-login-destination.png)

**Signed-out reports state**
![Signed-out reports state](https://raw.githubusercontent.com/shashank03-dev/sahidawa-india/proof-issue-1200-profile-auth-images/proof/issue-1200/sahidawa-issue-1200-pr-signed-out-reports.png)

Verification run from the rebased branch:

- `npm run test -w web -- profile-auth-status.test.tsx --runInBand` -> 5 passed
- `npx eslint app/[locale]/profile/page.tsx tests/profile-auth-status.test.tsx` -> passed
- `npx prettier --check app/[locale]/profile/page.tsx tests/profile-auth-status.test.tsx` -> passed
- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=local-anon-key npm run build -w web` -> passed

Known unrelated upstream failures still present on the final branch:

- `npm run lint -w web` fails in existing files outside this PR, including `vaccine-hub/page.test.tsx`, `proxy.ts`, `language-switcher-accessibility.test.tsx`, and `offline.test.ts`.
- `npm run test -w web -- --runInBand` has 31 suites passing and 152 tests passing, but fails before completion in existing `offline.test.ts` JSX parsing and `chat-route.test.ts` Gemini `Type` mock setup.
- Remote CI shows the same web test blockers while `tests/profile-auth-status.test.tsx` passes. The separate ML job also fails during collection in `apps/ml/tests/test_asr_duration.py` with `ValueError: faster_whisper.__spec__ is not set`; this PR does not touch `apps/ml`.

Strict self-review:

- Final PR diff is limited to `apps/web/app/[locale]/profile/page.tsx` and `apps/web/tests/profile-auth-status.test.tsx`.
- No screenshot/image proof files are included in this PR branch.
- The profile page never renders the raw access token and clears expired or malformed token values.

---

## ✅ Contributor Checklist

- [x] My PR has a linked issue (see above)
- [x] I have pulled the latest `main` and rebased/merged before opening this PR
- [x] My code follows the current app patterns and conventions. Note: `docs/code-guide.md` is referenced by the template but is not present in this checkout.
- [x] I ran the project locally and verified there are no compile/build errors
- [x] I have attached screenshots, screen recordings, or terminal logs as proof of testing (MANDATORY)
- [x] My backend responses return structured JSON `{ success: boolean, data?: any, error?: { message: string } }` (N/A: frontend-only PR)
- [x] I have performed a self-review of my own code

---

## 🎓 GSSoC 2026

- [x] I am a GSSoC 2026 participant
