### PR TITLE
fix(docs): correct ADR-020 date year from 2024 to 2026

### DIFF
--- a/docs/devtrack/adr/ADR-020-fix-lasa-add-lasalimiter-and-cap-medicinename-leng.md
+++ b/docs/devtrack/adr/ADR-020-fix-lasa-add-lasalimiter-and-cap-medicinename-leng.md
@@ -1,6 +1,6 @@
 # ADR — fix(lasa): add lasaLimiter and cap medicineName length on /check endpoint
 
-> **Date:** 2024-07-30 | **PR:** #1114 | **Status:** Accepted
+> **Date:** 2026-07-30 | **PR:** #1114 | **Status:** Accepted
 
 ## Context
 


### PR DESCRIPTION
## Summary

Fixed stale date year in ADR-020: `2024-07-30` ? `2026-07-30`.

Closes #1672