### PR TITLE
feat(api): add origin validation to batch report endpoint Closes #1937

### DIFF
--- a/apps/api/src/routes/batch.ts
+++ b/apps/api/src/routes/batch.ts
@@ -8,6 +8,7 @@ import {
     anonymizeIp,
     computeReportHash,
 } from "../services/reportValidation.service";
+import { isAllowedOrigin } from "../utils/originCheck";
 
 const router = Router();
 
@@ -335,6 +336,11 @@ router.get("/:batchNumber", batchLimiter, async (req: Request, res: Response) =>
  *         description: Failed to submit report
  */
 router.post("/report", batchLimiter, async (req: Request, res: Response) => {
+    if (!isAllowedOrigin(req)) {
+        res.status(403).json({ error: "Access denied: unrecognized origin" });
+        return;
+    }
+
     const parsed = reportBatchSchema.safeParse(req.body);
 
     if (!parsed.success) {

--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -6,6 +6,7 @@ import { optionalAuth } from "../middleware/auth";
 import logger from "../utils/logger";
 import { lookupDrugByBatch } from "../services/drugLookup.service";
 import { escapeIlike } from "../utils/db";
+import { isAllowedOrigin } from "../utils/originCheck";
 
 function getBatchStatus(recallStatus: string | null | undefined): "safe" | "recalled" | "unknown" {
     if (!recallStatus || recallStatus === "none") return "safe";
@@ -36,25 +37,7 @@ function maskClientIp(ip: string | undefined): string | null {
     return null;
 }
 
-const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
-    ? process.env.ALLOWED_ORIGINS.split(",").map((s) => s.trim())
-    : [
-          "http://localhost:3000",
-          "http://localhost:5173",
-          "https://sahidawa.vercel.app",
-          "https://sahidawa-india.vercel.app",
-          "https://sahidawa.goswav.in",
-      ];
-
 const router = Router();
-
-function isAllowedOrigin(req: Request): boolean {
-    const origin = req.headers.origin;
-    const referer = req.headers.referer;
-    const source = origin || (referer ? new URL(referer).origin : null);
-    if (!source) return true; // Allow requests with no Origin/Referer header
-    return ALLOWED_ORIGINS.includes(source);
-}
 
 const verifySchema = z.object({
     batchNumber: z

--- a/apps/api/src/utils/originCheck.ts
+++ b/apps/api/src/utils/originCheck.ts
@@ -1,0 +1,19 @@
+import { Request } from "express";
+
+export const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(",").map((s) => s.trim())
+    : [
+          "http://localhost:3000",
+          "http://localhost:5173",
+          "https://sahidawa.vercel.app",
+          "https://sahidawa-india.vercel.app",
+          "https://sahidawa.goswav.in",
+      ];
+
+export function isAllowedOrigin(req: Request): boolean {
+    const origin = req.headers.origin;
+    const referer = req.headers.referer;
+    const source = origin || (referer ? new URL(referer).origin : null);
+    if (!source) return true;
+    return ALLOWED_ORIGINS.includes(source);
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link
- **Closes #1937 **
- **Summary:** Extracts isAllowedOrigin() into a shared utility and applies origin validation to POST /api/verify/batch/report, bringing it in line with the /api/verify endpoint.

## 📸 Proof of Work
- Zero TypeScript errors in changed files
- git diff --stat main confirms exactly 3 files changed — all scoped to this issue
- Pre-existing TS error in medicine.ts (node-fetch types) is unrelated to this PR

## 🏷️ PR Type
- [x] 🔒 `type: security`
- [x] ✨ `type: feature`
- [x] ♻️ `type: refactor`

## ✅ Checklist
- [x] My PR has a linked issue
- [x] I have pulled the latest main and resolved any conflicts