### PR TITLE
refactor(api): clarify Supabase client permission scope

### DIFF
--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -107,7 +107,8 @@ async function pooledFetch(input: RequestInfo | URL, init?: RequestInit): Promis
 
 // ── Supabase client ───────────────────────────────────────────────────────────
 
-export const supabase: SupabaseClient = createClient(supabaseUrl, supabaseKey, {
+// Privileged backend client for server-side writes and admin-only access.
+export const serviceRoleSupabase: SupabaseClient = createClient(supabaseUrl, supabaseKey, {
     global: {
         fetch: pooledFetch as typeof fetch,
     },
@@ -116,6 +117,10 @@ export const supabase: SupabaseClient = createClient(supabaseUrl, supabaseKey, {
         autoRefreshToken: false,
     },
 });
+
+// Backward-compatible alias for existing API modules. New code should import
+// serviceRoleSupabase so the permission level is clear at the call site.
+export const supabase = serviceRoleSupabase;
 
 // ── Graceful shutdown ─────────────────────────────────────────────────────────
 

--- a/apps/api/src/db/supabase.ts
+++ b/apps/api/src/db/supabase.ts
@@ -25,10 +25,13 @@ function getSupabaseClient(): SupabaseClient {
                 autoRefreshToken: false,
             },
         });
-        logger.info("Supabase client initialized with connection timeout and retry config");
+        logger.info("Anon Supabase client initialized with connection timeout and retry config");
     }
     return supabaseInstance;
 }
 
-const supabase = getSupabaseClient();
-export default supabase;
+// RLS-bound client for public or user-scoped reads that should not bypass policies.
+export const anonSupabase = getSupabaseClient();
+
+// Backward-compatible default export for existing imports.
+export default anonSupabase;

