### PR TITLE
feat(api): add pgvector medicine RAG + symptom→pharmacy triage endpoints

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -48,6 +48,7 @@ import scanRouter from "./routes/scan";
 import alertsRouter from "./routes/alerts";
 import lasaRouter from "./routes/lasa";
 import mlRouter from "./routes/ml";
+import triageRouter from "./routes/triage";
 import { supabase } from "./db/client";
 import { createCorsOptions } from "./config/cors";
 import { errorHandler } from "./middleware/errorHandler";
@@ -202,6 +203,7 @@ app.use("/api/v1/scan", scanRouter);
 app.use("/api/v1/lasa", lasaRouter);
 app.use("/api/v1/alerts", alertsRouter);
 app.use("/api/ml", mlRouter);
+app.use("/api/triage", triageRouter);
 app.use("/api/map", mapRouter);
 
 // ── Swagger UI Documentation (/api/docs) ──────────────────────────────────

--- a/apps/api/src/routes/triage.ts
+++ b/apps/api/src/routes/triage.ts
@@ -1,0 +1,224 @@
+import { Router, Request, Response, NextFunction } from "express";
+import supabase from "../db/supabase";
+import logger from "../utils/logger";
+import {
+    assessUrgency,
+    medicineQuerySchema,
+    recommendSchema,
+    retrieveRelevantMedicines,
+    MEDICINE_RAG_DISCLAIMER,
+    type MedicineMatch,
+} from "../services/medicineRag.service";
+
+const router = Router();
+
+/** Maximum number of pharmacies returned alongside a recommendation. */
+const MAX_PHARMACY_RESULTS = 5;
+
+/** Pharmacy row as returned by the get_nearest_pharmacies RPC. */
+interface PharmacyRpcResult {
+    name: string;
+    address: string;
+    district: string | null;
+    state: string | null;
+    phone_number: string | null;
+    is_verified: boolean;
+    lat: number;
+    lng: number;
+    distance: number;
+}
+
+/** Formatted pharmacy object returned in triage responses. */
+interface FormattedPharmacy {
+    name: string;
+    address: string;
+    lat: number;
+    lng: number;
+    distance: string;
+    phone_number: string | null;
+    is_verified: boolean;
+    district: string | null;
+    state: string | null;
+}
+
+function formatPharmacy(p: PharmacyRpcResult): FormattedPharmacy {
+    return {
+        name: p.name || "Unknown Pharmacy",
+        address: p.address || "Unknown Address",
+        lat: p.lat,
+        lng: p.lng,
+        distance: `${Number(p.distance).toFixed(1)} km`,
+        phone_number: p.phone_number || null,
+        is_verified: p.is_verified ?? false,
+        district: p.district || null,
+        state: p.state || null,
+    };
+}
+
+/**
+ * Returns the nearest verified Jan Aushadhi pharmacies to a coordinate using
+ * the existing PostGIS RPC. Resolves to an empty array on any error so the
+ * recommendation can still return its medicine suggestions.
+ */
+async function findNearestPharmacies(
+    lat: number,
+    lng: number,
+    radius: number
+): Promise<FormattedPharmacy[]> {
+    const { data, error } = await supabase.rpc("get_nearest_pharmacies", {
+        query_lat: lat,
+        query_lng: lng,
+        search_radius_km: radius,
+    });
+
+    if (error || !Array.isArray(data)) {
+        logger.warn("get_nearest_pharmacies RPC unavailable for triage recommendation", {
+            error: error?.message,
+        });
+        return [];
+    }
+
+    return (data as PharmacyRpcResult[]).map(formatPharmacy).slice(0, MAX_PHARMACY_RESULTS);
+}
+
+/**
+ * @openapi
+ * /api/triage/medicine-query:
+ *   post:
+ *     summary: Answer a medicine-related question via RAG
+ *     description: >
+ *       Retrieves the medicines most relevant to a free-text query using a
+ *       pgvector semantic search over drug monographs, with a pg_trgm fuzzy
+ *       fallback. Intended for voice/chat queries such as "fever and body ache".
+ *     tags:
+ *       - Triage
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [query]
+ *             properties:
+ *               query:
+ *                 type: string
+ *                 example: "paracetamol for fever"
+ *               limit:
+ *                 type: integer
+ *                 minimum: 1
+ *                 maximum: 20
+ *                 default: 5
+ *     responses:
+ *       200:
+ *         description: Relevant medicines and a safety disclaimer
+ *       400:
+ *         description: Invalid request body
+ *       500:
+ *         description: Server or database error
+ */
+router.post("/medicine-query", async (req: Request, res: Response, next: NextFunction) => {
+    const parsed = medicineQuerySchema.safeParse(req.body);
+    if (!parsed.success) {
+        res.status(400).json({
+            error: "Invalid medicine query",
+            details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+    }
+
+    try {
+        const { query, limit } = parsed.data;
+        const medicines = await retrieveRelevantMedicines(query, limit);
+
+        res.json({
+            query,
+            medicines,
+            disclaimer: MEDICINE_RAG_DISCLAIMER,
+        });
+    } catch (err) {
+        next(err);
+    }
+});
+
+/**
+ * @openapi
+ * /api/triage/recommend:
+ *   post:
+ *     summary: Recommend medicines and nearby pharmacies for symptoms
+ *     description: >
+ *       Classifies urgency from the symptom description, retrieves relevant
+ *       medicines from the monograph RAG index, and — when coordinates are
+ *       supplied — returns the nearest Jan Aushadhi pharmacies that dispense
+ *       generic medicines. If urgent-care keywords are detected the response
+ *       advises seeking immediate medical attention.
+ *     tags:
+ *       - Triage
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [symptoms]
+ *             properties:
+ *               symptoms:
+ *                 type: string
+ *                 example: "fever and headache since morning"
+ *               lat:
+ *                 type: number
+ *                 example: 28.6304
+ *               lng:
+ *                 type: number
+ *                 example: 77.2177
+ *               radius:
+ *                 type: number
+ *                 default: 50
+ *               limit:
+ *                 type: integer
+ *                 default: 5
+ *     responses:
+ *       200:
+ *         description: Urgency flag, recommended medicines, and nearby pharmacies
+ *       400:
+ *         description: Invalid request body
+ *       500:
+ *         description: Server or database error
+ */
+router.post("/recommend", async (req: Request, res: Response, next: NextFunction) => {
+    const parsed = recommendSchema.safeParse(req.body);
+    if (!parsed.success) {
+        res.status(400).json({
+            error: "Invalid recommendation request",
+            details: parsed.error.flatten().fieldErrors,
+        });
+        return;
+    }
+
+    try {
+        const { symptoms, lat, lng, radius, limit } = parsed.data;
+
+        const urgency = assessUrgency(symptoms);
+        const medicines: MedicineMatch[] = await retrieveRelevantMedicines(symptoms, limit);
+
+        const pharmacies =
+            lat !== undefined && lng !== undefined
+                ? await findNearestPharmacies(lat, lng, radius)
+                : [];
+
+        res.json({
+            symptoms,
+            emergency: urgency.emergency,
+            urgentKeywords: urgency.matched,
+            medicines,
+            pharmacies,
+            disclaimer: urgency.emergency
+                ? "These symptoms may need urgent medical attention. Please contact a doctor or emergency services immediately. " +
+                  MEDICINE_RAG_DISCLAIMER
+                : MEDICINE_RAG_DISCLAIMER,
+        });
+    } catch (err) {
+        next(err);
+    }
+});
+
+export default router;

--- a/apps/api/src/services/medicineRag.service.ts
+++ b/apps/api/src/services/medicineRag.service.ts
@@ -1,0 +1,289 @@
+import { z } from "zod";
+import supabase from "../db/supabase";
+import logger from "../utils/logger";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** Dimensionality of Google's text-embedding-004 model (matches the DB column). */
+const EMBEDDING_DIMENSIONS = 768;
+
+/** Google Generative Language embedding endpoint (REST — no SDK dependency). */
+const EMBEDDING_MODEL = "text-embedding-004";
+const EMBEDDING_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/${EMBEDDING_MODEL}:embedContent`;
+const EMBEDDING_TIMEOUT_MS = 6000;
+
+/** Default number of medicines returned by a retrieval call. */
+export const DEFAULT_MATCH_COUNT = 5;
+
+/**
+ * Standard safety reminder appended to every triage response. Mirrors the
+ * disclaimer used by the voice-triage chat route so the wording stays consistent
+ * across the app.
+ */
+export const MEDICINE_RAG_DISCLAIMER =
+    "This guidance is for informational use only and is not a diagnosis or a prescription. " +
+    "Consult a doctor or pharmacist before taking any medicine, especially for severe or persistent symptoms.";
+
+/**
+ * Symptom keywords that indicate the user should seek urgent care rather than
+ * self-medicate. Kept intentionally small and language-light; the voice flow
+ * already runs richer multilingual emergency detection on the client.
+ */
+const EMERGENCY_KEYWORDS = [
+    "chest pain",
+    "heart attack",
+    "stroke",
+    "unconscious",
+    "not breathing",
+    "difficulty breathing",
+    "shortness of breath",
+    "severe bleeding",
+    "suicide",
+    "seizure",
+    "paralysis",
+    "fainting",
+    "high fever",
+];
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** Raw medicine row as returned by the retrieval RPCs / table fallback. */
+export interface MedicineRow {
+    id: string;
+    brand_name: string | null;
+    generic_name: string;
+    manufacturer: string | null;
+    composition: string | null;
+    strength: string | null;
+    dosage_form: string | null;
+    schedule: string | null;
+    mrp: number | string | null;
+    jan_aushadhi_price: number | string | null;
+    similarity?: number | null;
+}
+
+/** Formatted medicine returned in API responses. */
+export interface MedicineMatch {
+    id: string;
+    brand_name: string | null;
+    generic_name: string;
+    manufacturer: string | null;
+    composition: string | null;
+    strength: string | null;
+    dosage_form: string | null;
+    schedule: string | null;
+    mrp: number | null;
+    jan_aushadhi_price: number | null;
+    monograph: string;
+    similarity: number | null;
+}
+
+/** Result of the lightweight urgency classification step. */
+export interface UrgencyAssessment {
+    emergency: boolean;
+    matched: string[];
+}
+
+// ── Zod request schemas ──────────────────────────────────────────────────────
+
+export const medicineQuerySchema = z.object({
+    query: z.string().trim().min(2).max(500),
+    limit: z.coerce.number().int().min(1).max(20).default(DEFAULT_MATCH_COUNT),
+});
+
+export const recommendSchema = z.object({
+    symptoms: z.string().trim().min(2).max(500),
+    lat: z.coerce.number().min(-90).max(90).optional(),
+    lng: z.coerce.number().min(-180).max(180).optional(),
+    radius: z.coerce.number().min(1).max(200).default(50),
+    limit: z.coerce.number().int().min(1).max(20).default(DEFAULT_MATCH_COUNT),
+});
+
+// ── Pure helpers ─────────────────────────────────────────────────────────────
+
+function toNumberOrNull(value: number | string | null | undefined): number | null {
+    if (value === null || value === undefined) return null;
+    const parsed = typeof value === "number" ? value : Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Builds the human-readable monograph text for a medicine. This is the text
+ * that an embedding/indexing job would encode, and it is also returned to the
+ * client so the retrieval result is self-explanatory.
+ */
+export function buildMedicineMonograph(row: MedicineRow): string {
+    const parts: string[] = [];
+
+    const name = row.brand_name?.trim()
+        ? `${row.brand_name.trim()} (${row.generic_name.trim()})`
+        : row.generic_name.trim();
+    parts.push(name);
+
+    if (row.strength?.trim()) parts.push(`Strength: ${row.strength.trim()}`);
+    if (row.dosage_form?.trim()) parts.push(`Form: ${row.dosage_form.trim()}`);
+    if (row.composition?.trim()) parts.push(`Composition: ${row.composition.trim()}`);
+    if (row.manufacturer?.trim()) parts.push(`Manufacturer: ${row.manufacturer.trim()}`);
+    if (row.schedule?.trim()) parts.push(`Schedule: ${row.schedule.trim()}`);
+
+    return parts.join(". ");
+}
+
+/** Formats a raw medicine row into the API response shape. */
+export function formatMedicineMatch(row: MedicineRow): MedicineMatch {
+    return {
+        id: row.id,
+        brand_name: row.brand_name ?? null,
+        generic_name: row.generic_name,
+        manufacturer: row.manufacturer ?? null,
+        composition: row.composition ?? null,
+        strength: row.strength ?? null,
+        dosage_form: row.dosage_form ?? null,
+        schedule: row.schedule ?? null,
+        mrp: toNumberOrNull(row.mrp),
+        jan_aushadhi_price: toNumberOrNull(row.jan_aushadhi_price),
+        monograph: buildMedicineMonograph(row),
+        similarity:
+            typeof row.similarity === "number" && Number.isFinite(row.similarity)
+                ? row.similarity
+                : null,
+    };
+}
+
+/**
+ * Flags whether a free-text symptom description contains urgent-care keywords.
+ * When emergency is true, callers should advise the user to seek immediate
+ * medical attention instead of self-medicating.
+ */
+export function assessUrgency(text: string): UrgencyAssessment {
+    const normalized = text.toLowerCase();
+    const matched = EMERGENCY_KEYWORDS.filter((keyword) => normalized.includes(keyword));
+    return { emergency: matched.length > 0, matched };
+}
+
+// ── Query embedding (optional) ───────────────────────────────────────────────
+
+/**
+ * Embeds a query string with Google's text-embedding-004 model via REST.
+ * Returns null when GEMINI_API_KEY is unset or the request fails, so callers
+ * can fall back to text retrieval. Never throws.
+ */
+export async function embedQuery(text: string): Promise<number[] | null> {
+    const apiKey = process.env.GEMINI_API_KEY?.trim();
+    if (!apiKey) {
+        return null;
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), EMBEDDING_TIMEOUT_MS);
+
+    try {
+        const response = await fetch(`${EMBEDDING_ENDPOINT}?key=${encodeURIComponent(apiKey)}`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                model: `models/${EMBEDDING_MODEL}`,
+                content: { parts: [{ text }] },
+            }),
+            signal: controller.signal,
+        });
+
+        if (!response.ok) {
+            logger.warn("Medicine embedding request failed", { status: response.status });
+            return null;
+        }
+
+        const body = (await response.json().catch(() => null)) as {
+            embedding?: { values?: unknown };
+        } | null;
+        const values = body?.embedding?.values;
+
+        if (
+            Array.isArray(values) &&
+            values.length === EMBEDDING_DIMENSIONS &&
+            values.every((value) => typeof value === "number")
+        ) {
+            return values as number[];
+        }
+
+        logger.warn("Medicine embedding response had unexpected shape");
+        return null;
+    } catch (error) {
+        logger.warn("Medicine embedding request errored", {
+            error: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+// ── Retrieval ────────────────────────────────────────────────────────────────
+
+/**
+ * Retrieves the medicines most relevant to a free-text query, using a tiered
+ * strategy that degrades gracefully:
+ *
+ *   1. pgvector semantic search (match_medicines) when the query can be embedded.
+ *   2. pg_trgm fuzzy search (search_medicines_text) RPC.
+ *   3. In-memory ILIKE filter over the medicines table.
+ *
+ * This mirrors the "RPC primary, JS fallback" pattern used by the pharmacy
+ * search route. Always resolves to an array (never throws).
+ */
+export async function retrieveRelevantMedicines(
+    query: string,
+    limit: number = DEFAULT_MATCH_COUNT
+): Promise<MedicineMatch[]> {
+    // Tier 1 — semantic vector search.
+    const embedding = await embedQuery(query);
+    if (embedding) {
+        const { data, error } = await supabase.rpc("match_medicines", {
+            query_embedding: embedding,
+            match_count: limit,
+        });
+
+        if (!error && Array.isArray(data) && data.length > 0) {
+            return (data as MedicineRow[]).map(formatMedicineMatch);
+        }
+
+        if (error) {
+            logger.warn("match_medicines RPC failed, falling back to text search", {
+                error: error.message,
+            });
+        }
+    }
+
+    // Tier 2 — trigram fuzzy search RPC.
+    const { data: trgmData, error: trgmError } = await supabase.rpc("search_medicines_text", {
+        query_text: query,
+        match_count: limit,
+    });
+
+    if (!trgmError && Array.isArray(trgmData)) {
+        return (trgmData as MedicineRow[]).map(formatMedicineMatch);
+    }
+
+    logger.warn("search_medicines_text RPC unavailable, falling back to ILIKE query", {
+        error: trgmError?.message,
+    });
+
+    // Tier 3 — in-memory ILIKE filter over the table.
+    const pattern = `%${query}%`;
+    const { data: tableData, error: tableError } = await supabase
+        .from("medicines")
+        .select(
+            "id, brand_name, generic_name, manufacturer, composition, strength, dosage_form, schedule, mrp, jan_aushadhi_price"
+        )
+        .or(
+            `generic_name.ilike.${pattern},brand_name.ilike.${pattern},composition.ilike.${pattern}`
+        )
+        .limit(limit);
+
+    if (tableError) {
+        logger.error("Medicine retrieval fallback query failed", { error: tableError.message });
+        return [];
+    }
+
+    return ((tableData ?? []) as MedicineRow[]).map(formatMedicineMatch);
+}

--- a/apps/api/tests/triage.test.ts
+++ b/apps/api/tests/triage.test.ts
@@ -1,0 +1,198 @@
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || "http://localhost:54321";
+process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "test-anon-key";
+// Force the text-search retrieval path: with no API key, embedQuery() returns
+// null so the deterministic pg_trgm fallback is exercised instead of network.
+delete process.env.GEMINI_API_KEY;
+
+(global as any).WebSocket = (global as any).WebSocket || class {};
+
+jest.mock("../src/db/client", () => ({
+    supabase: {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        rpc: jest.fn(),
+    },
+}));
+
+jest.mock("../src/db/supabase", () => ({
+    __esModule: true,
+    default: {
+        rpc: jest.fn(),
+        from: jest.fn(),
+    },
+}));
+
+import request from "supertest";
+import app from "../src/app";
+import supabase from "../src/db/supabase";
+import {
+    assessUrgency,
+    buildMedicineMonograph,
+    embedQuery,
+    formatMedicineMatch,
+    retrieveRelevantMedicines,
+    type MedicineRow,
+} from "../src/services/medicineRag.service";
+
+const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
+
+const sampleRow: MedicineRow = {
+    id: "med-1",
+    brand_name: "Dolo 650",
+    generic_name: "Paracetamol 650mg",
+    manufacturer: "Micro Labs Ltd",
+    composition: "Paracetamol IP 650mg",
+    strength: "650mg",
+    dosage_form: "Tablet",
+    schedule: null,
+    mrp: "30.00",
+    jan_aushadhi_price: "12.50",
+    similarity: 0.91,
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+// ── Pure helpers ─────────────────────────────────────────────────────────────
+
+describe("medicineRag pure helpers", () => {
+    it("builds a readable monograph that includes brand, generic, and composition", () => {
+        const monograph = buildMedicineMonograph(sampleRow);
+        expect(monograph).toContain("Dolo 650");
+        expect(monograph).toContain("Paracetamol 650mg");
+        expect(monograph).toContain("Composition: Paracetamol IP 650mg");
+    });
+
+    it("falls back to the generic name when no brand name is present", () => {
+        const monograph = buildMedicineMonograph({ ...sampleRow, brand_name: null });
+        expect(monograph.startsWith("Paracetamol 650mg")).toBe(true);
+    });
+
+    it("coerces numeric string prices to numbers when formatting a match", () => {
+        const match = formatMedicineMatch(sampleRow);
+        expect(match.mrp).toBe(30);
+        expect(match.jan_aushadhi_price).toBe(12.5);
+        expect(match.similarity).toBe(0.91);
+    });
+
+    it("flags urgent-care keywords", () => {
+        expect(assessUrgency("I have severe chest pain").emergency).toBe(true);
+        expect(assessUrgency("mild headache and runny nose").emergency).toBe(false);
+    });
+
+    it("returns null from embedQuery when no API key is configured", async () => {
+        await expect(embedQuery("fever")).resolves.toBeNull();
+    });
+});
+
+// ── Tiered retrieval ─────────────────────────────────────────────────────────
+
+describe("retrieveRelevantMedicines", () => {
+    it("uses the pg_trgm RPC when embeddings are unavailable", async () => {
+        (mockedSupabase.rpc as jest.Mock).mockResolvedValueOnce({
+            data: [sampleRow],
+            error: null,
+        });
+
+        const matches = await retrieveRelevantMedicines("paracetamol", 5);
+
+        expect(mockedSupabase.rpc).toHaveBeenCalledWith("search_medicines_text", {
+            query_text: "paracetamol",
+            match_count: 5,
+        });
+        expect(matches).toHaveLength(1);
+        expect(matches[0].generic_name).toBe("Paracetamol 650mg");
+    });
+
+    it("falls back to an ILIKE table query when the RPC is unavailable", async () => {
+        (mockedSupabase.rpc as jest.Mock).mockResolvedValueOnce({
+            data: null,
+            error: { message: "function does not exist" },
+        });
+
+        const limit = jest.fn().mockResolvedValueOnce({ data: [sampleRow], error: null });
+        const or = jest.fn().mockReturnValue({ limit });
+        const select = jest.fn().mockReturnValue({ or });
+        (mockedSupabase.from as jest.Mock).mockReturnValue({ select });
+
+        const matches = await retrieveRelevantMedicines("paracetamol", 5);
+
+        expect(mockedSupabase.from).toHaveBeenCalledWith("medicines");
+        expect(matches).toHaveLength(1);
+        expect(matches[0].brand_name).toBe("Dolo 650");
+    });
+});
+
+// ── Routes ───────────────────────────────────────────────────────────────────
+
+describe("POST /api/triage/medicine-query", () => {
+    it("returns 400 when the query is missing", async () => {
+        const response = await request(app).post("/api/triage/medicine-query").send({});
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe("Invalid medicine query");
+    });
+
+    it("returns relevant medicines and a disclaimer", async () => {
+        (mockedSupabase.rpc as jest.Mock).mockResolvedValueOnce({
+            data: [sampleRow],
+            error: null,
+        });
+
+        const response = await request(app)
+            .post("/api/triage/medicine-query")
+            .send({ query: "fever medicine" });
+
+        expect(response.status).toBe(200);
+        expect(response.body.medicines).toHaveLength(1);
+        expect(response.body.medicines[0].generic_name).toBe("Paracetamol 650mg");
+        expect(typeof response.body.disclaimer).toBe("string");
+    });
+});
+
+describe("POST /api/triage/recommend", () => {
+    it("returns 400 when symptoms are missing", async () => {
+        const response = await request(app)
+            .post("/api/triage/recommend")
+            .send({ lat: 28, lng: 77 });
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe("Invalid recommendation request");
+    });
+
+    it("returns medicines and nearby pharmacies, flagging urgency", async () => {
+        (mockedSupabase.rpc as jest.Mock).mockImplementation((fn: string) => {
+            if (fn === "search_medicines_text") {
+                return Promise.resolve({ data: [sampleRow], error: null });
+            }
+            if (fn === "get_nearest_pharmacies") {
+                return Promise.resolve({
+                    data: [
+                        {
+                            name: "PMBJAK - AIIMS",
+                            address: "Ansari Nagar, New Delhi",
+                            district: "South Delhi",
+                            state: "Delhi",
+                            phone_number: "011-26588500",
+                            is_verified: true,
+                            lat: 28.5672,
+                            lng: 77.2088,
+                            distance: 2.3,
+                        },
+                    ],
+                    error: null,
+                });
+            }
+            return Promise.resolve({ data: null, error: { message: "unknown rpc" } });
+        });
+
+        const response = await request(app)
+            .post("/api/triage/recommend")
+            .send({ symptoms: "severe chest pain since morning", lat: 28.63, lng: 77.21 });
+
+        expect(response.status).toBe(200);
+        expect(response.body.emergency).toBe(true);
+        expect(response.body.medicines).toHaveLength(1);
+        expect(response.body.pharmacies).toHaveLength(1);
+        expect(response.body.pharmacies[0].distance).toBe("2.3 km");
+    });
+});

--- a/supabase/migrations/20260606000000_add_medicine_rag.sql
+++ b/supabase/migrations/20260606000000_add_medicine_rag.sql
@@ -1,0 +1,127 @@
+-- =============================================================================
+-- SahiDawa — pgvector RAG support for medicine monographs
+-- =============================================================================
+-- Adds an embedding column + ivfflat index to the medicines table and two
+-- SECURITY DEFINER retrieval functions used by the voice triage RAG pipeline:
+--
+--   1. match_medicines        — semantic search over monograph embeddings
+--                               (primary retrieval path).
+--   2. search_medicines_text  — pg_trgm fuzzy fallback over generic/brand
+--                               name + composition, used whenever embeddings
+--                               are unavailable or the query cannot be embedded.
+--
+-- Both functions are SECURITY DEFINER so they can be called via the anon key,
+-- matching the pattern established by get_nearest_pharmacies and
+-- find_lasa_conflicts.
+--
+-- NOTE: embeddings are populated out-of-band (ETL / backfill). Rows without an
+-- embedding are simply skipped by match_medicines, so the trgm fallback keeps
+-- retrieval working before any embeddings exist.
+-- =============================================================================
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- 768-dimensional vectors match Google's text-embedding-004 output.
+ALTER TABLE medicines ADD COLUMN IF NOT EXISTS embedding vector(768);
+
+-- ivfflat index for cosine-distance nearest-neighbour search.
+CREATE INDEX IF NOT EXISTS idx_medicines_embedding
+  ON medicines USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. match_medicines
+--    Returns medicines whose monograph embedding is most similar to the query
+--    embedding, ranked by cosine similarity and filtered by a threshold.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION match_medicines(
+  query_embedding vector(768),
+  match_count INTEGER DEFAULT 5,
+  similarity_threshold DOUBLE PRECISION DEFAULT 0.2
+)
+RETURNS TABLE (
+  id                 UUID,
+  brand_name         VARCHAR(255),
+  generic_name       VARCHAR(500),
+  manufacturer       VARCHAR(255),
+  composition        TEXT,
+  strength           VARCHAR(100),
+  dosage_form        VARCHAR(100),
+  schedule           VARCHAR(50),
+  mrp                NUMERIC(10, 2),
+  jan_aushadhi_price NUMERIC(10, 2),
+  similarity         DOUBLE PRECISION
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    m.id,
+    m.brand_name,
+    m.generic_name,
+    m.manufacturer,
+    m.composition,
+    m.strength,
+    m.dosage_form,
+    m.schedule,
+    m.mrp,
+    m.jan_aushadhi_price,
+    (1 - (m.embedding <=> query_embedding))::double precision AS similarity
+  FROM public.medicines m
+  WHERE m.embedding IS NOT NULL
+    AND (1 - (m.embedding <=> query_embedding)) >= similarity_threshold
+  ORDER BY m.embedding <=> query_embedding ASC
+  LIMIT GREATEST(match_count, 1);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. search_medicines_text
+--    pg_trgm fuzzy fallback. Leverages the existing GIN trgm indexes on
+--    generic_name and brand_name. Returns the best trigram similarity across
+--    generic name, brand name, and composition.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION search_medicines_text(
+  query_text TEXT,
+  match_count INTEGER DEFAULT 5
+)
+RETURNS TABLE (
+  id                 UUID,
+  brand_name         VARCHAR(255),
+  generic_name       VARCHAR(500),
+  manufacturer       VARCHAR(255),
+  composition        TEXT,
+  strength           VARCHAR(100),
+  dosage_form        VARCHAR(100),
+  schedule           VARCHAR(50),
+  mrp                NUMERIC(10, 2),
+  jan_aushadhi_price NUMERIC(10, 2),
+  similarity         DOUBLE PRECISION
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    m.id,
+    m.brand_name,
+    m.generic_name,
+    m.manufacturer,
+    m.composition,
+    m.strength,
+    m.dosage_form,
+    m.schedule,
+    m.mrp,
+    m.jan_aushadhi_price,
+    GREATEST(
+      similarity(COALESCE(m.generic_name, ''), query_text),
+      similarity(COALESCE(m.brand_name, ''), query_text),
+      similarity(COALESCE(m.composition, ''), query_text)
+    )::double precision AS similarity
+  FROM public.medicines m
+  WHERE m.generic_name ILIKE '%' || query_text || '%'
+     OR m.brand_name ILIKE '%' || query_text || '%'
+     OR m.composition ILIKE '%' || query_text || '%'
+     OR similarity(COALESCE(m.generic_name, ''), query_text) > 0.2
+     OR similarity(COALESCE(m.brand_name, ''), query_text) > 0.2
+  ORDER BY similarity DESC
+  LIMIT GREATEST(match_count, 1);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #1308
- **Summary:**

Completes the two remaining backend pieces of the end-to-end voice health
assistant. The voice pipeline (Whisper ASR + `noisereduce`, Gemini intent
classification, frontend UI, low-confidence fallback) already shipped; this PR
adds the parts that were still missing:

1. **RAG over drug monographs via pgvector** — a 768-dim `embedding` column +
   ivfflat cosine index on `medicines`, plus a `match_medicines()` semantic
   search RPC with a `search_medicines_text()` pg_trgm fallback.
2. **Symptom → nearest-pharmacy flow** — `POST /api/triage/recommend` classifies
   urgency, retrieves relevant generics from the RAG index, and returns the
   nearest Jan Aushadhi pharmacies via the existing `get_nearest_pharmacies` RPC.

All work lives in `apps/api` (the issue's designated area) and reuses the
established "RPC-primary, JS-fallback" pattern from the pharmacy route.

**New endpoints**
- `POST /api/triage/medicine-query` — RAG answer for a medicine-related query.
- `POST /api/triage/recommend` — `{ symptoms, lat?, lng? }` → urgency flag +
  relevant medicines + nearby pharmacies + safety disclaimer.

**Retrieval degrades gracefully** (vector → pg_trgm RPC → ILIKE), so it keeps
working before any embeddings are backfilled or when `GEMINI_API_KEY` is unset.

**Out of scope (intentionally, to keep the diff minimal):**
- No changes to the already-wired voice `page.tsx` UI.
- Embedding **backfill** is left to the ETL pipeline (the migration documents
  this); rows without an embedding are skipped by `match_medicines`.
- No new dependencies (query embedding uses the Google `text-embedding-004`
  REST API via `fetch`); no env changes (`GEMINI_API_KEY` already documented).

> Note: `pharmacies` has no stock table — these are Jan Aushadhi generic stores,
> so "nearest pharmacy with relevant stock" is implemented as nearest store +
> the relevant generic, rather than inventing a stock schema.

**Files changed**
- `supabase/migrations/20260606000000_add_medicine_rag.sql` *(new)* — embedding column, ivfflat index, `match_medicines` + `search_medicines_text` RPCs.
- `apps/api/src/services/medicineRag.service.ts` *(new)* — monograph builder, query embedding, tiered retrieval, urgency classification, zod schemas.
- `apps/api/src/routes/triage.ts` *(new)* — the two `/api/triage` endpoints.
- `apps/api/src/app.ts` *(+2 lines)* — mount `/api/triage`.
- `apps/api/tests/triage.test.ts` *(new)* — 11 tests.


