### PR TITLE
feat(compare): show safety alert banner for banned or recalled medicines

### DIFF
--- a/apps/web/src/components/ComparisonGrid.tsx
+++ b/apps/web/src/components/ComparisonGrid.tsx
@@ -1,3 +1,5 @@
+import { AlertTriangle } from "lucide-react";
+
 export interface Medicine {
     id: string;
     brand_name: string | null;
@@ -101,6 +103,11 @@ function formatStatus(status: string, labels: ComparisonGridLabels): string {
     return map[status.toLowerCase()] ?? status;
 }
 
+function isFlaggedStatus(status: string): boolean {
+    const normalized = status.toLowerCase();
+    return normalized === "recalled" || normalized === "banned";
+}
+
 function hasValidJanAushadhiPrice(
     m: Medicine | null | undefined
 ): m is Medicine & { jan_aushadhi_price: number } {
@@ -192,6 +199,10 @@ export default function ComparisonGrid({
 
     const directComparison = getDirectComparison(medicine1, medicine2);
 
+    const flaggedMedicines = [medicine1, medicine2].filter(
+        (m): m is Medicine => m != null && isFlaggedStatus(m.cdsco_approval_status)
+    );
+
     const rows: { label: string; getValue: (m: Medicine) => string }[] = [
         { label: labels.rows.brandName, getValue: (m) => m.brand_name?.trim() || "—" },
         { label: labels.rows.genericName, getValue: (m) => m.generic_name },
@@ -220,70 +231,92 @@ export default function ComparisonGrid({
     ];
 
     return (
-        <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
-            <table className="w-full text-sm">
-                <thead>
-                    <tr className="border-b border-slate-200 bg-slate-50">
-                        <th className="w-1/4 px-5 py-3 text-left text-xs font-semibold tracking-wide text-slate-500 uppercase">
-                            {labels.fieldHeader}
-                        </th>
-                        <th className="px-5 py-3 text-center text-sm font-semibold text-slate-800">
-                            {medicine1 ? displayName(medicine1) : labels.medicineA}
-                        </th>
-                        <th className="px-5 py-3 text-center text-sm font-semibold text-slate-800">
-                            {medicine2 ? displayName(medicine2) : labels.medicineB}
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {rows.map(({ label, getValue }) => (
-                        <tr key={label} className="border-b border-slate-100 last:border-0">
-                            <td className="px-5 py-3 font-medium text-slate-600">{label}</td>
-                            <td className="px-5 py-3 text-center text-slate-800">
-                                {medicine1 ? getValue(medicine1) : "—"}
-                            </td>
-                            <td className="px-5 py-3 text-center text-slate-800">
-                                {medicine2 ? getValue(medicine2) : "—"}
-                            </td>
+        <div className="space-y-4">
+            {flaggedMedicines.length > 0 && (
+                <div
+                    role="alert"
+                    className="flex items-start gap-3 rounded-xl border border-red-700 bg-red-600 p-4 text-white shadow-sm"
+                >
+                    <AlertTriangle aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0" />
+                    <div className="space-y-1">
+                        <p className="text-sm font-bold tracking-wide uppercase">Safety alert</p>
+                        {flaggedMedicines.map((m) => (
+                            <p key={m.id} className="text-sm font-medium">
+                                {displayName(m)} has been flagged as{" "}
+                                <span className="font-bold">
+                                    {formatStatus(m.cdsco_approval_status, labels)}
+                                </span>{" "}
+                                by CDSCO.
+                            </p>
+                        ))}
+                    </div>
+                </div>
+            )}
+            <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+                <table className="w-full text-sm">
+                    <thead>
+                        <tr className="border-b border-slate-200 bg-slate-50">
+                            <th className="w-1/4 px-5 py-3 text-left text-xs font-semibold tracking-wide text-slate-500 uppercase">
+                                {labels.fieldHeader}
+                            </th>
+                            <th className="px-5 py-3 text-center text-sm font-semibold text-slate-800">
+                                {medicine1 ? displayName(medicine1) : labels.medicineA}
+                            </th>
+                            <th className="px-5 py-3 text-center text-sm font-semibold text-slate-800">
+                                {medicine2 ? displayName(medicine2) : labels.medicineB}
+                            </th>
                         </tr>
-                    ))}
-                </tbody>
-            </table>
-            {medicine1 && medicine2 && (
-                <div className="flex justify-end border-t border-slate-200 p-4">
-                    <button
-                        type="button"
-                        onClick={() => shareComparison(medicine1, medicine2)}
-                        className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-                    >
-                        Share Comparison
-                    </button>
-                </div>
-            )}
-            {directComparison && (
-                <div className="border-t border-slate-200 bg-slate-50 p-4">
-                    {directComparison.type === "equal" ? (
-                        <p className="text-center text-sm text-slate-700">
-                            Both medicines have the same market price.
-                        </p>
-                    ) : (
-                        <p className="text-center text-sm font-medium text-slate-800">
-                            By choosing{" "}
-                            <span className="font-semibold">
-                                {displayName(directComparison.cheaper)}
-                            </span>{" "}
-                            instead of{" "}
-                            <span className="font-semibold">
-                                {displayName(directComparison.expensive)}
-                            </span>
-                            , you save ₹{directComparison.savings.toFixed(2)}
-                            {" ("}
-                            {directComparison.percentage.toFixed(1)}
-                            %).
-                        </p>
-                    )}
-                </div>
-            )}
+                    </thead>
+                    <tbody>
+                        {rows.map(({ label, getValue }) => (
+                            <tr key={label} className="border-b border-slate-100 last:border-0">
+                                <td className="px-5 py-3 font-medium text-slate-600">{label}</td>
+                                <td className="px-5 py-3 text-center text-slate-800">
+                                    {medicine1 ? getValue(medicine1) : "—"}
+                                </td>
+                                <td className="px-5 py-3 text-center text-slate-800">
+                                    {medicine2 ? getValue(medicine2) : "—"}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+                {medicine1 && medicine2 && (
+                    <div className="flex justify-end border-t border-slate-200 p-4">
+                        <button
+                            type="button"
+                            onClick={() => shareComparison(medicine1, medicine2)}
+                            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+                        >
+                            Share Comparison
+                        </button>
+                    </div>
+                )}
+                {directComparison && (
+                    <div className="border-t border-slate-200 bg-slate-50 p-4">
+                        {directComparison.type === "equal" ? (
+                            <p className="text-center text-sm text-slate-700">
+                                Both medicines have the same market price.
+                            </p>
+                        ) : (
+                            <p className="text-center text-sm font-medium text-slate-800">
+                                By choosing{" "}
+                                <span className="font-semibold">
+                                    {displayName(directComparison.cheaper)}
+                                </span>{" "}
+                                instead of{" "}
+                                <span className="font-semibold">
+                                    {displayName(directComparison.expensive)}
+                                </span>
+                                , you save ₹{directComparison.savings.toFixed(2)}
+                                {" ("}
+                                {directComparison.percentage.toFixed(1)}
+                                %).
+                            </p>
+                        )}
+                    </div>
+                )}
+            </div>
         </div>
     );
 }

--- a/apps/web/tests/ComparisonGrid.test.tsx
+++ b/apps/web/tests/ComparisonGrid.test.tsx
@@ -97,6 +97,43 @@ describe("ComparisonGrid", () => {
         expect(markup).toContain("Recalled");
     });
 
+    it("shows a safety alert banner when a medicine is recalled", () => {
+        const markup = renderToStaticMarkup(
+            <ComparisonGrid medicine1={medicineA} medicine2={medicineB} />
+        );
+
+        expect(markup).toContain('role="alert"');
+        expect(markup).toContain("Safety alert");
+        expect(markup).toContain("Dolo has been flagged as");
+    });
+
+    it("shows a safety alert banner when a medicine is banned", () => {
+        const bannedMedicine = {
+            ...medicineA,
+            cdsco_approval_status: "banned",
+        };
+
+        const markup = renderToStaticMarkup(
+            <ComparisonGrid medicine1={bannedMedicine} medicine2={null} />
+        );
+
+        expect(markup).toContain('role="alert"');
+        expect(markup).toContain("Crocin has been flagged as");
+    });
+
+    it("does not show a safety alert banner when both medicines are approved", () => {
+        const approvedMedicine = {
+            ...medicineB,
+            cdsco_approval_status: "approved",
+        };
+
+        const markup = renderToStaticMarkup(
+            <ComparisonGrid medicine1={medicineA} medicine2={approvedMedicine} />
+        );
+
+        expect(markup).not.toContain("Safety alert");
+    });
+
     it("shows unavailable text when prices are missing", () => {
         const medicine = {
             ...medicineA,


### PR DESCRIPTION
🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

📋 PR Summary & Link

- Closes #1717
- Summary:

When comparing medicines, users could unknowingly select one that CDSCO has
**banned** or **recalled**. This PR surfaces that risk with a prominent red
safety-alert banner rendered **above** the comparison table whenever any
selected medicine has a flagged CDSCO status.

What changed
- `apps/web/src/components/ComparisonGrid.tsx`
  - Added `isFlaggedStatus()` — case-insensitive check for `recalled` / `banned`.
  - Computed `flaggedMedicines` from the selected medicine(s) (handles `null`
    and single-selection safely via a type guard).
  - Rendered a full-width red banner (`role="alert"`, `AlertTriangle` icon from
    `lucide-react`, white bold text) above the table when at least one medicine
    is flagged. Each affected medicine is named, e.g.
    "Crocin has been flagged as Banned by CDSCO." — the status word reuses
    the existing localized `labels.status.`.
- `apps/web/tests/ComparisonGrid.test.tsx`
  - Added tests: banner shows for recalled, banner shows (with brand name) for
    banned, and banner is absent when both medicines are approved.

Design notes
- No new i18n keys were introduced — the status word reuses already-localized
  labels, and the banner text follows the same hardcoded-string pattern as the
  existing "Share Comparison" / savings messages in this same component.
- Responsive by default: `flex items-start gap-3` with `shrink-0` on the icon
  and natural text wrapping; multiple flagged medicines stack via `space-y-1`.
- Empty state (no medicine selected) is unchanged — no banner.


Runtime verification of the detection logic (the exact `isFlaggedStatus` +
filter from the component) against every scenario in the issue's validation
list — 9/9 passing:
