### PR TITLE
[Critical] fix(voice): replace unsafe 'as any' with safe keyof typeof keyMap accessor

### DIFF
--- a/apps/web/app/[locale]/voice/page.tsx
+++ b/apps/web/app/[locale]/voice/page.tsx
@@ -134,14 +134,15 @@ function getConfidenceValueLabel(
     confidence: ConfidenceMeta,
     t: ReturnType<typeof useTranslations>
 ) {
-    const keyMap: Record<ConfidenceMeta["id"], string> = {
+    const keyMap = {
         high: "confidence_values.high",
         medium: "confidence_values.medium",
         low: "confidence_values.low",
         unavailable: "confidence_values.unavailable",
-    };
+    } as const;
 
-    return t(keyMap[confidence.id] as any);
+    const key = keyMap[confidence.id as keyof typeof keyMap];
+    return t(key ?? "confidence_values.unavailable");
 }
 
 export default function VoiceTriagePage() {


### PR DESCRIPTION
## Issue
voice/page.tsx line 144 uses an unsafe 'as any' cast to index a translation keyMap: \eturn t(keyMap[confidence.id] as any)\. This bypasses TypeScript's type checking. If confidence.id is not a valid key in keyMap, the lookup returns undefined, and t(undefined) may return a wrong or empty translation string — making the confidence indicator display incorrectly with no type error to alert developers.

## Cause
confidence.id is typed as a general string rather than a union of specific literal values. TypeScript cannot verify at compile time that the key exists in keyMap. The 'as any' removes the safety net entirely, and if an unexpected id value appears (e.g., from an API response or a typo in the type definition), the code silently produces wrong output.

Before:
\\\	ypescript
const keyMap: Record<ConfidenceMeta['id'], string> = {
    high: 'confidence_values.high',
    medium: 'confidence_values.medium',
    low: 'confidence_values.low',
    unavailable: 'confidence_values.unavailable',
};
return t(keyMap[confidence.id] as any);
\\\

## Fix
Changed keyMap to a const object assertion (as const) to preserve literal types, then used a type-safe accessor: \keyMap[confidence.id as keyof typeof keyMap]\. The ?? operator provides a safe fallback to 'confidence_values.unavailable' if an unexpected id value is encountered.

After:
\\\	ypescript
const keyMap = {
    high: 'confidence_values.high',
    medium: 'confidence_values.medium',
    low: 'confidence_values.low',
    unavailable: 'confidence_values.unavailable',
} as const;
const key = keyMap[confidence.id as keyof typeof keyMap];
return t(key ?? 'confidence_values.unavailable');
\\\

## Additional Context
The fix demonstrates proper TypeScript patterns: using const assertions for literal types, keyof typeof for type-safe lookups, and optional chaining/fallbacks for unknown keys. The existing 'confidence_values.unavailable' translation key serves as a graceful fallback when an unexpected confidence level is encountered. This is a safe, non-breaking change that improves type safety without altering runtime behavior for valid inputs.

## Closes
Closes #1285