### PR TITLE
fix: expand extractMedicineName skip regex with common pharmaceutical terms

### DIFF
--- a/apps/web/src/utils/medicineParser.ts
+++ b/apps/web/src/utils/medicineParser.ts
@@ -102,7 +102,7 @@ export function extractMedicineName(text: string): string | null {
         .map((l) => l.trim())
         .filter(Boolean);
     const skip =
-        /^(exp(?:iry)?|batch|b\.?\s*no|mfg|date|composition|tablet|capsule|mg|mrp|rs|inr|use|manufacture|store|keep|dosage)/i;
+        /^(exp(?:iry)?|batch|b\.?\s*no|mfg|date|composition|tablet(?:s)?|capsule(?:s)?|strip(?:s)?|drops?|syrup|injection|suspension|solution|ointment|cream|gel|powder|granules?|spray|inhaler|mg|mrp|rs|inr|use|manufacture|store|keep|dosage)/i;
 
     for (const line of lines) {
         if (skip.test(line)) continue;

--- a/apps/web/tests/medicineParser.test.ts
+++ b/apps/web/tests/medicineParser.test.ts
@@ -72,4 +72,19 @@ describe("extractMedicineName", () => {
             "Some Random Line"
         );
     });
+
+    it("skips common pharmaceutical terms and extracts the medicine name", () => {
+        expect(extractMedicineName("TABLETS IP\nPARACETAMOL 500MG")).toBe("PARACETAMOL");
+        expect(extractMedicineName("CAPSULES\nAMOXICILLIN 250MG")).toBe("AMOXICILLIN");
+        expect(extractMedicineName("STRIP\nPARACETAMOL 500MG")).toBe("PARACETAMOL");
+        expect(extractMedicineName("DROPS\nCIPROFLOXACIN")).toBe("CIPROFLOXACIN");
+        expect(extractMedicineName("SYRUP\nAMBROXOL")).toBe("AMBROXOL");
+        expect(extractMedicineName("INJECTION\nDEXAMETHASONE")).toBe("DEXAMETHASONE");
+        expect(extractMedicineName("SUSPENSION\nCETIRIZINE")).toBe("CETIRIZINE");
+        expect(extractMedicineName("OINTMENT\nBETAMETHASONE")).toBe("BETAMETHASONE");
+        expect(extractMedicineName("CREAM\nCLOTRIMAZOL")).toBe("CLOTRIMAZOL");
+        expect(extractMedicineName("GEL\nDICLOFENAC")).toBe("DICLOFENAC");
+        expect(extractMedicineName("POWDER\nORS SACHET")).toBe("ORS SACHET");
+        expect(extractMedicineName("SPRAY\nFLUTICASONE")).toBe("FLUTICASONE");
+    });
 });


### PR DESCRIPTION
## Summary

- Expands the `skip` regex in `extractMedicineName()` with common pharmaceutical terms and their plurals
- Prevents lines starting with terms like `TABLETS`, `CAPSULES`, `DROPS`, `SYRUP`, etc. from being extracted as medicine names

## Files Changed

- `apps/web/src/utils/medicineParser.ts`: Added tablets, capsules, strips, drops, syrup, injection, suspension, solution, ointment, cream, gel, powder, granules, spray, inhaler to skip regex
- `apps/web/tests/medicineParser.test.ts`: Added test coverage for new skip terms

## Testing Performed

- `npm test -- tests/medicineParser.test.ts` — all 12 tests pass

## AI Assistance Disclosure

This PR was prepared with AI assistance and manually reviewed before submission.

Closes #1563
