### PR TITLE
feat: link scanned barcodes and medicine IDs to incident reports

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -62,6 +62,8 @@ const createReportSchema = z.object({
         .min(-180, "Longitude must be between -180 and 180")
         .max(180, "Longitude must be between -180 and 180")
         .optional(),
+    scannedBarcode: z.string().optional(),
+    medicineId: z.string().uuid().optional(),
 });
 
 const buildReportLocation = (latitude?: number, longitude?: number) => {
@@ -134,6 +136,8 @@ reportsRouter.post(
                     is_escalated: !validation.passed,
                     duplicate_group_id: validation.duplicateGroupId ?? null,
                     status: "pending",
+                    scanned_barcode: data.scannedBarcode ?? null,
+                    medicine_id: data.medicineId ?? null,
                 })
                 .select()
                 .single();

--- a/apps/api/tests/reports.test.ts
+++ b/apps/api/tests/reports.test.ts
@@ -28,6 +28,7 @@ jest.mock("../src/services/reportValidation.service", () => ({
     computeReportHash: jest
         .fn()
         .mockReturnValue("abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"),
+    anonymizeIp: jest.fn().mockReturnValue("127.0.0.1"),
 }));
 
 jest.mock("../src/middleware/auth", () => {

--- a/apps/web/components/reports/ReportWizard.tsx
+++ b/apps/web/components/reports/ReportWizard.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useState, useEffect, useId } from "react";
+import { useSearchParams } from "next/navigation";
 import { useForm, FormProvider, useFormContext } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -78,6 +79,8 @@ const schema = z.object({
                     "Enter a valid 6-digit Indian Pincode (cannot start with 0)"
                 )
         ),
+    scannedBarcode: z.string().optional(),
+    medicineId: z.string().optional(),
 });
 export type FormValues = z.infer<typeof schema>;
 
@@ -91,6 +94,8 @@ const EMPTY: FormValues = {
     city: "",
     state: "",
     pincode: "",
+    scannedBarcode: undefined,
+    medicineId: undefined,
 };
 
 // ─── Per-step field keys ────────────────────────────────────────────────────────
@@ -823,13 +828,14 @@ export default function ReportWizard() {
     const [pendingCount, setPendingCount] = useState(0);
     const [restoredDraft, setRestoredDraft] = useState(false);
     const submitErrorId = useId();
+    const searchParams = useSearchParams();
 
     const methods = useForm<FormValues>({
         resolver: zodResolver(schema),
         defaultValues: EMPTY,
         mode: "onTouched",
     });
-    const { trigger, handleSubmit, reset } = methods;
+    const { trigger, handleSubmit, reset, setValue } = methods;
 
     // Cleanup blob URLs on unmount to prevent memory leaks
     useEffect(() => {
@@ -860,6 +866,14 @@ export default function ReportWizard() {
             }
         })();
     }, []);
+
+    // Extract barcode and medicineId from URL query parameters
+    useEffect(() => {
+        const barcode = searchParams.get("barcode");
+        const medicineId = searchParams.get("medicineId");
+        if (barcode) setValue("scannedBarcode", barcode);
+        if (medicineId) setValue("medicineId", medicineId);
+    }, [searchParams, setValue]);
 
     // Background sync of queued offline reports
     useEffect(() => {

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -34,6 +34,8 @@ export type ReportPayload = {
     pincode: string;
     latitude?: number;
     longitude?: number;
+    scannedBarcode?: string;
+    medicineId?: string;
 };
 
 export type SubmittedReport = {


### PR DESCRIPTION
## Summary
Connect medicine scanner data to counterfeit incident reports for better tracking and verification.

## Problem
When a user gets a suspicious result in the medicine scanner and clicks "Report", the system cannot link the scanned barcode or database medicine entry to the final incident report. This disconnects the scanner workflow from the reporting workflow.

## Solution Implemented

### Backend Changes (POST /api/reports)
- Extended createReportSchema with two optional fields:
  - `scannedBarcode`: z.string().optional()
  - `medicineId`: z.string().uuid().optional()
- Updated Supabase insert to store these values:
  - scanned_barcode
  - medicine_id
- Changes are backward compatible (fields are optional)

### Frontend Changes (ReportWizard)
- Added useSearchParams hook to read URL query parameters
- Extract `barcode` and `medicineId` from URL on component mount
- Store extracted values in component form state
- Include barcode and medicineId in submitReport payload
- Conditionally include fields only if present

## Data Flow
1. User scans medicine, gets suspicious/fake result
2. Clicks "Report" which navigates to /report?barcode=XXX&medicineId=YYY
3. ReportWizard reads query parameters and stores them
4. User fills report details through wizard
5. On submit, barcode and medicineId are included in payload
6. Backend stores these values linking the scan to the report
7. Incident report now has full traceability to scanner result

## Testing
- ReportWizard extracts query parameters correctly
- Report submission includes barcode and medicineId when present
- Reports submitted without parameters still work (backward compatible)
- Barcode and medicineId properly stored in counterfeit_reports table

Fixes #1202

GSSoC 2026 Contribution