### PR TITLE
fix: restore debounced search suggestions

### DIFF
--- a/apps/web/app/[locale]/components/SearchBar.tsx
+++ b/apps/web/app/[locale]/components/SearchBar.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Search } from "lucide-react";
-import { useRouter, useParams } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import { useTranslations } from "next-intl";
 import { fuzzyMatchBrand } from "@/lib/api";
@@ -28,9 +27,6 @@ interface SearchBarProps {
  * - Selecting a suggestion navigates to the scan/verify flow & triggers home safety view
  */
 export default function SearchBar({ dark = false, onSearchChange }: SearchBarProps) {
-    const router = useRouter();
-    const params = useParams();
-    const locale = params.locale as string;
     const tHome = useTranslations("Home");
 
     // ── State ──────────────────────────────────────────────────────────────────
@@ -207,163 +203,38 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
         }
     }, []);
 
-    // const fetchSuggestions = useCallback(async (trimmed: string) => {
-    //     setError(null);
-    //     setNoResults(false);
-    //     if (!trimmed) {
-    //         setSuggestions([]);
-    //         setIsOpen(false);
-    //         setIsLoading(false);
-    //         // setError(null);
-    //         // setNoResults(false);
-    //         return;
-    //     }
-    //     // Check if offline
-    //     if (typeof window !== "undefined" && !window.navigator.onLine) {
-    //         setSuggestions([]);
-    //         setIsOpen(false);
-    //         setIsLoading(false);
-    //         return;
-    //     }
-    //     // Abort previous suggestions request
-    //     if (abortControllerRef.current) {
-    //         abortControllerRef.current.abort();
-    //     }
-    //     const controller = new AbortController();
-    //     abortControllerRef.current = controller;
-    //     setIsLoading(true);
-    //     try {
-    //         // Query both brand_name and batch_number columns for partial matches.
-    //         const { data, error } = await supabase
-    //             .from("medicines")
-    //             .select("brand_name, batch_number")
-    //             .or(`brand_name.ilike.%${trimmed}%,batch_number.ilike.%${trimmed}%`)
-    //             .abortSignal(controller.signal)
-    //             .limit(MAX_SUGGESTIONS);
-    //         if (controller.signal.aborted) {
-    //             return;
-    //         }
-    //         if (error) {
-    //             console.error("[SearchBar] Supabase suggestion error:", error.message);
-    //             setSuggestions([]);
-    //             setIsOpen(false);
-    //             return;
-    //         }
+    useEffect(() => {
+        const trimmed = query.trim();
 
-    //         const seen = new Set<string>();
-    //         const results: string[] = [];
-    //         if (data && data.length > 0) {
-    //             // Deduplicate and build a flat list of relevant strings.
-    //             for (const row of data) {
-    //                 const candidates = [
-    //                     row.brand_name as string | null,
-    //                     row.batch_number as string | null,
-    //                 ];
-    //                 for (const c of candidates) {
-    //                     if (c && c.toLowerCase().includes(trimmed.toLowerCase()) && !seen.has(c)) {
-    //                         seen.add(c);
-    //                         results.push(c);
-    //                         if (results.length >= MAX_SUGGESTIONS) break;
-    //                     }
-    //                 }
-    //                 if (results.length >= MAX_SUGGESTIONS) break;
-    //             }
-    //         }
+        if (debounceTimer.current) {
+            clearTimeout(debounceTimer.current);
+        }
 
-    //         // Typo-tolerance: if we got few or no exact results, query fuzzy matching from the backend!
-    //         if (results.length < 3) {
-    //             try {
-    //                 const fuzzyResults = await fuzzyMatchBrand(trimmed, controller.signal);
-    //                 for (const match of fuzzyResults) {
-    //                     if (match.name && !seen.has(match.name) && match.score >= 50) {
-    //                         seen.add(match.name);
-    //                         results.push(match.name);
-    //                         if (results.length >= MAX_SUGGESTIONS) break;
-    //                     }
-    //                 }
-    //             } catch (fuzzyErr) {
-    //                 // Ignore fuzzy errors and stick with what we have
-    //                 console.warn("[SearchBar] Fuzzy matching fallback error:", fuzzyErr);
-    //             }
-    //         }
+        if (!trimmed) {
+            setSuggestions([]);
+            setIsOpen(false);
+            setIsLoading(false);
+            setNoResults(false);
+            setError(null);
+            onSearchChange?.("");
+            return;
+        }
 
-    //         setSuggestions(results);
-    //         if (results.length === 0) {
-    //             setNoResults(true);
-    //             setIsOpen(true);
-    //         } else {
-    //             setNoResults(false);
-    //             setIsOpen(true);
-    //         }
-    //         setActiveIndex(-1);
-    //     } catch (err) {
-    //         if (err instanceof Error && err.name === "AbortError") {
-    //             // Silently ignore aborted suggestions queries
-    //             return;
-    //         }
-    //         console.error("[SearchBar] Unexpected error fetching suggestions:", err);
-    //         setSuggestions([]);
-    //         setError("Unable to fetch medicine suggestions.");
-    //         setIsOpen(true);
-    //     } finally {
-    //         if (!controller.signal.aborted) {
-    //             setIsLoading(false);
-    //         }
-    //     }
-    // }, []);
+        debounceTimer.current = setTimeout(() => {
+            fetchSuggestions(trimmed);
+        }, DEBOUNCE_MS);
+
+        return () => {
+            if (debounceTimer.current) {
+                clearTimeout(debounceTimer.current);
+            }
+            abortControllerRef.current?.abort();
+        };
+    }, [query, fetchSuggestions, onSearchChange]);
 
     // // ── Debounce query changes ─────────────────────────────────────────────────
