### PR TITLE
fix: correct .editorconfig JSON indent_size to match project prettier config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.{json,yml,yaml}]
-indent_size = 2
+indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
**Description**

Changed `.editorconfig` JSON/YAML `indent_size` from 2 to 4 to match the project's Prettier config (`tabWidth: 4`) and the actual indentation used across all JSON files.

Closes #1855

**gssoc26**