### PR TITLE
feat(web): add print and PDF export support for medicine comparison

### DIFF
--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -69,14 +69,21 @@ export default function ComparePage() {
 
     return (
         <div className="min-h-screen bg-(--color-surface-muted) text-(--color-text-primary)">
-            <PageHeader
-                title={t("pageTitle")}
-                subtitle={t("pageSubtitle")}
-                backHref="/"
-                variant="light"
-            />
+            <div className="print:hidden">
+                <PageHeader
+                    title={t("pageTitle")}
+                    subtitle={t("pageSubtitle")}
+                    backHref="/"
+                    variant="light"
+                />
+            </div>
+            <div className="mb-6 hidden text-center print:block">
+                <h1 className="text-2xl font-bold">SahiDawa Medicine Comparison Report</h1>
+
+                <p className="text-sm">Generated on {new Date().toLocaleDateString()}</p>
+            </div>
             <main className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
-                <section className="rounded-xl border border-(--color-border-muted) bg-(--color-surface-page) p-5 transition-all duration-300 hover:border-emerald-500/20 hover:shadow-md">
+                <section className="rounded-xl border border-(--color-border-muted) bg-(--color-surface-page) p-5 transition-all duration-300 hover:border-emerald-500/20 hover:shadow-md print:hidden">
                     <div className="grid gap-4 sm:grid-cols-2">
                         <MedicineSearchSelect
                             label={t("firstMedicine")}
@@ -94,12 +101,23 @@ export default function ComparePage() {
                         />
                     </div>
                 </section>
+                {medicine1 && medicine2 && (
+                    <div className="flex justify-end">
+                        <button
+                            type="button"
+                            onClick={() => window.print()}
+                            className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 print:hidden"
+                        >
+                            Print / Export PDF
+                        </button>
+                    </div>
+                )}
                 <ComparisonGrid
                     medicine1={medicine1}
                     medicine2={medicine2}
                     labels={comparisonLabels}
                 />
-                <p className="text-center text-sm text-(--color-text-secondary)">
+                <p className="text-center text-sm text-(--color-text-secondary) print:hidden">
                     <Link
                         href="/map"
                         className="text-emerald-700 hover:underline dark:text-emerald-400"


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link

* **Closes #1295**

### Summary

Implemented native Print / PDF Export support for the Medicine Price Comparison page using the browser's built-in printing functionality.

### Changes Made

* Added a **Print / Export PDF** button that appears when two medicines are selected.
* Added browser-native printing support using `window.print()`.
* Added a print-only report header containing:

  * SahiDawa branding
  * Report generation date
* Hidden non-essential UI elements during printing:

  * Page header
  * Search controls
  * Navigation links
  * Export button itself
* Kept implementation lightweight without introducing additional PDF libraries.

## 📸 Proof of Work (Screenshots / Logs)

Frontend UI screenshots attached below:

* Normal comparison page view
* Print preview view
* Export button visibility after selecting medicines

## 🏷️ PR Type

* [ ] 🐛 type: bug
* [x] ✨ type: feature
* [ ] 📖 type: docs
* [ ] 🧪 type: testing
* [ ] 🔒 type: security
* [ ] ⚡ type: performance
* [ ] 🎨 type: design
* [ ] ♻️ type: refactor
* [ ] 🛠️ type: devops
* [ ] ♿ type: accessibility

## ✅ Checklist

* [x] My PR has a linked issue (Closes #1295)
* [x] I have pulled the latest main and resolved any conflicts
