### PR TITLE
refactor(etl): add jitter to retry backoff

### DIFF
--- a/apps/etl/src/loaders/supabase_loader.py
+++ b/apps/etl/src/loaders/supabase_loader.py
@@ -19,6 +19,7 @@ BATCH INSERTS:
 
 import json
 import os
+import random
 import re
 import time
 from collections.abc import Callable
@@ -338,11 +339,13 @@ class SupabaseLoader:
                     or not self._is_transient_upsert_error(e)
                 ):
                     raise
-
-                wait_seconds = min(
+                base_wait = min(
                     BATCH_UPSERT_INITIAL_BACKOFF_SEC * (2 ** (attempt - 1)),
                     BATCH_UPSERT_MAX_BACKOFF_SEC,
                 )
+
+                wait_seconds = base_wait + random.uniform(0.1, 1.0)
+
                 logger.warning(
                     f"[Loader] {context} transient failure "
                     f"(attempt {attempt}/{BATCH_UPSERT_MAX_ATTEMPTS}): {e} — "

--- a/apps/etl/tests/test_loader.py
+++ b/apps/etl/tests/test_loader.py
@@ -208,7 +208,10 @@ def test_transient_batch_upsert_retries_with_exponential_backoff(tmp_path, monke
     assert client.transient_batch_attempts == 3
     assert len(client.upsert_calls) == 3
     assert all(len(payload) == 2 for _, payload, _ in client.upsert_calls)
-    assert sleep_calls == [2.0, 4.0]
+    assert len(sleep_calls) == 2
+
+    assert 2.1 <= sleep_calls[0] <= 3.0
+    assert 4.1 <= sleep_calls[1] <= 5.0
 
 
 def test_transient_batch_upsert_falls_back_after_retries(tmp_path, monkeypatch):
@@ -239,7 +242,11 @@ def test_transient_batch_upsert_falls_back_after_retries(tmp_path, monkeypatch):
         1,
         1,
     ]
-    assert sleep_calls == [2.0, 4.0, 8.0]
+    assert len(sleep_calls) == 3
+
+    assert 2.1 <= sleep_calls[0] <= 3.0
+    assert 4.1 <= sleep_calls[1] <= 5.0
+    assert 8.1 <= sleep_calls[2] <= 9.0
 
 
 def test_load_skips_unchanged_rows_already_present_in_target_db(tmp_path):
@@ -619,7 +626,10 @@ def test_ja_backfill_retries_transient_batch_upsert_before_fallback(tmp_path, mo
     assert client.transient_batch_attempts == 3
     assert len(client.upsert_calls) == 3
     assert client.update_calls == []
-    assert sleep_calls == [2.0, 4.0]
+    assert len(sleep_calls) == 2
+
+    assert 2.1 <= sleep_calls[0] <= 3.0
+    assert 4.1 <= sleep_calls[1] <= 5.0
     assert medicines[0]["jan_aushadhi_price"] == 18.50
     assert medicines[1]["jan_aushadhi_price"] == 25.00
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link

* Closes #1451

### Summary

* Added randomized jitter to transient retry backoff in `SupabaseLoader`.
* Preserved exponential backoff behavior while reducing synchronized retries across concurrent ETL workers.
* Updated retry-related tests to validate jittered retry ranges instead of fixed sleep durations.

### Files Modified

* `apps/etl/src/loaders/supabase_loader.py`
* `apps/etl/tests/test_loader.py`

## 📸 Proof of Work

### Validation

* Verified transient retries still follow exponential backoff.
* Verified random jitter is applied on every retry attempt.
* Updated tests to validate retry duration ranges.

## 🏷️ PR Type

* [x] ♻️ type: refactor

## ✅ Checklist

* [x] My PR has a linked issue (Closes #1451)
* [x] I have pulled the latest main and resolved any conflicts
