### PR TITLE
[Critical] fix(scan): replace silent catch blocks with logger.warn calls

### DIFF
--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -46,6 +46,7 @@ import {
 import { useOfflineStatus } from "@/hooks/useOfflineStatus";
 import { useTranslations } from "next-intl";
 import { buildVerificationShareText, type VerificationShareCopy } from "@/lib/verificationShare";
+import { structuredLog as logger } from "@/lib/structuredLogger";
 
 function formatExpiryForBadge(isoDate: string | null | undefined): string | undefined {
     if (!isoDate) return undefined;
@@ -831,8 +832,10 @@ export default function ScanPage() {
                     await handleVerify(barcodeText);
                     return;
                 }
-            } catch {
-                // ZXing failed — continue to OCR fallback
+            } catch (error) {
+                logger.warn("[scan] Barcode detection (ZXing) failed, falling back to OCR", {
+                    error: error instanceof Error ? error.message : String(error),
+                });
             }
 
             if (!isMountedRef.current || controller.signal.aborted) return;
@@ -904,8 +907,11 @@ export default function ScanPage() {
                     if (batchRes.verified) {
                         finalResult = batchRes;
                     }
-                } catch {
-                    // Silent fallback
+                } catch (error) {
+                    logger.warn("[scan] Batch verification failed, trying brand match", {
+                        batch: parsedBatchNum,
+                        error: error instanceof Error ? error.message : String(error),
+                    });
                 }
             }
 
@@ -927,8 +933,11 @@ export default function ScanPage() {
                             }
                         }
                     }
-                } catch {
-                    // Silent fallback
+                } catch (error) {
+                    logger.warn("[scan] Fuzzy brand match verification failed", {
+                        brand: medName,
+                        error: error instanceof Error ? error.message : String(error),
+                    });
                 }
             }
 


### PR DESCRIPTION
## Issue
scan/page.tsx contains 3 empty catch {} blocks at lines 834, 907-908, and 930 that silently swallow errors. When barcode detection, batch lookup, or fuzzy brand matching operations fail, the user receives no feedback and debugging becomes extremely difficult.

## Cause
The catch blocks were added as a quick way to implement fallback behavior without considering the debugging impact. When ZXing throws an unexpected error (not just 'no barcode found'), or when the batch verification API call fails with a network error, the error is completely invisible to both the user and the developer. If the @zxing/browser import itself fails (module not found, version mismatch), this silently falls through to OCR, which may also fail for a different reason — making root cause diagnosis nearly impossible.

Before (example at line 834):
\\\	ypescript
} catch {
    // ZXing failed — continue to OCR fallback
}
\\\

## Fix
Replaced empty catch blocks with descriptive logger.warn calls that preserve the fallback behavior while making failures visible. Each catch now logs the error message and relevant context (barcode/batch/brand) before continuing to the fallback.

After:
\\\	ypescript
} catch (error) {
    logger.warn('[scan] Barcode detection (ZXing) failed, falling back to OCR', {
        error: error instanceof Error ? error.message : String(error),
    });
}
\\\

Applied the same pattern to all 3 catch blocks:
- ZXing barcode detection failure → fallback to OCR
- Batch verification failure → fallback to fuzzy brand match  
- Fuzzy brand match failure → fallback continues gracefully

## Additional Context
The structuredLog utility (aliased as logger) is already available at apps/web/lib/structuredLogger.ts and used throughout the codebase. Using logger.warn() preserves the existing fallback behavior while making failures visible in development logs and production error tracking systems. The fix also includes structuredLog import since it was not previously imported in scan/page.tsx.

## Closes
Closes #1286