### PR TITLE
feat(web): add multi-select checkboxes and bulk delete to Expiry Tracker

### DIFF
--- a/apps/web/app/[locale]/expiry-tracker/page.tsx
+++ b/apps/web/app/[locale]/expiry-tracker/page.tsx
@@ -39,6 +39,7 @@ export default function ExpiryTrackerPage() {
     const [sortBy, setSortBy] = useState<SortOption>("expirySoonest");
     const [filterStatus, setFilterStatus] = useState<FilterStatus>("all");
     const [importError, setImportError] = useState<string | null>(null);
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     useEffect(() => {
@@ -162,6 +163,37 @@ export default function ExpiryTrackerPage() {
         } else {
             saveToLocalStorage(medicines.filter((med) => med.id !== id));
         }
+        setSelectedIds((prev) => {
+            if (!prev.has(id)) return prev;
+            const next = new Set(prev);
+            next.delete(id);
+            return next;
+        });
+    };
+
+    const toggleSelect = (id: string) => {
+        setSelectedIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(id)) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+            return next;
+        });
+    };
+
+    const handleBulkDelete = async () => {
+        if (selectedIds.size === 0) return;
+        const ids = Array.from(selectedIds);
+        if (userId) {
+            await supabase.from("expiry_tracker_items").delete().in("id", ids);
+
+            setMedicines(medicines.filter((med) => !selectedIds.has(med.id)));
+        } else {
+            saveToLocalStorage(medicines.filter((med) => !selectedIds.has(med.id)));
+        }
+        setSelectedIds(new Set());
     };
 
     const parseLocalDate = (dateStr: string) => {
@@ -391,9 +423,20 @@ export default function ExpiryTrackerPage() {
                     <div className="space-y-4 md:col-span-2">
                         <div className="flex items-center justify-between px-2">
                             <h2 className="text-xl font-bold">{t("trackedMedicines")}</h2>
-                            <span className="rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-xs font-bold text-emerald-500">
-                                {t("total")}: {medicines.length}
-                            </span>
+                            <div className="flex items-center gap-2">
+                                {selectedIds.size > 0 && (
+                                    <button
+                                        onClick={handleBulkDelete}
+                                        className="flex items-center gap-1.5 rounded-full border border-red-500/30 bg-red-500/10 px-4 py-1.5 text-xs font-bold text-red-500 transition hover:bg-red-500/20"
+                                    >
+                                        <Trash2 size={14} /> {t("deleteSelected")} (
+                                        {selectedIds.size})
+                                    </button>
+                                )}
+                                <span className="rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-xs font-bold text-emerald-500">
+                                    {t("total")}: {medicines.length}
+                                </span>
+                            </div>
                         </div>
 
                         {/* Search + Sort */}
@@ -457,22 +500,34 @@ export default function ExpiryTrackerPage() {
                                             key={med.id}
                                             className="flex items-center justify-between rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) p-5 shadow-sm transition-all hover:border-emerald-500/50"
                                         >
-                                            <div className="space-y-1">
-                                                <h3 className="text-lg leading-tight font-bold">
-                                                    {med.name}
-                                                </h3>
-                                                <div className="flex items-center gap-3 text-sm opacity-70">
-                                                    <span className="flex items-center gap-1">
-                                                        <Calendar size={14} />{" "}
-                                                        {parseLocalDate(
-                                                            med.expiryDate
-                                                        ).toLocaleDateString()}
-                                                    </span>
-                                                    {med.batchNumber && (
+                                            <div className="flex items-center gap-3">
+                                                <input
+                                                    type="checkbox"
+                                                    checked={selectedIds.has(med.id)}
+                                                    onChange={() => toggleSelect(med.id)}
+                                                    aria-label={t("selectMedicine", {
+                                                        name: med.name,
+                                                    })}
+                                                    className="h-4 w-4 cursor-pointer accent-emerald-600"
+                                                />
+                                                <div className="space-y-1">
+                                                    <h3 className="text-lg leading-tight font-bold">
+                                                        {med.name}
+                                                    </h3>
+                                                    <div className="flex items-center gap-3 text-sm opacity-70">
                                                         <span className="flex items-center gap-1">
-                                                            <Package size={14} /> {med.batchNumber}
+                                                            <Calendar size={14} />{" "}
+                                                            {parseLocalDate(
+                                                                med.expiryDate
+                                                            ).toLocaleDateString()}
                                                         </span>
-                                                    )}
+                                                        {med.batchNumber && (
+                                                            <span className="flex items-center gap-1">
+                                                                <Package size={14} />{" "}
+                                                                {med.batchNumber}
+                                                            </span>
+                                                        )}
+                                                    </div>
                                                 </div>
                                             </div>
                                             <div className="flex items-center gap-4">

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -469,7 +469,9 @@
         "importDateError": "Invalid date format found in backup. All dates must be in YYYY-MM-DD format.",
         "statusExpired": "Expired",
         "statusExpiringSoon": "Expiring soon ({days}d)",
-        "statusSafe": "Safe"
+        "statusSafe": "Safe",
+        "deleteSelected": "Delete Selected",
+        "selectMedicine": "Select {name}"
     },
     "Login": {
         "brandSubtitle": "Medicine safety platform",


### PR DESCRIPTION
## Description

Closes #1721 
Currently, users can only delete tracked medicines one at a time, which is tedious for large inventories. This PR adds multi-select checkboxes to the Expiry Tracker list so users can select multiple medicines and delete them in a single action.

## Changes

- Added a **checkbox** next to each medicine row in the tracked list.
- Added a **"Delete Selected (N)"** button in the list header that appears only when at least one item is checked, showing the live selection count.
- Implemented **bulk deletion** across both data paths:
  - **Logged-in users** → removes selected rows from Supabase via `delete().in("id", ids)`.
  - **Anonymous users** → removes selected rows from `localStorage`.
- Single-row delete now also clears that id from the selection, so the bulk button's count never goes stale.

## Implementation Notes

- All logic lives in `apps/web/app/[locale]/expiry-tracker/page.tsx`, where the list UI and both persistence backends already reside.
- Selection is tracked with a `Set<string>` of medicine ids.
- The existing card layout (`justify-between`) is preserved by wrapping the checkbox and the medicine details in a flex container.
- Two i18n keys (`deleteSelected`, `selectMedicine`) were added under the existing `ExpiryTracker` namespace in `messages/en.json`, following the component's existing `t()` pattern.

## Files Changed

| File | Reason |
|------|--------|
| `apps/web/app/[locale]/expiry-tracker/page.tsx` | Selection state, checkboxes, "Delete Selected" button, bulk delete handler (state + backend) |
| `apps/web/messages/en.json` | New `deleteSelected` and `selectMedicine` translation keys |

## Out of Scope / Preserved Behavior

- Single-row delete, add medicine, import/export, and search/sort/filter are unchanged.
- No new dependencies, renames, or unrelated styling changes.

## Testing

- Verified the existing `tests/expiry-tracker.test.tsx` suite remains valid: the single-delete test uses `within(card).getByRole("button")`, and since a checkbox has role `checkbox` (not `button`), the delete button still resolves uniquely.

## Screenshots

<!-- Add before/after screenshots of the list with checkboxes and the "Delete Selected" button -->