### PR TITLE
chore: add .history directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Thumbs.db
 .vscode/
 .idea/
 .vs/
+.history/
 *.swp
 *.swo
 


### PR DESCRIPTION
## Summary

Add  to  to prevent VS Code Local History extension backup files from being accidentally committed.

## Change
- Added  to the IDE/Editor folders section

Closes #1792

ref: gssoc26