### PR TITLE
fix(analytics): skip malformed coordinates in heatmap endpoint

### DIFF
--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -74,6 +74,8 @@ router.get("/heatmap", limiter, async (req: Request, res: Response) => {
         for (const scan of scans || []) {
             const lat = Math.round(parseFloat(scan.latitude as string) * 100) / 100;
             const lng = Math.round(parseFloat(scan.longitude as string) * 100) / 100;
+            if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue;
+            if (lat < -90 || lat > 90 || lng < -180 || lng > 180) continue;
             const key = `${lat},${lng}`;
             const entry = grouped.get(key) || { lat, lng, intensity: 0 };
             entry.intensity++;


### PR DESCRIPTION
## Description

- Adds coordinate validation to the analytics heatmap endpoint
- Skips rows where parsed latitude/longitude are not finite numbers (NaN, Infinity)
- Enforces valid coordinate bounds: lat in [-90, 90], lng in [-180, 180]

## Files Changed

- `apps/api/src/routes/analytics.ts`: Added `Number.isFinite` and bounds checks after `parseFloat` to skip malformed coordinates

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label so the contribution is scored correctly for GSSoC '26.

If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

- TypeScript type check passed (no new types introduced)

Result:

- The fix adds two guard conditions before adding a point to the grouped map
- Malformed values like `N/A`, empty strings, or out-of-bounds coordinates are now silently skipped
- Valid coordinates continue to work as before

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1801
