### PR TITLE
Fixed Medicine Compare Search Fails on Queries Containing Double Quotes #1822

### DIFF
--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -14,7 +14,8 @@ import { supabase } from "@/lib/supabase";
 import { mapMedicineRow } from "@/src/lib/mapMedicineRow";
 
 async function searchMedicines(query: string): Promise<Medicine[]> {
-    const q = query.trim();
+    // Strip double quotes to prevent breaking the PostgREST filter structure in the .or() builder
+    const q = query.replace(/"/g, "").trim();
     if (q.length < 2) return [];
 
     const pattern = `%${q.replace(/[%_\\]/g, "\\$&")}%`;


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1822 **
- **Summary:**

     - To prevent `PostgREST` syntax errors and potential application crashes when a user inputs a double quote (") into the medicine comparison search,  sanitization in the search query is required .
     - Since double quotes are not typically part of medicine names, stripping them is an effective and safe way to sanitize the input while maintaining valid `PostgREST` syntax.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1822 `)
- [x] I have pulled the latest `main` and resolved any conflicts
