### PR TITLE
feat: link scanned barcodes and medicine IDs to incident reports

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -56,6 +56,8 @@ const createReportSchema = z.object({
         .min(-180, "Longitude must be between -180 and 180")
         .max(180, "Longitude must be between -180 and 180")
         .optional(),
+    scannedBarcode: z.string().optional(),
+    medicineId: z.string().uuid().optional(),
 });
 
 const buildReportLocation = (latitude?: number, longitude?: number) => {
@@ -97,6 +99,8 @@ reportsRouter.post("/", optionalAuth, async (req: AuthenticatedRequest, res: Res
                 report_location: buildReportLocation(data.latitude, data.longitude),
                 reporter_id: req.user?.id ?? null,
                 status: "pending",
+                scanned_barcode: data.scannedBarcode ?? null,
+                medicine_id: data.medicineId ?? null,
             })
             .select()
             .single();

--- a/apps/web/app/[locale]/reports/me/page.tsx
+++ b/apps/web/app/[locale]/reports/me/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
     AlertTriangle,
     CheckCircle2,
@@ -54,47 +55,41 @@ function formatDate(iso: string): string {
     });
 }
 
-const STATUS_META: Record<
+const STATUS_STYLES: Record<
     ReportStatus,
-    { label: string; icon: typeof Clock; chip: string; dot: string }
+    { icon: typeof Clock; chip: string; dot: string }
 > = {
     pending: {
-        label: "Pending Review",
         icon: Clock,
         chip: "bg-amber-50 dark:bg-amber-950/30 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-900/30",
         dot: "bg-amber-500",
     },
     verified_fake: {
-        label: "Verified Fake",
         icon: ShieldCheck,
         chip: "bg-emerald-50 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-400 border-emerald-200 dark:border-emerald-900/30",
         dot: "bg-emerald-500",
     },
     false_alarm: {
-        label: "False Alarm",
         icon: XCircle,
         chip: "bg-(--color-surface-muted) text-(--color-text-secondary) border-(--color-border-muted)",
         dot: "bg-slate-400",
     },
 };
 
