### PR TITLE
fix(api): restrict admin write routes

### DIFF
--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -11,13 +11,21 @@ import { getPushNotificationAnalytics } from "./analytics";
 
 const router = Router();
 
-router.use(requireAuth, requireRole("admin", "moderator"));
+router.get("/reports", requireAuth, requireRole("admin", "moderator"), getPendingReports);
 
-router.get("/reports", getPendingReports);
-router.patch("/reports/:id/status", updateReportStatus);
-router.get("/medicines", getAllMedicines);
-router.post("/medicines", createMedicine);
-router.get("/logs", getAuditLogs);
-router.get("/push-notifications/analytics", getPushNotificationAnalytics);
+router.get("/medicines", requireAuth, requireRole("admin", "moderator"), getAllMedicines);
+
+router.get("/logs", requireAuth, requireRole("admin", "moderator"), getAuditLogs);
+
+router.get(
+    "/push-notifications/analytics",
+    requireAuth,
+    requireRole("admin", "moderator"),
+    getPushNotificationAnalytics
+);
+
+router.patch("/reports/:id/status", requireAuth, requireRole("admin"), updateReportStatus);
+
+router.post("/medicines", requireAuth, requireRole("admin"), createMedicine);
 
 export default router;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link

* Closes #1391

### Summary

* Removed global role middleware from admin routes.
* Applied route-level authorization controls.
* Restricted mutation endpoints to admin users only.
* Preserved moderator access to read-only endpoints.
* Implemented least-privilege access control for admin APIs.

## 📸 Proof of Work

### Validation

* Verified moderators can access:

  * GET /reports
  * GET /medicines
  * GET /logs
  * GET /push-notifications/analytics

* Verified moderators cannot access:

  * PATCH /reports/:id/status
  * POST /medicines

* Verified admin users retain access to all routes.

## 🏷️ PR Type

* [x] 🔒 type: security

## ✅ Checklist

* [x] My PR has a linked issue (Closes #1391)
* [x] I have pulled the latest main and resolved any conflicts
