### PR TITLE
fix(web): replace useEffectEvent with useCallback in voice page(Closes #1332)

### DIFF
--- a/apps/web/app/[locale]/voice/page.tsx
+++ b/apps/web/app/[locale]/voice/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useEffectEvent, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Mic } from "lucide-react";
 import { useRouter, useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -363,11 +363,11 @@ export default function VoiceTriagePage() {
         return () => window.clearTimeout(focusTimer);
     }, [error, result, step, t]);
 
-    const handleEscapeShortcut = useEffectEvent((event: KeyboardEvent) => {
+    const handleEscapeShortcut = useCallback((event: KeyboardEvent) => {
         if (event.key !== "Escape") {
             return;
         }
-
+        
         const activeElement =
             typeof document !== "undefined" ? (document.activeElement as HTMLElement | null) : null;
         const activeWithinVoiceRegion = Boolean(
@@ -401,7 +401,7 @@ export default function VoiceTriagePage() {
             event.preventDefault();
             resetFlow();
         }
-    });
+    }, [isSpeaking, step, handleStopSpeaking, stopListening, resetFlow]);
 
     useEffect(() => {
         if (typeof window === "undefined") {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1332**
- **Summary:**

Fixes a runtime crash on the voice page caused by importing `useEffectEvent`, a hook that was removed before React 19 stable release.

## 📸 Proof of Work (Screenshots / Logs)

<img width="1908" height="964" alt="image" src="https://github.com/user-attachments/assets/cb575321-f000-4568-8b99-9046e7479181" />


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
