### PR TITLE
fix: escape commas in medicine search query for PostgREST

### DIFF
--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -21,7 +21,7 @@ async function searchMedicines(query: string): Promise<Medicine[]> {
     const { data, error } = await supabase
         .from("medicines")
         .select(COMPARE_SELECT_FIELDS)
-        .or(`brand_name.ilike.${pattern},generic_name.ilike.${pattern}`)
+        .or(`brand_name.ilike."${pattern}",generic_name.ilike."${pattern}"`)
         .limit(25);
 
     if (error) {


### PR DESCRIPTION
Fixes #1390

## Problem
On the Medicine Compare page, searching for a medicine name containing 
a comma (e.g. `Aspirin, Paracetamol`) caused a 400/500 error.

PostgREST uses commas to separate `.or()` filter clauses, so an 
unescaped comma inside the `ilike` pattern was being parsed as a 
clause separator instead of part of the search value.

## Fix
Wrapped the `${pattern}` value in double quotes inside the `.or()` call:

**Before:**
.or(`brand_name.ilike.${pattern},generic_name.ilike.${pattern}`)

**After:**
.or(`brand_name.ilike."${pattern}",generic_name.ilike."${pattern}"`)

Double-quoting a value in PostgREST's filter syntax tells the parser 
to treat any comma inside as part of the value, not a separator.

## Changes
- `apps/web/app/[locale]/compare/page.tsx` — only the `.or()` line changed