### PR TITLE
fix(api): align map nearby RPC schema

### DIFF
--- a/apps/api/src/db/migrations/001_map_tables.sql
+++ b/apps/api/src/db/migrations/001_map_tables.sql
@@ -1,69 +1,14 @@
--- Enable PostGIS
-CREATE EXTENSION IF NOT EXISTS postgis;
-
--- Pharmacies table
-CREATE TABLE IF NOT EXISTS pharmacies (
-  id         SERIAL PRIMARY KEY,
-  name       TEXT NOT NULL,
-  type       TEXT CHECK (type IN ('Jan Aushadhi', 'private')) NOT NULL,
-  lat        DOUBLE PRECISION NOT NULL,
-  lng        DOUBLE PRECISION NOT NULL,
-  address    TEXT,
-  district   TEXT,
-  state      TEXT,
-  verified   BOOLEAN DEFAULT FALSE,
-  location   GEOGRAPHY(POINT, 4326) GENERATED ALWAYS AS (
-               ST_SetSRID(ST_MakePoint(lng, lat), 4326)::geography
-             ) STORED
-);
-
--- ASHA workers table
-CREATE TABLE IF NOT EXISTS asha_workers (
-  id       SERIAL PRIMARY KEY,
-  name     TEXT NOT NULL,
-  district TEXT,
-  lat      DOUBLE PRECISION NOT NULL,
-  lng      DOUBLE PRECISION NOT NULL,
-  contact  TEXT,
-  location GEOGRAPHY(POINT, 4326) GENERATED ALWAYS AS (
-               ST_SetSRID(ST_MakePoint(lng, lat), 4326)::geography
-             ) STORED
-);
-
--- Spatial indexes for fast ST_DWithin queries
-CREATE INDEX ON pharmacies USING GIST(location);
-CREATE INDEX ON asha_workers USING GIST(location);
-
--- Function for nearby pharmacies
-CREATE OR REPLACE FUNCTION get_nearby_pharmacies(
-  user_lat DOUBLE PRECISION,
-  user_lng DOUBLE PRECISION,
-  radius_m DOUBLE PRECISION
-)
-RETURNS TABLE (
-  id INT, name TEXT, type TEXT, lat DOUBLE PRECISION, lng DOUBLE PRECISION,
-  address TEXT, district TEXT, state TEXT, verified BOOLEAN, distance_km NUMERIC
-) LANGUAGE sql STABLE AS $$
-  SELECT id, name, type, lat, lng, address, district, state, verified,
-    ROUND(ST_Distance(location, ST_SetSRID(ST_MakePoint(user_lng, user_lat), 4326)::geography)::numeric / 1000, 2) AS distance_km
-  FROM pharmacies
-  WHERE ST_DWithin(location, ST_SetSRID(ST_MakePoint(user_lng, user_lat), 4326)::geography, radius_m)
-  ORDER BY distance_km ASC;
-$$;
-
--- Function for nearby ASHA workers
-CREATE OR REPLACE FUNCTION get_nearby_asha_workers(
-  user_lat DOUBLE PRECISION,
-  user_lng DOUBLE PRECISION,
-  radius_m DOUBLE PRECISION
-)
-RETURNS TABLE (
-  id INT, name TEXT, district TEXT, lat DOUBLE PRECISION, lng DOUBLE PRECISION,
-  contact TEXT, distance_km NUMERIC
-) LANGUAGE sql STABLE AS $$
-  SELECT id, name, district, lat, lng, contact,
-    ROUND(ST_Distance(location, ST_SetSRID(ST_MakePoint(user_lng, user_lat), 4326)::geography)::numeric / 1000, 2) AS distance_km
-  FROM asha_workers
-  WHERE ST_DWithin(location, ST_SetSRID(ST_MakePoint(user_lng, user_lat), 4326)::geography, radius_m)
-  ORDER BY distance_km ASC;
-$$;
+-- Deprecated local Express migration.
+--
+-- The canonical SahiDawa database schema is maintained in supabase/migrations.
+-- In particular:
+--   - supabase/migrations/20260511000000_initial_schema.sql defines
+--     public.pharmacies with UUID primary keys and a PostGIS geography column.
+--   - supabase/migrations/20260530000000_create_pharmacy_rpc_functions.sql
+--     defines get_nearest_pharmacies(...) and get_pharmacies_in_bounds(...).
+--
+-- This file previously created a divergent pharmacies table with SERIAL IDs,
+-- flat lat/lng columns, an ASHA worker table, and get_nearby_* RPC functions
+-- that do not exist in the Supabase project. It is intentionally left as a
+-- no-op tombstone so local scripts or documentation that reference this path do
+-- not recreate the conflicting schema.

