### PR TITLE
Link scanned barcodes and medicine IDs to counterfeit reports

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -46,6 +46,13 @@ const createReportSchema = z.object({
     city: z.string().min(2),
     state: z.string().min(2),
     pincode: z.string().regex(/^\d{6}$/),
+    // Optional scan context that links a Report Wizard submission back to the
+    // medicine scan it originated from. scanned_barcode is VARCHAR(100) and
+    // medicine_id is a UUID FK to medicines(id) in the schema, so the bounds
+    // here match the database constraints to fail fast with a 400 rather than a
+    // 500 on insert.
+    scannedBarcode: z.string().max(100).optional(),
+    medicineId: z.string().uuid().optional(),
     latitude: z.number().optional(),
     longitude: z.number().optional(),
 });
@@ -87,6 +94,11 @@ reportsRouter.post("/", optionalAuth, async (req: AuthenticatedRequest, res: Res
                 pincode: data.pincode,
                 district: data.city,
                 report_location: buildReportLocation(data.latitude, data.longitude),
+                // Link the report back to the originating scan when present.
+                // This mirrors the batch report route (/api/verify/batch/report),
+                // closing the gap where wizard-filed reports lost the scan context.
+                scanned_barcode: data.scannedBarcode ?? null,
+                medicine_id: data.medicineId ?? null,
                 reporter_id: req.user?.id ?? null,
                 status: "pending",
             })

--- a/apps/api/tests/reports.test.ts
+++ b/apps/api/tests/reports.test.ts
@@ -173,6 +173,112 @@ describe("Reports API Routes", () => {
             expect(response.status).toBe(201);
             expect(response.body.report.report_location).toBe("POINT(72.8777 19.0760)");
         });
