### PR TITLE
fix(web): retry queued offline requests

### DIFF
--- a/apps/web/hooks/useOnlineRetry.ts
+++ b/apps/web/hooks/useOnlineRetry.ts
@@ -7,51 +7,68 @@ import { toast } from "sonner";
  * Hook to automatically retry failed API requests when coming back online
  */
 export const useOnlineRetry = () => {
-    const { isOffline, isStatusDirty, registerRetryCallback } = useOfflineStatus();
+    const { registerRetryCallback, unregisterRetryCallback } = useOfflineStatus();
 
-    const retryQueuedRequests = useCallback(async () => {
-        const queued = offlineRequestQueue.getAll();
+    const scheduleRetryRegistration = useCallback(
+        (callback: () => void) => {
+            void Promise.resolve().then(() => registerRetryCallback(callback));
+        },
+        [registerRetryCallback]
+    );
 
-        if (queued.length === 0) return;
+    const retryQueuedRequests = useCallback(
+        async function retryQueuedRequests() {
+            const queued = offlineRequestQueue.getAll();
 
-        // Show toast about retrying
-        const toastId = toast.loading(`Retrying ${queued.length} request(s)...`);
-
-        let successCount = 0;
-        let failureCount = 0;
-
-        // Retry each request with a small delay between them
-        for (const request of queued) {
-            try {
-                // Simulate retry delay
-                await new Promise((resolve) => setTimeout(resolve, 100));
-
-                // In a real implementation, you would re-execute the original request here
-                // For now, we'll just remove it from the queue
-                offlineRequestQueue.remove(request.id);
-                successCount++;
-            } catch (error) {
-                console.error(`Failed to retry request ${request.id}:`, error);
-                failureCount++;
+            if (queued.length === 0) {
+                scheduleRetryRegistration(retryQueuedRequests);
+                return;
             }
-        }
 
-        // Update toast with results
-        if (successCount > 0 && failureCount === 0) {
-            toast.success(`${successCount} request(s) retried successfully`, {
-                id: toastId,
-            });
-        } else if (failureCount > 0) {
-            toast.error(`${successCount} succeeded, ${failureCount} failed to retry`, {
-                id: toastId,
-            });
-        } else {
-            toast.dismiss(toastId);
-        }
-    }, []);
+            // Show toast about retrying
+            const toastId = toast.loading(`Retrying ${queued.length} request(s)...`);
+
+            let successCount = 0;
+            let failureCount = 0;
+
+            // Retry each request and keep failures queued for a later attempt.
+            for (const request of queued) {
+                try {
+                    const response = await fetch(request.url, request.options);
+
+                    if (!response.ok) {
+                        throw new Error(`Server returned status ${response.status}`);
+                    }
+
+                    offlineRequestQueue.remove(request.id);
+                    successCount++;
+                } catch (error) {
+                    console.error(`Failed to retry request ${request.id}:`, error);
+                    failureCount++;
+                }
+            }
+
+            // Update toast with results
+            if (successCount > 0 && failureCount === 0) {
+                toast.success(`${successCount} request(s) retried successfully`, {
+                    id: toastId,
+                });
+            } else if (failureCount > 0) {
+                toast.error(`${successCount} succeeded, ${failureCount} failed to retry`, {
+                    id: toastId,
+                });
+            } else {
+                toast.dismiss(toastId);
+            }
+
+            scheduleRetryRegistration(retryQueuedRequests);
+        },
+        [scheduleRetryRegistration]
+    );
 
     // Register retry callback when coming back online
     useEffect(() => {
         registerRetryCallback(retryQueuedRequests);
-    }, [registerRetryCallback, retryQueuedRequests]);
+        return () => unregisterRetryCallback(retryQueuedRequests);
+    }, [registerRetryCallback, unregisterRetryCallback, retryQueuedRequests]);
 };


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1400**
- **Summary:**
  - Re-executes queued offline requests with their original URL and fetch options.
  - Removes a queue entry only after a successful `response.ok` result.
  - Keeps failed retries queued and re-registers the retry callback for future reconnects.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> Hook-only behavior change, so terminal proof is included below instead of screenshots.

```bash
npm test -w web -- offline.test.tsx
# Result: 33 passed

git diff --check main..HEAD
# Result: passed
```

Additional check run:

```bash
npx tsc --noEmit -p apps/web/tsconfig.json
```

This still fails on unrelated existing dependency/import issues outside this PR:
- `recharts` missing in `apps/web/app/[locale]/admin/analytics/page.tsx`
- `vitest` and `@testing-library/user-event` missing in vaccine test files
- `../DoseSchedule` unresolved in `apps/web/components/vaccine/DoseSchedule.test.tsx`

Review note: an independent read-only review found the retry logic merge-ready within the strict `apps/web/hooks/useOnlineRetry.ts` scope. It also noted an existing integration risk: `useOnlineRetry` does not appear to be mounted by a production component. I left that out of this PR because the issue explicitly restricts the change to `useOnlineRetry.ts`.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1400`)
- [x] I have pulled the latest `main` and resolved any conflicts
