### PR TITLE
fix(ui): add dark mode background to root loading page

### DIFF
--- a/apps/web/app/loading.tsx
+++ b/apps/web/app/loading.tsx
@@ -1,6 +1,6 @@
 export default function Loading() {
     return (
-        <div className="flex min-h-screen items-center justify-center bg-white">
+        <div className="flex min-h-screen items-center justify-center bg-white dark:bg-slate-950">
             <div className="h-14 w-14 animate-spin rounded-full border-4 border-emerald-200 border-t-emerald-500" />
         </div>
     );


### PR DESCRIPTION
**Description**

Added `dark:bg-slate-950` to the root loading page container so it displays a dark background in dark mode instead of a white flash.

Related issue: #1867

**gssoc26**