### PR TITLE
[Critical] fix(api): add logging to geocodePincode silent catch block (#1315)

### DIFF
--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -137,7 +137,10 @@ export async function geocodePincode(
         const lng = parseFloat(arr[0].lon);
         if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
         return { latitude: lat, longitude: lng };
-    } catch {
+    } catch (error) {
+        if (typeof window !== "undefined") {
+            console.warn(`[api] Geocoding pincode ${pincode} failed: ${error instanceof Error ? error.message : String(error)}`);
+        }
         return null;
     }
 }


### PR DESCRIPTION
## Issue
`apps/web/lib/api.ts` lines 140-142 defined a `geocodePincode()` function that caught all errors and returned `null` with zero logging. When geocoding failed — whether due to network timeout, DNS failure, malformed pincode, or Nominatim rate limiting — callers received `null` silently, making it extremely difficult to diagnose failures in production.

## Cause
The catch block was designed for graceful degradation (if geocoding fails, the report can still be submitted without coordinates). However, swallowing the error entirely removed all observability. Operators could not distinguish between "user has poor connectivity", "Nominatim is rate limiting us", or "user entered an invalid pincode".

Before:
```
} catch {
    return null;
}
```

## Fix
Added a parameter to the catch and descriptive logging before returning null:

After:
```
} catch (error) {
    if (typeof window !== 'undefined') {
        console.warn(`[api] Geocoding pincode ${pincode} failed: ${error instanceof Error ? error.message : String(error)}`);
    }
    return null;
}
```

## Additional Context
- `geocodePincode` is called from `submitReport()` to optionally enrich reports with GPS coordinates
- The Nominatim usage policy requires max 1 request/second and recommends identifying the application
- The function already had a 4-second timeout via `AbortSignal.timeout(4000)` at line 123
- This is a low-risk observability fix — the `return null` fallback behavior is unchanged, only logging is added

## Closes
Closes #1315