### PR TITLE
fix(docs): correct ADR-017-feat date year from 2024 to 2026

### DIFF
--- a/docs/devtrack/adr/ADR-017-feat-scan-share-verification-results.md
+++ b/docs/devtrack/adr/ADR-017-feat-scan-share-verification-results.md
@@ -1,6 +1,6 @@
 # ADR — feat(scan): share verification results
 
-> **Date:** 2024-07-20 | **PR:** [PR_NUMBER] | **Status:** Accepted
+> **Date:** 2026-07-20 | **PR:** [PR_NUMBER] | **Status:** Accepted
 
 ## Context
 


### PR DESCRIPTION
## Summary

Fixed stale date year in ADR-017-feat-scan-share-verification-results.md from 2024 to 2026.

Closes #1687