### PR TITLE
test(api): add notifications route coverage

### DIFF
--- a/apps/api/tests/notifications.test.ts
+++ b/apps/api/tests/notifications.test.ts
@@ -1,0 +1,50 @@
+import express from "express";
+import request from "supertest";
+import notificationsRouter from "../src/routes/notifications";
+
+describe("notifications routes", () => {
+    const app = express();
+
+    beforeAll(() => {
+        app.use(express.json());
+        app.use("/api/notifications", notificationsRouter);
+    });
+
+    it("returns vapid public key payload", async () => {
+        const response = await request(app).get("/api/notifications/vapid-public-key");
+
+        expect(response.status).toBe(200);
+    });
+
+    it("returns mock recall feed", async () => {
+        const response = await request(app).get("/api/notifications/recalls/mock");
+
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty("recalls");
+    });
+
+    it("returns vapid configuration status", async () => {
+        const response = await request(app).get("/api/notifications/vapid-public-key");
+
+        expect(response.body).toHaveProperty("publicKey");
+        expect(response.body).toHaveProperty("configured");
+    });
+
+    it("returns recalls array", async () => {
+        const response = await request(app).get("/api/notifications/recalls/mock");
+
+        expect(Array.isArray(response.body.recalls)).toBe(true);
+    });
+
+    it("vapid endpoint returns configured field as boolean", async () => {
+        const response = await request(app).get("/api/notifications/vapid-public-key");
+
+        expect(typeof response.body.configured).toBe("boolean");
+    });
+
+    it("vapid endpoint contains publicKey field", async () => {
+        const response = await request(app).get("/api/notifications/vapid-public-key");
+
+        expect(response.body).toHaveProperty("publicKey");
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link

* **Closes #1304**

### Summary

Added initial unit tests for the Notifications API routes to improve baseline test coverage.

Covered endpoints:

* GET `/api/notifications/vapid-public-key`
* GET `/api/notifications/recalls/mock`

Implemented test cases for:

* VAPID public key response
* VAPID configuration status
* Mock recall feed response
* Recall array validation
* Response structure validation

## 📸 Proof of Work (Screenshots / Logs)

```bash
PASS tests/notifications.test.ts

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
```

## 🏷️ PR Type

* [ ] 🐛 type: bug
* [ ] ✨ type: feature
* [ ] 📖 type: docs
* [x] 🧪 type: testing
* [ ] 🔒 type: security
* [ ] ⚡ type: performance
* [ ] 🎨 type: design
* [ ] ♻️ type: refactor
* [ ] 🛠️ type: devops
* [ ] ♿ type: accessibility

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #1304`)
* [x] I have pulled the latest `main` and resolved any conflicts
