### PR TITLE
feat(upload): rate limit report image uploads

### DIFF
--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -2,9 +2,64 @@ import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 
 const MAX_UPLOAD_SIZE = 10 * 1024 * 1024;
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const UPLOAD_RATE_LIMIT = 10;
+const UPLOAD_RATE_WINDOW_MS = 60 * 1000;
+
+const uploadRateBuckets = new Map<string, { count: number; resetAt: number }>();
+
+function getUploadClientIp(req: NextRequest) {
+    const forwardedFor = req.headers.get("x-forwarded-for");
+    const realIp = req.headers.get("x-real-ip");
+
+    return forwardedFor?.split(",")[0]?.trim() || realIp?.trim() || "127.0.0.1";
+}
+
+function pruneExpiredUploadBuckets(now: number) {
+    for (const [ip, bucket] of uploadRateBuckets) {
+        if (bucket.resetAt <= now) {
+            uploadRateBuckets.delete(ip);
+        }
+    }
+}
+
+function consumeUploadQuota(ip: string, now = Date.now()) {
+    pruneExpiredUploadBuckets(now);
+
+    const bucket = uploadRateBuckets.get(ip);
+
+    if (!bucket || bucket.resetAt <= now) {
+        uploadRateBuckets.set(ip, { count: 1, resetAt: now + UPLOAD_RATE_WINDOW_MS });
+        return { allowed: true, retryAfter: 0 };
+    }
+
+    if (bucket.count >= UPLOAD_RATE_LIMIT) {
+        return {
+            allowed: false,
+            retryAfter: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+        };
+    }
+
+    bucket.count += 1;
+    return { allowed: true, retryAfter: 0 };
+}
 
 export async function POST(req: NextRequest) {
     try {
+        const quota = consumeUploadQuota(getUploadClientIp(req));
+        if (!quota.allowed) {
+            return NextResponse.json(
+                {
+                    error: "Too many upload requests. Please try again later.",
+                    retryAfter: quota.retryAfter,
+                },
+                {
+                    status: 429,
+                    headers: { "Retry-After": quota.retryAfter.toString() },
+                }
+            );
+        }
+
         const formData = await req.formData();
         const file = formData.get("file") as File | null;
 
@@ -12,20 +67,19 @@ export async function POST(req: NextRequest) {
             return NextResponse.json({ error: "No file provided" }, { status: 400 });
         }
 
-        if (file.size > MAX_UPLOAD_SIZE) {
-                    
-        const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
         if (!ALLOWED_MIME_TYPES.includes(file.type)) {
             return NextResponse.json(
-                { 
+                {
                     error: "invalid_file_type",
                     message: "Invalid file type. Only JPEG, PNG, and WEBP images are allowed.",
                     allowedTypes: ALLOWED_MIME_TYPES,
-                    receivedType: file.type
+                    receivedType: file.type,
                 },
                 { status: 400 }
             );
         }
+
+        if (file.size > MAX_UPLOAD_SIZE) {
             return NextResponse.json(
                 {
                     error: "file_too_large",
@@ -36,7 +90,7 @@ export async function POST(req: NextRequest) {
                 { status: 413 }
             );
         }
-        
+
         const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
         const apiKey = process.env.CLOUDINARY_API_KEY;
         const apiSecret = process.env.CLOUDINARY_API_SECRET;

--- a/apps/web/tests/upload-route.test.ts
+++ b/apps/web/tests/upload-route.test.ts
@@ -1,19 +1,23 @@
 import crypto from "crypto";
 
-import { POST } from "../app/api/upload/route";
-
 const CLOUD_NAME = "test-cloud";
 const API_KEY = "test-key";
 const API_SECRET = "test-secret";
+type UploadPost = typeof import("../app/api/upload/route").POST;
 
-function buildRequest(fields: Record<string, string> = {}) {
+function buildRequest(
+    fields: Record<string, string> = {},
+    headers?: HeadersInit,
+    fileType = "image/jpeg"
+) {
     const formData = new FormData();
-    formData.append("file", new Blob(["fake-image-bytes"], { type: "image/jpeg" }), "photo.jpg");
+    formData.append("file", new Blob(["fake-image-bytes"], { type: fileType }), "photo.jpg");
     for (const [key, value] of Object.entries(fields)) {
         formData.append(key, value);
     }
     return new Request("http://localhost/api/upload", {
         method: "POST",
+        headers,
         body: formData,
     });
 }
@@ -25,8 +29,14 @@ function captureCloudinaryFormData(fetchMock: jest.Mock): FormData {
 
 describe("POST /api/upload", () => {
     let fetchMock: jest.Mock;
+    let post: UploadPost;
 
     beforeEach(() => {
+        jest.resetModules();
+        ({ POST: post } = require("../app/api/upload/route") as {
+            POST: UploadPost;
+        });
+
         process.env.CLOUDINARY_CLOUD_NAME = CLOUD_NAME;
         process.env.CLOUDINARY_API_KEY = API_KEY;
         process.env.CLOUDINARY_API_SECRET = API_SECRET;
@@ -49,7 +59,7 @@ describe("POST /api/upload", () => {
     });
 
     it("stores the image under sahidawa/reports with a {batch_number}_{timestamp} public_id", async () => {
-        const response = await POST(buildRequest({ batch_number: "BATCH123" }));
+        const response = await post(buildRequest({ batch_number: "BATCH123" }));
 
         expect(response.status).toBe(200);
         expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -62,7 +72,7 @@ describe("POST /api/upload", () => {
     });
 
     it("falls back to a 'report' prefix when no batch number is supplied", async () => {
-        await POST(buildRequest());
+        await post(buildRequest());
 
         const sent = captureCloudinaryFormData(fetchMock);
         const timestamp = sent.get("timestamp") as string;
@@ -71,7 +81,7 @@ describe("POST /api/upload", () => {
     });
 
     it("signs the request over the sorted params including public_id", async () => {
-        await POST(buildRequest({ batch_number: "BATCH123" }));
+        await post(buildRequest({ batch_number: "BATCH123" }));
 
         const sent = captureCloudinaryFormData(fetchMock);
         const timestamp = sent.get("timestamp") as string;
@@ -85,5 +95,87 @@ describe("POST /api/upload", () => {
             .digest("hex");
 
         expect(sent.get("signature")).toBe(expectedSignature);
+    });
+
+    it("rejects non-image uploads before calling Cloudinary", async () => {
+        const response = await post(
+            buildRequest(
+                { batch_number: "BATCH123" },
+                { "x-forwarded-for": "203.0.113.30" },
+                "text/plain"
+            )
+        );
+        const body = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(body).toEqual({
+            error: "invalid_file_type",
+            message: "Invalid file type. Only JPEG, PNG, and WEBP images are allowed.",
+            allowedTypes: ["image/jpeg", "image/png", "image/webp"],
+            receivedType: "text/plain",
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("returns 429 after 10 uploads in one minute for the same forwarded IP", async () => {
+        jest.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+        const headers = { "x-forwarded-for": "203.0.113.10, 10.0.0.1" };
+
+        for (let i = 0; i < 10; i += 1) {
+            const response = await post(buildRequest({ batch_number: `BATCH${i}` }, headers));
+            expect(response.status).toBe(200);
+        }
+
+        const response = await post(buildRequest({ batch_number: "BATCH10" }, headers));
+        const body = await response.json();
+
+        expect(response.status).toBe(429);
+        expect(response.headers.get("Retry-After")).toBe("60");
+        expect(body).toEqual({
+            error: "Too many upload requests. Please try again later.",
+            retryAfter: 60,
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(10);
+    });
+
+    it("uses the first x-forwarded-for IP as the rate limit key", async () => {
+        jest.spyOn(Date, "now").mockReturnValue(1_700_000_100_000);
+        const firstIpHeaders = { "x-forwarded-for": "198.51.100.20, 10.0.0.1" };
+
+        for (let i = 0; i < 10; i += 1) {
+            await post(buildRequest({ batch_number: `FIRST${i}` }, firstIpHeaders));
+        }
+
+        const secondIpResponse = await post(
+            buildRequest(
+                { batch_number: "SECOND" },
+                { "x-forwarded-for": "198.51.100.21, 10.0.0.1" }
+            )
+        );
+        const firstIpResponse = await post(
+            buildRequest({ batch_number: "FIRST10" }, firstIpHeaders)
+        );
+
+        expect(secondIpResponse.status).toBe(200);
+        expect(firstIpResponse.status).toBe(429);
+    });
+
+    it("allows the same IP again after the one-minute window resets", async () => {
+        const dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(1_700_000_200_000);
+        const headers = { "x-forwarded-for": "203.0.113.40" };
+
+        for (let i = 0; i < 10; i += 1) {
+            const response = await post(buildRequest({ batch_number: `RESET${i}` }, headers));
+            expect(response.status).toBe(200);
+        }
+
+        const limitedResponse = await post(buildRequest({ batch_number: "RESET10" }, headers));
+        expect(limitedResponse.status).toBe(429);
+
+        dateNowSpy.mockReturnValue(1_700_000_260_001);
+
+        const resetResponse = await post(buildRequest({ batch_number: "RESET11" }, headers));
+        expect(resetResponse.status).toBe(200);
+        expect(fetchMock).toHaveBeenCalledTimes(11);
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1425**
- **Summary:** Adds a lightweight in-memory rate limiter to `/api/upload`, keyed by client IP, with a 10 uploads/minute window. Requests over the limit return `429 Too Many Requests` with `Retry-After`. The route still rejects oversized files and now rejects invalid image MIME types before calling downstream services.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

API-route-only change, so terminal proof is attached instead of screenshots.

```bash
npm test -w web -- upload-route.test.ts --runInBand
npx prettier --check apps/web/app/api/upload/route.ts apps/web/tests/upload-route.test.ts
git diff --check
```

Result: `upload-route.test.ts` passed with 7 tests, Prettier passed for both touched files, and `git diff --check` passed.

Note: this is intentionally in-memory and per process, which matches the issue suggestion allowing a simple memory cache for a single-instance deployment.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
