### PR TITLE
fix(web): Remove unused COLORS constant in analytics dashboard to (Fixes GitHub Checks)

### DIFF
--- a/apps/web/app/[locale]/admin/analytics/page.tsx
+++ b/apps/web/app/[locale]/admin/analytics/page.tsx
@@ -33,19 +33,6 @@ const AnalyticsCharts = dynamic(() => import("@/components/admin/AnalyticsCharts
     ),
 });
 
-const COLORS = {
-    emerald: "#10b981",
-    blue: "#3b82f6",
-    amber: "#f59e0b",
-    red: "#ef4444",
-    purple: "#8b5cf6",
-    teal: "#14b8a6",
-    slate: "#64748b",
-    rose: "#f43f5e",
-    cyan: "#06b6d4",
-    indigo: "#6366f1",
-};
-
 type PushFailureReason = {
     reason: string;
     httpStatus: number | null;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.



## 📋 PR Summary & Link

- **Closes #** *[Insert the number of the issue you just created, e.g. Closes #1767]*
- **Summary:**
  Removed the unused `COLORS` constant definition from `apps/web/app/[locale]/admin/analytics/page.tsx`. This constant was left behind as an unused variable after chart rendering was extracted into `AnalyticsCharts.tsx` in a previous PR. Its presence triggers a strict `@typescript-eslint/no-unused-vars` error in the `web` workspace, causing lint checks to fail on the CI pipeline and blocking PR runs.

## 📸 Proof of Work (Screenshots / Logs)

### ESLint Check Verification (Local vs CI):
- **Before Fix:** Running `npm run lint -w web` fails with:
  ```bash
  /home/runner/work/sahidawa-india/sahidawa-india/apps/web/app/[locale]/admin/analytics/page.tsx
  Error:   36:7  error  'COLORS' is assigned a value but never used  @typescript-eslint/no-unused-vars
  ```
- **After Fix:** Running `npm run lint -w web` compiles and lints with **0 errors**.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1767 `)
- [x] I have pulled the latest `main` and resolved any conflicts
```