### PR TITLE
fix(ml): offload synchronous LangGraph triage execution to threadpool

### DIFF
--- a/apps/ml/routers/triage.py
+++ b/apps/ml/routers/triage.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, Field
 from typing import List, Dict, Any, Optional
 import logging
 
+from starlette.concurrency import run_in_threadpool
 from services.triage_graph import run_triage_flow
 
 router = APIRouter(prefix="/triage", tags=["Triage"])
@@ -47,7 +48,7 @@ async def triage_chat(payload: TriageRequest):
 
     try:
         logging.info(f"Invoking triage flow for chat of length {len(messages_list)}")
-        result = run_triage_flow(messages_list, locale=payload.locale)
+        result = await run_in_threadpool(run_triage_flow, messages_list, locale=payload.locale)
         return TriageResponse(
             response=result.get("response", ""),
             emergency=result.get("emergency", False),


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #1928 **
- **Summary:**
This PR resolves a performance issue in the POST /triage/chat endpoint.
The route is implemented as an async FastAPI handler but directly executes the synchronous run_triage_flow() workflow, which ultimately invokes LangGraph and performs multiple blocking Gemini API calls. As a result, the event loop thread handling the request remains occupied for the duration of the triage workflow.
This change imports Starlette's run_in_threadpool and offloads the execution of run_triage_flow() to a worker thread. The FastAPI event loop is therefore free to continue serving other requests while the LangGraph workflow executes in the background.
  
  **Fix implemented:**
  - Imported Starlette's `run_in_threadpool`.
  - Wrapped the `run_triage_flow()` execution in `await run_in_threadpool(...)`.
  - The heavy, blocking LLM inference is now safely offloaded to an isolated background worker thread, ensuring the main FastAPI event loop remains unblocked and highly concurrent.

## 📸 Proof of Work (Screenshots / Logs)
<img width="1842" height="696" alt="image" src="https://github.com/user-attachments/assets/a3463f01-61d3-4de0-86de-bc3cd9edc93c" />
<img width="1895" height="902" alt="image" src="https://github.com/user-attachments/assets/78241292-e325-44d4-8173-d07e77f4f50b" />
<img width="1176" height="418" alt="image" src="https://github.com/user-attachments/assets/3c1a6e35-8cb2-4fa9-8666-1e001b4d788e" />

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] ⚡ `type: performance`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1928`)
- [x] I have pulled the latest `main` and resolved any conflicts
