### PR TITLE
test(api): cover analytics heatmap route

### DIFF
--- a/apps/api/tests/analytics.test.ts
+++ b/apps/api/tests/analytics.test.ts
@@ -1,0 +1,178 @@
+import request from "supertest";
+import app from "../src/app";
+
+jest.mock("../src/db/client", () => ({
+    supabase: {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        not: jest.fn().mockReturnThis(),
+        gte: jest.fn(),
+    },
+}));
+
+import { supabase } from "../src/db/client";
+
+type MockScan = {
+    latitude: string;
+    longitude: string;
+    created_at: string;
+};
+
+type HeatmapSupabaseMock = {
+    from: jest.Mock;
+    select: jest.Mock;
+    not: jest.Mock;
+    gte: jest.Mock;
+};
+
+const mockedSupabase = supabase as unknown as HeatmapSupabaseMock;
+
+function mockHeatmapRows(rows: MockScan[]) {
+    mockedSupabase.gte.mockResolvedValueOnce({
+        data: rows,
+        error: null,
+    });
+}
+
+describe("GET /api/analytics/heatmap", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("returns a GeoJSON FeatureCollection with Point features", async () => {
+        mockHeatmapRows([
+            {
+                latitude: "28.6139",
+                longitude: "77.2090",
+                created_at: "2026-06-05T10:00:00.000Z",
+            },
+        ]);
+
+        const response = await request(app).get("/api/analytics/heatmap");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toMatchObject({
+            type: "FeatureCollection",
+            features: [
+                {
+                    type: "Feature",
+                    geometry: {
+                        type: "Point",
+                        coordinates: [77.21, 28.61],
+                    },
+                    properties: {
+                        intensity: 1,
+                    },
+                },
+            ],
+        });
+    });
+
+    it("rounds nearby coordinates to two decimals and groups their intensity", async () => {
+        mockHeatmapRows([
+            {
+                latitude: "28.1234567",
+                longitude: "77.9876543",
+                created_at: "2026-06-05T10:00:00.000Z",
+            },
+            {
+                latitude: "28.1241111",
+                longitude: "77.9859999",
+                created_at: "2026-06-05T10:05:00.000Z",
+            },
+        ]);
+
+        const response = await request(app).get("/api/analytics/heatmap?days=7");
+
+        expect(response.status).toBe(200);
+        expect(response.body.features).toEqual([
+            {
+                type: "Feature",
+                geometry: {
+                    type: "Point",
+                    coordinates: [77.99, 28.12],
+                },
+                properties: {
+                    intensity: 2,
+                },
+            },
+        ]);
+    });
+
+    it("returns an empty FeatureCollection when no incidents have coordinates", async () => {
+        mockHeatmapRows([]);
+
+        const response = await request(app).get("/api/analytics/heatmap");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual({
+            type: "FeatureCollection",
+            features: [],
+        });
+    });
+
+    it("transforms multiple coordinate groups into multiple GeoJSON features", async () => {
+        mockHeatmapRows([
+            {
+                latitude: "19.0760",
+                longitude: "72.8777",
+                created_at: "2026-06-05T10:00:00.000Z",
+            },
+            {
+                latitude: "12.9716",
+                longitude: "77.5946",
+                created_at: "2026-06-05T11:00:00.000Z",
+            },
+            {
+                latitude: "12.9730",
+                longitude: "77.5920",
+                created_at: "2026-06-05T12:00:00.000Z",
+            },
+        ]);
+
+        const response = await request(app).get("/api/analytics/heatmap");
+
+        expect(response.status).toBe(200);
+        expect(response.body.features).toHaveLength(2);
+        expect(response.body.features).toEqual([
+            {
+                type: "Feature",
+                geometry: {
+                    type: "Point",
+                    coordinates: [72.88, 19.08],
+                },
+                properties: {
+                    intensity: 1,
+                },
+            },
+            {
+                type: "Feature",
+                geometry: {
+                    type: "Point",
+                    coordinates: [77.59, 12.97],
+                },
+                properties: {
+                    intensity: 2,
+                },
+            },
+        ]);
+    });
+
+    it("queries recent scan coordinates and excludes null latitude or longitude values", async () => {
+        jest.spyOn(Date, "now").mockReturnValue(new Date("2026-06-05T12:00:00.000Z").getTime());
+        mockHeatmapRows([]);
+
+        const response = await request(app).get("/api/analytics/heatmap?days=3");
+
+        expect(response.status).toBe(200);
+        expect(mockedSupabase.from).toHaveBeenCalledWith("scan_history");
+        expect(mockedSupabase.select).toHaveBeenCalledWith("latitude, longitude, created_at");
+        expect(mockedSupabase.not).toHaveBeenCalledWith("latitude", "is", null);
+        expect(mockedSupabase.not).toHaveBeenCalledWith("longitude", "is", null);
+        expect(mockedSupabase.gte).toHaveBeenCalledWith("created_at", "2026-06-02T12:00:00.000Z");
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1306**
- **Summary:** Added focused Jest coverage for the Analytics Heatmap route so the GeoJSON output is protected against regressions. The tests mock the Supabase scan history query and cover the response shape, coordinate rounding/grouping, empty results, multiple coordinate groups, and the query filters used by the route.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

No screenshot is attached because this PR only adds backend API route tests. I verified it with these commands:

```bash
npm test -w sahidawa-api -- analytics.test.ts --detectOpenHandles
```

Result: `1 passed` test suite, `5 passed` tests.

```bash
npm run build -w sahidawa-api
```

Result: TypeScript build completed successfully.

```bash
npm test -w sahidawa-api
```

Result: `11 passed` test suites, `85 passed` tests.

Note: the full API suite still prints the existing Jest worker teardown warning after completion. The focused analytics test was also run with `--detectOpenHandles` and passed cleanly.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1306`)
- [x] I have pulled the latest `main` and resolved any conflicts
