### PR TITLE
fix(security): add missing HTTP security headers (#2013)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -17,6 +17,17 @@ const nextConfig = {
     async headers() {
         return [
             {
+                source: "/(.*)",
+                headers: [
+                    { key: "X-Frame-Options", value: "DENY" },
+                    { key: "X-Content-Type-Options", value: "nosniff" },
+                    { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+                    { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
+                    { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+                    { key: "Content-Security-Policy", value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;" },
+                ],
+            },
+            {
                 source: "/api/:path*",
                 headers: [{ key: "Vary", value: "Accept-Encoding" }],
             },


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2013**
- **Summary:** Added global HTTP security headers (CSP, X-Frame-Options, HSTS, etc.) to `next.config.mjs` to protect the application against XSS, clickjacking, and other common vulnerabilities. The previous configuration only included a `Vary: Accept-Encoding` header for API routes, which has been successfully preserved.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

*(Since this is a configuration change without visible UI updates, I recommend running the app locally, opening the browser's Network tab, and taking a screenshot of the response headers for the document request to show that the new security headers are present. You can drag and drop that screenshot here.)*

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2013`)
- [x] I have pulled the latest `main` and resolved any conflicts