### PR TITLE
fix(docs): correct ADR-006 date year from 2024 to 2026

### DIFF
--- a/docs/devtrack/adr/ADR-006-refactor-web-centralize-layout-colors-into-theme-t.md
+++ b/docs/devtrack/adr/ADR-006-refactor-web-centralize-layout-colors-into-theme-t.md
@@ -1,6 +1,6 @@
 # ADR — refactor(web): centralize layout colors into theme tokens
 
-> **Date:** 2024-05-21 | **PR:** #377 | **Status:** Accepted
+> **Date:** 2026-05-21 | **PR:** #377 | **Status:** Accepted
 
 ## Context
 


### PR DESCRIPTION
## Summary

Fixed stale date year in ADR-006: `2024-05-21` ? `2026-05-21`.

Closes #1670