### PR TITLE
chore: add .turbo to .dockerignore to reduce build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ out
 dist
 build
 *.log
+.turbo
 
 # ── Version control & metadata ──
 .git


### PR DESCRIPTION
**Description**

Added `.turbo` to `.dockerignore` to exclude Turborepo cache files from Docker build context, reducing image build time. The `.gitignore` already excludes this directory.

Closes #1857

**gssoc26**