### PR TITLE
Added File Size Validation on OCR Text Extraction Endpoint #1829

### DIFF
--- a/apps/ml/routers/ocr.py
+++ b/apps/ml/routers/ocr.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/ocr", tags=["OCR"])
 
+MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024  # 5MB limit
+
 @router.post("/extract")
 async def extract_text(file: UploadFile = File(...)):
     """
@@ -22,6 +24,13 @@ async def extract_text(file: UploadFile = File(...)):
     # Validate file type
     if not file.content_type.startswith("image/"):
         raise HTTPException(status_code=400, detail="File uploaded is not an image.")
+
+    # Validate file size to prevent Denial of Service (DoS) via memory exhaustion
+    if file.size and file.size > MAX_IMAGE_SIZE_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File too large. Maximum allowed size is {MAX_IMAGE_SIZE_BYTES // (1024 * 1024)}MB."
+        )
 
     try:
         # Read image content


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1829 **
- **Summary:**
  This PR updated the `extract_text` endpoint in the OCR router to include a 5MB size check. This check is performed before the file content is read into memory, ensuring that excessively large payloads are rejected early with an` HTTP 413 Payload` Too Large error.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
