### PR TITLE
fix: handle localStorage errors and cap search history to 20 entries

### DIFF
--- a/apps/web/app/[locale]/components/SearchBar.tsx
+++ b/apps/web/app/[locale]/components/SearchBar.tsx
@@ -44,13 +44,13 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
     const [history, setHistory] = useState<HistoryItem[]>([]);
 
     useEffect(() => {
-        const stored = localStorage.getItem("sahidawa_search_history");
-        if (stored) {
-            try {
+        try {
+            const stored = localStorage.getItem("sahidawa_search_history");
+            if (stored) {
                 setHistory(JSON.parse(stored));
-            } catch (e) {
-                console.error("Failed to parse search history:", e);
             }
+        } catch (e) {
+            console.error("Failed to access or parse search history:", e);
         }
     }, []);
 
@@ -78,9 +78,14 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
                     if (!a.pinned && b.pinned) return 1;
                     return b.timestamp - a.timestamp;
                 })
-                .slice(0, 10); // Limit to 10 items
+                .slice(0, 20); // Limit to 20 items
 
-            localStorage.setItem("sahidawa_search_history", JSON.stringify(sortedFinal));
+            try {
+                localStorage.setItem("sahidawa_search_history", JSON.stringify(sortedFinal));
+            } catch (e) {
+                // Storage quota exceeded — silently skip persisting
+                console.warn("Failed to persist search history:", e);
+            }
             return sortedFinal;
         });
     }, []);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1961 **
- **Summary:**
- l`ocalStorage.setItem` in `addToHistory` is wrapped in try/catch
- Stored history is capped at a maximum of 20 entries 
- localStorage.getItem on mount is also wrapped in try/catch ✅ — The corrected useEffect wraps both getItem and JSON.parse in a single try/catch. 

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
