### PR TITLE
 fixed history/page.tsx delete button missing aria-label — unusable f…

### DIFF
--- a/apps/web/app/[locale]/history/page.tsx
+++ b/apps/web/app/[locale]/history/page.tsx
@@ -168,6 +168,7 @@ export default function HistoryPage() {
 
                                     <button
                                         onClick={() => handleDelete(item.id)}
+                                        aria-label={`Delete ${item.medicineName} from history`}
                                         className="rounded-lg bg-red-500 px-3 py-2 text-sm font-medium text-white transition hover:bg-red-400"
                                     >
                                         Delete


### PR DESCRIPTION
…or screen readers #1951

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1951 **
- **Summary:**
  - Added `aria-label={Delete ${item.medicineName} from history}` to the delete button inside the history list's .map().
  - Screen readers now announce each button with the specific medicine name (e.g. "Delete Paracetamol 500mg from history"), giving users full context before acting.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [x] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
