### PR TITLE
fix(ui): add missing type="button" to CopyButton component

### DIFF
--- a/apps/web/components/ui/CopyButton.tsx
+++ b/apps/web/components/ui/CopyButton.tsx
@@ -37,6 +37,7 @@ export const CopyButton = ({
 
     return (
         <button
+            type="button"
             onClick={handleCopy}
             className={clsx(
                 "inline-flex items-center justify-center rounded-md p-1.5 transition-all hover:bg-slate-100 active:scale-95 dark:hover:bg-slate-800",


### PR DESCRIPTION
## Summary

Added `type="button"` to `CopyButton` component to prevent unintended form submission when used inside forms.

Closes #1675