### PR TITLE
feat(web): add scroll animations to how-it-works timeline

### DIFF
--- a/apps/web/app/[locale]/how-it-works/page.tsx
+++ b/apps/web/app/[locale]/how-it-works/page.tsx
@@ -18,7 +18,7 @@ import {
 import { Link } from "@/i18n/routing";
 import { PageHeader } from "../components/PageHeader";
 import { useTranslations } from "next-intl";
-
+import { motion } from "framer-motion";
 
 const steps = [
     {
@@ -28,7 +28,7 @@ const steps = [
     },
     {
         icon: <Search size={34} />,
-       titleKey: "features.cards.scanOrSearch.title",
+        titleKey: "features.cards.scanOrSearch.title",
         descriptionKey: "features.cards.scanOrSearch.description",
     },
     {
@@ -57,8 +57,7 @@ const timelineSteps = [
     {
         icon: <QrCode size={24} />,
         titleKey: "steps.scan.title",
-        descriptionKey:
-            "steps.scan.description",
+        descriptionKey: "steps.scan.description",
         bgClass: "bg-emerald-50 dark:bg-emerald-950/30 text-emerald-600 dark:text-emerald-400",
         badgeClass: "bg-emerald-600 dark:bg-emerald-500",
         borderClass:
@@ -67,8 +66,7 @@ const timelineSteps = [
     {
         icon: <ShieldCheck size={24} />,
         titleKey: "steps.verify.title",
-        descriptionKey:
-            "steps.verify.description",
+        descriptionKey: "steps.verify.description",
         bgClass: "bg-blue-50 dark:bg-blue-950/30 text-blue-600 dark:text-blue-400",
         badgeClass: "bg-blue-600 dark:bg-blue-500",
         borderClass:
@@ -77,8 +75,7 @@ const timelineSteps = [
     {
         icon: <BellRing size={24} />,
         titleKey: "steps.alerts.title",
-        descriptionKey:
-            "steps.alerts.description",
+        descriptionKey: "steps.alerts.description",
         bgClass: "bg-amber-50 dark:bg-amber-950/30 text-amber-600 dark:text-amber-400",
         badgeClass: "bg-amber-600 dark:bg-amber-500",
         borderClass:
@@ -87,8 +84,7 @@ const timelineSteps = [
     {
         icon: <MapPin size={24} />,
         titleKey: "steps.pharmacies.title",
-        descriptionKey:
-            "steps.pharmacies.description",
+        descriptionKey: "steps.pharmacies.description",
         bgClass: "bg-purple-50 dark:bg-purple-950/30 text-purple-600 dark:text-purple-400",
         badgeClass: "bg-purple-600 dark:bg-purple-500",
         borderClass:
@@ -97,8 +93,7 @@ const timelineSteps = [
     {
         icon: <Shield size={24} />,
         titleKey: "steps.protect.title",
-        descriptionKey:
-            "steps.protect.description",
+        descriptionKey: "steps.protect.description",
         bgClass: "bg-rose-50 dark:bg-rose-950/30 text-rose-600 dark:text-rose-400",
         badgeClass: "bg-rose-600 dark:bg-rose-500",
         borderClass:
@@ -106,8 +101,31 @@ const timelineSteps = [
     },
 ];
 
+const timelineContainerVariants = {
+    hidden: {},
+    visible: {
+        transition: {
+            staggerChildren: 0.15,
+        },
+    },
+};
+
+const timelineCardVariants = {
+    hidden: {
+        opacity: 0,
+        y: 20,
+    },
+    visible: {
+        opacity: 1,
+        y: 0,
+        transition: {
+            duration: 0.5,
+        },
+    },
+};
+
 export default function HowItWorksPage() {
-    const t = useTranslations("howItWorks")
+    const t = useTranslations("howItWorks");
     return (
         <main className="min-h-screen overflow-x-hidden bg-gradient-to-b from-(--color-surface-page) via-emerald-500/[0.03] to-(--color-surface-page) text-(--color-text-primary)">
             <PageHeader backHref="/" variant="light" hideBackButton />
@@ -124,7 +142,7 @@ export default function HowItWorksPage() {
                     </div>
 
                     <h1 className="text-4xl leading-tight font-black tracking-tight text-(--color-text-primary) sm:text-5xl md:text-7xl">
-                       {t.rich("heroTitle", {
+                        {t.rich("heroTitle", {
                             highlight: (chunks) => (
                                 <span className="text-emerald-600 dark:text-emerald-400">
                                     {chunks}
@@ -134,7 +152,7 @@ export default function HowItWorksPage() {
                     </h1>
 
                     <p className="mx-auto mt-6 max-w-3xl text-lg leading-relaxed text-(--color-text-secondary) md:text-xl">
-                       {t("heroSubtitle")}
+                        {t("heroSubtitle")}
                     </p>
 
                     {/* CTA Buttons */}
@@ -163,10 +181,17 @@ export default function HowItWorksPage() {
                     {/* Desktop Connected Path */}
                     <div className="absolute top-[52px] right-[10%] left-[10%] z-0 hidden h-[2px] bg-gradient-to-r from-emerald-500/30 via-purple-500/30 to-rose-500/30 md:block" />
 
-                    <div className="no-scrollbar relative z-10 flex snap-x snap-mandatory flex-row gap-6 overflow-x-auto pb-6 md:grid md:grid-cols-5 md:gap-6 md:overflow-x-visible md:pb-0">
+                    <motion.div
+                        className="no-scrollbar relative z-10 flex snap-x snap-mandatory flex-row gap-6 overflow-x-auto pb-6 md:grid md:grid-cols-5 md:gap-6 md:overflow-x-visible md:pb-0"
+                        variants={timelineContainerVariants}
+                        initial="hidden"
+                        whileInView="visible"
+                        viewport={{ once: true }}
+                    >
                         {timelineSteps.map((step, index) => (
-                            <div
+                            <motion.div
                                 key={index}
+                                variants={timelineCardVariants}
                                 className="group relative min-w-[250px] flex-shrink-0 snap-start sm:min-w-[280px] md:min-w-0"
                             >
                                 <div
@@ -186,17 +211,17 @@ export default function HowItWorksPage() {
 
                                     {/* Title */}
                                     <h3 className="mb-2 text-base font-extrabold text-(--color-text-primary) md:text-lg">
-                                       { t(step.titleKey)}
+                                        {t(step.titleKey)}
                                     </h3>
 
                                     {/* Description */}
                                     <p className="text-xs leading-relaxed text-(--color-text-secondary) md:text-sm">
-                                       { t(step.descriptionKey)}
+                                        {t(step.descriptionKey)}
                                     </p>
                                 </div>
-                            </div>
+                            </motion.div>
                         ))}
-                    </div>
+                    </motion.div>
                 </div>
             </section>
 
@@ -209,7 +234,7 @@ export default function HowItWorksPage() {
                         </h2>
 
                         <p className="mt-4 text-lg text-(--color-text-secondary)">
-                             {t("features.subtitle")}
+                            {t("features.subtitle")}
                         </p>
                     </div>
 
@@ -244,12 +269,10 @@ export default function HowItWorksPage() {
                     <div className="pointer-events-none absolute -top-20 -right-20 h-64 w-64 rounded-full border-2 border-white/20" />
 
                     <div className="pointer-events-none absolute -bottom-24 -left-24 h-72 w-72 rounded-full border-2 border-white/20" />
-                    <h2 className="mb-6 text-4xl font-black md:text-5xl">
-                        {t("ctaBanner.title")}
-                    </h2>
+                    <h2 className="mb-6 text-4xl font-black md:text-5xl">{t("ctaBanner.title")}</h2>
 
                     <p className="mx-auto max-w-3xl text-lg leading-relaxed text-white/90 md:text-xl">
-                       {t("ctaBanner.subtitle")}
+                        {t("ctaBanner.subtitle")}
                     </p>
 
                     <div className="mt-10 flex flex-wrap justify-center gap-4">


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #1556 **
- **Summary:**
  - Added smooth scroll-triggered animations to the timeline cards on the How It Works page using Framer Motion.
  - Implemented fade-in and slide-up effects (`opacity: 0 → 1`, `y: 20 → 0`).
  - Added staggered animations so timeline cards appear sequentially.
  - Configured animations to trigger only once when cards enter the viewport using `viewport={{ once: true }}`.
  - Maintained existing layout and styling without introducing layout shifts.

## 📸 Proof of Work (Screenshots / Logs)

> Attach screenshots or a GIF/video showing the timeline cards animating into view while scrolling.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [x] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1556 `)
- [x] I have pulled the latest `main` and resolved any conflicts