### PR TITLE
[Critical] fix(analytics): remove dead code - unused getToken() function (#1314)

### DIFF
--- a/apps/web/app/[locale]/admin/analytics/page.tsx
+++ b/apps/web/app/[locale]/admin/analytics/page.tsx
@@ -49,11 +49,6 @@ function formatNumber(n: number): string {
     return n.toLocaleString();
 }
 
-function getToken(): string {
-    if (globalThis.window === undefined) return "";
-    return localStorage.getItem("sb-access-token") ?? "";
-}
-
 export default function AnalyticsDashboard() {
     const t = useTranslations("AdminAnalytics");
     const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Issue
`apps/web/app/[locale]/admin/analytics/page.tsx` lines 52-55 defined a `getToken()` function that was never called anywhere in the file. This was dead code that served no purpose and cluttered the codebase.

## Cause
The `getToken()` function was likely introduced for a planned authentication check on the analytics dashboard but was never integrated into the component's logic. It reads the Supabase access token from localStorage but the analytics page fetches data directly from Supabase using the browser client (configured with session persistence), so this token check was unnecessary.

Before:
```
function getToken(): string {
    if (globalThis.window === undefined) return '';
    return localStorage.getItem('sb-access-token') ?? '';
}
```

The function was defined at module level but `fetchData()` uses `supabase.from(...)` directly without any token pre-check, making `getToken()` completely redundant.

## Fix
Deleted the `getToken()` function entirely (lines 52-55). If future work requires authentication checks on this page, the implementation should use Supabase's built-in session management (`supabase.auth.getSession()`) rather than directly reading the localStorage token.

After:
```
// getToken() removed — unused dead code
export default function AnalyticsDashboard() {
```

## Additional Context
This is a straightforward dead code removal. The analytics dashboard is an admin-only page. Authentication is handled by the Supabase client configured with session persistence — no manual token retrieval is needed. A search of the entire codebase confirmed no other code references `getToken()`.

## Closes
Closes #1314