### PR TITLE
feat: add Export to CSV button on scan history page (#1430)

### DIFF
--- a/apps/web/app/[locale]/history/page.tsx
+++ b/apps/web/app/[locale]/history/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { getScanHistory, deleteScanHistory } from "@/lib/db/scanHistory";
+import { Download } from "lucide-react";
 
 export default function HistoryPage() {
     const [history, setHistory] = useState<any[]>([]);
@@ -38,12 +39,35 @@ export default function HistoryPage() {
     ).length;
 
     const fakeCount = history.filter((item) => item.status?.toLowerCase() === "fake").length;
-
+    function exportToCSV() {
+        if (history.length === 0) return;
+        const headers = ["Scan Date", "Medicine Name", "Status"];
+        const rows = history.map((item) => [
+            new Date(item.timestamp).toLocaleString(),
+            `"${item.medicineName}"`,
+            item.status,
+        ]);
+        const csv = [headers.join(","), ...rows.map((r) => r.join(","))].join("\n");
+        const blob = new Blob([csv], { type: "text/csv" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "sahidawa_scan_history.csv";
+        a.click();
+        URL.revokeObjectURL(url);
+    }
     return (
         <div className="min-h-screen bg-(--color-surface-page) p-6 text-(--color-text-primary)">
             <div className="mx-auto max-w-3xl">
                 <h1 className="mb-6 text-4xl font-black">Scan History</h1>
-
+                {history.length > 0 && (
+                    <button
+                        onClick={exportToCSV}
+                        className="mb-6 flex items-center gap-2 rounded-xl bg-emerald-600 px-5 py-2.5 text-sm font-bold text-white shadow-lg transition hover:bg-emerald-700 active:scale-95"
+                    >
+                        <Download size={16} /> Export to CSV
+                    </button>
+                )}
                 <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-4">
                     <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
                         <p className="text-sm opacity-70">Total</p>


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #1430**
- **Summary:** Adds an "Export to CSV" button to the `/history` page that generates a CSV file containing scan date, medicine name, and verification status from the existing IndexedDB records and triggers a browser download of `sahidawa_scan_history.csv`. The button only renders when history entries exist.

## 📸 Proof of Work (Screenshots / Logs)
<img width="1193" height="757" alt="image" src="https://github.com/user-attachments/assets/0e29ce72-a91c-493d-9d41-b93fd6b843dd" />


## 🏷️ PR Type
- [x] ✨ `type: feature`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #1430`)
- [x] I have pulled the latest `main` and resolved any conflicts

---

**File changed:**
`apps/web/app/[locale]/history/page.tsx` — only file modified

**What was added:**
- `exportToCSV()` function that maps history entries to CSV rows with headers: `Scan Date`, `Medicine Name`, `Status`
- Creates a `Blob` with `text/csv` type and triggers a browser download via a temporary anchor element
- `Export to CSV` button rendered above the stats cards, only visible when `history.length > 0`
- Added `Download` icon import from `lucide-react`