### PR TITLE
docs: add contact email env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ NEXT_PUBLIC_API_URL=http://localhost:4000
 NEXT_PUBLIC_ML_SERVICE_URL=http://localhost:8000
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+NEXT_PUBLIC_CONTACT_EMAIL=contact@sahidawa.in
 FRONTEND_URL=http://localhost:3000
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4000,http://localhost:8000
 


### PR DESCRIPTION
Closes #1383

GSSoC labels: `gssoc:approved`, `level:beginner`

## Summary
- Added `NEXT_PUBLIC_CONTACT_EMAIL=contact@sahidawa.in` to the root `.env.example` file.
- Kept the change scoped to the frontend environment variable documentation requested by the issue.

## Validation
- Confirmed `apps/web/app/[locale]/contact/page.tsx` reads `process.env.NEXT_PUBLIC_CONTACT_EMAIL` with the same fallback value.
- Searched for related `NEXT_PUBLIC_*CONTACT` / contact email references to avoid missing the requested config variable.
- No runtime tests required for this documentation-only change.