### PR TITLE
feat: enhance Vaccine Hub section with updated design and localized c…

### DIFF
--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -200,34 +200,55 @@ export default function SahiDawaHome() {
 
                     {/* ── Vaccine Hub & Tracker ── */}
                     <section className="mb-6">
-                        <h2 className="sr-only">Featured Services</h2>
+                        <h2 className="sr-only">Vaccine Hub</h2>
                         <Link
                             href="/vaccine-hub"
-                            className="group relative flex flex-col justify-between overflow-hidden rounded-2xl border border-emerald-100 bg-white p-6 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-emerald-200 hover:shadow-md focus-visible:-translate-y-1 focus-visible:scale-[1.01] focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white focus-visible:outline-none dark:border-slate-800/50 dark:bg-slate-900/55 dark:hover:border-emerald-400/30 dark:hover:shadow-emerald-400/5 dark:focus-visible:ring-offset-slate-900"
+                            className="group relative flex w-full transform-gpu cursor-pointer flex-col overflow-hidden rounded-3xl border border-emerald-200/60 bg-white p-6 shadow-[0_4px_24px_rgba(16,185,129,0.07)] transition-all duration-300 select-none hover:-translate-y-1 hover:border-emerald-300/80 hover:shadow-[0_12px_32px_rgba(16,185,129,0.15)] focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:outline-none dark:border-slate-700/60 dark:bg-slate-900/70 dark:hover:border-emerald-500/40 dark:hover:shadow-[0_12px_32px_rgba(16,185,129,0.08)]"
+                            aria-label="Open Vaccine Hub"
                         >
-                            <div>
-                                {/* Icon Container */}
-                                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-emerald-50 text-emerald-600 transition-colors group-hover:bg-emerald-600 group-hover:text-white">
-                                    <Syringe size={24} />
+                            {/* Subtle gradient wash */}
+                            <div className="pointer-events-none absolute inset-0 bg-linear-to-br from-emerald-500/5 via-transparent to-teal-500/5 opacity-0 transition-opacity duration-300 group-hover:opacity-100 dark:from-emerald-500/10 dark:to-teal-500/10" />
+
+                            {/* Header row: icon badge + CTA arrow */}
+                            <div className="relative z-10 flex items-start justify-between gap-4">
+                                {/* Circular icon badge */}
+                                <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-linear-to-br from-emerald-100 to-teal-50 text-emerald-600 shadow-inner transition-all duration-300 group-hover:scale-110 group-hover:rotate-3 group-hover:from-emerald-500 group-hover:to-teal-400 group-hover:text-white group-hover:shadow-[0_0_18px_rgba(16,185,129,0.4)] dark:from-emerald-950/60 dark:to-teal-900/40 dark:text-emerald-400">
+                                    <Syringe
+                                        size={26}
+                                        strokeWidth={2.5}
+                                        className="transition-transform duration-300"
+                                    />
                                 </div>
 
-                                {/* Text Context */}
-                                <h3 className="mt-4 text-lg font-bold text-slate-900 dark:text-white">
+                                {/* Animated arrow indicator */}
+                                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-50 opacity-0 transition-all duration-300 group-hover:opacity-100 dark:bg-emerald-900/40">
+                                    <ChevronRight
+                                        className="h-5 w-5 text-emerald-600 dark:text-emerald-400"
+                                        aria-hidden="true"
+                                    />
+                                </div>
+                            </div>
+
+                            {/* Text hierarchy */}
+                            <div className="relative z-10 mt-4">
+                                <h3 className="text-xl font-bold tracking-tight text-slate-900 transition-colors group-hover:text-emerald-700 dark:text-white dark:group-hover:text-emerald-300">
                                     {tHome("vaccine_title")}
                                 </h3>
-                                <p className="mt-2 text-sm leading-relaxed text-slate-500 dark:text-slate-400">
+                                <p className="mt-2 text-sm leading-relaxed font-medium text-slate-500 transition-colors group-hover:text-slate-600 dark:text-slate-400 dark:group-hover:text-slate-300">
                                     {tHome("vaccine_subtitle")}
                                 </p>
                             </div>
 
-                            {/* Action Footer Indicator */}
-                            <div className="mt-6 flex items-center gap-1.5 text-sm font-bold text-emerald-600 dark:text-emerald-400">
-                                <span>{tHome("vaccine_open")}</span>
-                                <ArrowRight
-                                    size={16}
-                                    className="transition-transform group-hover:translate-x-1"
-                                    aria-hidden="true"
-                                />
+                            {/* Pill-shaped CTA button */}
+                            <div className="relative z-10 mt-6">
+                                <span className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm font-bold text-emerald-700 transition-all duration-300 group-hover:border-emerald-400 group-hover:bg-emerald-600 group-hover:text-white dark:border-emerald-800/60 dark:bg-emerald-900/30 dark:text-emerald-400 dark:group-hover:border-emerald-500 dark:group-hover:bg-emerald-600 dark:group-hover:text-white">
+                                    {tHome("vaccine_open")}
+                                    <ArrowRight
+                                        size={15}
+                                        className="transition-transform duration-300 group-hover:translate-x-0.5"
+                                        aria-hidden="true"
+                                    />
+                                </span>
                             </div>
                         </Link>
                     </section>

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -33,6 +33,9 @@
         "alerts_empty_title": "All clear!",
         "alerts_empty_description": "No active regulatory alerts right now. Stay safe and verify your medicines.",
         "view_full_alert_log": "View Full Alert Log",
+        "vaccine_title": "Vaccine Hub & Immunization Tracker",
+        "vaccine_subtitle": "Explore vaccine schedules, safety info, and aftercare guidance for better public health awareness.",
+        "vaccine_open": "Open Vaccine Hub",
         "heroTitle": {
             "prefix": "Your Health, ",
             "highlight": "Verified & Protected."


### PR DESCRIPTION
## ✨ feat: Redesign Vaccine Hub Card and Fix Missing i18n Translation Keys

Closes #1538 

### Summary
This PR redesigns the flat and unappealing Vaccine Hub card on the main dashboard to match the premium, modern visual language of the application (incorporating smooth animations, gradient overlays, and clear layout hierarchies). Additionally, it adds the missing English translation strings to `en.json` that were previously causing raw translation keys to show up on the UI.

---

### 🐛 Problem
1. **Visual Styling**: The Vaccine Hub card lacked depth, hovered states, and visual consistency with the "Scan Medicine" card above it.
2. **Missing Translation Keys**: The localization keys `Home.vaccine_title`, `Home.vaccine_subtitle`, and `Home.vaccine_open` were not defined in `en.json`, rendering as raw key text in the browser.

---

### ✅ Changes

###Before
<img width="1352" height="344" alt="Screenshot 2026-06-08 at 10 05 39 PM" src="https://github.com/user-attachments/assets/41f7f6e3-e97b-4ada-8cf4-096a9a07877b" />


###After
<img width="1247" height="455" alt="Screenshot 2026-06-08 at 10 06 22 PM" src="https://github.com/user-attachments/assets/7b2f0658-51ff-4e6f-9509-067b1962813c" />



#### 🎨 UI Redesign in [page.tsx](file:///Users/tanushreeharika/Downloads/Gssoc26%20(sahidawa)/sahidawa-india/apps/web/app/[locale]/page.tsx)
- Replaced the flat box with a premium card styling utilizing a `rounded-3xl` border radius and soft directional shadows.
- Added a **gradient icon badge** (`emerald-100` to `teal-50`) that slightly scales and rotates on hover.
- Implemented a **gradient wash overlay** (`emerald-500/5` to `teal-500/5`) that fades in smoothly upon hover.
- Introduced a **sliding `ChevronRight` arrow** that transitions into view on hover.
- Updated typography to present a bold `text-xl` title with interactive color transitions, and a clean, muted `text-sm` description.
- Restyled the CTA to a **pill-shaped outline button** (`rounded-full`) which transitions to a solid emerald fill on hover.
- Fully supported **dark mode** across all styles.

#### 🌐 Internationalization in [en.json](file:///Users/tanushreeharika/Downloads/Gssoc26%20(sahidawa)/sahidawa-india/apps/web/messages/en.json)
Added the following missing key-value pairs to the `"Home"` translation namespace:
- `"vaccine_title"`: `"Vaccine Hub & Immunization Tracker"`
- `"vaccine_subtitle"`: `"Explore vaccine schedules, safety info, and aftercare guidance for better public health awareness."`
- `"vaccine_open"`: `"Open Vaccine Hub"`

---

### 📁 Files Affected
- **Modify**: [apps/web/app/\[locale\]/page.tsx](file:///Users/tanushreeharika/Downloads/Gssoc26%20(sahidawa)/sahidawa-india/apps/web/app/[locale]/page.tsx)
- **Modify**: [apps/web/messages/en.json](file:///Users/tanushreeharika/Downloads/Gssoc26%20(sahidawa)/sahidawa-india/apps/web/messages/en.json)

---

### 🔍 Checklist
- [x] Tested changes locally in browser on port `3000`
- [x] Verified dark mode responsiveness
- [x] Checked that no warnings/errors are produced in the console
- [x] Followed existing Tailwind CSS class conventions

## ✅ Checklist

- [ ] My PR has a linked issue (`Closes #1538 `)
- [ ] I have pulled the latest `main` and resolved any conflicts
