### PR TITLE
fix(docs): correct ADR-026 date year from 2024 to 2026

### DIFF
--- a/docs/devtrack/adr/ADR-026-critical-refactor-extract-shared-fetch-timeout-ret.md
+++ b/docs/devtrack/adr/ADR-026-critical-refactor-extract-shared-fetch-timeout-ret.md
@@ -1,6 +1,6 @@
 # ADR — [Critical] refactor: extract shared fetch-timeout-retry logic from duplicated Supabase client files
 
-> **Date:** 2024-07-30 | **PR:** #1270 | **Status:** Accepted
+> **Date:** 2026-07-30 | **PR:** #1270 | **Status:** Accepted
 
 ## Context
 


### PR DESCRIPTION
## Summary

Fixed stale date year in ADR-026 from 2024 to 2026.

Closes #1681