### PR TITLE
fix(tts): prevent duplicate onStart callback invocation

### DIFF
--- a/apps/web/app/[locale]/voice/lib/useCloudTTS.ts
+++ b/apps/web/app/[locale]/voice/lib/useCloudTTS.ts
@@ -27,7 +27,6 @@ export function useCloudTTS() {
 
             try {
                 setIsLoading(true);
-                options?.onStart?.();
 
                 // Request TTS audio from backend
                 const response = await fetch("/api/voice/tts", {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #1702**
* **Summary:** Fixed duplicate `onStart` callback invocation in `useCloudTTS`.

### Root Cause

`onStart` was being triggered twice during a single `playTTS()` invocation:

1. Immediately before the TTS fetch request.
2. Again when the audio element emitted the `play` event.

This could cause duplicate analytics events, counters, and other side effects.

### Fix

* Removed the premature `options?.onStart?.()` call before the network request.
* Kept the `audio.onplay` handler as the single source of truth for invoking `onStart` when playback actually begins.

## 📸 Proof of Work (Screenshots / Logs)

### Code Verification

Before:
<img width="960" height="313" alt="image" src="https://github.com/user-attachments/assets/6ba0ac07-d300-4616-9792-399acd2df90c" />

```ts
setIsLoading(true);
options?.onStart?.();
```
<img width="978" height="313" alt="image" src="https://github.com/user-attachments/assets/bec99e84-c408-431c-b65c-78a1ad0723b1" />

This will remain as it is.

After:
<img width="687" height="559" alt="image" src="https://github.com/user-attachments/assets/c0cd452f-cdc5-4931-9765-28229b58ed96" />

```ts
setIsLoading(true);
```

`onStart` is now only triggered from:

```ts
const handlePlay = () => {
    setIsLoading(false);
    options?.onStart?.();
};
```

## 🏷️ PR Type

* [x] 🐛 `type: bug`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #1702`)
* [x] I have pulled the latest `main` and resolved any conflicts