--- a/apps/api/src/routes/map.ts
+++ b/apps/api/src/routes/map.ts
@@ -1,35 +1,75 @@
-import { Router, Request, Response } from 'express';
-import { supabase } from '../db/client';
+import { Router, Request, Response } from "express";
+import { supabase } from "../db/client";
 
 const router = Router();
 
+interface PharmacyRpcResult {
+    id: string;
+    name: string | null;
+    address: string | null;
+    district: string | null;
+    state: string | null;
+    phone_number: string | null;
+    is_verified: boolean | null;
+    lat: number;
+    lng: number;
+    distance: number | null;
+}
+
+function formatNearbyPharmacy(pharmacy: PharmacyRpcResult) {
+    const isVerified = pharmacy.is_verified ?? false;
+    const distanceKm = Number(pharmacy.distance ?? 0);
+
+    return {
+        id: pharmacy.id,
+        name: pharmacy.name,
+        type: "Jan Aushadhi",
+        lat: pharmacy.lat,
+        lng: pharmacy.lng,
+        address: pharmacy.address,
+        district: pharmacy.district,
+        state: pharmacy.state,
+        phone_number: pharmacy.phone_number,
+        is_verified: isVerified,
+        verified: isVerified,
+        distance: distanceKm,
+        distance_km: distanceKm,
+    };
+}
+
 // GET /api/map/nearby?lat=18.52&lng=73.85&radius_km=10
-router.get('/nearby', async (req: Request, res: Response) => {
-  const lat = parseFloat(req.query.lat as string);
-  const lng = parseFloat(req.query.lng as string);
-  const radius_km = parseFloat((req.query.radius_km as string) || '10');
+router.get("/nearby", async (req: Request, res: Response) => {
+    const lat = parseFloat(req.query.lat as string);
+    const lng = parseFloat(req.query.lng as string);
+    const radius_km = parseFloat((req.query.radius_km as string) || "10");
 
-  if (isNaN(lat) || isNaN(lng)) {
-    return res.status(400).json({ error: 'lat and lng are required query params' });
-  }
+    if (isNaN(lat) || isNaN(lng)) {
+        return res.status(400).json({ error: "lat and lng are required query params" });
+    }
 
-  try {
-    const [pharmaciesRes, ashaRes] = await Promise.all([
-      supabase.rpc('get_nearby_pharmacies', { user_lat: lat, user_lng: lng, radius_m: radius_km * 1000 }),
-      supabase.rpc('get_nearby_asha_workers', { user_lat: lat, user_lng: lng, radius_m: radius_km * 1000 }),
-    ]);
+    try {
+        const pharmaciesRes = await supabase.rpc("get_nearest_pharmacies", {
+            query_lat: lat,
+            query_lng: lng,
+            search_radius_km: radius_km,
+        });
 
-    if (pharmaciesRes.error) throw pharmaciesRes.error;
-    if (ashaRes.error) throw ashaRes.error;
+        if (pharmaciesRes.error) throw pharmaciesRes.error;
 
-    res.json({
-      pharmacies: pharmaciesRes.data,
-      asha_workers: ashaRes.data,
-    });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Internal server error' });
-  }
+        const pharmacies = Array.isArray(pharmaciesRes.data)
+            ? (pharmaciesRes.data as PharmacyRpcResult[]).map(formatNearbyPharmacy)
+            : [];
+
+        res.json({
+            pharmacies,
+            // Canonical Supabase migrations currently define pharmacy geo RPCs only.
+            // Keep the legacy response key stable until an ASHA schema/RPC exists.
+            asha_workers: [],
+        });
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: "Internal server error" });
+    }
 });
 
 export default router;

--- a/apps/api/tests/map.test.ts
+++ b/apps/api/tests/map.test.ts
@@ -44,36 +44,23 @@ describe("GET /api/map/nearby", () => {
         expect(rpcMock).not.toHaveBeenCalled();
     });
 
