### PR TITLE
fix: standardize postgrest escaping

### DIFF
--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import { supabase } from "../db/client";
 import { z } from "zod";
 import { triggerRecallAlert } from "../services/notifications";
+import { escapePostgrest } from "../utils/postgrest";
 
 const AlertSchema = z
     .object({
@@ -51,10 +52,13 @@ alertsRouter.get("/", async (req: Request, res: Response) => {
     let query = supabase.from("drug_alerts").select("*", { count: "exact" });
 
     if (brand) {
-        query = query.ilike("reported_brand_name", `%${brand}%`);
+        query = query.ilike(
+            "reported_brand_name",
+            escapePostgrest(`%${brand.replace(/[%_\\]/g, "\\$&")}%`)
+        );
     }
     if (region) {
-        query = query.ilike("state", `%${region}%`);
+        query = query.ilike("state", escapePostgrest(`%${region.replace(/[%_\\]/g, "\\$&")}%`));
     }
     if (batchNumber) {
         query = query.eq("batch_number", batchNumber);

--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -8,6 +8,7 @@ import { supabase } from "../db/client";
 import { getMlServiceUrl, MISSING_ML_SERVICE_URL_MESSAGE } from "../config/mlService";
 import { validateUploadSize } from "../middleware/uploadSizeValidator";
 import { uploadRateLimiter } from "../middleware/uploadRateLimit";
+import { escapePostgrest } from "../utils/postgrest";
 
 /**
  * Escape ILIKE wildcard characters in a string derived from untrusted input
@@ -370,7 +371,7 @@ router.post("/extract", uploadRateLimiter, validateUploadSize, (req: Request, re
                     const orFilter = searchWords
                         .map((w) => {
                             const safe = escapeIlike(w);
-                            return `brand_name.ilike.%${safe}%,generic_name.ilike.%${safe}%`;
+                            return `brand_name.ilike.${escapePostgrest(`%${safe}%`)},generic_name.ilike.${escapePostgrest(`%${safe}%`)}`;
                         })
                         .join(",");
 
@@ -658,7 +659,9 @@ router.post("/match", async (req: Request, res: Response) => {
         const { data, error } = await supabase
             .from("medicines")
             .select("brand_name, generic_name")
-            .or(`brand_name.ilike.%${keyword}%,generic_name.ilike.%${keyword}%`)
+            .or(
+                `brand_name.ilike.${escapePostgrest(`%${keyword}%`)},generic_name.ilike.${escapePostgrest(`%${keyword}%`)}`
+            )
             .limit(100);
 
         if (error) {
@@ -731,7 +734,9 @@ router.post("/verify-brand", async (req: Request, res: Response) => {
                 "brand_name, generic_name, manufacturer, batch_number, expiry_date, cdsco_approval_status, is_counterfeit_alert"
             )
             .or(
-                `brand_name.ilike.%${escapeIlike(brandName)}%,generic_name.ilike.%${escapeIlike(brandName)}%`
+                `brand_name.ilike.${escapePostgrest(
+                    `%${escapeIlike(brandName)}%`
+                )},generic_name.ilike.${escapePostgrest(`%${escapeIlike(brandName)}%`)}`
             )
             .limit(1)
             .maybeSingle();

--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { supabase } from "../db/client";
 import { verifyLimiter } from "../middleware/rateLimit";
 import { optionalAuth } from "../middleware/auth";
+import { escapePostgrest } from "../utils/postgrest";
 
 const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
     ? process.env.ALLOWED_ORIGINS.split(",").map((s) => s.trim())
@@ -165,7 +166,7 @@ router.post(
                 .select(
                     "id, barcode_id, brand_name, generic_name, manufacturer, batch_number, expiry_date, cdsco_approval_status, is_counterfeit_alert"
                 )
-                .ilike("batch_number", escaped)
+                .ilike("batch_number", escapePostgrest(escaped))
                 .limit(1)
                 .maybeSingle();
 

--- a/apps/api/src/utils/postgrest.ts
+++ b/apps/api/src/utils/postgrest.ts
@@ -1,0 +1,3 @@
+export function escapePostgrest(value: string): string {
+    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}

--- a/apps/api/tests/postgrest.test.ts
+++ b/apps/api/tests/postgrest.test.ts
@@ -1,0 +1,11 @@
+import { escapePostgrest } from "../src/utils/postgrest";
+
+describe("escapePostgrest", () => {
+    it("wraps values in double quotes and preserves wildcard patterns", () => {
+        expect(escapePostgrest("%aspirin%")).toBe('"%aspirin%"');
+    });
+
+    it("escapes embedded quotes and backslashes", () => {
+        expect(escapePostgrest('a"b\\c')).toBe('"a\\"b\\\\c"');
+    });
+});

--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -7,13 +7,14 @@ import ComparisonGrid, { type Medicine } from "@/src/components/ComparisonGrid";
 import MedicineSearchSelect from "@/src/components/MedicineSearchSelect";
 import { COMPARE_SELECT_FIELDS } from "@/src/lib/compareSelectFields";
 import { supabase } from "@/lib/supabase";
+import { escapePostgrest } from "@/lib/supabase/utils";
 import { mapMedicineRow } from "@/src/lib/mapMedicineRow";
 
 async function searchMedicines(query: string): Promise<Medicine[]> {
     const q = query.trim();
     if (q.length < 2) return [];
 
-    const pattern = `%${q.replace(/[%_\\]/g, "\\$&")}%`;
+    const pattern = escapePostgrest(`%${q.replace(/[%_\\]/g, "\\$&")}%`);
     const { data, error } = await supabase
         .from("medicines")
         .select(COMPARE_SELECT_FIELDS)

--- a/apps/web/app/[locale]/components/SearchBar.tsx
+++ b/apps/web/app/[locale]/components/SearchBar.tsx
@@ -1,11 +1,12 @@
 "use client";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Search } from "lucide-react";
 import { useRouter, useParams } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import { useTranslations } from "next-intl";
 import { fuzzyMatchBrand } from "@/lib/api";
 import SearchSuggestions from "@/components/SearchSuggestions";
+import { escapePostgrest } from "@/lib/supabase/utils";
 /** Maximum number of suggestions shown at once */
 const MAX_SUGGESTIONS = 8;
 /** Debounce delay in milliseconds */
@@ -77,10 +78,11 @@ export default function SearchBar({ dark = false }: { dark?: boolean }) {
         setIsLoading(true);
         try {
             // Query both brand_name and batch_number columns for partial matches.
+            const escapedPattern = escapePostgrest(`%${trimmed.replace(/[%_\\]/g, "\\$&")}%`);
             const { data, error } = await supabase
                 .from("medicines")
                 .select("brand_name, batch_number")
-                .or(`brand_name.ilike.%${trimmed}%,batch_number.ilike.%${trimmed}%`)
+                .or(`brand_name.ilike.${escapedPattern},batch_number.ilike.${escapedPattern}`)
                 .abortSignal(controller.signal)
                 .limit(MAX_SUGGESTIONS);
             if (controller.signal.aborted) {

--- a/apps/web/lib/supabase/utils.ts
+++ b/apps/web/lib/supabase/utils.ts
@@ -1,0 +1,3 @@
+export function escapePostgrest(value: string): string {
+    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}


### PR DESCRIPTION
## What does this PR do?
Adds a shared `escapePostgrest` helper and updates the Supabase search call sites in the web app and API to use quoted PostgREST patterns instead of raw string interpolation.

## Related issue
Fixes #1543

## Checklist
- [x] I added a unit test for the new escaping helper.
- [x] I updated the affected search/filter call sites in `apps/web` and `apps/api`.
- [x] I verified formatting, TypeScript, and the targeted API test.
