### PR TITLE
feat(env): add LOG_LEVEL environment variable to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4000,http://localhost:800
 # --- API Gateway ---
 PORT=4000
 NODE_ENV=development
+LOG_LEVEL=info
 JWT_SECRET=your_jwt_secret_key
 JWT_EXPIRES_IN=7d
 


### PR DESCRIPTION
## Summary

Added missing `LOG_LEVEL` environment variable to `.env.example` under the API Gateway section. The logger at `apps/api/src/utils/logger.ts` already reads this var (defaults to "info").

Closes #1692