### PR TITLE
fix: add login password visibility toggle

### DIFF
--- a/apps/web/app/[locale]/login/page.tsx
+++ b/apps/web/app/[locale]/login/page.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { Mail, Lock, ShieldCheck, ArrowRight, Hand, AlertTriangle } from "lucide-react";
+import {
+    Mail,
+    Lock,
+    ShieldCheck,
+    ArrowRight,
+    Hand,
+    AlertTriangle,
+    Eye,
+    EyeOff,
+} from "lucide-react";
 import { FcGoogle } from "react-icons/fc";
 import { useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
@@ -18,6 +27,7 @@ export default function LoginPage() {
     const supabase = createBrowserClient(supabaseUrl, supabaseKey);
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
+    const [showPassword, setShowPassword] = useState(false);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState("");
 
@@ -186,7 +196,7 @@ export default function LoginPage() {
                                 <Lock className="h-5 w-5 text-(--color-text-muted)" />
 
                                 <input
-                                    type="password"
+                                    type={showPassword ? "text" : "password"}
                                     placeholder={t("passwordPlaceholder")}
                                     value={password}
                                     onChange={(e) => setPassword(e.target.value)}
@@ -194,6 +204,23 @@ export default function LoginPage() {
                                     disabled={isMissingEnvVars}
                                     className="w-full bg-transparent text-(--color-text-primary) outline-none placeholder:text-(--color-text-muted) disabled:cursor-not-allowed disabled:opacity-50"
                                 />
+
+                                <button
+                                    type="button"
+                                    onClick={() => setShowPassword((current) => !current)}
+                                    disabled={isMissingEnvVars}
+                                    aria-label={
+                                        showPassword ? t("hidePassword") : t("showPassword")
+                                    }
+                                    aria-pressed={showPassword}
+                                    className="rounded-full p-1 text-(--color-text-muted) transition hover:text-(--color-text-primary) focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    {showPassword ? (
+                                        <EyeOff className="h-5 w-5" aria-hidden="true" />
+                                    ) : (
+                                        <Eye className="h-5 w-5" aria-hidden="true" />
+                                    )}
+                                </button>
                             </div>
                         </div>
 

--- a/apps/web/messages/as.json
+++ b/apps/web/messages/as.json
@@ -474,6 +474,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "পাছৱৰ্ড",
         "passwordPlaceholder": "আপোনাৰ পাছৱৰ্ড দিয়ক",
+        "showPassword": "পাছৱৰ্ড দেখুৱাওক",
+        "hidePassword": "পাছৱৰ্ড লুকুৱাওক",
         "signingIn": "চাইন ইন হৈছে...",
         "signIn": "চাইন ইন কৰক",
         "footerPrompt": "ঘূৰি যাব লাগিব?",

--- a/apps/web/messages/bn.json
+++ b/apps/web/messages/bn.json
@@ -468,6 +468,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "পাসওয়ার্ড",
         "passwordPlaceholder": "আপনার পাসওয়ার্ড লিখুন",
+        "showPassword": "পাসওয়ার্ড দেখান",
+        "hidePassword": "পাসওয়ার্ড লুকান",
         "signingIn": "সাইন ইন করা হচ্ছে...",
         "signIn": "সাইন ইন করুন",
         "footerPrompt": "ফিরে যেতে চান?",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -485,6 +485,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "Password",
         "passwordPlaceholder": "Enter your password",
+        "showPassword": "Show password",
+        "hidePassword": "Hide password",
         "signingIn": "Signing in...",
         "signIn": "Sign In",
         "footerPrompt": "Need to go back?",

--- a/apps/web/messages/gu.json
+++ b/apps/web/messages/gu.json
@@ -469,6 +469,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "પાસવર્ડ",
         "passwordPlaceholder": "તમારો પાસવર્ડ દાખલ કરો",
+        "showPassword": "પાસવર્ડ બતાવો",
+        "hidePassword": "પાસવર્ડ છુપાવો",
         "signingIn": "સાઇન ઇન થઈ રહ્યું છે...",
         "signIn": "સાઇન ઇન કરો",
         "footerPrompt": "પાછા જવું છે?",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -481,6 +481,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "पासवर्ड",
         "passwordPlaceholder": "अपना पासवर्ड दर्ज करें",
+        "showPassword": "पासवर्ड दिखाएँ",
+        "hidePassword": "पासवर्ड छिपाएँ",
         "signingIn": "साइन इन किया जा रहा है...",
         "signIn": "साइन इन करें",
         "footerPrompt": "वापस जाना चाहते हैं?",

--- a/apps/web/messages/kn.json
+++ b/apps/web/messages/kn.json
@@ -468,6 +468,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "ಪಾಸ್‌ವರ್ಡ್",
         "passwordPlaceholder": "ನಿಮ್ಮ ಪಾಸ್‌ವರ್ಡ್ ನಮೂದಿಸಿ",
+        "showPassword": "ಪಾಸ್‌ವರ್ಡ್ ತೋರಿಸಿ",
+        "hidePassword": "ಪಾಸ್‌ವರ್ಡ್ ಮರೆಮಾಡಿ",
         "signingIn": "ಸೈನ್ ಇನ್ ಆಗುತ್ತಿದೆ...",
         "signIn": "ಸೈನ್ ಇನ್ ಮಾಡಿ",
         "footerPrompt": "ಹಿಂದೆ ಹೋಗಬೇಕೇ?",

--- a/apps/web/messages/ks.json
+++ b/apps/web/messages/ks.json
@@ -474,6 +474,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "پاس ورڈ",
         "passwordPlaceholder": "پاس ورڈ دِیو",
+        "showPassword": "پاس ورڈ ہٲویو",
+        "hidePassword": "پاس ورڈ چھُپٲویو",
         "signingIn": "سائن اِن گژھان...",
         "signIn": "سائن اِن",
         "footerPrompt": "واپس گژھنہٕ چھُو؟",

--- a/apps/web/messages/mai.json
+++ b/apps/web/messages/mai.json
@@ -477,6 +477,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "पासवर्ड",
         "passwordPlaceholder": "अपन पासवर्ड दिअ",
+        "showPassword": "पासवर्ड देखाउ",
+        "hidePassword": "पासवर्ड नुकाउ",
         "signingIn": "साइन इन भऽ रहल अछि...",
         "signIn": "साइन इन करू",
         "footerPrompt": "वापस जेबाक अछि?",

--- a/apps/web/messages/ml.json
+++ b/apps/web/messages/ml.json
@@ -474,6 +474,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "പാസ്‌വേഡ്",
         "passwordPlaceholder": "നിങ്ങളുടെ പാസ്‌വേഡ് നൽകുക",
+        "showPassword": "പാസ്‌വേഡ് കാണിക്കുക",
+        "hidePassword": "പാസ്‌വേഡ് മറയ്ക്കുക",
         "signingIn": "സൈൻ ഇൻ ചെയ്യുന്നു...",
         "signIn": "സൈൻ ഇൻ ചെയ്യുക",
         "footerPrompt": "തിരികെ പോകണോ?",

--- a/apps/web/messages/mr.json
+++ b/apps/web/messages/mr.json
@@ -468,6 +468,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "पासवर्ड",
         "passwordPlaceholder": "तुमचा पासवर्ड प्रविष्ट करा",
+        "showPassword": "पासवर्ड दाखवा",
+        "hidePassword": "पासवर्ड लपवा",
         "signingIn": "साइन इन होत आहे...",
         "signIn": "साइन इन करा",
         "footerPrompt": "परत जायचे आहे का?",

--- a/apps/web/messages/or.json
+++ b/apps/web/messages/or.json
@@ -468,6 +468,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "ପାସୱାର୍ଡ",
         "passwordPlaceholder": "ଆପଣଙ୍କ ପାସୱାର୍ଡ ଲେଖନ୍ତୁ",
+        "showPassword": "ପାସୱାର୍ଡ ଦେଖାନ୍ତୁ",
+        "hidePassword": "ପାସୱାର୍ଡ ଲୁଚାନ୍ତୁ",
         "signingIn": "ସାଇନ୍ ଇନ୍ ହେଉଛି...",
         "signIn": "ସାଇନ୍ ଇନ୍ କରନ୍ତୁ",
         "footerPrompt": "ଫେରିବାକୁ ଚାହୁଁଛନ୍ତି କି?",

--- a/apps/web/messages/pa.json
+++ b/apps/web/messages/pa.json
@@ -468,6 +468,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "ਪਾਸਵਰਡ",
         "passwordPlaceholder": "ਆਪਣਾ ਪਾਸਵਰਡ ਦਰਜ ਕਰੋ",
+        "showPassword": "ਪਾਸਵਰਡ ਵੇਖਾਓ",
+        "hidePassword": "ਪਾਸਵਰਡ ਲੁਕਾਓ",
         "signingIn": "ਸਾਈਨ ਇਨ ਹੋ ਰਿਹਾ ਹੈ...",
         "signIn": "ਸਾਈਨ ਇਨ ਕਰੋ",
         "footerPrompt": "ਵਾਪਸ ਜਾਣਾ ਚਾਹੁੰਦੇ ਹੋ?",

--- a/apps/web/messages/sa.json
+++ b/apps/web/messages/sa.json
@@ -468,6 +468,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "गुह्यशब्दः",
         "passwordPlaceholder": "स्वीयं गुह्यशब्दं प्रविशन्तु",
+        "showPassword": "गुप्तशब्दं दर्शयतु",
+        "hidePassword": "गुप्तशब्दं गोपयतु",
         "signingIn": "प्रवेशः क्रियते...",
         "signIn": "प्रविशतु",
         "footerPrompt": "प्रतिगन्तुम् इच्छथ?",

--- a/apps/web/messages/ta.json
+++ b/apps/web/messages/ta.json
@@ -468,6 +468,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "கடவுச்சொல்",
         "passwordPlaceholder": "உங்கள் கடவுச்சொல்லை உள்ளிடவும்",
+        "showPassword": "கடவுச்சொல்லைக் காட்டு",
+        "hidePassword": "கடவுச்சொல்லை மறை",
         "signingIn": "உள்நுழைகிறது...",
         "signIn": "உள்நுழையவும்",
         "footerPrompt": "திரும்பிச் செல்ல வேண்டுமா?",

--- a/apps/web/messages/te.json
+++ b/apps/web/messages/te.json
@@ -468,6 +468,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "పాస్‌వర్డ్",
         "passwordPlaceholder": "మీ పాస్‌వర్డ్‌ను నమోదు చేయండి",
+        "showPassword": "పాస్‌వర్డ్ చూపించు",
+        "hidePassword": "పాస్‌వర్డ్ దాచు",
         "signingIn": "సైన్ ఇన్ అవుతోంది...",
         "signIn": "సైన్ ఇన్ చేయండి",
         "footerPrompt": "వెనక్కి వెళ్లాలనుకుంటున్నారా?",

--- a/apps/web/messages/ur.json
+++ b/apps/web/messages/ur.json
@@ -468,6 +468,8 @@
         "emailPlaceholder": "you@example.com",
         "passwordLabel": "پاس ورڈ",
         "passwordPlaceholder": "اپنا پاس ورڈ درج کریں",
+        "showPassword": "پاس ورڈ دکھائیں",
+        "hidePassword": "پاس ورڈ چھپائیں",
         "signingIn": "سائن ان ہو رہا ہے...",
         "signIn": "سائن ان کریں",
         "footerPrompt": "واپس جانا چاہتے ہیں؟",

--- a/apps/web/tests/login-password-visibility.test.tsx
+++ b/apps/web/tests/login-password-visibility.test.tsx
@@ -1,0 +1,50 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+import LoginPage from "../app/[locale]/login/page";
+
+const push = jest.fn();
+
+jest.mock("@/i18n/routing", () => ({
+    Link: ({ children, href, ...props }: { children: React.ReactNode; href: string }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
+    useRouter: () => ({ push }),
+}));
+
+jest.mock("next-intl", () => ({
+    useLocale: () => "en",
+    useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+}));
+
+jest.mock("@supabase/ssr", () => ({
+    createBrowserClient: () => ({
+        auth: {
+            signInWithPassword: jest.fn(),
+            signInWithOAuth: jest.fn(),
+        },
+    }),
+}));
+
+describe("login password visibility", () => {
+    it("renders an accessible password visibility toggle", () => {
+        const markup = renderToStaticMarkup(<LoginPage />);
+
+        expect(markup).toContain('type="password"');
+        expect(markup).toContain('type="button"');
+        expect(markup).toContain('aria-label="Login.showPassword"');
+        expect(markup).toContain('aria-pressed="false"');
+    });
+
+    it("keeps the toggle wired to component state and translations", () => {
+        const source = readFileSync(join(process.cwd(), "app/[locale]/login/page.tsx"), "utf8");
+
+        expect(source).toContain("const [showPassword, setShowPassword] = useState(false)");
+        expect(source).toContain('type={showPassword ? "text" : "password"}');
+        expect(source).toContain("setShowPassword((current) => !current)");
+        expect(source).toContain('showPassword ? t("hidePassword") : t("showPassword")');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds a show/hide password toggle to the login form
- Uses accessible button semantics with localized labels and pressed state
- Adds focused regression coverage for the login password visibility control

## Test Plan
- `npm test -w web -- login-password-visibility.test.tsx --runInBand`
- `git diff HEAD~1 HEAD --check`
- Added-line security scan: 0 findings

Closes #1698