### PR TITLE
fix: handle overnight operating hours in PharmacyStatusBadge

### DIFF
--- a/apps/web/components/PharmacyCard.tsx
+++ b/apps/web/components/PharmacyCard.tsx
@@ -19,7 +19,10 @@ export function isPharmacyOpen(operatingHours: string): boolean {
     const openMinutes = openH * 60 + openM;
     const closeMinutes = closeH * 60 + closeM;
 
-    return currentMinutes >= openMinutes && currentMinutes < closeMinutes;
+    if (openMinutes < closeMinutes) {
+        return currentMinutes >= openMinutes && currentMinutes < closeMinutes;
+    }
+    return currentMinutes >= openMinutes || currentMinutes < closeMinutes;
 }
 
 interface PharmacyStatusBadgeProps {


### PR DESCRIPTION
Closes #1500

When the closing time is earlier than the opening time (e.g. `21:00 - 06:00`), the range now correctly treats it as crossing midnight. The pharmacy shows as open if the current time is after opening OR before closing.