-    it("returns nearby pharmacies and ASHA workers from PostGIS RPC responses", async () => {
-        const pharmacies = [
+    it("returns canonical PostGIS pharmacies and preserves an empty ASHA key", async () => {
+        const rpcPharmacies = [
             {
-                id: 1,
+                id: "9cb1ba95-ae3c-4c8b-a6f8-c02d1b447b94",
                 name: "Jan Aushadhi Kendra Pune",
-                type: "Jan Aushadhi",
-                lat: 18.5204,
-                lng: 73.8567,
                 address: "Shivajinagar",
                 district: "Pune",
                 state: "Maharashtra",
-                verified: true,
-                distance_km: 1.24,
-            },
-        ];
-        const ashaWorkers = [
-            {
-                id: 11,
-                name: "Meera Patil",
-                district: "Pune",
+                phone_number: "+912012345678",
+                is_verified: true,
                 lat: 18.521,
                 lng: 73.855,
-                contact: "+919876543210",
-                distance_km: 0.72,
+                distance: 1.24,
             },
         ];
 
-        rpcMock
-            .mockResolvedValueOnce({ data: pharmacies, error: null })
-            .mockResolvedValueOnce({ data: ashaWorkers, error: null });
+        rpcMock.mockResolvedValueOnce({ data: rpcPharmacies, error: null });
 
         const response = await request(app).get(
             "/api/map/nearby?lat=18.5204&lng=73.8567&radius_km=5"
@@ -81,18 +68,30 @@ describe("GET /api/map/nearby", () => {
 
         expect(response.status).toBe(200);
         expect(response.body).toEqual({
-            pharmacies,
-            asha_workers: ashaWorkers,
+            pharmacies: [
+                {
+                    id: "9cb1ba95-ae3c-4c8b-a6f8-c02d1b447b94",
+                    name: "Jan Aushadhi Kendra Pune",
+                    type: "Jan Aushadhi",
+                    lat: 18.521,
+                    lng: 73.855,
+                    address: "Shivajinagar",
+                    district: "Pune",
+                    state: "Maharashtra",
+                    phone_number: "+912012345678",
+                    is_verified: true,
+                    verified: true,
+                    distance: 1.24,
+                    distance_km: 1.24,
+                },
+            ],
+            asha_workers: [],
         });
-        expect(rpcMock).toHaveBeenNthCalledWith(1, "get_nearby_pharmacies", {
-            user_lat: 18.5204,
-            user_lng: 73.8567,
-            radius_m: 5000,
-        });
-        expect(rpcMock).toHaveBeenNthCalledWith(2, "get_nearby_asha_workers", {
-            user_lat: 18.5204,
-            user_lng: 73.8567,
-            radius_m: 5000,
+        expect(rpcMock).toHaveBeenCalledTimes(1);
+        expect(rpcMock).toHaveBeenCalledWith("get_nearest_pharmacies", {
+            query_lat: 18.5204,
+            query_lng: 73.8567,
+            search_radius_km: 5,
         });
     });
 
@@ -102,15 +101,11 @@ describe("GET /api/map/nearby", () => {
         const response = await request(app).get("/api/map/nearby?lat=18.5204&lng=73.8567");
 
         expect(response.status).toBe(200);
-        expect(rpcMock).toHaveBeenNthCalledWith(1, "get_nearby_pharmacies", {
-            user_lat: 18.5204,
-            user_lng: 73.8567,
-            radius_m: 10000,
-        });
-        expect(rpcMock).toHaveBeenNthCalledWith(2, "get_nearby_asha_workers", {
-            user_lat: 18.5204,
-            user_lng: 73.8567,
-            radius_m: 10000,
+        expect(rpcMock).toHaveBeenCalledTimes(1);
+        expect(rpcMock).toHaveBeenCalledWith("get_nearest_pharmacies", {
+            query_lat: 18.5204,
+            query_lng: 73.8567,
+            search_radius_km: 10,
         });
     });
 
@@ -118,12 +113,10 @@ describe("GET /api/map/nearby", () => {
         const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
 
         try {
-            rpcMock
-                .mockResolvedValueOnce({
-                    data: null,
-                    error: { message: "PostGIS function unavailable" },
-                })
-                .mockResolvedValueOnce({ data: [], error: null });
+            rpcMock.mockResolvedValueOnce({
+                data: null,
+                error: { message: "PostGIS function unavailable" },
+            });
 
             const response = await request(app).get(
                 "/api/map/nearby?lat=18.5204&lng=73.8567&radius_km=5"


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1402**
- **Summary:** Aligns `/api/map/nearby` with the canonical Supabase geo RPC by calling `get_nearest_pharmacies(query_lat, query_lng, search_radius_km)`. The local Express migration that redefined incompatible map tables is now a tombstone pointing developers to `supabase/migrations`, which removes the schema drift source.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

Backend/API-only change, so terminal proof is attached instead of screenshots.

```bash
npm test -w sahidawa-api -- map.test.ts --runInBand
npm exec -w sahidawa-api -- tsc -p tsconfig.json --noEmit
node scripts/check-migrations.js
git diff --check
```

Result: `map.test.ts` passed with 7 tests, API typecheck passed, migration checker reported `All migrations are synchronized`, and `git diff --check` passed.

Notes for review: `asha_workers` remains an empty array because the canonical Supabase migrations only define pharmacy geo RPCs today. Keeping the key preserves the existing response shape while removing the failing nonexistent ASHA RPC call. I could not capture live Supabase curl proof in this environment because local Supabase startup was still pulling large Docker images; the route-level RPC contract, API typecheck, and migration checker all pass.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
