### PR TITLE
fix(api): retain push subscriptions on transient failures

### DIFF
--- a/apps/api/src/services/notifications.ts
+++ b/apps/api/src/services/notifications.ts
@@ -1,6 +1,7 @@
 import webPush, { PushSubscription } from "web-push";
 import { z } from "zod";
 import { supabase } from "../db/client";
+import logger from "../utils/logger";
 
 export const pushSubscriptionSchema = z.object({
     endpoint: z.string().url(),
@@ -158,6 +159,59 @@ export function buildRecallPayload(alert: RecallAlert) {
     };
 }
 
+function getPushErrorStatusCode(reason: unknown): number | null {
+    if (!reason || typeof reason !== "object") {
+        return null;
+    }
+
+    const error = reason as Record<string, unknown>;
+    const rawStatus = error.statusCode ?? error.status;
+
+    if (typeof rawStatus === "number" && Number.isInteger(rawStatus)) {
+        return rawStatus;
+    }
+
+    if (typeof rawStatus === "string" && /^\d{3}$/.test(rawStatus)) {
+        return Number(rawStatus);
+    }
+
+    return null;
+}
+
+function getPushErrorLabel(reason: unknown, key: "code" | "name") {
+    if (!reason || typeof reason !== "object") {
+        return "unknown";
+    }
+
+    const value = (reason as Record<string, unknown>)[key];
+    return typeof value === "string" && value.length > 0 ? value : "unknown";
+}
+
+function getPushEndpointHost(endpoint: string) {
+    try {
+        return new URL(endpoint).hostname;
+    } catch {
+        return "unknown";
+    }
+}
+
+function shouldRemovePushSubscription(reason: unknown) {
+    const statusCode = getPushErrorStatusCode(reason);
+    return statusCode === 404 || statusCode === 410;
+}
+
+function logRetainedPushFailure(endpoint: string, reason: unknown) {
+    const statusCode = getPushErrorStatusCode(reason);
+    const statusLabel = statusCode === null ? "none" : statusCode;
+
+    logger.warn(
+        "Retaining push subscription after non-terminal push delivery failure " +
+            `(host=${getPushEndpointHost(endpoint)}, status=${statusLabel}, ` +
+            `code=${getPushErrorLabel(reason, "code")}, ` +
+            `name=${getPushErrorLabel(reason, "name")})`
+    );
+}
+
 export async function triggerRecallAlert(alert: RecallAlert) {
     const configured = configureWebPush();
     const subscriptions = await listPushSubscriptions();
@@ -175,7 +229,7 @@ export async function triggerRecallAlert(alert: RecallAlert) {
 
     const BATCH_SIZE = 50;
     const results: PromiseSettledResult<any>[] = [];
-    const failedEndpoints: string[] = [];
+    const expiredEndpoints: string[] = [];
 
     for (let i = 0; i < subscriptions.length; i += BATCH_SIZE) {
         const chunk = subscriptions.slice(i, i + BATCH_SIZE);
@@ -188,7 +242,12 @@ export async function triggerRecallAlert(alert: RecallAlert) {
         chunkResults.forEach((result, index) => {
             results.push(result);
             if (result.status === "rejected") {
-                failedEndpoints.push(chunk[index].endpoint);
+                const endpoint = chunk[index].endpoint;
+                if (shouldRemovePushSubscription(result.reason)) {
+                    expiredEndpoints.push(endpoint);
+                } else {
+                    logRetainedPushFailure(endpoint, result.reason);
+                }
             }
         });
 
@@ -197,13 +256,13 @@ export async function triggerRecallAlert(alert: RecallAlert) {
         }
     }
 
-    await Promise.all(failedEndpoints.map(removePushSubscription));
+    await Promise.all(expiredEndpoints.map(removePushSubscription));
 
     return {
         configured: true,
         attempted: subscriptions.length,
         sent: results.filter((result) => result.status === "fulfilled").length,
-        failed: failedEndpoints.length,
+        failed: results.filter((result) => result.status === "rejected").length,
         payload,
     };
 }


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1387**
- **Summary:**
  - Keeps push subscriptions when web-push delivery fails for temporary provider or network reasons.
  - Deletes subscriptions only for explicit terminal `404` or `410` responses.
  - Logs retained failures with host/status/code/name, without dumping the full endpoint URL.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> Backend/API-only change, so terminal proof is included below instead of screenshots.

```bash
npx tsc --noEmit -p apps/api/tsconfig.json
npm run build -w sahidawa-api
git diff --check main..HEAD
```

Result: all commands exited with code 0 locally.

Review note: an independent read-only code review found no merge-blocking correctness or security issues. The source notification test is not wired into the repo Jest config, so I used API compile/build checks as the proof for this scoped service change.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1387`)
- [x] I have pulled the latest `main` and resolved any conflicts
