### PR TITLE
security: mask client IP before storing scan history

### DIFF
--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -6,6 +6,30 @@ import { optionalAuth } from "../middleware/auth";
 import logger from "../utils/logger";
 import { escapeIlike } from "../utils/db";
 
+function maskClientIp(ip: string | undefined): string | null {
+    if (!ip) return null;
+
+    // Express behind proxies sometimes gives ::ffff:x.x.x.x
+    const normalized = ip.replace(/^::ffff:/, "");
+
+    // IPv4
+    if (normalized.includes(".")) {
+        const parts = normalized.split(".");
+        if (parts.length === 4) {
+            parts[3] = "0";
+            return parts.join(".");
+        }
+    }
+
+    // IPv6
+    if (normalized.includes(":")) {
+        const parts = normalized.split(":");
+        return parts.slice(0, 4).concat(["0000", "0000", "0000", "0000"]).join(":");
+    }
+
+    return null;
+}
+
 const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
     ? process.env.ALLOWED_ORIGINS.split(",").map((s) => s.trim())
     : [
@@ -230,7 +254,7 @@ router.post(
                     batch_number: data.batch_number,
                     medicine_id: data.id,
                     barcode_id: data.barcode_id,
-                    client_ip: req.ip || null,
+                    client_ip: maskClientIp(req.ip),
                     origin: req.headers.origin ?? null,
                     user_agent: req.headers["user-agent"] ?? null,
                     latitude: latitude ?? null,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

---

## 📋 PR Summary & Link

- **Closes #1448**
- **Summary:**
  - Added a privacy-preserving IP masking utility in `apps/api/src/routes/verify.ts`.
  - Replaced storage of raw client IP addresses with masked IP addresses before insertion into the `scan_history` table.
  - Preserved duplicate-scan detection capabilities while reducing exposure of personally identifiable information (PII).
  - Added handling for:
    - IPv4 addresses (last octet masked)
    - IPv6 addresses (lower segments masked)
    - Proxy-formatted addresses (`::ffff:x.x.x.x`)
  - Improved compliance with privacy requirements and DPDP-aligned data minimization practices by preventing storage of exact client IP addresses.

---

## 📸 Proof of Work (Screenshots / Logs)

### Verification Performed

- Confirmed raw IP storage:

```ts
client_ip: req.ip || null
```

was replaced with:

```ts
client_ip: maskClientIp(req.ip)
```

- Verified IPv4 masking:

```text
192.168.1.123 → 192.168.1.0
```

- Verified IPv6 masking:

```text
2001:db8:85a3:8d3:1319:8a2e:370:7348
→
2001:db8:85a3:8d3:0000:0000:0000:0000
```

- Verified proxy-formatted IPv4 normalization:

```text
::ffff:192.168.1.123
→
192.168.1.0
```

- Verified only the target route file was modified.
- Verified scan history insertion now stores masked IP values instead of raw client addresses.

> Backend-only change. No UI changes were introduced.

---

## 🏷️ PR Type

- [x] 🔒 `type: security`

---

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1448`)
- [x] I have pulled the latest `main` and resolved any conflicts