### PR TITLE
fix: restrict sticky sidebar to desktop on expiry tracker mobile view (#1280)

### DIFF
--- a/apps/web/app/[locale]/expiry-tracker/page.tsx
+++ b/apps/web/app/[locale]/expiry-tracker/page.tsx
@@ -184,7 +184,7 @@ export default function ExpiryTrackerPage() {
             <main className="mx-auto max-w-6xl p-6 pt-32 md:pt-40">
                 <div className="mt-4 grid grid-cols-1 gap-8 md:grid-cols-3">
                     {/* Sidebar */}
-                    <div className="sticky top-32 h-fit rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) p-6 shadow-sm md:col-span-1">
+                    <div className="md:sticky md:top-32 h-fit rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) p-6 shadow-sm md:col-span-1">
                         <h2 className="mb-4 text-lg font-bold tracking-tight uppercase">
                             {t("addMedicine")}
                         </h2>


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #1280**
- **Summary:** On mobile viewports, the "Add Medicine" sidebar in the Expiry Tracker page was using `sticky top-32` unconditionally, causing it to overlap the Tracked Medicines section (search bar, filter chips, medicine cards) when scrolling. Fixed by scoping the sticky behavior to desktop only using `md:sticky md:top-32`, so on mobile the sidebar flows naturally above the list.

**File changed:** `apps/web/app/[locale]/expiry-tracker/page.tsx` — one className change.

## 📸 Proof of Work (Screenshots / Logs)
<img width="397" height="792" alt="image" src="https://github.com/user-attachments/assets/8e91e072-478d-4349-ab70-3ee86bc6f426" />
<img width="361" height="776" alt="img#1280" src="https://github.com/user-attachments/assets/4f1eee1e-fe88-4736-93b8-e7bf3cff4a42" />


## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #1280`)
- [x] I have pulled the latest `main` and resolved any conflicts