### PR TITLE
fix(api): return 404 for non-existent report updates

### DIFF
--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -105,6 +105,12 @@ export const updateReportStatus = async (
             .single();
 
         if (error) {
+            // Return 404 when the report does not exist
+            if (error.code === "PGRST116") {
+                res.status(404).json({ error: "Report not found" });
+                return;
+            }
+
             res.status(500).json({ error: "Failed to update report" });
             return;
         }


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #2011 **
* **Summary:**

  * Fixed incorrect error handling in `updateReportStatus()`.
  * Added handling for Supabase "no rows found" errors.
  * The endpoint now returns **404 Not Found** when attempting to update a report that does not exist instead of returning a generic **500 Internal Server Error**.

## 📸 Proof of Work (Screenshots / Logs)

<img width="1647" height="963" alt="image" src="https://github.com/user-attachments/assets/5a29b6ff-423e-4603-b618-03b5fe83f113" />


### Test Case 1: Existing Report

* Updated an existing report successfully.
* Received a successful response with HTTP 200.

### Test Case 2: Non-Existent Report

* Attempted to update a report using an invalid/non-existent report ID.
* Verified that the API now returns HTTP 404 with the message:

```json
{
  "error": "Report not found"
}
```

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2011 `)
* [x] I have pulled the latest `main` and resolved any conflicts
