### PR TITLE
fix(ci): correct dependabot pip directory path from /ml_service to /apps/ml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
 
   # Maintain dependencies for Python (FastAPI/ML)
   - package-ecosystem: "pip"
-    directory: "/ml_service"
+    directory: "/apps/ml"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

Fixed the dependabot pip ecosystem directory path from the non-existent `/ml_service` to `/apps/ml` where the actual requirements.txt lives.

Closes #1677