### PR TITLE
Implement Frontend Unit Tests for Expiry Tracker and Profile Pages

### DIFF
--- a/apps/web/tests/expiry-tracker.test.tsx
+++ b/apps/web/tests/expiry-tracker.test.tsx
@@ -1,0 +1,83 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+
+import ExpiryTrackerPage from "../app/[locale]/expiry-tracker/page";
+
+jest.mock("next-intl", () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("../app/[locale]/components/PageHeader", () => ({
+    PageHeader: ({ title, subtitle }: { title?: string; subtitle?: string }) => (
+        <header>
+            <a href="/">Back</a>
+            <h1>{title}</h1>
+            <p>{subtitle}</p>
+        </header>
+    ),
+}));
+
+const STORAGE_KEY = "sahidawa_expiry_tracker";
+
+describe("ExpiryTrackerPage", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it("renders the add-medicine form with name, expiry and batch inputs", () => {
+        const { container } = render(<ExpiryTrackerPage />);
+
+        expect(screen.getByPlaceholderText("namePlaceholder")).toBeInTheDocument();
+        expect(container.querySelector('input[type="date"]')).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("batchPlaceholder")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "addToTracker" })).toBeInTheDocument();
+    });
+
+    it("adds a submitted medicine to the tracked list and persists it to localStorage", async () => {
+        const { container } = render(<ExpiryTrackerPage />);
+
+        fireEvent.change(screen.getByPlaceholderText("namePlaceholder"), {
+            target: { value: "Paracetamol" },
+        });
+        fireEvent.change(container.querySelector('input[type="date"]')!, {
+            target: { value: "2027-01-15" },
+        });
+        fireEvent.change(screen.getByPlaceholderText("batchPlaceholder"), {
+            target: { value: "BATCH-001" },
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "addToTracker" }));
+
+        expect(await screen.findByRole("heading", { name: "Paracetamol" })).toBeInTheDocument();
+
+        const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]");
+        expect(stored).toHaveLength(1);
+        expect(stored[0]).toMatchObject({
+            name: "Paracetamol",
+            expiryDate: "2027-01-15",
+            batchNumber: "BATCH-001",
+        });
+    });
+
+    it("removes a medicine from the list and localStorage when its delete button is clicked", async () => {
+        localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify([
+                { id: "1", name: "Amoxicillin", expiryDate: "2027-05-20", batchNumber: "AMX-9" },
+            ])
+        );
+
+        render(<ExpiryTrackerPage />);
+
+        const heading = await screen.findByRole("heading", { name: "Amoxicillin" });
+        const card = heading.closest("div.rounded-2xl") as HTMLElement;
+        fireEvent.click(within(card).getByRole("button"));
+
+        await waitFor(() => {
+            expect(screen.queryByRole("heading", { name: "Amoxicillin" })).not.toBeInTheDocument();
+        });
+        expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null")).toEqual([]);
+    });
+});

--- a/apps/web/tests/profile-page.test.tsx
+++ b/apps/web/tests/profile-page.test.tsx
@@ -1,0 +1,30 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import ProfilePage from "../app/[locale]/profile/page";
+
+describe("ProfilePage navigation and guest state", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it("renders a back-to-home link pointing at the localized home route", () => {
+        render(<ProfilePage />);
+
+        const backLink = screen.getByRole("link", { name: /back to home/i });
+        expect(backLink).toHaveAttribute("href", "/");
+    });
+
+    it("renders guest information on initial load when no session token exists", async () => {
+        render(<ProfilePage />);
+
+        expect(await screen.findByText("Guest User")).toBeInTheDocument();
+        expect(screen.getByText("No account connected")).toBeInTheDocument();
+
+        const signInLink = screen.getByRole("link", { name: /sign in \/ register/i });
+        expect(signInLink).toHaveAttribute("href", "/login");
+        expect(screen.queryByRole("button", { name: /sign out/i })).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Add unit tests for Expiry Tracker and Profile pages
What & why
SahiDawa had unit tests for the home page, FAQ, and language switcher, but no test coverage for two client pages:

Medicine Expiry Tracker (apps/web/app/[locale]/expiry-tracker/page.tsx)
Profile (apps/web/app/[locale]/profile/page.tsx)
This PR adds focused unit tests for both, so future GSSoC contributions can't silently break their local-state management or navigation logic.

Closes #1209

Changes
Two new test files, written to match the existing Jest + React Testing Library conventions in apps/web/tests/ (jsdom docblock, next-intl / @/i18n/routing mocks, mocked PageHeader):

apps/web/tests/expiry-tracker.test.tsx

Renders the add-medicine form with the Name, Expiry (type="date"), and Batch inputs plus the submit button.
Submitting the form adds the medicine to the tracked list and persists it under the sahidawa_expiry_tracker localStorage key.
Clicking a tracked medicine's delete button removes it from both the list and localStorage.
apps/web/tests/profile-page.test.tsx

The "Back to Home" navigation link renders with href="/".
Guest info renders on initial load when no session token exists (Guest User, No account connected, a Sign In / Register link to /login, and no Sign Out button).
Notes
The issue referenced a "Back to Home Page" link; the page's actual link text is "Back to Home", so the test asserts the real text/attribute rather than changing the component.
The existing profile-auth-status.test.tsx already covers token decoding and auth/sign-out flows, so this new file deliberately focuses on the navigation-link and guest-state aspects called out in the issue without duplicating that coverage.
No source/component files were modified — this is purely additive test coverage.
Testing
cd apps/web && npm test
New files: 5 tests, all passing.
