### PR TITLE
chore: remove unused imports from distributed_lock_manager.py

### DIFF
--- a/src/services/distributed_lock_manager.py
+++ b/src/services/distributed_lock_manager.py
@@ -1,9 +1,6 @@
 import time
-import json
-import hashlib
 import logging
 from typing import Any, Dict, Optional, List, Tuple
-from collections import OrderedDict
 import threading
 import pickle
 


### PR DESCRIPTION
**Description**

Removed unused imports (`json`, `hashlib`, `OrderedDict`) from `src/services/distributed_lock_manager.py`. These modules were imported but never used in the file.

Closes #1849

**gssoc26**