### PR TITLE
fix(i18n): change 'Analyse Anyway' to 'Analyze Anyway' in en.json

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -111,7 +111,7 @@
         "review_message": "The microphone picked up your symptoms with low confidence. You can retry for a clearer result or analyse this transcript anyway.",
         "retry_button": "Try Again",
         "switch_to_text_button": "Type Instead",
-        "analyse_anyway_button": "Analyse Anyway",
+        "analyse_anyway_button": "Analyze Anyway",
         "result_heading": "AI Analysis",
         "result_subheading": "Medical Triage",
         "transcript_label": "Your Transcript",


### PR DESCRIPTION
**Description**

Changed the English label from British spelling 'Analyse Anyway' to American English 'Analyze Anyway' for consistency with the rest of the codebase.

Closes #1853

**gssoc26**