-    // useEffect(() => {
-    //     const trimmed = query.trim();
-    //     // Cancel any pending debounce
-    //     if (debounceTimer.current) clearTimeout(debounceTimer.current);
-    //     if (!trimmed) {
-    //         setSuggestions([]);
-    //         setIsOpen(false);
-    //         setIsLoading(false);
-    //         if (onSearchChange) onSearchChange(""); // Reset parent view if empty
-    //         return;
-    //     }
-    //     debounceTimer.current = setTimeout(() => {
-    //         fetchSuggestions(trimmed);
-    //     }, DEBOUNCE_MS);
-    //     // Cleanup on unmount or next effect run
-    //     return () => {
-    //         if (debounceTimer.current) clearTimeout(debounceTimer.current);
-    //         if (abortControllerRef.current) abortControllerRef.current.abort();
-    //     };
-    // }, [query, fetchSuggestions, onSearchChange]);
-
     //  ----------------
     // ── Select a suggestion ────────────────────────────────────────────────────
-    // const selectSuggestion = useCallback(
-    //     (value: string) => {
-    //         setQuery(value);
-    //         setIsOpen(false);
-    //         setActiveIndex(-1);
-    //         if (onSearchChange) onSearchChange(value); // Sync query to safety panel
-
-    //         // Comment out router line below if you want to stay on home page to show the details card
-    //         // instead of redirecting to the scan page directly on click.
-    //         router.push(`/${locale}/scan?q=${encodeURIComponent(value)}`);
-    //     },
-    //     [locale, router, onSearchChange]
-    // );
-
-    // // ── Perform search (Enter without active suggestion, or Search button) ─────
-    // const performSearch = useCallback(
-    //     (value: string) => {
-    //         const trimmed = value.trim();
-    //         if (!trimmed) return;
-    //         setIsOpen(false);
-    //         setActiveIndex(-1);
-    //         if (onSearchChange) onSearchChange(trimmed); // Sync query to safety panel
-
-    //         router.push(`/${locale}/scan?q=${encodeURIComponent(trimmed)}`);
-    //     },
-    //     [locale, router, onSearchChange]
-    // );
-
     const selectSuggestion = useCallback(
         (value: string) => {
             setQuery(value);
@@ -371,10 +242,8 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
             setActiveIndex(-1);
             if (onSearchChange) onSearchChange(value); // Sync query to safety panel
 
-            // 🔴 COMMENT THIS LINE OUT SO IT DOES NOT REDIRECT:
-            // router.push(`/${locale}/scan?q=${encodeURIComponent(value)}`);
         },
-        [locale, router, onSearchChange]
+        [onSearchChange]
     );
 
     // ── Perform search (Enter without active suggestion, or Search button) ─────
@@ -386,10 +255,8 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
             setActiveIndex(-1);
             if (onSearchChange) onSearchChange(trimmed); // Sync query to safety panel
 
-            // 🔴 COMMENT THIS LINE OUT SO IT DOES NOT REDIRECT:
-            // router.push(`/${locale}/scan?q=${encodeURIComponent(trimmed)}`);
         },
-        [locale, router, onSearchChange]
+        [onSearchChange]
     );
     // ── Keyboard navigation ────────────────────────────────────────────────────
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/apps/web/tests/searchbar-debounce.test.ts
+++ b/apps/web/tests/searchbar-debounce.test.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 
 describe("SearchBar debounced suggestions", () => {
     const source = readFileSync(
-        join(process.cwd(), "app/[locale]/components/SearchBar.tsx"),
+        join(__dirname, "../app/[locale]/components/SearchBar.tsx"),
         "utf8"
     );
 

--- a/apps/web/tests/searchbar-debounce.test.ts
+++ b/apps/web/tests/searchbar-debounce.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("SearchBar debounced suggestions", () => {
+    const source = readFileSync(
+        join(process.cwd(), "app/[locale]/components/SearchBar.tsx"),
+        "utf8"
+    );
+
+    it("debounces query changes before fetching suggestions", () => {
+        expect(source).toContain("setTimeout(() =>");
+        expect(source).toContain("fetchSuggestions(trimmed)");
+        expect(source).toContain("DEBOUNCE_MS");
+        expect(source).toContain("[query, fetchSuggestions, onSearchChange]");
+    });
+
+    it("clears stale suggestion state when the search query becomes empty", () => {
+        expect(source).toContain("setSuggestions([])");
+        expect(source).toContain("setIsOpen(false)");
+        expect(source).toContain("setNoResults(false)");
+        expect(source).toContain('onSearchChange?.("")');
+    });
+
+    it("aborts stale suggestion requests during rapid input changes", () => {
+        expect(source).toContain("abortControllerRef.current?.abort()");
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #<issue-number>**
- **Summary:** Restores debounced homepage search suggestions in the `SearchBar` component so medicine and batch suggestions can load while users type.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

```txt
git diff --check
# Passed

npm.cmd test -w web -- searchbar-debounce.test.ts
# Could not run locally because Jest is not available in this workspace:
# 'jest' is not recognized as an internal or external command
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #<issue-number>`)
- [ ] I have pulled the latest `main` and resolved any conflicts