### PR TITLE
docs(asr): add OpenAPI response documentation for transcription endpoint

### DIFF
--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -729,7 +729,23 @@ class StreamingAsrSession:
         self.decoder = None
 
 
-@router.post("/transcribe")
+@router.post(
+        "/transcribe",
+        responses={
+            400: {
+                "description": "Invalid audio input, unsupported format, corrupted audio, or duration exceeds limit."
+            },
+            422: {
+                "description": "Unable to process the uploaded audio file."
+            },
+            503: {
+                "description": "Transcription service temporarily unavailable."
+            },
+            500: {
+                "description": "Internal server error during transcription."
+            },
+        },
+)
 async def transcribe_audio(file: UploadFile = File(...), language: str | None = Form(default=None)):
     """
     Accepts any supported audio file upload and returns transcribed text.


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #1802**
* **Summary:**

  * Added OpenAPI response documentation for the `/asr/transcribe` endpoint.
  * Documented HTTP 400, 422, 500, and 503 responses.
  * Improved Swagger/OpenAPI visibility for error scenarios that were previously shown as "Undocumented".

## 📸 Proof of Work (Screenshots / Logs)

### Before
<img width="700" height="360" alt="image" src="https://github.com/user-attachments/assets/50da282b-b6c4-464a-b04e-91a8f260aa09" />

* Swagger UI displayed error responses such as **400 Bad Request** as **"Undocumented"**.

### After
<img width="843" height="438" alt="image" src="https://github.com/user-attachments/assets/9eb844e7-94c5-4f4b-be32-61c64c482d6b" />

* Swagger UI now displays:

  * 400 – Invalid audio input, unsupported format, corrupted audio, or duration exceeds limit.
  * 422 – Unable to process the uploaded audio file.
  * 500 – Internal server error during transcription.
  * 503 – Transcription service temporarily unavailable.

> Attached screenshot showing the updated Swagger response documentation.

## 🏷️ PR Type

* [ ] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [x] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #1802`)
* [x] I have pulled the latest `main` and resolved any conflicts.
* [x] I tested the changes locally using FastAPI Swagger UI.
* [x] The changes are limited to the required file (`apps/ml/routers/asr.py`).
