### PR TITLE
[Critical] fix(api): add res.ok check and csrfToken validation in getCsrfToken

### DIFF
--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -11,9 +11,15 @@ async function getCsrfToken(): Promise<string> {
     const res = await fetch(`${API_BASE}/api/csrf-token`, {
         credentials: "include",
     });
+    if (!res.ok) {
+        throw new Error(`Failed to fetch CSRF token: ${res.status} ${res.statusText}`);
+    }
     const data = await res.json();
+    if (!data.csrfToken) {
+        throw new Error("CSRF token not found in response body");
+    }
     csrfTokenCache = data.csrfToken;
-    return csrfTokenCache!;
+    return csrfTokenCache;
 }
 
 export type ReportPayload = {


### PR DESCRIPTION
## Issue
getCsrfToken in api.ts parses JSON from an HTTP response without first checking if the response was successful. If the CSRF token endpoint returns a 4xx/5xx error, the code attempts to parse error page HTML as JSON, which could throw or return undefined for data.csrfToken, leading to subtle authentication failures downstream.

## Cause
The code assumed all HTTP responses from the CSRF endpoint are successful. The bang operator on the return line would then return undefined, which propagates to any code that uses this token.

Before:
\\\	ypescript
const res = await fetch(\\/api/csrf-token\, { credentials: 'include' });
const data = await res.json();  // No check for res.ok!
csrfTokenCache = data.csrfToken;
return csrfTokenCache!;
\\\

## Fix
Added explicit error checking before parsing JSON: res.ok guard throws a descriptive error if the HTTP response is not OK, and a secondary guard validates data.csrfToken exists before caching it.

After:
\\\	ypescript
if (!res.ok) {
    throw new Error(\Failed to fetch CSRF token: \ \\);
}
const data = await res.json();
if (!data.csrfToken) {
    throw new Error('CSRF token not found in response body');
}
csrfTokenCache = data.csrfToken;
return csrfTokenCache;
\\\

## Additional Context
This follows the same error handling pattern used by other functions in the same file (e.g., apiFetch handles errors explicitly). Throwing on failure forces callers to handle the error rather than silently proceeding with undefined tokens. The fetch itself succeeds at the network layer; the error is at the HTTP response layer, which must be handled explicitly.

## Closes
Closes #1284