### PR TITLE
fix(docs): correct ADR-017-fix date year from 2024 to 2026

### DIFF
--- a/docs/devtrack/adr/ADR-017-fix-833-optimize-load-time-with-lazy-loading-and-i.md
+++ b/docs/devtrack/adr/ADR-017-fix-833-optimize-load-time-with-lazy-loading-and-i.md
@@ -1,6 +1,6 @@
 # ADR — Fix #833: Optimize Load Time with Lazy Loading and Image Optimization
 
-> **Date:** 2024-07-30 | **PR:** #833 | **Status:** Accepted
+> **Date:** 2026-07-30 | **PR:** #833 | **Status:** Accepted
 
 ## Context
 


### PR DESCRIPTION
## Summary

Fixed stale date year in ADR-017-fix-833-optimize-load-time-with-lazy-loading-and-i.md from 2024 to 2026.

Closes #1689