--- a/apps/api/src/routes/triage.ts
+++ b/apps/api/src/routes/triage.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from "express";
-import supabase from "../db/supabase";
+import { anonSupabase } from "../db/supabase";
 import logger from "../utils/logger";
 import {
     assessUrgency,
@@ -65,7 +65,7 @@ async function findNearestPharmacies(
     lng: number,
     radius: number
 ): Promise<FormattedPharmacy[]> {
-    const { data, error } = await supabase.rpc("get_nearest_pharmacies", {
+    const { data, error } = await anonSupabase.rpc("get_nearest_pharmacies", {
         query_lat: lat,
         query_lng: lng,
         search_radius_km: radius,

--- a/apps/api/src/services/medicineRag.service.ts
+++ b/apps/api/src/services/medicineRag.service.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import supabase from "../db/supabase";
+import { anonSupabase } from "../db/supabase";
 import logger from "../utils/logger";
 import { escapeIlike } from "../utils/db";
 
@@ -239,7 +239,7 @@ export async function retrieveRelevantMedicines(
     // Tier 1 — semantic vector search.
     const embedding = await embedQuery(query);
     if (embedding) {
-        const { data, error } = await supabase.rpc("match_medicines", {
+        const { data, error } = await anonSupabase.rpc("match_medicines", {
             query_embedding: embedding,
             match_count: limit,
         });
@@ -256,7 +256,7 @@ export async function retrieveRelevantMedicines(
     }
 
     // Tier 2 — trigram fuzzy search RPC.
-    const { data: trgmData, error: trgmError } = await supabase.rpc("search_medicines_text", {
+    const { data: trgmData, error: trgmError } = await anonSupabase.rpc("search_medicines_text", {
         query_text: query,
         match_count: limit,
     });
@@ -271,7 +271,7 @@ export async function retrieveRelevantMedicines(
 
     // Tier 3 — in-memory ILIKE filter over the table.
     const pattern = `%${escapeIlike(query)}%`;
-    const { data: tableData, error: tableError } = await supabase
+    const { data: tableData, error: tableError } = await anonSupabase
         .from("medicines")
         .select(
             "id, brand_name, generic_name, manufacturer, composition, strength, dosage_form, schedule, mrp, jan_aushadhi_price"

--- a/apps/api/tests/supabaseClients.test.ts
+++ b/apps/api/tests/supabaseClients.test.ts
@@ -1,0 +1,89 @@
+describe("Supabase client permission boundaries", () => {
+    const mockCreateClient = jest.fn();
+    const mockLogger = {
+        error: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+        process.env.SUPABASE_URL = "http://localhost:54321";
+        process.env.SUPABASE_ANON_KEY = "test-anon-key";
+        process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-role-key";
+    });
+
+    function setupModuleMocks() {
+        jest.doMock("@supabase/supabase-js", () => ({
+            createClient: mockCreateClient,
+        }));
+        jest.doMock("../src/utils/logger", () => ({
+            __esModule: true,
+            default: mockLogger,
+        }));
+        jest.doMock("../src/db/fetchUtils", () => ({
+            CONNECTION_TIMEOUT_MS: 1000,
+            MAX_RETRIES: 1,
+            RETRY_DELAY_MS: 1,
+            fetchWithRetry: jest.fn(),
+        }));
+    }
+
+    it("initializes the privileged client with the service-role key", () => {
+        const setIntervalSpy = jest
+            .spyOn(global, "setInterval")
+            .mockImplementation(() => 0 as unknown as NodeJS.Timeout);
+        const processOnSpy = jest.spyOn(process, "on").mockReturnValue(process);
+        setupModuleMocks();
+
+        const privilegedClient = { auth: {}, from: jest.fn() };
+        mockCreateClient.mockReturnValue(privilegedClient);
+
+        let exports: typeof import("../src/db/client");
+        jest.isolateModules(() => {
+            exports = require("../src/db/client");
+        });
+
+        expect(exports!.serviceRoleSupabase).toBe(privilegedClient);
+        expect(exports!.supabase).toBe(privilegedClient);
+        expect(mockCreateClient).toHaveBeenCalledWith(
+            "http://localhost:54321",
+            "test-service-role-key",
+            expect.objectContaining({
+                auth: expect.objectContaining({
+                    autoRefreshToken: false,
+                    persistSession: false,
+                }),
+            })
+        );
+
+        setIntervalSpy.mockRestore();
+        processOnSpy.mockRestore();
+    });
+
+    it("initializes the RLS-bound client with the anon key", () => {
+        setupModuleMocks();
+
+        const anonClient = { auth: {}, from: jest.fn(), rpc: jest.fn() };
+        mockCreateClient.mockReturnValue(anonClient);
+
+        let exports: typeof import("../src/db/supabase");
+        jest.isolateModules(() => {
+            exports = require("../src/db/supabase");
+        });
+
+        expect(exports!.anonSupabase).toBe(anonClient);
+        expect(exports!.default).toBe(anonClient);
+        expect(mockCreateClient).toHaveBeenCalledWith(
+            "http://localhost:54321",
+            "test-anon-key",
+            expect.objectContaining({
+                auth: expect.objectContaining({
+                    autoRefreshToken: false,
+                    persistSession: false,
+                }),
+            })
+        );
+    });
+});

--- a/apps/api/tests/triage.test.ts
+++ b/apps/api/tests/triage.test.ts
@@ -16,7 +16,7 @@ jest.mock("../src/db/client", () => ({
 
 jest.mock("../src/db/supabase", () => ({
     __esModule: true,
-    default: {
+    anonSupabase: {
         rpc: jest.fn(),
         from: jest.fn(),
     },
@@ -24,7 +24,7 @@ jest.mock("../src/db/supabase", () => ({
 
 import request from "supertest";
 import app from "../src/app";
-import supabase from "../src/db/supabase";
+import { anonSupabase } from "../src/db/supabase";
 import {
     assessUrgency,
     buildMedicineMonograph,
@@ -34,7 +34,7 @@ import {
     type MedicineRow,
 } from "../src/services/medicineRag.service";
 
-const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
+const mockedSupabase = anonSupabase as jest.Mocked<typeof anonSupabase>;
 
 const sampleRow: MedicineRow = {
     id: "med-1",


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1751**
- **Summary:** This PR makes the API Supabase client permissions explicit without doing a repo-wide rename. The privileged backend client is now exported as `serviceRoleSupabase`, and the RLS-bound client is now exported as `anonSupabase`. I kept backward-compatible aliases for existing imports, then updated the triage/RAG anon-client path and added tests that lock the key usage.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

Backend/API refactor, so screenshot proof is not needed.

```bash
npm run build --workspace=sahidawa-api
npm test --workspace=sahidawa-api -- --runInBand tests/supabaseClients.test.ts tests/triage.test.ts
```

Both commands passed locally.

Full API test note: `npm test --workspace=sahidawa-api -- --runInBand` still has existing route expectation failures in unrelated suites (`interactions`, `alternatives`, `eligibility`, and one analytics expectation). Those are outside this client-permission refactor.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
