### PR TITLE
feat(api): add structured audit log when batch report rejected by abuse safeguard (Closes #1936)

### DIFF
--- a/apps/api/src/routes/batch.ts
+++ b/apps/api/src/routes/batch.ts
@@ -363,6 +363,15 @@ router.post("/report", batchLimiter, async (req: Request, res: Response) => {
     const validation = await validateReport(reportPayload, hashedIp, null);
 
     if (!validation.passed) {
+        logger.warn({
+            message: "Batch report rejected by abuse safeguards",
+            risk_score: validation.riskScore,
+            reasons: validation.reasons,
+            ip_address: hashedIp ?? "unknown",
+            batch_number: batchNumber,
+            duplicate_group_id: validation.duplicateGroupId ?? null,
+            route: "/api/verify/batch/report",
+        });
         res.status(429).json({
             error: "Report rejected due to abuse safeguards.",
             reasons: validation.reasons,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link
- **Closes #1936 **
- **Summary:** Adds a structured logger.warn entry when POST /api/verify/batch/report rejects a report due to abuse safeguards, enabling security monitoring of rejected reports.

## 📸 Proof of Work
- Zero TypeScript errors in changed files
- git diff --stat main confirms only apps/api/src/routes/batch.ts modified (1 file, 9 insertions)
- Pre-existing TS error in medicine.ts (node-fetch types) is unrelated to this PR

## 🏷️ PR Type
- [x] 🔒 `type: security`
- [x] ✨ `type: feature`

## ✅ Checklist
- [x] My PR has a linked issue
- [x] I have pulled the latest main and resolved any conflicts