### PR TITLE
Added Click outside to close behavior for language switcher Dropdown

### DIFF
--- a/apps/web/app/[locale]/LanguageSwitcher.tsx
+++ b/apps/web/app/[locale]/LanguageSwitcher.tsx
@@ -91,16 +91,30 @@ export default function LanguageSwitcher() {
         }
     };
 
-    // Close dropdown on Escape key
+    // Handle global dismiss events (Escape key and outside clicks)
     useEffect(() => {
-        function handleEscape(e: KeyboardEvent) {
-            if (e.key === "Escape") {
+        if (!open) return;
+
+        function handleDismiss(e: MouseEvent | KeyboardEvent) {
+            if (e instanceof KeyboardEvent && e.key === "Escape") {
+                setOpen(false);
+                triggerRef.current?.focus();
+            } else if (
+                e instanceof MouseEvent &&
+                ref.current &&
+                !ref.current.contains(e.target as Node)
+            ) {
                 setOpen(false);
             }
         }
-        document.addEventListener("keydown", handleEscape);
-        return () => document.removeEventListener("keydown", handleEscape);
-    }, []);
+
+        document.addEventListener("mousedown", handleDismiss);
+        document.addEventListener("keydown", handleDismiss);
+        return () => {
+            document.removeEventListener("mousedown", handleDismiss);
+            document.removeEventListener("keydown", handleDismiss);
+        };
+    }, [open]);
 
     const current = languages.find((l) => l.code === locale) || languages[0];
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1373 
- **Summary:**
  - Click-Outside Logic: Added a 'mousedown' listener that checks if the click target is contained within the component's ref. If not, the menu closes.
  - State-Aware Listener: The effect now only attaches listeners when the dropdown is open, reducing unnecessary overhead and improving performance.
  - Enhanced Focus Flow: For Escape key dismissals, focus is programmatically returned to the globe trigger button, maintaining accessibility for keyboard users.
  - Cleanup: Properly removes both mousedown and keydown listeners upon unmount or when the dropdown closes.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [x] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1373 `)
- [x] I have pulled the latest `main` and resolved any conflicts
