### PR TITLE
fix(api): Disable db pool pressure check interval in test environment (Fixes Github Checks)

### DIFF
--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -144,12 +144,14 @@ process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
 process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 
 // Log pool exhaustion warnings
-setInterval(() => {
-    const { active, queued, max } = pool.stats;
-    if (queued > 0) {
-        logger.warn(`DB pool pressure: ${active}/${max} active, ${queued} queued`);
-    }
-}, 5_000);
+if (process.env.NODE_ENV !== "test") {
+    setInterval(() => {
+        const { active, queued, max } = pool.stats;
+        if (queued > 0) {
+            logger.warn(`DB pool pressure: ${active}/${max} active, ${queued} queued`);
+        }
+    }, 5_000);
+}
 
 // Quick check on startup to see if Supabase is offline
 if (process.env.NODE_ENV !== "test") {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.



## 📋 PR Summary & Link

- **Closes #1770**
- **Summary:**
  Wrapped the database connection pool pressure logging `setInterval` timer in `apps/api/src/db/client.ts` within a `process.env.NODE_ENV !== "test"` block. This prevents the background timer from executing when files (like `app.ts` or routes) are imported inside tests, resolving the Jest test suite hang (open handle) and allowing the CI test runs to exit cleanly with code `0`.

## 📸 Proof of Work (Screenshots / Logs)
### Jest Exit Code Verification:
- **Before Fix:** The Jest test runner would pass all 255 tests but hang due to the active `setInterval` loop, printing:
  ```bash
  Test Suites: 43 passed, 43 total
  Tests:       255 passed, 255 total
  Snapshots:   0 total
  Time:        7.58 s
  Ran all test suites.
  Error: Process completed with exit code 1.
  ```
- **After Fix:** Jest runs all test suites and exits cleanly with **exit code 0** (no lingering timers on the event loop).

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1770`)
- [x] I have pulled the latest `main` and resolved any conflicts