### PR TITLE
fix: correct Dependabot pip directory path from /ml_service to /apps/ml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
 
   # Maintain dependencies for Python (FastAPI/ML)
   - package-ecosystem: "pip"
-    directory: "/ml_service"
+    directory: "/apps/ml"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
**Description**

Fixed the Dependabot pip ecosystem directory path from "/ml_service" (non-existent) to "/apps/ml" (where the actual Python ML service lives). This ensures Dependabot can properly track and update Python dependencies.

Closes #1863

**gssoc26**