### PR TITLE
feat(web): replace custom back buttons with PageHeader

### DIFF
--- a/apps/web/app/[locale]/alerts/page.tsx
+++ b/apps/web/app/[locale]/alerts/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 import React, { useEffect, useState } from "react";
+import { PageHeader } from "../components/PageHeader";
 import {
     Activity,
-    ArrowLeft,
     Filter,
     AlertTriangle,
     Search,
@@ -16,7 +16,6 @@ import {
     CheckCircle2,
     ShieldAlert,
 } from "lucide-react";
-import { Link } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
 import RecallPushSubscriber from "@/components/alerts/RecallPushSubscriber";
 import { CopyButton } from "@/components/ui/CopyButton";
@@ -146,14 +145,8 @@ export default function FullAlertsLogPage() {
                 className="mx-auto max-w-5xl px-4 py-8 text-(--color-text-primary)"
             >
                 {/* Top Navigation Row */}
-                <div className="mb-6 flex flex-col items-start gap-4">
-                    <Link
-                        href="/"
-                        className="inline-flex items-center gap-2 text-sm font-bold text-(--color-text-secondary) transition-colors hover:text-(--color-text-primary)"
-                    >
-                        <ArrowLeft size={16} />
-                        {t("backHome")}
-                    </Link>
+                <div className="mb-6 flex flex-col gap-4">
+                    <PageHeader backHref="/" variant="light" />
 
                     <div className="animate-in fade-in slide-in-from-bottom-4 inline-flex items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-4 py-1.5 text-xs font-black text-emerald-700 duration-700 dark:border-emerald-900/30 dark:bg-emerald-950/20 dark:text-emerald-400">
                         <span className="relative flex h-2 w-2">

--- a/apps/web/app/[locale]/interaction-checker/page.tsx
+++ b/apps/web/app/[locale]/interaction-checker/page.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import { useEffect, useState, useRef } from "react";
-import { Link } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
 import {
     AlertTriangle,
-    ArrowLeft,
     Plus,
     Trash2,
     X,
@@ -17,6 +15,7 @@ import {
 } from "lucide-react";
 import { fuzzyMatchBrand } from "@/lib/api";
 import { checkInteractions, type InteractionResult } from "@/lib/api/interactions";
+import { PageHeader } from "../components/PageHeader";
 
 const STORAGE_KEY = "sahidawa-my-medicines";
 
@@ -179,14 +178,7 @@ export default function InteractionCheckerPage() {
     return (
         <div className="flex-grow bg-(--color-surface-muted) px-6 py-8 text-(--color-text-primary)">
             <div className="mx-auto max-w-3xl">
-                {/* Back Button */}
-                <Link
-                    href="/"
-                    className="mb-6 inline-flex items-center gap-2 rounded-xl px-3 py-2 font-medium text-(--color-text-secondary) transition-all hover:bg-(--color-surface-page) hover:text-emerald-600 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:outline-none dark:hover:text-emerald-400"
-                >
-                    <ArrowLeft size={18} />
-                    <span>Back to Home</span>
-                </Link>
+                <PageHeader backHref="/" variant="light" />
 
                 {/* Header */}
                 <div className="mb-8 flex items-center gap-4">

--- a/apps/web/app/[locale]/profile/page.tsx
+++ b/apps/web/app/[locale]/profile/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from "react";
 import { Link, useRouter } from "@/i18n/routing";
-import { User, ShieldCheck, Bell, ChevronRight, ArrowLeft, LogIn, LogOut } from "lucide-react";
+import { PageHeader } from "../components/PageHeader";
+import { User, ShieldCheck, Bell, ChevronRight, LogIn, LogOut } from "lucide-react";
 import { useSession } from "@/src/components/AuthProvider";
 
 type ProfileSession =
@@ -114,15 +115,7 @@ export default function ProfilePage() {
     return (
         <div className="flex-grow bg-(--color-surface-muted) px-6 py-8 text-(--color-text-primary)">
             <div className="mx-auto max-w-3xl">
-                {/* Back Button */}
-                <Link
-                    href="/"
-                    className="mb-6 inline-flex items-center gap-2 rounded-xl px-3 py-2 font-medium text-(--color-text-secondary) transition-all hover:bg-(--color-surface-page) hover:text-emerald-600 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:outline-none dark:hover:text-emerald-400"
-                >
-                    <ArrowLeft size={18} />
-
-                    <span className="font-medium">Back to Home</span>
-                </Link>
+                <PageHeader backHref="/" variant="light" />
 
                 {/* Header */}
                 <div className="mb-8 flex items-center gap-4">

--- a/apps/web/app/[locale]/settings/page.tsx
+++ b/apps/web/app/[locale]/settings/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Link } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
-import { Bell, ArrowLeft, Loader2, Save, Trash2, CheckCircle, AlertTriangle } from "lucide-react";
+import { Bell, Loader2, Save, Trash2, CheckCircle, AlertTriangle } from "lucide-react";
 import {
     getSubscriptionStatus,
     registerSubscription,
@@ -11,6 +10,7 @@ import {
     optOutSubscription,
 } from "@/lib/api/notifications";
 import { useSession } from "@/src/components/AuthProvider";
+import { PageHeader } from "../components/PageHeader";
 
 const GUEST_PHONE_KEY = "sahidawa-sms-phone";
 
@@ -200,14 +200,7 @@ export default function SettingsPage() {
     return (
         <div className="flex-grow bg-(--color-surface-muted) px-6 py-8 text-(--color-text-primary)">
             <div className="mx-auto max-w-2xl">
-                {/* Back Button */}
-                <Link
-                    href="/profile"
-                    className="mb-6 inline-flex items-center gap-2 rounded-xl px-3 py-2 font-medium text-(--color-text-secondary) transition-all hover:bg-(--color-surface-page) hover:text-emerald-600 focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:outline-none dark:hover:text-emerald-400"
-                >
-                    <ArrowLeft size={18} />
-                    <span>Back to Profile</span>
-                </Link>
+                <PageHeader backHref="/" variant="light" />
 
                 {/* Header */}
                 <div className="mb-8 flex items-center gap-4">


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link

- **Closes #1544 **
- **Summary:**
  - Replaced custom back button implementations with the reusable `PageHeader` component.
  - Updated the following auxiliary pages:
    - `apps/web/app/[locale]/alerts/page.tsx`
    - `apps/web/app/[locale]/settings/page.tsx`
    - `apps/web/app/[locale]/interaction-checker/page.tsx`
    - `apps/web/app/[locale]/profile/page.tsx`
  - Removed now-unused imports (`ArrowLeft`, `Link`) where applicable.
  - Ensured back button alignment is consistent with the standardized layout introduced on the "How it works" page.

## 📸 Proof of Work (Screenshots / Logs)

### Verification

```bash
grep -R "ArrowLeft" apps/web/app/\[locale\] --include="*.tsx"
```

Output:

```text
apps/web/app/[locale]/schedule/new/page.tsx
apps/web/app/[locale]/components/PageHeader.tsx
```

This confirms the audited auxiliary pages no longer use custom back buttons and now rely on `PageHeader`.

(Attach UI screenshots of Alerts, Settings, Interaction Checker, and Profile pages here.)

## 🏷️ PR Type

- [ ] 🐛 type: bug
- [x] ✨ type: feature
- [ ] 📖 type: docs
- [ ] 🧪 type: testing
- [ ] 🔒 type: security
- [ ] ⚡ type: performance
- [ ] 🎨 type: design
- [x] ♻️ type: refactor
- [ ] 🛠️ type: devops
- [ ] ♿ type: accessibility

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1544 `)
- [x] I have pulled the latest `main` and resolved any conflicts