### PR TITLE
feat(etl): cache unchanged CDSCO upserts

### DIFF
--- a/apps/api/src/db/schema.sql
+++ b/apps/api/src/db/schema.sql
@@ -106,7 +106,7 @@ CREATE INDEX IF NOT EXISTS idx_medicines_brand_name_trgm ON medicines USING gin 
 CREATE INDEX IF NOT EXISTS idx_medicines_generic_name_trgm ON medicines USING gin (generic_name gin_trgm_ops);
 
 -- Constraints for Upsert Operations
-ALTER TABLE medicines ADD CONSTRAINT idx_medicines_unique_variant UNIQUE NULLS NOT DISTINCT (generic_name, strength, dosage_form, source);
+ALTER TABLE medicines ADD CONSTRAINT idx_medicines_unique_variant UNIQUE NULLS NOT DISTINCT (generic_name, brand_name, manufacturer, barcode_id);
 
 -- 4. Barcode Mappings (Real-world scanning intelligence)
 CREATE TABLE IF NOT EXISTS barcode_mappings (

--- a/apps/etl/run_all.py
+++ b/apps/etl/run_all.py
@@ -253,6 +253,7 @@ def _summary(stats: dict) -> None:
         f"  Pipeline Complete!\n"
         f"  Total processed  : {stats['total']}\n"
         f"  Inserted/updated : {stats['inserted']}\n"
+        f"  Skipped unchanged: {stats.get('skipped_unchanged', 0)}\n"
         f"  Failed           : {stats['failed']}\n"
         f"  Success rate     : {stats['success_rate']}%"
         + validation_line

--- a/apps/etl/src/loaders/supabase_loader.py
+++ b/apps/etl/src/loaders/supabase_loader.py
@@ -7,7 +7,7 @@ Shared loader used by all ETL pipelines.
 Accepts any normalized pd.DataFrame and upserts it into a Supabase table.
 
 UPSERT STRATEGY:
-    Conflict key: (generic_name, strength, dosage_form, source)
+    Conflict key: (generic_name, brand_name, manufacturer, barcode_id)
     On conflict → UPDATE (handles re-runs and MRP changes safely).
 
 BATCH INSERTS:
@@ -44,6 +44,15 @@ DELAY_SEC = 0.5
 RETRY_TABLE = "etl_failed_rows"
 SUCCESS_RATE_ALERT_THRESHOLD = 95.0
 FAILED_ROWS_BASE_DIR = Path(__file__).resolve().parents[4] / "data" / "failed"
+
+CONFLICT_COLUMNS = {
+    "medicines": (
+        "generic_name",
+        "brand_name",
+        "manufacturer",
+        "barcode_id",
+    ),
+}
 
 ALLOWED_COLUMNS = {
     "medicines": {
@@ -132,33 +141,50 @@ class SupabaseLoader:
         logger.info(f"[Loader] Loading {total} records into '{table}'...")
 
         raw_records = df.to_dict(orient="records")
-        records = [
-            {
-                "row_index": i,
-                "payload": {k: (None if pd.isna(v) else v) for k, v in row.items()},
-            }
-            for i, row in enumerate(raw_records)
-        ]
+        records = []
+        for i, row in enumerate(raw_records):
+            payload = {k: (None if pd.isna(v) else v) for k, v in row.items()}
+            records.append(
+                {
+                    "row_index": i,
+                    "payload": payload,
+                    "write_payload": self._prepare_payload(payload, table),
+                }
+            )
 
         inserted, failures = 0, []
+        records_to_write, skipped_unchanged = self._filter_unchanged_records(
+            records,
+            table,
+        )
 
-        for batch_start in range(0, total, BATCH_SIZE):
-            batch = records[batch_start: batch_start + BATCH_SIZE]
+        if skipped_unchanged:
+            logger.info(
+                f"[Loader] Skipping {skipped_unchanged} unchanged records for "
+                f"'{table}' based on current Supabase state"
+            )
+
+        writable_total = len(records_to_write)
+        for batch_start in range(0, writable_total, BATCH_SIZE):
+            batch = records_to_write[batch_start: batch_start + BATCH_SIZE]
             batch_end = batch_start + len(batch)
             try:
-                self._upsert_payloads([item["payload"] for item in batch], table)
+                self._upsert_payloads([item["write_payload"] for item in batch], table)
                 inserted += len(batch)
-                logger.info(f"[Loader] Batch {batch_start}–{batch_end} ✅  ({inserted}/{total})")
+                logger.info(
+                    f"[Loader] Batch {batch_start}–{batch_end} ✅  "
+                    f"({inserted}/{writable_total} writes, {inserted + skipped_unchanged}/{total} processed)"
+                )
             except Exception as e:
                 logger.warning(f"[Loader] Batch {batch_start}–{batch_end} ❌ {e} — retrying row-by-row")
                 bi, bf = self._load_batch_row_by_row(batch, table)
                 inserted += bi
                 failures.extend(bf)
 
-            if batch_end < total:
+            if batch_end < writable_total:
                 time.sleep(DELAY_SEC)
 
-        stats = self._build_stats(total, inserted, failures)
+        stats = self._build_stats(total, inserted, failures, skipped_unchanged)
         stats["failed_rows_csv"] = self._export_failed_rows(failures)
         self._print_summary(stats)
         return stats
@@ -230,11 +256,15 @@ class SupabaseLoader:
 
     # ── Private helpers ────────────────────────────────────────────────────────
 
-    def _load_batch_row_by_row(self, batch: list[dict], table: str) -> tuple[int, list[dict]]:
+    def _load_batch_row_by_row(
+        self,
+        batch: list[dict],
+        table: str,
+    ) -> tuple[int, list[dict]]:
         inserted, failures = 0, []
         for item in batch:
             try:
-                self._upsert_payloads([item["payload"]], table)
+                self._upsert_payloads([item["write_payload"]], table)
                 inserted += 1
             except Exception as e:
                 failure = self._build_failure(item["payload"], item["row_index"], e)
@@ -244,16 +274,90 @@ class SupabaseLoader:
         return inserted, failures
 
     def _upsert_payloads(self, payloads: list[dict], table: str) -> None:
-        if table in ALLOWED_COLUMNS:
-            allowed = ALLOWED_COLUMNS[table]
-            payloads = [
-                {k: v for k, v in p.items() if k in allowed}
-                for p in payloads
-            ]
+        payloads = [self._prepare_payload(payload, table) for payload in payloads]
+        if not payloads:
+            return
+        conflict_columns = CONFLICT_COLUMNS.get(table)
         self.client.table(table).upsert(
             payloads,
-            on_conflict="generic_name,brand_name,strength,dosage_form,source,barcode_id",
+            on_conflict=",".join(conflict_columns) if conflict_columns else None,
         ).execute()
+
+    def _prepare_payload(self, payload: dict, table: str) -> dict:
+        if table in ALLOWED_COLUMNS:
+            allowed = ALLOWED_COLUMNS[table]
+            return {k: v for k, v in payload.items() if k in allowed}
+        return dict(payload)
+
+    def _filter_unchanged_records(
+        self,
+        records: list[dict],
+        table: str,
+    ) -> tuple[list[dict], int]:
+        existing_by_key = self._load_existing_rows_by_key(records, table)
+        if not existing_by_key:
+            return records, 0
+
+        changed = []
+        skipped = 0
+        for item in records:
+            cache_key = self._cache_key(item["write_payload"], table)
+            existing = existing_by_key.get(cache_key)
+            if existing and self._payload_matches_existing(item["write_payload"], existing):
+                skipped += 1
+                continue
+            changed.append(item)
+        return changed, skipped
+
+    def _load_existing_rows_by_key(self, records: list[dict], table: str) -> dict[str, dict]:
+        if not records or table not in CONFLICT_COLUMNS:
+            return {}
+
+        columns = sorted(
+            set(CONFLICT_COLUMNS[table]).union(
+                *[set(item["write_payload"].keys()) for item in records]
+            )
+        )
+        selected_columns = ",".join(columns)
+        existing_by_key: dict[str, dict] = {}
+        page_size = 1000
+        offset = 0
+
+        try:
+            while True:
+                response = (
+                    self.client.table(table)
+                    .select(selected_columns)
+                    .range(offset, offset + page_size - 1)
+                    .execute()
+                )
+                rows = getattr(response, "data", None) or []
+                for row in rows:
+                    existing_by_key[self._cache_key(row, table)] = row
+                if len(rows) < page_size:
+                    break
+                offset += page_size
+        except Exception as e:
+            logger.warning(
+                f"[Loader] Could not read existing '{table}' rows for ETL change detection; "
+                f"writing all incoming records instead: {e}"
+            )
+            return {}
+
+        return existing_by_key
+
+    def _cache_key(self, payload: dict, table: str) -> str:
+        key_columns = CONFLICT_COLUMNS.get(table)
+        if key_columns:
+            key_payload = {column: payload.get(column) for column in key_columns}
+        else:
+            key_payload = payload
+        encoded = json.dumps(key_payload, default=str, separators=(",", ":"), sort_keys=True)
+        return sha256(encoded.encode("utf-8")).hexdigest()
+
+    def _payload_matches_existing(self, payload: dict, existing: dict) -> bool:
+        existing_subset = {key: existing.get(key) for key in payload}
+        return self._row_fingerprint(payload) == self._row_fingerprint(existing_subset)
 
     def _build_failure(self, payload: dict, row_index: int, error: Exception) -> dict:
         msg = str(error)
@@ -348,12 +452,20 @@ class SupabaseLoader:
         pd.DataFrame(rows).to_csv(output_path, index=False)
         return str(output_path)
 
-    def _build_stats(self, total: int, inserted: int, failures: list[dict]) -> dict:
+    def _build_stats(
+        self,
+        total: int,
+        inserted: int,
+        failures: list[dict],
+        skipped_unchanged: int = 0,
+    ) -> dict:
         failed = len(failures)
-        success_rate = round((inserted / total) * 100, 2) if total else 100.0
+        successful = inserted + skipped_unchanged
+        success_rate = round((successful / total) * 100, 2) if total else 100.0
         return {
             "inserted": inserted,
             "failed": failed,
+            "skipped_unchanged": skipped_unchanged,
             "total": total,
             "success_rate": success_rate,
             "error_counts": dict(Counter(f["error_category"] for f in failures)),
@@ -363,6 +475,7 @@ class SupabaseLoader:
         logger.info(
             f"[Loader] Summary — total: {stats['total']}, "
             f"inserted: {stats['inserted']}, failed: {stats['failed']}, "
+            f"skipped_unchanged: {stats.get('skipped_unchanged', 0)}, "
             f"success_rate: {stats['success_rate']}%"
         )
         if stats["error_counts"]:

--- a/apps/etl/tests/test_loader.py
+++ b/apps/etl/tests/test_loader.py
@@ -24,6 +24,7 @@ class FakeTable:
         self.eq_filters = []
         self.operation = None
         self.limit_value = None
+        self.range_bounds = None
 
     def upsert(self, payload, on_conflict=None):
         self.operation = "upsert"
@@ -55,15 +56,19 @@ class FakeTable:
         return self
 
     def range(self, start, end):
+        self.range_bounds = (start, end)
         return self
 
     def execute(self):
         if self.operation == "select":
-            rows = self.client.retry_rows
+            rows = list(self.client.table_rows.get(self.name, []))
             for column, value in self.eq_filters:
                 rows = [row for row in rows if row.get(column) == value]
             if self.limit_value is not None:
                 rows = rows[: self.limit_value]
+            if self.range_bounds is not None:
+                start, end = self.range_bounds
+                rows = rows[start: end + 1]
             return FakeExecuteResponse(rows)
 
         if self.operation == "update":
@@ -80,17 +85,21 @@ class FakeTable:
             payload = dict(self.pending_payload)
             payload.setdefault("id", f"insert-{len(self.client.retry_rows) + 1}")
             self.client.retry_rows.append(payload)
+            self.client.table_rows.setdefault(self.name, []).append(payload)
             return FakeExecuteResponse()
 
         if self.operation == "upsert":
             payload = self.pending_payload
             if isinstance(payload, list) and len(payload) > 1 and self.client.fail_batches:
                 raise Exception("22P02: invalid input syntax for type double precision")
-            row = payload[0] if isinstance(payload, list) else payload
-            if row.get("generic_name") in self.client.errors_by_generic_name:
-                raise Exception(self.client.errors_by_generic_name[row.get("generic_name")])
-            if row.get("generic_name") in self.client.fail_generic_names:
-                raise Exception("23505: duplicate key value violates unique constraint")
+            rows = payload if isinstance(payload, list) else [payload]
+            for row in rows:
+                if row.get("generic_name") in self.client.errors_by_generic_name:
+                    raise Exception(self.client.errors_by_generic_name[row.get("generic_name")])
+                if row.get("generic_name") in self.client.fail_generic_names:
+                    raise Exception("23505: duplicate key value violates unique constraint")
+            for row in rows:
+                self.client.upsert_table_row(self.name, row)
             return FakeExecuteResponse()
 
         return FakeExecuteResponse()
@@ -105,18 +114,34 @@ class FakeSupabaseClient:
         retry_rows=None,
         errors_by_generic_name=None,
         update_fail_ids=None,
+        table_rows=None,
     ):
         self.fail_batches = fail_batches
         self.fail_generic_names = set(fail_generic_names or [])
         self.errors_by_generic_name = errors_by_generic_name or {}
         self.retry_rows = retry_rows or []
         self.update_fail_ids = set(update_fail_ids or [])
+        self.table_rows = table_rows if table_rows is not None else {"medicines": []}
         self.upsert_calls = []
         self.insert_calls = []
         self.update_calls = []
 
     def table(self, name):
         return FakeTable(name, self)
+
+    def upsert_table_row(self, table, row):
+        rows = self.table_rows.setdefault(table, [])
+        if table == "medicines":
+            conflict_columns = ("generic_name", "brand_name", "manufacturer", "barcode_id")
+        else:
+            rows.append(dict(row))
+            return
+
+        for existing in rows:
+            if all(existing.get(column) == row.get(column) for column in conflict_columns):
+                existing.update(row)
+                return
+        rows.append(dict(row))
 
 
 def make_loader(client, tmp_path):
@@ -142,10 +167,226 @@ def test_batch_success_returns_summary_without_failed_rows_csv(tmp_path):
     assert stats["total"] == 2
     assert stats["inserted"] == 2
     assert stats["failed"] == 0
+    assert stats["skipped_unchanged"] == 0
     assert stats["success_rate"] == 100.0
     assert stats["error_counts"] == {}
     assert stats["failed_rows_csv"] is None
     assert len(client.upsert_calls) == 1
+
+
+def test_load_skips_unchanged_rows_already_present_in_target_db(tmp_path):
+    table_rows = {"medicines": []}
+    df = pd.DataFrame(
+        [
+            {
+                "generic_name": "Paracetamol",
+                "brand_name": "Dolo",
+                "manufacturer": "Micro Labs",
+                "strength": "500mg",
+                "dosage_form": "Tablet",
+                "source": "commercial",
+                "barcode_id": "8900000000012",
+                "mrp": 18.5,
+                "cdsco_match_score": 97.2,
+            },
+            {
+                "generic_name": "Cetirizine",
+                "brand_name": "Cetzine",
+                "manufacturer": "GSK",
+                "strength": "10mg",
+                "dosage_form": "Tablet",
+                "source": "commercial",
+                "barcode_id": "8900000000029",
+                "mrp": 25.0,
+                "cdsco_match_score": 95.0,
+            },
+        ]
+    )
+
+    first_client = FakeSupabaseClient(table_rows=table_rows)
+    first_loader = make_loader(first_client, tmp_path)
+    first_stats = first_loader.load(df)
+
+    second_client = FakeSupabaseClient(table_rows=table_rows)
+    second_loader = make_loader(second_client, tmp_path)
+    validation_only_change = df.copy()
+    validation_only_change["cdsco_match_score"] = [88.1, 90.4]
+    second_stats = second_loader.load(validation_only_change)
+
+    assert first_stats["inserted"] == 2
+    assert first_stats["skipped_unchanged"] == 0
+    assert len(first_client.upsert_calls) == 1
+
+    assert second_stats["total"] == 2
+    assert second_stats["inserted"] == 0
+    assert second_stats["failed"] == 0
+    assert second_stats["skipped_unchanged"] == 2
+    assert second_stats["success_rate"] == 100.0
+    assert second_client.upsert_calls == []
+
+
+def test_load_upserts_only_rows_whose_hash_changed(tmp_path):
+    table_rows = {"medicines": []}
+    df = pd.DataFrame(
+        [
+            {
+                "generic_name": "Paracetamol",
+                "brand_name": "Dolo",
+                "manufacturer": "Micro Labs",
+                "strength": "500mg",
+                "dosage_form": "Tablet",
+                "source": "commercial",
+                "barcode_id": "8900000000012",
+                "mrp": 18.5,
+            },
+            {
+                "generic_name": "Cetirizine",
+                "brand_name": "Cetzine",
+                "manufacturer": "GSK",
+                "strength": "10mg",
+                "dosage_form": "Tablet",
+                "source": "commercial",
+                "barcode_id": "8900000000029",
+                "mrp": 25.0,
+            },
+        ]
+    )
+    changed_df = df.copy()
+    changed_df.loc[changed_df["generic_name"] == "Cetirizine", "mrp"] = 27.5
+
+    first_client = FakeSupabaseClient(table_rows=table_rows)
+    first_loader = make_loader(first_client, tmp_path)
+    first_loader.load(df)
+
+    second_client = FakeSupabaseClient(table_rows=table_rows)
+    second_loader = make_loader(second_client, tmp_path)
+    stats = second_loader.load(changed_df)
+
+    assert stats["total"] == 2
+    assert stats["inserted"] == 1
+    assert stats["failed"] == 0
+    assert stats["skipped_unchanged"] == 1
+    assert stats["success_rate"] == 100.0
+    assert len(second_client.upsert_calls) == 1
+    _, payload, _ = second_client.upsert_calls[0]
+    assert payload == [
+        {
+            "generic_name": "Cetirizine",
+            "brand_name": "Cetzine",
+            "manufacturer": "GSK",
+            "strength": "10mg",
+            "dosage_form": "Tablet",
+            "source": "commercial",
+            "barcode_id": "8900000000029",
+            "mrp": 27.5,
+        }
+    ]
+
+
+def test_load_does_not_cache_failed_rows_until_successful_upsert(tmp_path):
+    table_rows = {"medicines": []}
+    df = pd.DataFrame(
+        [
+            {
+                "generic_name": "Paracetamol",
+                "brand_name": "Dolo",
+                "manufacturer": "Micro Labs",
+                "strength": "500mg",
+                "dosage_form": "Tablet",
+                "source": "commercial",
+                "barcode_id": "8900000000012",
+            },
+            {
+                "generic_name": "Cetirizine",
+                "brand_name": "Cetzine",
+                "manufacturer": "GSK",
+                "strength": "10mg",
+                "dosage_form": "Tablet",
+                "source": "commercial",
+                "barcode_id": "8900000000029",
+            },
+        ]
+    )
+
+    failing_client = FakeSupabaseClient(
+        fail_batches=True,
+        fail_generic_names={"Cetirizine"},
+        table_rows=table_rows,
+    )
+    failing_loader = make_loader(failing_client, tmp_path)
+    first_stats = failing_loader.load(df)
+
+    retry_client = FakeSupabaseClient(table_rows=table_rows)
+    retry_loader = make_loader(retry_client, tmp_path)
+    retry_stats = retry_loader.load(df)
+
+    assert first_stats["inserted"] == 1
+    assert first_stats["failed"] == 1
+    assert first_stats["skipped_unchanged"] == 0
+
+    assert retry_stats["inserted"] == 1
+    assert retry_stats["failed"] == 0
+    assert retry_stats["skipped_unchanged"] == 1
+    assert len(retry_client.upsert_calls) == 1
+    _, payload, _ = retry_client.upsert_calls[0]
+    assert payload[0]["generic_name"] == "Cetirizine"
+
+
+def test_load_does_not_skip_when_target_db_has_no_matching_rows(tmp_path):
+    df = pd.DataFrame(
+        [
+            {
+                "generic_name": "Paracetamol",
+                "brand_name": "Dolo",
+                "manufacturer": "Micro Labs",
+                "barcode_id": "8900000000012",
+                "mrp": 18.5,
+            }
+        ]
+    )
+
+    client = FakeSupabaseClient(table_rows={"medicines": []})
+    loader = make_loader(client, tmp_path)
+    stats = loader.load(df)
+
+    assert stats["inserted"] == 1
+    assert stats["skipped_unchanged"] == 0
+    assert len(client.upsert_calls) == 1
+
+
+def test_load_treats_manufacturer_as_part_of_medicine_identity(tmp_path):
+    table_rows = {
+        "medicines": [
+            {
+                "generic_name": "Paracetamol",
+                "brand_name": "Dolo",
+                "manufacturer": "Micro Labs",
+                "barcode_id": None,
+                "mrp": 18.5,
+            }
+        ]
+    }
+    df = pd.DataFrame(
+        [
+            {
+                "generic_name": "Paracetamol",
+                "brand_name": "Dolo",
+                "manufacturer": "Different Pharma",
+                "barcode_id": None,
+                "mrp": 18.5,
+            }
+        ]
+    )
+
+    client = FakeSupabaseClient(table_rows=table_rows)
+    loader = make_loader(client, tmp_path)
+    stats = loader.load(df)
+
+    assert stats["inserted"] == 1
+    assert stats["skipped_unchanged"] == 0
+    assert len(client.upsert_calls) == 1
+    _, _, on_conflict = client.upsert_calls[0]
+    assert on_conflict == "generic_name,brand_name,manufacturer,barcode_id"
 
 
 # ── Tests for merge_jan_aushadhi_price ───────────────────────────────────────
@@ -335,4 +576,3 @@ def test_ja_backfill_returns_zeros_when_csv_missing(tmp_path):
     stats = loader.merge_jan_aushadhi_price(nppa_csv=missing_path)
 
     assert stats == {"checked": 0, "updated": 0, "skipped": 0, "failed": 0}
-

--- a/docs/etl-pipeline.md
+++ b/docs/etl-pipeline.md
@@ -29,9 +29,10 @@ The `apps/etl/` workspace is the single source of truth for all data ingestion i
 │                          │                                  │
 │                          ▼  validated pd.DataFrame          │
 │  STEP 3  SupabaseLoader.load()                              │
-│          └─ Batched upserts (100 rows/batch)                │
-│          └─ Conflict key: generic_name+strength+            │
-│             dosage_form+source                              │
+│          └─ Skips unchanged rows already matching Supabase  │
+│          └─ Batched upserts for changed rows (100/batch)    │
+│          └─ Conflict key: generic_name+brand_name+          │
+│             manufacturer+barcode_id                         │
 │          └─ Failed rows → etl_failed_rows table + CSV       │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -46,6 +47,15 @@ The `apps/etl/` workspace is the single source of truth for all data ingestion i
 | Validate    | DataFrame + reference CSV | DataFrame + 6 new columns                       | `src/validators/cdsco_validator.py` |
 | Load        | validated DataFrame       | Supabase `medicines` table                      | `src/loaders/supabase_loader.py`    |
 | Retry       | `etl_failed_rows` table   | updated rows in Supabase                        | `src/loaders/supabase_loader.py`    |
+
+### Loader change detection
+
+`SupabaseLoader.load()` reads the current Supabase rows for the incoming medicine
+identity keys and hashes the exact payload that would be written. Rows are
+skipped only when the target database already contains the same values, which
+reduces Supabase write operations without relying on local cache files. Empty,
+rebuilt, or repointed databases naturally receive fresh upserts because they have
+no matching rows to compare.
 
 ### CDSCO validation scoring
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1431**
- **Summary:**
  - Adds DB-backed change detection for CDSCO ETL rows so unchanged medicines are skipped before upsert.
  - Aligns the loader conflict key and checked-in schema artifact with the existing migration key: `generic_name, brand_name, manufacturer, barcode_id`.
  - Adds loader tests for unchanged rows, changed rows, empty targets, failed-row retry, and manufacturer-specific medicine identity.

## 📸 Proof of Work (Screenshots / Logs)

Backend/ETL proof:

```bash
python3 -m pytest apps/etl/tests
# 14 passed, 1 existing pytest config warning

python3 -m py_compile apps/etl/src/loaders/supabase_loader.py apps/etl/run_all.py apps/etl/tests/test_loader.py
# passed

npm run check:migrations
# All migrations are synchronized. Ready to deploy!

git diff --check upstream/main..HEAD
# passed
```

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