-// Accepts `string` rather than `ReportStatus` so an unexpected status from
-// the API (a future migration adds a new value, a corrupted row) renders a
-// neutral badge instead of crashing the page with `Cannot read property of undefined`.
-function StatusBadge({ status }: { status: string }) {
-    const meta = STATUS_META[status as ReportStatus] ?? STATUS_META.pending;
+function StatusBadge({ status, label }: { status: string; label: string }) {
+    const meta = STATUS_STYLES[status as ReportStatus] ?? STATUS_STYLES.pending;
     const Icon = meta.icon;
     return (
         <span
             className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold ${meta.chip}`}
         >
             <Icon size={12} />
-            {meta.label}
+            {label}
         </span>
     );
 }
 
-function ReportCard({ report }: { report: MyReport }) {
+function ReportCard({ report, statusLabel, districtLabel, submittedLabel, batchLabel, noPhotoLabel }: { report: MyReport; statusLabel: string; districtLabel: string; submittedLabel: string; batchLabel: string; noPhotoLabel: string }) {
     const title =
         report.reported_brand_name?.trim() || report.scanned_barcode || "Unnamed medicine";
 
@@ -112,7 +107,7 @@ function ReportCard({ report }: { report: MyReport }) {
                     <div className="flex flex-col items-center text-(--color-text-muted)">
                         <ImageOff size={24} />
                         <span className="mt-1 text-[10px] font-medium tracking-wider uppercase">
-                            No photo
+                            {noPhotoLabel}
                         </span>
                     </div>
                 )}
@@ -121,26 +116,26 @@ function ReportCard({ report }: { report: MyReport }) {
             <div className="flex min-w-0 flex-1 flex-col gap-2 p-4">
                 <div className="flex items-start justify-between gap-3">
                     <h3 className="truncate font-bold text-(--color-text-primary)">{title}</h3>
-                    <StatusBadge status={report.status} />
+                    <StatusBadge status={report.status} label={statusLabel} />
                 </div>
 
                 <dl className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-(--color-text-secondary)">
                     {report.district && (
                         <div className="flex items-center gap-1">
                             <MapPin size={12} className="text-(--color-text-muted)" />
-                            <dt className="sr-only">District</dt>
+                            <dt className="sr-only">{districtLabel}</dt>
                             <dd>{report.district}</dd>
                         </div>
                     )}
                     <div className="flex items-center gap-1">
                         <Clock size={12} className="text-(--color-text-muted)" />
-                        <dt className="sr-only">Submitted</dt>
+                        <dt className="sr-only">{submittedLabel}</dt>
                         <dd>{formatDate(report.created_at)}</dd>
                     </div>
                     {report.scanned_barcode && (
                         <div className="flex items-center gap-1">
                             <FileText size={12} className="text-(--color-text-muted)" />
-                            <dt className="sr-only">Batch</dt>
+                            <dt className="sr-only">{batchLabel}</dt>
                             <dd className="font-mono">{report.scanned_barcode}</dd>
                         </div>
                     )}
@@ -157,6 +152,7 @@ type LoadState =
     | { kind: "ready"; reports: MyReport[] };
 
 export default function MyReportsPage() {
+    const t = useTranslations("MyReports");
     const [state, setState] = useState<LoadState>({ kind: "loading" });
 
     const fetchMine = useCallback(async () => {
@@ -166,7 +162,7 @@ export default function MyReportsPage() {
         if (!token) {
             setState({
                 kind: "authError",
-                message: "Please sign in to view the reports you have filed.",
+                message: t("auth_error_description"),
             });
             return;
         }
@@ -179,7 +175,7 @@ export default function MyReportsPage() {
             if (res.status === 401) {
                 setState({
                     kind: "authError",
-                    message: "Your session has expired. Please sign in again.",
+                    message: t("auth_error_expired"),
                 });
                 return;
             }
@@ -197,20 +193,33 @@ export default function MyReportsPage() {
         } catch {
             setState({
                 kind: "networkError",
-                message: "Cannot reach the API. Is the backend server running on port 4000?",
+                message: t("network_error_api_unreachable"),
             });
         }
-    }, []);
+    }, [t]);
 
     useEffect(() => {
         fetchMine();
     }, [fetchMine]);
 
+    const getStatusLabel = (status: ReportStatus): string => {
+        switch (status) {
+            case "pending":
+                return t("status_pending_review");
+            case "verified_fake":
+                return t("status_verified_fake");
+            case "false_alarm":
+                return t("status_false_alarm");
+            default:
+                return t("status_pending_review");
+        }
+    };
+
     return (
         <div className="flex min-h-screen flex-col bg-(--color-surface-muted) font-sans text-(--color-text-primary)">
             <PageHeader
-                title="My Reports"
-                subtitle="Status of reports you have filed"
+                title={t("header_title")}
+                subtitle={t("header_subtitle")}
                 backHref="/"
                 variant="light"
             />
@@ -219,17 +228,17 @@ export default function MyReportsPage() {
                 <div className="mb-6 flex items-center justify-between gap-3">
                     <div>
                         <h1 className="text-2xl font-black tracking-tight text-(--color-text-primary)">
-                            My Reports
+                            {t("page_title")}
                         </h1>
                         <p className="mt-0.5 text-sm text-(--color-text-secondary)">
-                            Track what happened to the counterfeit medicines you reported.
+                            {t("page_description")}
                         </p>
                     </div>
                     <button
                         type="button"
                         onClick={fetchMine}
                         disabled={state.kind === "loading"}
-                        aria-label="Refresh reports"
+                        aria-label={t("refresh_button_aria_label")}
                         className="rounded-full border border-(--color-border-muted) bg-(--color-surface-page) p-2.5 text-(--color-text-secondary) shadow-sm transition hover:bg-(--color-surface-muted) hover:text-(--color-text-primary) disabled:opacity-50"
                     >
                         <RefreshCw
@@ -240,7 +249,7 @@ export default function MyReportsPage() {
                 </div>
 
                 {state.kind === "loading" && (
-                    <div className="flex flex-col gap-3" aria-label="Loading your reports">
+                    <div className="flex flex-col gap-3" aria-label={t("loading_aria_label")}>
                         {[1, 2, 3].map((i) => (
                             <Card
                                 key={i}
@@ -265,9 +274,9 @@ export default function MyReportsPage() {
                 {state.kind === "authError" && (
                     <EmptyState
                         icon={<LogIn size={26} className="text-amber-600" />}
-                        title="Sign in required"
+                        title={t("auth_error_title")}
                         description={state.message}
-                        actionLabel="Go to Login"
+                        actionLabel={t("auth_error_action")}
                         actionHref="/login"
                         className="border-(--color-border-muted) bg-(--color-surface-page)!"
                     />
@@ -276,9 +285,9 @@ export default function MyReportsPage() {
                 {state.kind === "networkError" && (
                     <EmptyState
                         icon={<AlertTriangle size={26} className="text-rose-600" />}
-                        title="Connection Error"
+                        title={t("network_error_title")}
                         description={state.message}
-                        actionLabel="Try again"
+                        actionLabel={t("network_error_action")}
                         onAction={fetchMine}
                         className="border-rose-200 bg-(--color-surface-page)! dark:border-rose-950/40"
                     />
@@ -287,9 +296,9 @@ export default function MyReportsPage() {
                 {state.kind === "ready" && state.reports.length === 0 && (
                     <EmptyState
                         icon={<CheckCircle2 size={26} className="text-emerald-600" />}
-                        title="You haven't filed any reports yet"
-                        description="Spotted a suspicious or counterfeit medicine? Reporting it helps protect your community."
-                        actionLabel="File your first report"
+                        title={t("empty_state_title")}
+                        description={t("empty_state_description")}
+                        actionLabel={t("empty_state_action")}
                         actionHref="/report"
                         className="border-(--color-border-muted) bg-(--color-surface-page)!"
                     />
@@ -298,7 +307,15 @@ export default function MyReportsPage() {
                 {state.kind === "ready" && state.reports.length > 0 && (
                     <section className="flex flex-col gap-3" aria-label="Your reports">
                         {state.reports.map((report) => (
-                            <ReportCard key={report.id} report={report} />
+                            <ReportCard
+                                key={report.id}
+                                report={report}
+                                statusLabel={getStatusLabel(report.status)}
+                                districtLabel={t("report_card_district_label")}
+                                submittedLabel={t("report_card_submitted_label")}
+                                batchLabel={t("report_card_batch_label")}
+                                noPhotoLabel={t("no_photo_label")}
+                            />
                         ))}
                     </section>
                 )}

--- a/apps/web/components/reports/ReportWizard.tsx
+++ b/apps/web/components/reports/ReportWizard.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useState, useEffect, useId } from "react";
+import { useSearchParams } from "next/navigation";
 import { useForm, FormProvider, useFormContext } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -772,6 +773,7 @@ function Success({ onReset, reportId }: { onReset: () => void; reportId: string 
 // MAIN EXPORT
 // ─────────────────────────────────────────────────────────────────────────────
 export default function ReportWizard() {
+    const searchParams = useSearchParams();
     const [step, setStep] = useState(1);
     const [dir, setDir] = useState(1);
     const [images, setImages] = useState<ImageEntry[]>([]);
@@ -779,7 +781,19 @@ export default function ReportWizard() {
     const [submitErr, setSubmitErr] = useState<string | null>(null);
     const [done, setDone] = useState(false);
     const [reportId, setReportId] = useState<string | null>(null);
+    const [scannedBarcode, setScannedBarcode] = useState<string | null>(null);
+    const [medicineId, setMedicineId] = useState<string | null>(null);
     const submitErrorId = useId();
+
+    // Extract barcode and medicineId from URL query parameters
+    useEffect(() => {
+        if (searchParams) {
+            const barcode = searchParams.get("barcode");
+            const medId = searchParams.get("medicineId");
+            if (barcode) setScannedBarcode(barcode);
+            if (medId) setMedicineId(medId);
+        }
+    }, [searchParams]);
 
     // Cleanup blob URLs on unmount to prevent memory leaks
     useEffect(() => {
@@ -824,7 +838,13 @@ export default function ReportWizard() {
                 }
             }
             const geo = await geocodePincode(data.pincode);
-            const { report } = await submitReport({ ...data, ...(geo ?? {}) }, token);
+            const reportData = {
+                ...data,
+                ...(geo ?? {}),
+                ...(scannedBarcode && { scannedBarcode }),
+                ...(medicineId && { medicineId }),
+            };
+            const { report } = await submitReport(reportData, token);
             setReportId(report.id);
             setDone(true);
         } catch (e) {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -792,5 +792,30 @@
         "status_fake": "Fake Only",
         "export_button": "Generate CSV",
         "cancel": "Cancel"
+    },
+    "MyReports": {
+        "header_title": "My Reports",
+        "header_subtitle": "Status of reports you have filed",
+        "page_title": "My Reports",
+        "page_description": "Track what happened to the counterfeit medicines you reported.",
+        "refresh_button_aria_label": "Refresh reports",
+        "loading_aria_label": "Loading your reports",
+        "status_pending_review": "Pending Review",
+        "status_verified_fake": "Verified Fake",
+        "status_false_alarm": "False Alarm",
+        "auth_error_title": "Sign in required",
+        "auth_error_expired": "Your session has expired. Please sign in again.",
+        "auth_error_description": "Please sign in to view the reports you have filed.",
+        "auth_error_action": "Go to Login",
+        "network_error_title": "Connection Error",
+        "network_error_action": "Try again",
+        "network_error_api_unreachable": "Cannot reach the API. Is the backend server running on port 4000?",
+        "empty_state_title": "You haven't filed any reports yet",
+        "empty_state_description": "Spotted a suspicious or counterfeit medicine? Reporting it helps protect your community.",
+        "empty_state_action": "File your first report",
+        "no_photo_label": "No photo",
+        "report_card_district_label": "District",
+        "report_card_submitted_label": "Submitted",
+        "report_card_batch_label": "Batch"
     }
 }


### PR DESCRIPTION
## Summary
Connect medicine scanner data to counterfeit incident reports for better tracking and verification.

## Problem
When a user gets a suspicious result in the medicine scanner and clicks "Report", the system cannot link the scanned barcode or database medicine entry to the final incident report. This disconnects the scanner workflow from the reporting workflow.

## Solution Implemented

### Backend Changes (POST /api/reports)
- Extended createReportSchema with two optional fields:
  - `scannedBarcode`: z.string().optional()
  - `medicineId`: z.string().uuid().optional()
- Updated Supabase insert to store these values:
  - scanned_barcode
  - medicine_id
- Changes are backward compatible (fields are optional)

### Frontend Changes (ReportWizard)
- Added useSearchParams hook to read URL query parameters
- Extract `barcode` and `medicineId` from URL on component mount
- Store extracted values in component state
- Include barcode and medicineId in submitReport payload
- Conditionally include fields only if present

## Data Flow
1. User scans medicine, gets suspicious/fake result
2. Clicks "Report" which navigates to /report?barcode=XXX&medicineId=YYY
3. ReportWizard reads query parameters and stores them
4. User fills report details through wizard
5. On submit, barcode and medicineId are included in payload
6. Backend stores these values linking the scan to the report
7. Incident report now has full traceability to scanner result

## Testing
- ReportWizard extracts query parameters correctly
- Report submission includes barcode and medicineId when present
- Reports submitted without parameters still work (backward compatible)
- Barcode and medicineId properly stored in counterfeit_reports table

Fixes #1202

GSSoC 2026 Contribution