### PR TITLE
feat(compare): add direct medicine savings comparison

### DIFF
--- a/apps/web/src/components/ComparisonGrid.tsx
+++ b/apps/web/src/components/ComparisonGrid.tsx
@@ -134,6 +134,34 @@ function getSavingsText(medicine: Medicine | null, labels: ComparisonGridLabels)
     const percent = computeSavingsPercent(medicine.mrp, medicine.jan_aushadhi_price);
     return labels.saveAmount(amount.toFixed(2), percent.toFixed(1));
 }
+function getDirectComparison(medicine1: Medicine | null, medicine2: Medicine | null) {
+    if (!medicine1 || !medicine2) return null;
+
+    if (!hasValidMrp(medicine1) || !hasValidMrp(medicine2)) {
+        return null;
+    }
+
+    if (medicine1.mrp === medicine2.mrp) {
+        return {
+            type: "equal" as const,
+        };
+    }
+
+    const cheaper = medicine1.mrp < medicine2.mrp ? medicine1 : medicine2;
+    const expensive = medicine1.mrp > medicine2.mrp ? medicine1 : medicine2;
+
+    const savings = expensive.mrp - cheaper.mrp;
+
+    const percentage = computeSavingsPercent(expensive.mrp, cheaper.mrp);
+
+    return {
+        type: "savings" as const,
+        cheaper,
+        expensive,
+        savings,
+        percentage,
+    };
+}
 
 export default function ComparisonGrid({
     medicine1,
@@ -151,6 +179,8 @@ export default function ComparisonGrid({
             </div>
         );
     }
+
+    const directComparison = getDirectComparison(medicine1, medicine2);
 
     const rows: { label: string; getValue: (m: Medicine) => string }[] = [
         { label: labels.rows.brandName, getValue: (m) => m.brand_name?.trim() || "—" },
@@ -209,6 +239,30 @@ export default function ComparisonGrid({
                     ))}
                 </tbody>
             </table>
+            {directComparison && (
+                <div className="border-t border-slate-200 bg-slate-50 p-4">
+                    {directComparison.type === "equal" ? (
+                        <p className="text-center text-sm text-slate-700">
+                            Both medicines have the same market price.
+                        </p>
+                    ) : (
+                        <p className="text-center text-sm font-medium text-slate-800">
+                            By choosing{" "}
+                            <span className="font-semibold">
+                                {displayName(directComparison.cheaper)}
+                            </span>{" "}
+                            instead of{" "}
+                            <span className="font-semibold">
+                                {displayName(directComparison.expensive)}
+                            </span>
+                            , you save ₹{directComparison.savings.toFixed(2)}
+                            {" ("}
+                            {directComparison.percentage.toFixed(1)}
+                            %).
+                        </p>
+                    )}
+                </div>
+            )}
         </div>
     );
 }

--- a/apps/web/tests/compare-pricing.test.tsx
+++ b/apps/web/tests/compare-pricing.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
-
+import { describe, it, expect } from "@jest/globals";
 import ComparisonGrid, { type Medicine } from "../src/components/ComparisonGrid";
 import { COMPARE_SELECT_FIELDS } from "../src/lib/compareSelectFields";
 import { mapMedicineRow } from "../src/lib/mapMedicineRow";
@@ -132,5 +132,39 @@ describe("compare pricing", () => {
         );
 
         expect(markup).toContain("No savings");
+    });
+    it("shows direct savings comparison between two medicines", () => {
+        const markup = renderToStaticMarkup(
+            <ComparisonGrid
+                medicine1={buildMedicine({
+                    brand_name: "Brand Medicine",
+                    mrp: 120,
+                })}
+                medicine2={buildMedicine({
+                    id: "med-2",
+                    brand_name: "Generic Medicine",
+                    generic_name: "Paracetamol",
+                    mrp: 30,
+                })}
+            />
+        );
+
+        expect(markup).toContain("you save ₹90.00");
+        expect(markup).toContain("75.0%");
+    });
+    it("shows equal price message when both medicines have the same price", () => {
+        const markup = renderToStaticMarkup(
+            <ComparisonGrid
+                medicine1={buildMedicine({
+                    mrp: 100,
+                })}
+                medicine2={buildMedicine({
+                    id: "med-2",
+                    mrp: 100,
+                })}
+            />
+        );
+
+        expect(markup).toContain("Both medicines have the same market price.");
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #1150**
* **Summary:**
  Added a direct medicine price comparison summary to the compare page. The comparison grid now calculates and displays the absolute savings amount and percentage savings when one selected medicine is cheaper than the other. An equal-price message is shown when both medicines have the same MRP.

### Changes Made

* Added `getDirectComparison()` helper in `ComparisonGrid.tsx`
* Calculated direct price difference using medicine MRP values
* Added a summary section below the comparison table
* Displays:

  * Savings amount (₹)
  * Percentage savings (%)
  * Cheaper vs more expensive medicine names
* Added equal-price handling
* Added Jest test coverage for:

  * Direct savings comparison
  * Equal-price scenario

## 📸 Proof of Work (Screenshots / Logs)

### Test Output

```text
PASS apps/web/tests/compare-pricing.test.tsx

Test Suites: 1 passed, 1 total
Tests: 9 passed, 9 total
Snapshots: 0 total
```

### Note

I attempted to run the application locally for UI screenshots, but the repository currently fails to start due to unrelated project setup issues (missing environment/dependency configuration such as Supabase variables and SWC bindings). The feature implementation was validated through automated Jest tests.

### CI Failure Note

The failing GitHub Actions build is caused by an existing syntax error in:

```text
apps/web/app/[locale]/scan/page.tsx
```

Build log excerpt:

```text
Error: Expression expected

1106 |         },
     |          ^
1107 |         [handleVerify]
1108 |     );
```

This file is unrelated to the changes in this PR.

Files modified in this PR:

```text
apps/web/src/components/ComparisonGrid.tsx
apps/web/tests/compare-pricing.test.tsx
```

Local verification for the modified feature:

```text
PASS apps/web/tests/compare-pricing.test.tsx

Test Suites: 1 passed, 1 total
Tests: 9 passed, 9 total
```

The direct savings comparison feature and its associated tests are working as expected. The current CI failure appears to originate from unrelated code in `scan/page.tsx`.


## 🏷️ PR Type

* [ ] 🐛 type: bug
* [x] ✨ type: feature
* [ ] 📖 type: docs
* [ ] 🧪 type: testing
* [ ] 🔒 type: security
* [ ] ⚡ type: performance
* [ ] 🎨 type: design
* [ ] ♻️ type: refactor
* [ ] 🛠️ type: devops
* [ ] ♿ type: accessibility

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #1150`)
* [x] I have pulled the latest `main` and resolved any conflicts
* [x] Added/updated tests for the new functionality
* [x] Verified all related tests are passing
