### PR TITLE
fix: remove dead l1_lock dict assignment overwritten by RLock

### DIFF
--- a/src/services/distributed_lock_manager.py
+++ b/src/services/distributed_lock_manager.py
@@ -56,7 +56,6 @@ class MultiTierLockManager:
         self.l2_capacity = l2_capacity
         
         # L1 Memory Lock (LFU implementation)
-        self.l1_lock: Dict[str, LFUNode] = {}
         self.freq_map: Dict[int, LFUDoublyLinkedList] = {}
         self.min_freq = 0
         self.l1_lock = threading.RLock()


### PR DESCRIPTION
**Description**

Removed dead code in `src/services/distributed_lock_manager.py` where `self.l1_lock` was declared as an empty Dict on line 59, then immediately overwritten with `threading.RLock()` on line 62. The dict initialization was never used.

Closes #1851

**gssoc26**