### PR TITLE
fix(api): add abuse safeguards to batch report endpoint (Closes #1820)

### DIFF
--- a/apps/api/src/routes/batch.ts
+++ b/apps/api/src/routes/batch.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 import { supabase } from "../db/client";
 import { batchLimiter } from "../middleware/rateLimit";
 import logger from "../utils/logger";
+import {
+    validateReport,
+    anonymizeIp,
+    computeReportHash,
+} from "../services/reportValidation.service";
 
 const router = Router();
 
@@ -328,7 +333,29 @@ router.post("/report", batchLimiter, async (req: Request, res: Response) => {
     }
 
     const { batchNumber, description, city, state, pincode, pharmacyName } = parsed.data;
+    const hashedIp = anonymizeIp(req.ip);
 
+    const reportPayload = {
+        medicineName: batchNumber,
+        manufacturer: "",
+        description,
+        pharmacyName: pharmacyName ?? "",
+        address: "",
+        city: city ?? "",
+        state: state ?? "",
+        pincode: pincode ?? "",
+        district: city ?? "",
+    };
+
+    const validation = await validateReport(reportPayload, hashedIp, null);
+
+    if (!validation.passed) {
+        res.status(429).json({
+            error: "Report rejected due to abuse safeguards.",
+            reasons: validation.reasons,
+        });
+        return;
+    }
     try {
         // Use .eq() instead of .ilike() — exact match, no wildcard risk
         let medicine_id: string | null = null;
@@ -352,6 +379,11 @@ router.post("/report", batchLimiter, async (req: Request, res: Response) => {
             pincode: pincode ?? null,
             pharmacy_name: pharmacyName ?? null,
             status: "pending",
+            ip_address: hashedIp ?? null,
+            report_hash: computeReportHash(reportPayload),
+            risk_score: validation.riskScore,
+            is_escalated: validation.riskScore >= 0.6,
+            duplicate_group_id: validation.duplicateGroupId ?? null,
         });
 
         if (error) {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link
- **Closes #1820**
- **Summary:** Adds abuse safeguards to `POST /api/verify/batch/report` by integrating `validateReport`, `anonymizeIp`, and `computeReportHash` from `reportValidation.service.ts`, bringing it in line with the security logic already present in `reports.ts`.

## 📸 Proof of Work
Only `apps/api/src/routes/batch.ts` modified — confirmed via `git diff --stat main`.
Zero TypeScript errors (`npx tsc --noEmit` clean).
Pre-existing lint errors in `AnalyticsCharts.tsx` and `CacheStatsCard.tsx` are unrelated to this PR and were present before this branch.

## 🏷️ PR Type
- [x] 🐛 `type: bug`
- [x] 🔒 `type: security`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #1820`)
- [x] I have pulled the latest `main` and resolved any conflicts