### PR TITLE
fix(ocr): offload synchronous pytesseract calls to thread pool

### DIFF
--- a/apps/ml/routers/ocr.py
+++ b/apps/ml/routers/ocr.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, UploadFile, File, HTTPException
+from starlette.concurrency import run_in_threadpool
 from PIL import Image
 import pytesseract
 import io
@@ -29,10 +30,14 @@ async def extract_text(file: UploadFile = File(...)):
 
         # Perform OCR to extract text
         # We can also use lang='eng+hin' if we want to support Hindi
-        text = pytesseract.image_to_string(image)
+        text = await run_in_threadpool(pytesseract.image_to_string, image)
         
         # Extract detailed data to calculate overall confidence
-        data = pytesseract.image_to_data(image, output_type=pytesseract.Output.DICT)
+        data = await run_in_threadpool(
+            pytesseract.image_to_data, 
+            image, 
+            output_type=pytesseract.Output.DICT
+        )
         
         # Tesseract returns confidence as integers from 0 to 100. -1 indicates no text.
         valid_confidences = [


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #1783**
- **Summary:** The `/extract` endpoint previously invoked `pytesseract.image_to_string` and `image_to_data` directly inside an `async def` function. Because these are synchronous, blocking operations, they froze the entire FastAPI event loop thread, completely destroying request concurrency during OCR parsing. This PR imports Starlette's `run_in_threadpool` and offloads the OCR operations to a worker thread, keeping the main event loop unblocked and free to serve other incoming requests.

## 📸 Proof of Work (Screenshots / Logs)
<img width="823" height="261" alt="image" src="https://github.com/user-attachments/assets/46a7ba6c-ed04-40c2-bcdf-cb2991667095" />


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1783`)
- [x] I have pulled the latest `main` and resolved any conflicts
