### PR TITLE
feat(i18n): add missing languages ks, kok, mai, ml, sa to LanguageSwitcher

### DIFF
--- a/apps/web/app/[locale]/LanguageSwitcher.tsx
+++ b/apps/web/app/[locale]/LanguageSwitcher.tsx
@@ -19,6 +19,11 @@ const languages = [
     { code: "kn", label: "Kannada", native: "ಕನ್ನಡ" },
     { code: "pa", label: "Punjabi", native: "ਪੰਜਾਬੀ" },
     { code: "as", label: "Assamese", native: "অসমীয়া" },
+    { code: "kok", label: "Konkani", native: "कोंकणी" },
+    { code: "ks", label: "Kashmiri", native: "कॉशुर" },
+    { code: "mai", label: "Maithili", native: "मैथिली" },
+    { code: "ml", label: "Malayalam", native: "മലയാളം" },
+    { code: "sa", label: "Sanskrit", native: "संस्कृतम्" },
 ];
 
 export default function LanguageSwitcher() {


### PR DESCRIPTION
**Description**

Added 5 missing languages to the LanguageSwitcher dropdown: Konkani (kok), Kashmiri (ks), Maithili (mai), Malayalam (ml), and Sanskrit (sa). These locales already have translation files but were not selectable in the UI.

Closes #1859

**gssoc26**