### PR TITLE
fix(docker): load env vars in api container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,11 +45,14 @@ services:
       - PORT=4000
       - REDIS_URL=redis://redis:6379
       - ML_SERVICE_URL=http://ml:8000
+    env_file:
+      - .env
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
       - redis
       - ml
+
 
   ml:
     build:


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [ ] I am assigned to this issue.
* [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link

* **Closes #1233**
* **Summary:**
  Added `env_file: .env` to the `api` service in `docker-compose.yml`.

  The production Docker Compose configuration already loads the root `.env` file for the API service, while the development configuration did not. This change aligns both configurations and ensures environment variables defined in the root `.env` file are available to the API container.

## 📸 Proof of Work (Screenshots / Logs)

Before
<img width="804" height="344" alt="image" src="https://github.com/user-attachments/assets/a78ea256-f27a-4786-854c-157ba4b8bd37" />

After
<img width="482" height="315" alt="image" src="https://github.com/user-attachments/assets/eef4d785-d9a9-414f-93df-79752c0e61de" />

### Files Changed

```diff
api:
  environment:
    - PORT=4000
    - REDIS_URL=redis://redis:6379
    - ML_SERVICE_URL=http://ml:8000
+ env_file:
+   - .env
```

### Verification

Compared the API service definitions in:

* `docker-compose.yml`
* `docker-compose.prod.yml`

The production configuration already loaded `.env`, while the development configuration did not.

This PR aligns the two configurations.

## 🏷️ PR Type

* [x] 🐛 type: bug
* [ ] ✨ type: feature
* [ ] 📖 type: docs
* [ ] 🧪 type: testing
* [ ] 🔒 type: security
* [ ] ⚡ type: performance
* [ ] 🎨 type: design
* [ ] ♻️ type: refactor
* [x] 🛠️ type: devops
* [ ] ♿ type: accessibility

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #1233`)
* [x] I have pulled the latest `main` and resolved any conflicts
