### PR TITLE
fix: add navigation links for profile menu items

### DIFF
--- a/apps/web/app/[locale]/profile/page.tsx
+++ b/apps/web/app/[locale]/profile/page.tsx
@@ -191,8 +191,8 @@ export default function ProfilePage() {
                             </button>
                         )}
 
-                        <button
-                            type="button"
+                        <Link
+                            href="/settings"
                             className="flex w-full items-center justify-between p-5 transition-colors hover:bg-(--color-surface-muted)"
                         >
                             <div className="flex items-center gap-3">
@@ -204,10 +204,10 @@ export default function ProfilePage() {
                             </div>
 
                             <ChevronRight size={18} className="text-(--color-text-muted)" />
-                        </button>
+                        </Link>
 
-                        <button
-                            type="button"
+                        <Link
+                            href="/privacy"
                             className="flex w-full items-center justify-between p-5 transition-colors hover:bg-(--color-surface-muted)"
                         >
                             <div className="flex items-center gap-3">
@@ -222,7 +222,7 @@ export default function ProfilePage() {
                             </div>
 
                             <ChevronRight size={18} className="text-(--color-text-muted)" />
-                        </button>
+                        </Link>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #1828**
* **Summary:**

  * Replaced the non-functional **Notification Settings** button with a localized navigation link to `/settings`.
  * Replaced the non-functional **Privacy & Security** button with a localized navigation link to `/privacy`.
  * Preserved the existing UI layout and styling.

## 📸 Proof of Work (Screenshots / Logs)

### Local Verification

* Confirmed the routes exist:

  * `apps/web/app/[locale]/settings`
  * `apps/web/app/[locale]/privacy`
* Verified the profile page was updated to use localized `Link` components for navigation.
* Only the required file was modified:

  * `apps/web/app/[locale]/profile/page.tsx`

### Development Environment

The Next.js development server starts successfully after upgrading to Node.js v22.

However, full UI navigation testing is currently blocked because required project environment variables are not configured locally:

```text
NEXT_PUBLIC_SUPABASE_URL is not defined.
This environment variable is required for the application to start.
```

Attached: terminal log / screenshot showing successful Next.js startup and the environment-variable error.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #1828`)
* [x] I have pulled the latest `main` and resolved any conflicts
