### PR TITLE
fix: add missing core navigation links to mobile hamburger menu

### DIFF
--- a/apps/web/app/[locale]/components/Navbar.tsx
+++ b/apps/web/app/[locale]/components/Navbar.tsx
@@ -96,7 +96,15 @@ export default function Navbar() {
     // Close hamburger menu when clicking outside
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
-            if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+            const target = event.target as Element;
+            const isOutsideMenu = menuRef.current && !menuRef.current.contains(target);
+            const isInsideDropdown =
+                target.closest("[data-radix-popper-content]") ||
+                target.closest('[role="menu"]') ||
+                target.closest('[role="dialog"]') ||
+                target.closest('[id^="radix-"]');
+
+            if (isOutsideMenu && !isInsideDropdown) {
                 setIsMenuOpen(false);
             }
         };
@@ -232,29 +240,63 @@ export default function Navbar() {
 
                             {/* Dropdown Vertical Panel Menu */}
                             {isMenuOpen && (
-                                <div className="animate-in fade-in slide-in-from-top-2 absolute top-full right-0 z-50 mt-2 w-44 origin-top-right rounded-xl border border-slate-200 bg-white p-2 shadow-xl duration-150 dark:border-slate-800 dark:bg-slate-950">
+                                <div className="animate-in fade-in slide-in-from-top-2 absolute top-full right-0 z-50 mt-2 w-52 origin-top-right rounded-xl border border-slate-200 bg-white p-2 shadow-xl duration-150 dark:border-slate-800 dark:bg-slate-950">
                                     <div className="flex flex-col gap-1.5">
+                                        {/* Added Core Navigation Links */}
+                                        <div className="flex flex-col gap-1 px-1">
+                                            <Link
+                                                href="/how-it-works"
+                                                onClick={() => setIsMenuOpen(false)}
+                                                className="rounded-md px-2 py-1.5 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                                            >
+                                                {tNav("how_it_works")}
+                                            </Link>
+                                            <Link
+                                                href="/alerts"
+                                                onClick={() => setIsMenuOpen(false)}
+                                                className="rounded-md px-2 py-1.5 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                                            >
+                                                {tNav("alerts")}
+                                            </Link>
+                                            <Link
+                                                href="/map"
+                                                onClick={() => setIsMenuOpen(false)}
+                                                className="rounded-md px-2 py-1.5 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                                            >
+                                                {tNav("pharmacy_map")}
+                                            </Link>
+                                            <Link
+                                                href="/reports/me"
+                                                onClick={() => setIsMenuOpen(false)}
+                                                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                                            >
+                                                <History size={14} /> {tNav("my_reports")}
+                                            </Link>
+                                        </div>
+
+                                        <div className="my-1 border-t border-slate-100 dark:border-slate-900" />
+
                                         {/* Added Sign In / Sign Up Option */}
                                         <Link
                                             href="/login"
                                             onClick={() => setIsMenuOpen(false)}
-                                            className="flex w-full items-center gap-2 rounded-lg bg-emerald-50 px-2.5 py-2 text-left text-xs font-bold text-emerald-700 transition-colors hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-400 dark:hover:bg-emerald-950/70"
+                                            className="flex w-full items-center gap-2 rounded-lg bg-emerald-50 px-2.5 py-2 text-left text-sm font-bold text-emerald-700 transition-colors hover:bg-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-400 dark:hover:bg-emerald-950/70"
                                         >
-                                            <LogIn size={14} />
+                                            <LogIn size={16} />
                                             <span>{tHome("sign_in")}</span>
                                         </Link>
 
                                         <div className="my-0.5 border-t border-slate-100 dark:border-slate-900" />
 
                                         {/* Language Settings */}
-                                        <div className="flex items-center justify-between rounded-lg px-2.5 py-1.5 text-xs font-semibold text-slate-500 dark:text-slate-400">
+                                        <div className="flex items-center justify-between rounded-lg px-2.5 py-1.5 text-sm font-semibold text-slate-500 dark:text-slate-400">
                                             <LanguageSwitcher />
                                         </div>
 
                                         <div className="border-t border-slate-100 dark:border-slate-900" />
 
                                         {/* Dark Mode Theme Settings */}
-                                        <div className="flex items-center justify-between rounded-lg px-2.5 py-1.5 text-xs font-semibold text-slate-500 dark:text-slate-400">
+                                        <div className="flex items-center justify-between rounded-lg px-2.5 py-1.5 text-sm font-semibold text-slate-500 dark:text-slate-400">
                                             <ThemeToggle />
                                         </div>
                                     </div>


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #1523 **
- **Summary:** Added the missing navigation links ("How it Works", "Alerts", "Pharmacy Map", and "My Reports") to the mobile hamburger menu to improve site navigation for mobile users. Updated font sizing to text-sm to ensure better tap accessibility.

## 📸 Proof of Work (Screenshots / Logs)

<img width="386" height="310" alt="image" src="https://github.com/user-attachments/assets/7cd214d8-1528-4651-b77c-22449de84a1c" />


## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [x] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue
- [x] I have pulled the latest `main` and resolved any conflicts
