### PR TITLE
fix(alternatives): validate lat/lng bounds before RPC call

### DIFF
--- a/apps/api/src/routes/map.ts
+++ b/apps/api/src/routes/map.ts
@@ -60,10 +60,19 @@ router.get("/nearby", mapLimiter, async (req: Request, res: Response) => {
         return res.status(400).json({ error: "lat and lng are required query params" });
     }
 
-    // Explicit bounds checking for lat and lng
-    if (lat < -90 || lat > 90 || lng < -180 || lng > 180) {
-        return res.status(400).json({
-            error: "Latitude must be between -90 and 90, and longitude between -180 and 180.",
+    if (lat < -90 || lat > 90) {
+        return res.status(400).json({ error: "Latitude must be between -90 and 90" });
+    }
+
+    if (lng < -180 || lng > 180) {
+        return res.status(400).json({ error: "Longitude must be between -180 and 180" });
+    }
+
+    try {
+        const pharmaciesRes = await supabase.rpc("get_nearest_pharmacies", {
+            query_lat: lat,
+            query_lng: lng,
+            search_radius_km: radius_km,
         });
     }
 

--- a/apps/api/tests/map.test.ts
+++ b/apps/api/tests/map.test.ts
@@ -123,6 +123,20 @@ describe("GET /api/map/nearby", () => {
         });
     });
 
+    it.each([
+        ["latitude exceeds 90", "/api/map/nearby?lat=91&lng=73.85"],
+        ["latitude below -90", "/api/map/nearby?lat=-91&lng=73.85"],
+        ["longitude exceeds 180", "/api/map/nearby?lat=18.52&lng=181"],
+        ["longitude below -180", "/api/map/nearby?lat=18.52&lng=-181"],
+        ["both out of range", "/api/map/nearby?lat=999&lng=999"],
+    ])("returns 400 when %s", async (_desc, path) => {
+        const response = await request(app).get(path);
+
+        expect(response.status).toBe(400);
+        expect(response.body.error).toMatch(/must be between/);
+        expect(rpcMock).not.toHaveBeenCalled();
+    });
+
     it("returns 500 when a Supabase RPC reports an error", async () => {
         const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
 


### PR DESCRIPTION
## 📋 PR Summary & Link

- **Closes #1800**
- **Summary:** Added coordinate validation in the alternatives endpoint to reject impossible lat/lng values before the RPC call.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## 📸 Proof of Work

N/A — backend-only fix

## ✅ Checklist

- [x] My PR has a linked issue (Closes #1800)
- [x] I have pulled the latest `main` and resolved any conflicts