### PR TITLE
fix(db): tighten dose log RLS ownership checks

### DIFF
--- a/supabase/migrations/20260616192724_tighten_dose_logs_rls.sql
+++ b/supabase/migrations/20260616192724_tighten_dose_logs_rls.sql
@@ -1,0 +1,23 @@
+DROP POLICY IF EXISTS "Users can manage their own dose logs" ON public.dose_logs;
+
+CREATE POLICY "Users can manage their own dose logs"
+    ON public.dose_logs
+    FOR ALL
+    USING (
+        user_id = auth.uid()
+        AND EXISTS (
+            SELECT 1
+            FROM public.medicine_schedules AS schedules
+            WHERE schedules.id = dose_logs.schedule_id
+              AND schedules.user_id = auth.uid()
+        )
+    )
+    WITH CHECK (
+        user_id = auth.uid()
+        AND EXISTS (
+            SELECT 1
+            FROM public.medicine_schedules AS schedules
+            WHERE schedules.id = dose_logs.schedule_id
+              AND schedules.user_id = auth.uid()
+        )
+    );


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1969**
- **Summary:**
  - Adds one migration: `supabase/migrations/20260616192724_tighten_dose_logs_rls.sql`.
  - Recreates the `dose_logs` owner policy so the row `user_id` and referenced `medicine_schedules` owner must both match `auth.uid()`.
  - Leaves the existing `Service role full access` policy untouched.
  - Blocks the reported trigger: user A cannot insert, update, or upsert a dose log using user A's `user_id` with user B's `schedule_id`.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

No screenshots needed for this PR. This is a database RLS migration only.

Proof run locally:

```bash
npm run check:migrations
```

Result: passed. Migration checker parsed `20260616192724_tighten_dose_logs_rls.sql` and reported all migrations synchronized.

```bash
npm run test -w sahidawa-api
```

Result: passed. `23` test suites, `190` tests.

```bash
git diff --check -- supabase/migrations/20260616192724_tighten_dose_logs_rls.sql
```

Result: passed with no whitespace errors.

Static SQL review:

```text
PASS DROP POLICY IF EXISTS owner policy
PASS CREATE POLICY owner policy
PASS FOR ALL
PASS USING auth user
PASS WITH CHECK auth user
PASS schedule ownership join
PASS schedule owner auth uid
```

Extra checks I ran, with honest status:

```bash
supabase db lint --local --workdir supabase
```

Could not run because local Postgres was not up: `dial tcp 127.0.0.1:54322: connect: connection refused`.

```bash
npm run build -w sahidawa-api
```

Blocked by an existing API type issue outside this PR: `src/routes/medicine.ts(4,19): error TS7016: Could not find a declaration file for module 'node-fetch'`.

```bash
npm run test --workspaces --if-present
```

API tests passed. Web tests have existing unrelated failures in `profile-page.test.tsx` and `MedicineSearchSelect.test.tsx`; this PR does not touch web code.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
