### PR TITLE
feat(admin): gate mutation controls by role

### DIFF
--- a/apps/web/app/[locale]/admin/dashboard/page.tsx
+++ b/apps/web/app/[locale]/admin/dashboard/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback, useId } from "react";
 import { useTranslations } from "next-intl";
+import { createBrowserClient } from "@supabase/ssr";
 import { Link } from "@/i18n/routing";
 import {
     AlertTriangle,
@@ -20,7 +21,9 @@ import {
     Activity,
 } from "lucide-react";
 import { LiveMessage } from "@/components/ui/LiveMessage";
+import { canMutateAdminData, getAdminRoleFromSession, type AdminRole } from "@/lib/adminAuth";
 import { ADMIN_API_BASE } from "@/lib/adminApi";
+import { getSupabaseAnonKey, getSupabaseUrl } from "@/lib/env";
 
 type ReportStatus = "pending" | "verified_fake" | "false_alarm";
 type MedicineStatus = "approved" | "recalled" | "banned";
@@ -80,6 +83,7 @@ export default function AdminDashboard() {
     const [acting, setActing] = useState<string | null>(null);
     const [authError, setAuthError] = useState<string | null>(null);
     const [showForm, setShowForm] = useState(false);
+    const [adminRole, setAdminRole] = useState<AdminRole | null>(null);
     const [newMed, setNewMed] = useState<Omit<Medicine, "id">>({
         brand_name: "",
         generic_name: "",
@@ -88,6 +92,7 @@ export default function AdminDashboard() {
         cdsco_approval_status: "approved",
     });
     const [toast, setToast] = useState<{ msg: React.ReactNode; ok: boolean } | null>(null);
+    const canMutate = canMutateAdminData(adminRole);
 
     const notify = (msg: React.ReactNode, ok = true) => {
         setToast({ msg, ok });
@@ -149,6 +154,28 @@ export default function AdminDashboard() {
     }, []);
 
     useEffect(() => {
+        let mounted = true;
+        const supabase = createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey());
+
+        supabase.auth
+            .getSession()
+            .then(({ data }) => {
+                if (mounted) {
+                    setAdminRole(getAdminRoleFromSession(data.session));
+                }
+            })
+            .catch(() => {
+                if (mounted) {
+                    setAdminRole(null);
+                }
+            });
+
+        return () => {
+            mounted = false;
+        };
+    }, []);
+
+    useEffect(() => {
         fetchReports();
         fetchMedicines();
     }, [fetchReports, fetchMedicines]);
@@ -160,6 +187,8 @@ export default function AdminDashboard() {
     }, [tab, fetchAuditLogs]);
 
     const handleReportAction = async (reportId: string, status: ReportStatus) => {
+        if (!canMutate) return;
+
         setActing(reportId + status);
         try {
             const res = await fetch(`${ADMIN_API_BASE}/reports/${reportId}/status`, {
@@ -196,7 +225,8 @@ export default function AdminDashboard() {
     };
 
     const handleAddMedicine = async () => {
-        if (!newMed.brand_name || !newMed.generic_name) return;
+        if (!canMutate || !newMed.brand_name || !newMed.generic_name) return;
+
         try {
             const res = await fetch(`${ADMIN_API_BASE}/medicines`, {
                 method: "POST",
@@ -342,6 +372,7 @@ export default function AdminDashboard() {
                                 loading={loading}
                                 authError={authError}
                                 acting={acting}
+                                canMutate={canMutate}
                                 onAction={handleReportAction}
                                 t={t}
                             />
@@ -356,15 +387,17 @@ export default function AdminDashboard() {
                                 <h2 className="font-semibold text-slate-800">
                                     {t("medicine.title")}
                                 </h2>
-                                <button
-                                    onClick={() => setShowForm((v) => !v)}
-                                    className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-blue-700"
-                                >
-                                    <Plus className="h-3.5 w-3.5" /> {t("actions.addMedicine")}
-                                </button>
+                                {canMutate && (
+                                    <button
+                                        onClick={() => setShowForm((v) => !v)}
+                                        className="flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-blue-700"
+                                    >
+                                        <Plus className="h-3.5 w-3.5" /> {t("actions.addMedicine")}
+                                    </button>
+                                )}
                             </div>
 
-                            {showForm && (
+                            {canMutate && showForm && (
                                 <div className="border-b border-slate-100 bg-slate-50 px-6 py-4">
                                     <div className="mb-3 grid grid-cols-2 gap-3">
                                         {(
@@ -620,6 +653,7 @@ function ReportsTable({
     loading,
     authError,
     acting,
+    canMutate,
     onAction,
     t,
 }: Readonly<{
@@ -627,6 +661,7 @@ function ReportsTable({
     loading: boolean;
     authError: string | null;
     acting: string | null;
+    canMutate: boolean;
     onAction: (id: string, s: ReportStatus) => void;
     t: ReturnType<typeof useTranslations>;
 }>) {
@@ -682,7 +717,9 @@ function ReportsTable({
                             <th className="px-6 py-3">{t("reports.columns.district")}</th>
                             <th className="px-6 py-3">{t("reports.columns.barcode")}</th>
                             <th className="px-6 py-3">{t("reports.columns.reported")}</th>
-                            <th className="px-6 py-3">{t("reports.columns.actions")}</th>
+                            {canMutate && (
+                                <th className="px-6 py-3">{t("reports.columns.actions")}</th>
+                            )}
                         </tr>
                     </thead>
                     <tbody className="divide-y divide-slate-100">
@@ -702,26 +739,28 @@ function ReportsTable({
                                 <td className="px-6 py-3 text-sm text-slate-400">
                                     {timeAgo(r.created_at)}
                                 </td>
-                                <td className="px-6 py-3">
-                                    <div className="flex gap-2">
-                                        <ActionBtn
-                                            label={t("actions.markFake")}
-                                            icon={XCircle}
-                                            color="red"
-                                            loading={acting === r.id + "verified_fake"}
-                                            disabled={!!acting?.startsWith(r.id)}
-                                            onClick={() => onAction(r.id, "verified_fake")}
-                                        />
-                                        <ActionBtn
-                                            label={t("actions.falseAlarm")}
-                                            icon={CheckCircle}
-                                            color="green"
-                                            loading={acting === r.id + "false_alarm"}
-                                            disabled={!!acting?.startsWith(r.id)}
-                                            onClick={() => onAction(r.id, "false_alarm")}
-                                        />
-                                    </div>
-                                </td>
+                                {canMutate && (
+                                    <td className="px-6 py-3">
+                                        <div className="flex gap-2">
+                                            <ActionBtn
+                                                label={t("actions.markFake")}
+                                                icon={XCircle}
+                                                color="red"
+                                                loading={acting === r.id + "verified_fake"}
+                                                disabled={!!acting?.startsWith(r.id)}
+                                                onClick={() => onAction(r.id, "verified_fake")}
+                                            />
+                                            <ActionBtn
+                                                label={t("actions.falseAlarm")}
+                                                icon={CheckCircle}
+                                                color="green"
+                                                loading={acting === r.id + "false_alarm"}
+                                                disabled={!!acting?.startsWith(r.id)}
+                                                onClick={() => onAction(r.id, "false_alarm")}
+                                            />
+                                        </div>
+                                    </td>
+                                )}
                             </tr>
                         ))}
                     </tbody>

--- a/apps/web/app/[locale]/admin/layout.tsx
+++ b/apps/web/app/[locale]/admin/layout.tsx
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/routing";
+import { getAdminRoleFromSession } from "@/lib/adminAuth";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
 
 export const dynamic = "force-dynamic";
@@ -44,7 +45,7 @@ export default async function AdminLayout({
         return redirect(`/${resolvedParams.locale}/login`);
     }
 
-    const role = session.user.app_metadata?.role || session.user.user_metadata?.role;
+    const role = getAdminRoleFromSession(session);
 
     if (role !== "admin" && role !== "moderator") {
         return (

--- a/apps/web/lib/adminAuth.ts
+++ b/apps/web/lib/adminAuth.ts
@@ -1,0 +1,27 @@
+import type { Session, User } from "@supabase/supabase-js";
+
+export type AdminRole = "admin" | "moderator";
+
+function toAdminRole(value: unknown): AdminRole | null {
+    if (value === "admin" || value === "moderator") {
+        return value;
+    }
+
+    return null;
+}
+
+export function getAdminRoleFromUser(
+    user: Pick<User, "app_metadata" | "user_metadata"> | null | undefined
+): AdminRole | null {
+    return toAdminRole(user?.app_metadata?.role) ?? toAdminRole(user?.user_metadata?.role);
+}
+
+export function getAdminRoleFromSession(
+    session: Pick<Session, "user"> | null | undefined
+): AdminRole | null {
+    return getAdminRoleFromUser(session?.user);
+}
+
+export function canMutateAdminData(role: AdminRole | null | undefined): boolean {
+    return role === "admin";
+}

--- a/apps/web/tests/admin-dashboard-role-gating.test.tsx
+++ b/apps/web/tests/admin-dashboard-role-gating.test.tsx
@@ -1,0 +1,199 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import AdminDashboard from "../app/[locale]/admin/dashboard/page";
+
+type MockRole = "admin" | "moderator" | null;
+
+let mockSessionRole: MockRole = null;
+
+const mockGetSession = jest.fn(async () => ({
+    data: {
+        session: mockSessionRole
+            ? {
+                  user: {
+                      app_metadata: { role: mockSessionRole },
+                      user_metadata: {},
+                  },
+              }
+            : null,
+    },
+}));
+
+jest.mock("@supabase/ssr", () => ({
+    createBrowserClient: () => ({
+        auth: {
+            getSession: () => mockGetSession(),
+        },
+    }),
+}));
+
+jest.mock("@/lib/env", () => ({
+    getSupabaseAnonKey: () => "test-anon-key",
+    getSupabaseUrl: () => "http://localhost:54321",
+}));
+
+jest.mock("@/i18n/routing", () => ({
+    Link: ({
+        children,
+        href,
+        ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
+}));
+
+jest.mock("next-intl", () => ({
+    useTranslations: () => {
+        const messages: Record<string, string> = {
+            "actions.addMedicine": "Add Medicine",
+            "actions.falseAlarm": "False alarm",
+            "actions.markFake": "Mark fake",
+            "actions.refresh": "Refresh",
+            "actions.signIn": "Sign In",
+            "header.subtitle": "Manage community-reported counterfeit medicines",
+            "header.title": "Moderation Dashboard",
+            "medicine.columns.barcode": "Barcode",
+            "medicine.columns.brand": "Brand",
+            "medicine.columns.generic": "Generic",
+            "medicine.columns.manufacturer": "Manufacturer",
+            "medicine.columns.status": "Status",
+            "medicine.empty": "No medicines found",
+            "medicine.title": "Medicine Master",
+            "nav.logs": "Audit Logs",
+            "nav.medicine": "Medicine Master",
+            "nav.reports": "Reports",
+            "reports.columns.actions": "Actions",
+            "reports.columns.barcode": "Barcode",
+            "reports.columns.district": "District",
+            "reports.columns.medicine": "Medicine",
+            "reports.columns.reported": "Reported",
+            "reports.empty": "No pending reports",
+            "reports.loading": "Loading reports...",
+            "reports.title": "Incoming Reports",
+            searchPlaceholder: "Search...",
+        };
+
+        return (key: string, values?: Record<string, unknown>) => {
+            if (key === "reports.pendingCount") {
+                return `${String(values?.count ?? 0)} pending reports`;
+            }
+
+            return messages[key] ?? key;
+        };
+    },
+}));
+
+const report = {
+    id: "report-1",
+    reported_brand_name: "Suspect Med",
+    district: "Jaipur",
+    status: "pending",
+    created_at: new Date().toISOString(),
+    scanned_barcode: "8901234567890",
+};
+
+const medicine = {
+    id: "medicine-1",
+    brand_name: "Catalog Med",
+    generic_name: "Paracetamol",
+    manufacturer: "Sahi Labs",
+    barcode_id: "8900000000000",
+    cdsco_approval_status: "approved",
+};
+
+function jsonResponse(body: unknown, status = 200) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+    } as Response;
+}
+
+describe("AdminDashboard role-based mutation controls", () => {
+    beforeEach(() => {
+        mockSessionRole = null;
+        mockGetSession.mockClear();
+        localStorage.setItem("sb-access-token", "test-token");
+        Object.defineProperty(global, "fetch", {
+            configurable: true,
+            writable: true,
+            value: jest.fn(async (input) => {
+                const url = String(input);
+
+                if (url.endsWith("/reports")) {
+                    return jsonResponse({ reports: [report] });
+                }
+
+                if (url.endsWith("/medicines")) {
+                    return jsonResponse({ medicines: [medicine] });
+                }
+
+                if (url.endsWith("/logs")) {
+                    return jsonResponse({ logs: [] });
+                }
+
+                if (url.endsWith("/reports/report-1/status")) {
+                    return jsonResponse({ report: { ...report, status: "verified_fake" } });
+                }
+
+                return jsonResponse({}, 404);
+            }),
+        });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        localStorage.clear();
+    });
+
+    it("lets moderators view reports and medicines without mutation controls", async () => {
+        mockSessionRole = "moderator";
+
+        render(<AdminDashboard />);
+
+        expect(await screen.findByText("Suspect Med")).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: /mark fake/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: /false alarm/i })).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /medicine master/i }));
+
+        expect(await screen.findByText("Catalog Med")).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: /add medicine/i })).not.toBeInTheDocument();
+    });
+
+    it("keeps mutation controls available for admins", async () => {
+        mockSessionRole = "admin";
+
+        render(<AdminDashboard />);
+
+        expect(await screen.findByRole("button", { name: /mark fake/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /false alarm/i })).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /medicine master/i }));
+
+        expect(await screen.findByRole("button", { name: /add medicine/i })).toBeInTheDocument();
+    });
+
+    it("sends report mutation requests for admins", async () => {
+        mockSessionRole = "admin";
+        const fetchMock = global.fetch as jest.Mock;
+
+        render(<AdminDashboard />);
+
+        fireEvent.click(await screen.findByRole("button", { name: /mark fake/i }));
+
+        await waitFor(() => {
+            expect(fetchMock).toHaveBeenCalledWith(
+                expect.stringContaining("/reports/report-1/status"),
+                expect.objectContaining({
+                    method: "PATCH",
+                })
+            );
+        });
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1487**
- **Summary:**
  - Reads the admin role from the Supabase session metadata and normalizes it through a shared admin auth helper.
  - Hides report mutation controls and add-medicine controls for moderators while keeping read-only dashboard content visible.
  - Keeps admin mutation controls active and covered by tests, including the PATCH request path.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

This role-gated UI depends on Supabase session roles, so I verified it with mocked moderator/admin sessions in component tests instead of a real browser session.

Verification run after rebasing on latest `upstream/main` (`f53a8f2`):

```bash
npm run test -w web -- tests/admin-dashboard-role-gating.test.tsx tests/adminApi.test.ts --runInBand
# 2 test suites passed, 10 tests passed

git diff --check
```

Focused coverage includes:

- Moderators can view dashboard reports and medicines without mutation controls.
- Admins can see mutation controls.
- Admin report mutations still send the expected PATCH request.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1487`)
- [x] I have pulled the latest `main` and resolved any conflicts
