### PR TITLE
fix: Restrict and Validate Pagination parameters in Admin controllers

### DIFF
--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -21,6 +21,11 @@ const medicineSchema = z.object({
     status: z.enum(["safe", "suspicious", "recalled", "pending_review"]).default("safe").optional(),
 });
 
+const paginationSchema = z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+
 export const getPendingReports = async (
     req: AuthenticatedRequest,
     res: Response
@@ -121,8 +126,17 @@ export const updateReportStatus = async (
 
 export const getAllMedicines = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
-        const page = parseInt(req.query.page as string) || 1;
-        const limit = parseInt(req.query.limit as string) || 50;
+        const parsed = paginationSchema.safeParse(req.query);
+
+        if (!parsed.success) {
+            res.status(400).json({
+                error: "Invalid pagination parameters",
+                details: parsed.error.issues,
+            });
+            return;
+        }
+
+        const { page, limit } = parsed.data;
         const offset = (page - 1) * limit;
 
         const { data, error, count } = await supabase
@@ -180,8 +194,19 @@ export const createMedicine = async (req: AuthenticatedRequest, res: Response): 
 
 export const getAuditLogs = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
-        const page = parseInt(req.query.page as string) || 1;
-        const limit = parseInt(req.query.limit as string) || 20;
+        const parsed = paginationSchema
+            .extend({ limit: z.coerce.number().int().min(1).max(100).default(20) })
+            .safeParse(req.query);
+
+        if (!parsed.success) {
+            res.status(400).json({
+                error: "Invalid pagination parameters",
+                details: parsed.error.issues,
+            });
+            return;
+        }
+
+        const { page, limit } = parsed.data;
         const offset = (page - 1) * limit;
 
         const { data, error, count } = await supabase


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

-Closes #1384 

Fixes unsafe pagination parameter parsing in getAllMedicines and getAuditLogs in admin.controller.ts.

Problem: page and limit were parsed with raw parseInt and no boundary checks, allowing negative offsets (causing DB crashes) and arbitrarily large limits (DoS vector).

Changes:

-Added a paginationSchema using Zod (already a project dependency) that enforces page ≥ 1 and 1 ≤ limit ≤ 100
-Applied it in getAllMedicines and getAuditLogs - invalid params now return a 400 Bad Request with descriptive error details
-getAuditLogs uses paginationSchema.extend() to preserve its original default limit of 20

Files changed: apps/api/src/controllers/admin.controller.ts only**

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> 
<img width="692" height="98" alt="Screenshot 2026-06-07 113643" src="https://github.com/user-attachments/assets/3a0338f4-3dd1-4245-9405-0ede5cde41c4" />
<img width="631" height="297" alt="Screenshot 2026-06-07 113659" src="https://github.com/user-attachments/assets/993fe13a-5a4f-46a5-8722-d79433e733cc" />
<img width="677" height="362" alt="Screenshot 2026-06-07 113713" src="https://github.com/user-attachments/assets/9a38dbc7-5a06-4eae-9927-14c767b25d8c" />



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
