### PR TITLE
perf(ml): offload ASR WebSocket teardown to threadpool to prevent Event Loop freezing

### DIFF
--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -18,7 +18,7 @@ import numpy as np
 import soundfile as sf
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
 from faster_whisper import WhisperModel
-
+from starlette.concurrency import run_in_threadpool
 from services.fuzzy_matcher import get_phonetic_fuzzy_match  # Imported utility service
 from services.telemetry import (
     get_audio_duration_seconds,
@@ -946,4 +946,4 @@ async def stream_transcription(websocket: WebSocket):
         return
     finally:
         if session is not None:
-            session.close()
+            await run_in_threadpool(session.close)

--- a/apps/ml/routers/triage.py
+++ b/apps/ml/routers/triage.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, Field
 from typing import List, Dict, Any, Optional
 import logging
 
+from starlette.concurrency import run_in_threadpool
 from services.triage_graph import run_triage_flow
 
 router = APIRouter(prefix="/triage", tags=["Triage"])
@@ -47,7 +48,7 @@ async def triage_chat(payload: TriageRequest):
 
     try:
         logging.info(f"Invoking triage flow for chat of length {len(messages_list)}")
-        result = run_triage_flow(messages_list, locale=payload.locale)
+        result = await run_in_threadpool(run_triage_flow, messages_list, locale=payload.locale)
         return TriageResponse(
             response=result.get("response", ""),
             emergency=result.get("emergency", False),

--- a/apps/ml/routers/triage.py
+++ b/apps/ml/routers/triage.py
@@ -3,7 +3,6 @@ from pydantic import BaseModel, Field
 from typing import List, Dict, Any, Optional
 import logging
 
-from starlette.concurrency import run_in_threadpool
 from services.triage_graph import run_triage_flow
 
 router = APIRouter(prefix="/triage", tags=["Triage"])
@@ -48,7 +47,7 @@ async def triage_chat(payload: TriageRequest):
 
     try:
         logging.info(f"Invoking triage flow for chat of length {len(messages_list)}")
-        result = await run_in_threadpool(run_triage_flow, messages_list, locale=payload.locale)
+        result = run_triage_flow(messages_list, locale=payload.locale)
         return TriageResponse(
             response=result.get("response", ""),
             emergency=result.get("emergency", False),


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #1968 **
- **Summary:**
This PR resolves a performance issue in the ASR WebSocket teardown path(`/stream`). 
  
Previously, when a WebSocket session was closed, the route executed session.close() directly inside the async handler's cleanup block. The shutdown path eventually reached StreamingAudioDecoder._wait_for_process_exit(), which performs synchronous subprocess.wait(timeout=...) calls while waiting for the FFmpeg subprocess to terminate.
Because this cleanup occurred on the event loop thread, WebSocket disconnect handling could temporarily block other work being processed by the same FastAPI worker.
  
  **The Fix:**
  - Imported Starlette's native `run_in_threadpool`.
  - Wrapped the teardown logic in `await run_in_threadpool(session.close)`.
  - FFmpeg shutdown and process cleanup now execute in a worker thread instead of on the event loop thread.
  - Existing shutdown behavior is preserved, including graceful process termination and cleanup of the decoder process.

## 📸 Proof of Work (Screenshots / Logs)
<img width="952" height="488" alt="image" src="https://github.com/user-attachments/assets/624ed1ad-d99a-4822-a6fd-ab4578d36670" />

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] ⚡ `type: performance`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1968 `)
- [x] I have pulled the latest `main` and resolved any conflicts