+
+        it("persists scanned_barcode and medicine_id when provided", async () => {
+            const medicineId = "11111111-1111-4111-8111-111111111111";
+            const payload = {
+                medicineName: "Aspirin 500mg",
+                manufacturer: "TestCo",
+                description: "This is a detailed description of the issue",
+                images: ["https://example.com/image1.jpg"],
+                pharmacyName: "Test Pharmacy",
+                address: "123 Main St",
+                city: "Delhi",
+                state: "Delhi",
+                pincode: "110001",
+                scannedBarcode: "8901234567890",
+                medicineId,
+            };
+
+            const insertMock = jest.fn().mockReturnValue({
+                select: jest.fn().mockReturnValue({
+                    single: jest.fn().mockResolvedValueOnce({
+                        data: { id: "report-id-789", created_at: "2026-06-04T00:00:00Z" },
+                        error: null,
+                    }),
+                }),
+            });
+            mockedSupabase.insert = insertMock;
+
+            const response = await request(app).post("/api/reports").send(payload);
+
+            expect(response.status).toBe(201);
+            expect(insertMock).toHaveBeenCalledTimes(1);
+            const insertedRow = insertMock.mock.calls[0][0];
+            expect(insertedRow.scanned_barcode).toBe("8901234567890");
+            expect(insertedRow.medicine_id).toBe(medicineId);
+        });
+
+        it("defaults scanned_barcode and medicine_id to null when omitted", async () => {
+            const payload = {
+                medicineName: "Aspirin 500mg",
+                manufacturer: "TestCo",
+                description: "This is a detailed description of the issue",
+                images: ["https://example.com/image1.jpg"],
+                pharmacyName: "Test Pharmacy",
+                address: "123 Main St",
+                city: "Delhi",
+                state: "Delhi",
+                pincode: "110001",
+            };
+
+            const insertMock = jest.fn().mockReturnValue({
+                select: jest.fn().mockReturnValue({
+                    single: jest.fn().mockResolvedValueOnce({
+                        data: { id: "report-id-790", created_at: "2026-06-04T00:00:00Z" },
+                        error: null,
+                    }),
+                }),
+            });
+            mockedSupabase.insert = insertMock;
+
+            const response = await request(app).post("/api/reports").send(payload);
+
+            expect(response.status).toBe(201);
+            const insertedRow = insertMock.mock.calls[0][0];
+            expect(insertedRow.scanned_barcode).toBeNull();
+            expect(insertedRow.medicine_id).toBeNull();
+        });
+
+        it("returns 400 when medicineId is not a valid UUID", async () => {
+            const payload = {
+                medicineName: "Aspirin 500mg",
+                manufacturer: "TestCo",
+                description: "This is a detailed description of the issue",
+                images: ["https://example.com/image1.jpg"],
+                pharmacyName: "Test Pharmacy",
+                address: "123 Main St",
+                city: "Delhi",
+                state: "Delhi",
+                pincode: "110001",
+                medicineId: "not-a-uuid",
+            };
+
+            const response = await request(app).post("/api/reports").send(payload);
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe("Invalid report payload");
+        });
+
+        it("returns 400 when scannedBarcode exceeds 100 characters", async () => {
+            const payload = {
+                medicineName: "Aspirin 500mg",
+                manufacturer: "TestCo",
+                description: "This is a detailed description of the issue",
+                images: ["https://example.com/image1.jpg"],
+                pharmacyName: "Test Pharmacy",
+                address: "123 Main St",
+                city: "Delhi",
+                state: "Delhi",
+                pincode: "110001",
+                scannedBarcode: "x".repeat(101),
+            };
+
+            const response = await request(app).post("/api/reports").send(payload);
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe("Invalid report payload");
+        });
     });
 
     describe("GET /api/reports/mine", () => {

--- a/apps/web/components/reports/ReportWizard.tsx
+++ b/apps/web/components/reports/ReportWizard.tsx
@@ -34,6 +34,51 @@ const WEBP_FILE_EXTENSION = ".webp";
 /** Strip HTML/script tags and trim whitespace to prevent stored XSS. */
 const sanitize = (v: string) => v.replace(/<[^>]*>/g, "").trim();
 
+// ─── Scan context ──────────────────────────────────────────────────────────────
+/**
+ * Optional scan details carried from the medicine scanner into the report.
+ * When the wizard is opened from a scan result, the URL carries `barcode`
+ * and/or `medicineId` so the filed report can be linked back to the scan.
+ */
+interface ScanContext {
+    scannedBarcode?: string;
+    medicineId?: string;
+}
+
+// UUID v1–v5, matching the backend's z.string().uuid() expectation for medicineId.
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// scanned_barcode is VARCHAR(100) in the schema; mirror that bound client-side.
+const MAX_BARCODE_LENGTH = 100;
+
+/**
+ * Reads and validates scan context from a URL query string. Only well-formed
+ * values are returned so the wizard never forwards data the backend would
+ * reject with a 400 (e.g. a malformed medicineId or an over-long barcode).
+ *
+ * @param search - location.search, e.g. "?barcode=123&medicineId=<uuid>"
+ * @returns Validated scan context (fields omitted when absent or invalid)
+ */
+const parseScanContext = (search: string): ScanContext => {
+    const context: ScanContext = {};
+    try {
+        const params = new URLSearchParams(search);
+
+        const barcode = params.get("barcode")?.trim();
+        if (barcode && barcode.length > 0 && barcode.length <= MAX_BARCODE_LENGTH) {
+            context.scannedBarcode = barcode;
+        }
+
+        const medicineId = params.get("medicineId")?.trim();
+        if (medicineId && UUID_PATTERN.test(medicineId)) {
+            context.medicineId = medicineId;
+        }
+    } catch {
+        // Malformed query string; fall back to an empty context.
+    }
+    return context;
+};
+
 const renameFileForMimeType = (fileName: string, mimeType: string) => {
     if (mimeType !== "image/webp" || fileName.toLowerCase().endsWith(WEBP_FILE_EXTENSION)) {
         return fileName;
@@ -747,6 +792,16 @@ export default function ReportWizard() {
     const [reportId, setReportId] = useState<string | null>(null);
     const submitErrorId = useId();
 
+    // Scan context (barcode / medicineId) carried in the URL when the wizard is
+    // opened from a scan result. Held in a ref because it never changes after
+    // mount and must not trigger re-renders.
+    const scanContextRef = useRef<ScanContext>({});
+    useEffect(() => {
+        if (typeof window !== "undefined") {
+            scanContextRef.current = parseScanContext(window.location.search);
+        }
+    }, []);
+
     // Cleanup blob URLs on unmount to prevent memory leaks
     useEffect(() => {
         return () => {
@@ -782,7 +837,10 @@ export default function ReportWizard() {
                     ? (localStorage.getItem("sb-access-token") ?? undefined)
                     : undefined;
             const geo = await geocodePincode(data.pincode);
-            const { report } = await submitReport({ ...data, ...(geo ?? {}) }, token);
+            const { report } = await submitReport(
+                { ...data, ...(geo ?? {}), ...scanContextRef.current },
+                token
+            );
             setReportId(report.id);
             setDone(true);
         } catch (e) {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -28,6 +28,11 @@ export type ReportPayload = {
     pincode: string;
     latitude?: number;
     longitude?: number;
+    // Optional scan context forwarded when the wizard is opened from a scan
+    // result, so the backend can link the report to the scanned barcode and
+    // medicine record.
+    scannedBarcode?: string;
+    medicineId?: string;
 };
 
 export type SubmittedReport = {


### PR DESCRIPTION
## Summary
Closes the functional disconnect between scanning a suspicious medicine and filing a report through the Report Wizard. The batch report route (`POST /api/verify/batch/report`) already associates `scanned_barcode` and `medicine_id`, but `POST /api/reports` ignored both, so a report filed after a scan lost the link to the scanned barcode and the medicine record.

## Detailed Technical Analysis
`createReportSchema` and the `counterfeit_reports` insert in `apps/api/src/routes/reports.ts` did not include `scanned_barcode` or `medicine_id`, even though both columns exist in the schema (`medicine_id UUID REFERENCES medicines(id)`, `scanned_barcode VARCHAR(100)`) and are already populated by the batch route. On the frontend, the Report Wizard never read the `barcode` / `medicineId` query parameters that a scan-result screen would pass when launching the wizard, so the context was dropped before submission.

## Real-World Scenario
1. A user scans a medicine and gets a suspicious result
2. They click "Report", landing on the wizard at `/report?barcode=8901234567890&medicineId=<uuid>`
3. They add a description, pharmacy details, and photos, then submit
4. Before this change, the resulting report had `scanned_barcode = null` and `medicine_id = null`, so analysts could not tie the incident back to the scanned product

## Implementation
### Backend (`apps/api/src/routes/reports.ts`)
- Extended `createReportSchema` with `scannedBarcode: z.string().max(100).optional()` (matches the `VARCHAR(100)` column) and `medicineId: z.string().uuid().optional()` (matches the UUID FK), so malformed input fails fast with a 400 instead of a 500 on insert
- Persisted `scanned_barcode: data.scannedBarcode ?? null` and `medicine_id: data.medicineId ?? null` on insert, mirroring the batch route

### Frontend (`apps/web/components/reports/ReportWizard.tsx`, `apps/web/lib/api.ts`)
- Added `parseScanContext`, which reads and validates `barcode` and `medicineId` from `location.search` (UUID format and 100-char bound mirror the backend, so invalid scan context is dropped rather than sent)
- Stored the parsed context in a ref on mount so it never triggers re-renders, and forwarded `scannedBarcode` / `medicineId` in the submit payload
- Extended `ReportPayload` with the two optional fields

## Testing Strategy
Added four backend tests to `apps/api/tests/reports.test.ts`:
1. Insert receives `scanned_barcode` and `medicine_id` when provided
2. Both default to `null` when omitted
3. A non-UUID `medicineId` returns 400
4. An over-length `scannedBarcode` (101 chars) returns 400

Verification:
- All 84 API tests pass (`jest`, 10 suites)
- API and web `tsc --noEmit` are clean for the changed files
- Prettier and lint-staged pass on all changed files

## Backward Compatibility
Both fields are optional. Existing clients that omit them are unaffected, and the columns simply store `null` as before.

Fixes #1202

/assign anshul23102