### PR TITLE
feat(etl): retry transient Supabase batch upserts

### DIFF
--- a/apps/etl/src/loaders/supabase_loader.py
+++ b/apps/etl/src/loaders/supabase_loader.py
@@ -12,7 +12,8 @@ UPSERT STRATEGY:
 
 BATCH INSERTS:
     Rows are inserted in batches of 100 to reduce network round-trips.
-    On batch failure → falls back to row-by-row retry.
+    Transient batch failures are retried with exponential backoff.
+    On final batch failure → falls back to row-by-row retry.
     Persistent failures are written to etl_failed_rows table + local CSV.
 """
 
@@ -20,6 +21,7 @@ import json
 import os
 import re
 import time
+from collections.abc import Callable
 from collections import Counter
 from datetime import datetime, timezone
 from hashlib import sha256
@@ -41,6 +43,9 @@ SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 
 BATCH_SIZE = 100
 DELAY_SEC = 0.5
+BATCH_UPSERT_MAX_ATTEMPTS = 4
+BATCH_UPSERT_INITIAL_BACKOFF_SEC = 2.0
+BATCH_UPSERT_MAX_BACKOFF_SEC = 8.0
 RETRY_TABLE = "etl_failed_rows"
 SUCCESS_RATE_ALERT_THRESHOLD = 95.0
 FAILED_ROWS_BASE_DIR = Path(__file__).resolve().parents[4] / "data" / "failed"
@@ -94,6 +99,38 @@ ALLOWED_COLUMNS = {
         "updated_at",
     }
 }
+
+TRANSIENT_UPSERT_ERROR_KEYWORDS = (
+    "bad gateway",
+    "connection aborted",
+    "connection closed",
+    "connection refused",
+    "connection reset",
+    "gateway timeout",
+    "network",
+    "remote protocol",
+    "server disconnected",
+    "service unavailable",
+    "ssl",
+    "temporarily unavailable",
+    "timed out",
+    "timeout",
+    "too many requests",
+    "502",
+    "503",
+    "504",
+)
+
+TRANSIENT_UPSERT_EXCEPTION_NAME_KEYWORDS = (
+    "connect",
+    "connection",
+    "network",
+    "pooltimeout",
+    "readerror",
+    "remoteprotocol",
+    "timeout",
+    "writeerror",
+)
 
 
 # ── Loader ─────────────────────────────────────────────────────────────────────
@@ -169,7 +206,10 @@ class SupabaseLoader:
             batch = records_to_write[batch_start: batch_start + BATCH_SIZE]
             batch_end = batch_start + len(batch)
             try:
-                self._upsert_payloads([item["write_payload"] for item in batch], table)
+                self._upsert_batch_payloads_with_retries(
+                    [item["write_payload"] for item in batch],
+                    table,
+                )
                 inserted += len(batch)
                 logger.info(
                     f"[Loader] Batch {batch_start}–{batch_end} ✅  "
@@ -273,6 +313,43 @@ class SupabaseLoader:
                 self._persist_failure(failure, table)
         return inserted, failures
 
+    def _upsert_batch_payloads_with_retries(
+        self,
+        payloads: list[dict],
+        table: str,
+    ) -> None:
+        self._run_upsert_with_transient_retries(
+            lambda: self._upsert_payloads(payloads, table),
+            "Batch upsert",
+        )
+
+    def _run_upsert_with_transient_retries(
+        self,
+        operation: Callable[[], object],
+        context: str,
+    ) -> None:
+        for attempt in range(1, BATCH_UPSERT_MAX_ATTEMPTS + 1):
+            try:
+                operation()
+                return
+            except Exception as e:
+                if (
+                    attempt == BATCH_UPSERT_MAX_ATTEMPTS
+                    or not self._is_transient_upsert_error(e)
+                ):
+                    raise
+
+                wait_seconds = min(
+                    BATCH_UPSERT_INITIAL_BACKOFF_SEC * (2 ** (attempt - 1)),
+                    BATCH_UPSERT_MAX_BACKOFF_SEC,
+                )
+                logger.warning(
+                    f"[Loader] {context} transient failure "
+                    f"(attempt {attempt}/{BATCH_UPSERT_MAX_ATTEMPTS}): {e} — "
+                    f"retrying in {wait_seconds:g}s"
+                )
+                time.sleep(wait_seconds)
+
     def _upsert_payloads(self, payloads: list[dict], table: str) -> None:
         payloads = [self._prepare_payload(payload, table) for payload in payloads]
         if not payloads:
@@ -282,6 +359,35 @@ class SupabaseLoader:
             payloads,
             on_conflict=",".join(conflict_columns) if conflict_columns else None,
         ).execute()
+
+    @staticmethod
+    def _is_transient_upsert_error(error: Exception) -> bool:
+        for current in SupabaseLoader._iter_exception_chain(error):
+            if isinstance(current, (TimeoutError, ConnectionError)):
+                return True
+
+            class_name = current.__class__.__name__.lower()
+            message = str(current).lower()
+
+            if any(
+                keyword in class_name
+                for keyword in TRANSIENT_UPSERT_EXCEPTION_NAME_KEYWORDS
+            ):
+                return True
+
+            if any(keyword in message for keyword in TRANSIENT_UPSERT_ERROR_KEYWORDS):
+                return True
+
+        return False
+
+    @staticmethod
+    def _iter_exception_chain(error: Exception):
+        current = error
+        seen = set()
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            yield current
+            current = current.__cause__ or current.__context__
 
     def _prepare_payload(self, payload: dict, table: str) -> dict:
         if table in ALLOWED_COLUMNS:
@@ -685,7 +791,10 @@ class SupabaseLoader:
             batch_end = batch_start + len(batch)
 
             try:
-                self.client.table(table).upsert(batch).execute()
+                self._run_upsert_with_transient_retries(
+                    lambda: self.client.table(table).upsert(batch).execute(),
+                    f"merge_jan_aushadhi_price batch {batch_number}/{total_batches} upsert",
+                )
                 updated += len(batch)
                 logger.info(
                     f"[Loader] merge_jan_aushadhi_price: batch "

--- a/apps/etl/tests/test_loader.py
+++ b/apps/etl/tests/test_loader.py
@@ -90,6 +90,13 @@ class FakeTable:
 
         if self.operation == "upsert":
             payload = self.pending_payload
+            if isinstance(payload, list) and len(payload) > 1:
+                self.client.transient_batch_attempts += 1
+                if (
+                    self.client.transient_batch_attempts
+                    <= self.client.transient_batch_failures
+                ):
+                    raise TimeoutError("connection timed out during batch upsert")
             if isinstance(payload, list) and len(payload) > 1 and self.client.fail_batches:
                 raise Exception("22P02: invalid input syntax for type double precision")
             rows = payload if isinstance(payload, list) else [payload]
@@ -115,6 +122,7 @@ class FakeSupabaseClient:
         errors_by_generic_name=None,
         update_fail_ids=None,
         table_rows=None,
+        transient_batch_failures=0,
     ):
         self.fail_batches = fail_batches
         self.fail_generic_names = set(fail_generic_names or [])
@@ -122,6 +130,8 @@ class FakeSupabaseClient:
         self.retry_rows = retry_rows or []
         self.update_fail_ids = set(update_fail_ids or [])
         self.table_rows = table_rows if table_rows is not None else {"medicines": []}
+        self.transient_batch_failures = transient_batch_failures
+        self.transient_batch_attempts = 0
         self.upsert_calls = []
         self.insert_calls = []
         self.update_calls = []
@@ -172,6 +182,64 @@ def test_batch_success_returns_summary_without_failed_rows_csv(tmp_path):
     assert stats["error_counts"] == {}
     assert stats["failed_rows_csv"] is None
     assert len(client.upsert_calls) == 1
+
+
+def test_transient_batch_upsert_retries_with_exponential_backoff(tmp_path, monkeypatch):
+    client = FakeSupabaseClient(transient_batch_failures=2)
+    loader = make_loader(client, tmp_path)
+    sleep_calls = []
+    monkeypatch.setattr(
+        "src.loaders.supabase_loader.time.sleep",
+        lambda seconds: sleep_calls.append(seconds),
+    )
+    df = pd.DataFrame(
+        [
+            {"generic_name": "Paracetamol", "strength": "500mg", "dosage_form": "Tablet"},
+            {"generic_name": "Cetirizine", "strength": "10mg", "dosage_form": "Tablet"},
+        ]
+    )
+
+    stats = loader.load(df)
+
+    assert stats["total"] == 2
+    assert stats["inserted"] == 2
+    assert stats["failed"] == 0
+    assert stats["failed_rows_csv"] is None
+    assert client.transient_batch_attempts == 3
+    assert len(client.upsert_calls) == 3
+    assert all(len(payload) == 2 for _, payload, _ in client.upsert_calls)
+    assert sleep_calls == [2.0, 4.0]
+
+
+def test_transient_batch_upsert_falls_back_after_retries(tmp_path, monkeypatch):
+    client = FakeSupabaseClient(transient_batch_failures=4)
+    loader = make_loader(client, tmp_path)
+    sleep_calls = []
+    monkeypatch.setattr(
+        "src.loaders.supabase_loader.time.sleep",
+        lambda seconds: sleep_calls.append(seconds),
+    )
+    df = pd.DataFrame(
+        [
+            {"generic_name": "Paracetamol", "strength": "500mg", "dosage_form": "Tablet"},
+            {"generic_name": "Cetirizine", "strength": "10mg", "dosage_form": "Tablet"},
+        ]
+    )
+
+    stats = loader.load(df)
+
+    assert stats["inserted"] == 2
+    assert stats["failed"] == 0
+    assert client.transient_batch_attempts == 4
+    assert [len(payload) for _, payload, _ in client.upsert_calls] == [
+        2,
+        2,
+        2,
+        2,
+        1,
+        1,
+    ]
+    assert sleep_calls == [2.0, 4.0, 8.0]
 
 
 def test_load_skips_unchanged_rows_already_present_in_target_db(tmp_path):
@@ -323,6 +391,7 @@ def test_load_does_not_cache_failed_rows_until_successful_upsert(tmp_path):
     assert first_stats["inserted"] == 1
     assert first_stats["failed"] == 1
     assert first_stats["skipped_unchanged"] == 0
+    assert failing_client.transient_batch_attempts == 1
 
     assert retry_stats["inserted"] == 1
     assert retry_stats["failed"] == 0
@@ -448,15 +517,34 @@ class MergeFakeTable(FakeTable):
 class MergeFakeSupabaseClient:
     """Minimal Supabase fake for merge_jan_aushadhi_price tests."""
 
-    def __init__(self, medicines=None):
+    def __init__(self, medicines=None, transient_batch_failures=0):
         self.medicines = medicines or []
         self.update_calls = []
+        self.upsert_calls = []
+        self.transient_batch_failures = transient_batch_failures
+        self.transient_batch_attempts = 0
 
     def table(self, name):
         t = MergeFakeTable(name, self)
         original_execute = t.execute
 
         def patched_execute():
+            if t.operation == "upsert":
+                payload = t.pending_payload
+                rows = payload if isinstance(payload, list) else [payload]
+                if isinstance(payload, list) and len(payload) > 1:
+                    self.transient_batch_attempts += 1
+                    if self.transient_batch_attempts <= self.transient_batch_failures:
+                        raise TimeoutError(
+                            "connection timed out during Jan Aushadhi price batch upsert"
+                        )
+                for update in rows:
+                    row_id = update.get("id")
+                    for med in self.medicines:
+                        if med.get("id") == row_id:
+                            med.update(update)
+                return FakeExecuteResponse()
+
             if t.operation == "update":
                 row_id = next((v for c, v in t.eq_filters if c == "id"), None)
                 self.update_calls.append((name, t.pending_update, t.eq_filters))
@@ -498,6 +586,40 @@ def test_ja_backfill_updates_null_jan_aushadhi_price_rows(tmp_path):
     assert stats["updated"] == 2
     assert stats["skipped"] == 0
     assert stats["failed"] == 0
+    assert medicines[0]["jan_aushadhi_price"] == 18.50
+    assert medicines[1]["jan_aushadhi_price"] == 25.00
+
+
+def test_ja_backfill_retries_transient_batch_upsert_before_fallback(tmp_path, monkeypatch):
+    medicines = [
+        {"id": "m1", "generic_name": "Paracetamol", "strength": "500mg",
+         "source": "commercial", "jan_aushadhi_price": None},
+        {"id": "m2", "generic_name": "Cetirizine", "strength": "10mg",
+         "source": "commercial", "jan_aushadhi_price": None},
+    ]
+    nppa_csv = _write_nppa_csv(tmp_path, [
+        {"generic_name": "paracetamol", "strength": "500mg", "mrp": "18.50"},
+        {"generic_name": "cetirizine", "strength": "10mg", "mrp": "25.00"},
+    ])
+    client = MergeFakeSupabaseClient(
+        medicines=medicines,
+        transient_batch_failures=2,
+    )
+    loader = make_merge_loader(client, tmp_path)
+    sleep_calls = []
+    monkeypatch.setattr(
+        "src.loaders.supabase_loader.time.sleep",
+        lambda seconds: sleep_calls.append(seconds),
+    )
+
+    stats = loader.merge_jan_aushadhi_price(nppa_csv=nppa_csv)
+
+    assert stats["updated"] == 2
+    assert stats["failed"] == 0
+    assert client.transient_batch_attempts == 3
+    assert len(client.upsert_calls) == 3
+    assert client.update_calls == []
+    assert sleep_calls == [2.0, 4.0]
     assert medicines[0]["jan_aushadhi_price"] == 18.50
     assert medicines[1]["jan_aushadhi_price"] == 25.00
 

--- a/docs/etl-pipeline.md
+++ b/docs/etl-pipeline.md
@@ -164,7 +164,9 @@ apps/etl/
 
 ## Error handling & retry
 
-When a batch upsert fails, the loader automatically falls back to row-by-row inserts. Rows that still fail are:
+When a batch upsert fails with a transient network/server error, the loader retries
+the batch with exponential backoff before falling back to row-by-row inserts. Rows
+that still fail are:
 
 1. Logged as structured JSON to stdout (for CI/log aggregators)
 2. Written to `data/failed/<pipeline>/failed_rows_<timestamp>.csv`


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1427**
- **Summary:** Adds exponential backoff around Supabase ETL batch upserts before the existing row-by-row fallback runs. The loader now retries transient network/server failures with 2s, 4s, and 8s waits, then falls back cleanly if the batch still fails. Jan Aushadhi price backfill uses the same retry path.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

Backend/ETL-only change, so terminal proof is attached instead of screenshots.

```bash
cd apps/etl
python3 -m pytest tests/test_loader.py -q
python3 -m pytest -q
python3 -m compileall -q src tests
git diff --check
```

Result: `14 passed` for `tests/test_loader.py`, `17 passed` for the full ETL test suite, compileall passed, and `git diff --check` passed. Pytest still prints the existing `asyncio_mode` config warning.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
