### PR TITLE
Fix IST date calculation in medicine schedule summary endpoint

### DIFF
--- a/apps/api/src/routes/medicineSchedules.ts
+++ b/apps/api/src/routes/medicineSchedules.ts
@@ -37,6 +37,20 @@ const statsSchema = z.object({
     to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD"),
 });
 
+const IST_OFFSET_MINUTES = 330;
+const IST_OFFSET_MS = IST_OFFSET_MINUTES * 60 * 1000;
+
+const getIstDateTime = (timestamp: number = Date.now()) => {
+    // Medicine schedules are stored and queried by Indian calendar dates.
+    // toISOString() uses UTC, so shift by IST's fixed UTC+05:30 offset first.
+    const istDate = new Date(timestamp + IST_OFFSET_MS);
+
+    return {
+        today: istDate.toISOString().split("T")[0],
+        nowTime: istDate.toISOString().slice(11, 16),
+    };
+};
+
 // List user's active schedules
 router.get("/", requireAuth, async (req: AuthenticatedRequest, res: Response) => {
     try {
@@ -315,8 +329,7 @@ router.get("/:id/stats", requireAuth, async (req: AuthenticatedRequest, res: Res
 // Get today's pending doses for all user's active schedules
 router.get("/today/summary", requireAuth, async (req: AuthenticatedRequest, res: Response) => {
     try {
-        const today = new Date().toISOString().split("T")[0];
-        const nowTime = new Date().toTimeString().slice(0, 5);
+        const { today, nowTime } = getIstDateTime();
 
         const { data: schedules, error: schedError } = await supabase
             .from("medicine_schedules")

--- a/apps/api/tests/medicineSchedules.test.ts
+++ b/apps/api/tests/medicineSchedules.test.ts
@@ -54,6 +54,10 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
 describe("GET /api/schedules", () => {
     it("returns empty list when no schedules", async () => {
         mockedSupabase.single.mockResolvedValue({ data: null, error: null });
@@ -333,6 +337,59 @@ describe("GET /api/schedules/today/summary", () => {
         expect(res.status).toBe(200);
         expect(res.body.schedules).toHaveLength(1);
         expect(res.body.schedules[0].medicine_name).toBe("Paracetamol");
+    });
+
+    it("uses the IST calendar date before UTC midnight", async () => {
+        jest.spyOn(Date, "now").mockReturnValue(new Date("2026-06-13T20:00:00.000Z").getTime()); // 01:30 IST on 2026-06-14
+
+        const activeSchedules = [
+            {
+                id: "sched-1",
+                medicine_name: "Paracetamol",
+                dosage: "1 tablet",
+                times: ["01:00", "08:00"],
+                frequency: 2,
+                user_id: "test-user-id",
+                start_date: "2026-06-14",
+                end_date: null,
+                notes: null,
+                is_active: true,
+                created_at: "2026-06-14T00:00:00Z",
+                updated_at: "2026-06-14T00:00:00Z",
+            },
+        ];
+
+        (mockedSupabase.from as jest.Mock).mockReturnValue(mockedSupabase);
+        (mockedSupabase.select as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.lte as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.or as jest.Mock).mockResolvedValueOnce({
+            data: activeSchedules,
+            error: null,
+        });
+
+        (mockedSupabase.select as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockResolvedValueOnce({
+            data: [],
+            error: null,
+        });
+
+        const res = await request(app)
+            .get("/api/schedules/today/summary")
+            .set("Authorization", "Bearer test-token");
+
+        expect(res.status).toBe(200);
+        expect(res.body.date).toBe("2026-06-14");
+        expect(mockedSupabase.lte).toHaveBeenCalledWith("start_date", "2026-06-14");
+        expect(mockedSupabase.or).toHaveBeenCalledWith("end_date.is.null,end_date.gte.2026-06-14");
+        expect(mockedSupabase.eq).toHaveBeenCalledWith("log_date", "2026-06-14");
+        expect(res.body.schedules[0].doses).toEqual([
+            { time: "01:00", status: "pending" },
+            { time: "08:00", status: "upcoming" },
+        ]);
     });
 });
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #1870,#1821**
* **Summary:**
  Fixed the timezone issue in the `today/summary` endpoint where the current date was being calculated using UTC. This caused users accessing the application before 5:30 AM IST to receive the previous day's medicine schedule. Added an IST-based date helper, updated the endpoint to use IST dates consistently, and added a regression test covering the UTC-to-IST date boundary case.

## 📸 Proof of Work (Screenshots / Logs)

<img width="1877" height="747" alt="image" src="https://github.com/user-attachments/assets/8c66fdf4-db8a-4277-b03e-c8fcd462531d" />


### Files Changed

```txt
M apps/api/src/routes/medicineSchedules.ts
M apps/api/tests/medicineSchedules.test.ts
```

### Test Coverage Added

* Added a regression test verifying that:

  * UTC timestamp: `2026-06-13T20:00:00.000Z`
  * IST date used for queries: `2026-06-14`

### Verification

* Endpoint now uses IST date calculation instead of UTC.
* Existing functionality remains unchanged.
* Added test cleanup using `jest.restoreAllMocks()`.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #1870,#1821`)
* [x] I have pulled the latest `main` and resolved any conflicts
