### PR TITLE
perf(etl): batch Jan Aushadhi price backfill

### DIFF
--- a/apps/etl/src/loaders/supabase_loader.py
+++ b/apps/etl/src/loaders/supabase_loader.py
@@ -517,6 +517,7 @@ class SupabaseLoader:
             if not page:
                 break
 
+            page_updates: list[dict] = []
             for record in page:
                 checked += 1
                 record_id = record.get("id")
@@ -536,17 +537,15 @@ class SupabaseLoader:
                     skipped += 1
                     continue
 
-                try:
-                    self.client.table(table).update(
-                        {"jan_aushadhi_price": ja_price}
-                    ).eq("id", record_id).execute()
-                    updated += 1
-                except Exception as e:
-                    logger.warning(
-                        f"[Loader] merge_jan_aushadhi_price: failed to update "
-                        f"id={record_id}: {e}"
-                    )
-                    failed += 1
+                page_updates.append({"id": record_id, "jan_aushadhi_price": ja_price})
+
+            if page_updates:
+                page_updated, page_failed = self._upsert_ja_price_update_batches(
+                    page_updates,
+                    table,
+                )
+                updated += page_updated
+                failed += page_failed
 
             last_id = page[-1].get("id")
             if len(page) < page_size:
@@ -557,3 +556,64 @@ class SupabaseLoader:
             f"updated: {updated}, skipped: {skipped}, failed: {failed}"
         )
         return {"checked": checked, "updated": updated, "skipped": skipped, "failed": failed}
+
+    def _upsert_ja_price_update_batches(
+        self,
+        updates: list[dict],
+        table: str,
+    ) -> tuple[int, int]:
+        updated = failed = 0
+        total = len(updates)
+        total_batches = (total + BATCH_SIZE - 1) // BATCH_SIZE
+
+        for batch_start in range(0, total, BATCH_SIZE):
+            batch = updates[batch_start: batch_start + BATCH_SIZE]
+            batch_number = (batch_start // BATCH_SIZE) + 1
+            batch_end = batch_start + len(batch)
+
+            try:
+                self.client.table(table).upsert(batch).execute()
+                updated += len(batch)
+                logger.info(
+                    f"[Loader] merge_jan_aushadhi_price: batch "
+                    f"{batch_number}/{total_batches} upserted {len(batch)} rows "
+                    f"({updated}/{total} page matches)"
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[Loader] merge_jan_aushadhi_price: batch "
+                    f"{batch_number}/{total_batches} rows {batch_start}-{batch_end} "
+                    f"failed: {e} - retrying row-by-row"
+                )
+                batch_updated, batch_failed = self._update_ja_price_rows_one_by_one(
+                    batch,
+                    table,
+                )
+                updated += batch_updated
+                failed += batch_failed
+
+        return updated, failed
+
+    def _update_ja_price_rows_one_by_one(
+        self,
+        updates: list[dict],
+        table: str,
+    ) -> tuple[int, int]:
+        updated = failed = 0
+
+        for update in updates:
+            record_id = update.get("id")
+            try:
+                self.client.table(table).update(
+                    {"jan_aushadhi_price": update.get("jan_aushadhi_price")}
+                ).eq("id", record_id).execute()
+                updated += 1
+            except Exception as e:
+                logger.warning(
+                    f"[Loader] merge_jan_aushadhi_price: failed row fallback "
+                    f"update id={record_id}, "
+                    f"jan_aushadhi_price={update.get('jan_aushadhi_price')}: {e}"
+                )
+                failed += 1
+
+        return updated, failed


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1380**
- **Summary:**
  - Replaces per-record Jan Aushadhi price updates with 100-row batch upserts.
  - Keeps row-by-row fallback only for failed chunks.
  - Preserves the existing NPPA matching and pagination behavior.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> Backend/ETL-only change, so terminal proof is included below instead of screenshots.

```bash
cd apps/etl
python3 -m pytest tests/test_loader.py
# Result: 6 passed, 1 existing pytest config warning

python3 -m compileall src/loaders/supabase_loader.py
# Result: passed

# Direct in-memory batch proof for the new helper
# Result: batch proof passed: updated=250 failed=0 chunks=[100, 100, 50]

git diff --check main..HEAD
# Result: passed
```

Independent review note: the loader code was reviewed for matching semantics, count accuracy, chunk fallback, and scope. A direct fake-client proof was added to show the successful batch path, because the existing tests mainly cover the fallback-compatible behavior.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1380`)
- [x] I have pulled the latest `main` and resolved any conflicts
