### PR TITLE
feat(web): add expiry tracker barcode autofill

### DIFF
--- a/apps/web/app/[locale]/expiry-tracker/page.tsx
+++ b/apps/web/app/[locale]/expiry-tracker/page.tsx
@@ -48,6 +48,16 @@ function isValidDateString(dateStr: string): boolean {
     return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
 }
 
+function formatMonthYearInputValue(year: string, month: string): string | null {
+    const yearNumber = year.length === 2 ? 2000 + Number(year) : Number(year);
+    const monthNumber = Number(month);
+    if (yearNumber < 1000 || yearNumber > 9999) return null;
+    if (monthNumber < 1 || monthNumber > 12) return null;
+
+    const lastDayOfMonth = new Date(yearNumber, monthNumber, 0).getDate();
+    return `${yearNumber}-${String(monthNumber).padStart(2, "0")}-${String(lastDayOfMonth).padStart(2, "0")}`;
+}
+
 function formatDateInputValue(rawDate: string | null): string | null {
     if (!rawDate) return null;
 
@@ -66,16 +76,13 @@ function formatDateInputValue(rawDate: string | null): string | null {
         return null;
     }
 
-    const monthYearMatch = trimmedDate.match(/^(\d{1,2})\/(\d{4})$/);
-    if (monthYearMatch) {
-        const [, month, year] = monthYearMatch;
-        const monthNumber = Number(month);
-        if (monthNumber >= 1 && monthNumber <= 12) {
-            const lastDayOfMonth = new Date(Number(year), monthNumber, 0).getDate();
-            return `${year}-${String(monthNumber).padStart(2, "0")}-${String(lastDayOfMonth).padStart(2, "0")}`;
-        }
-        return null;
-    }
+    const slashMonthYearMatch = trimmedDate.match(/^(\d{1,2})\/(\d{2}|\d{4})$/);
+    if (slashMonthYearMatch)
+        return formatMonthYearInputValue(slashMonthYearMatch[2], slashMonthYearMatch[1]);
+
+    const hyphenYearMonthMatch = trimmedDate.match(/^(\d{4})-(\d{1,2})$/);
+    if (hyphenYearMonthMatch)
+        return formatMonthYearInputValue(hyphenYearMonthMatch[1], hyphenYearMonthMatch[2]);
 
     const parsedDate = new Date(trimmedDate);
     if (Number.isNaN(parsedDate.getTime())) return null;

--- a/apps/web/app/[locale]/expiry-tracker/page.tsx
+++ b/apps/web/app/[locale]/expiry-tracker/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect, useRef } from "react";
+import React, { useCallback, useState, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { PageHeader } from "../components/PageHeader";
 import { supabase } from "@/lib/supabase";
@@ -33,6 +33,54 @@ interface Medicine {
 
 type FilterStatus = "all" | "expired" | "expiringSoon" | "safe";
 type SortOption = "expirySoonest" | "expiryLatest" | "alpha";
+
+function parseLocalDate(dateStr: string) {
+    const [year, month, day] = dateStr.split("-").map(Number);
+    return new Date(year, month - 1, day);
+}
+
+function isValidDateString(dateStr: string): boolean {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return false;
+    const [year, month, day] = dateStr.split("-").map(Number);
+    if (month < 1 || month > 12) return false;
+    if (day < 1 || day > 31) return false;
+    const date = new Date(year, month - 1, day);
+    return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+}
+
+function formatDateInputValue(rawDate: string | null): string | null {
+    if (!rawDate) return null;
+
+    const trimmedDate = rawDate.trim();
+    const isoDateMatch = trimmedDate.match(/^(\d{4})-(\d{2})-(\d{2})/);
+    if (isoDateMatch) {
+        const [, year, month, day] = isoDateMatch;
+        const date = parseLocalDate(`${year}-${month}-${day}`);
+        if (
+            date.getFullYear() === Number(year) &&
+            date.getMonth() === Number(month) - 1 &&
+            date.getDate() === Number(day)
+        ) {
+            return `${year}-${month}-${day}`;
+        }
+        return null;
+    }
+
+    const monthYearMatch = trimmedDate.match(/^(\d{1,2})\/(\d{4})$/);
+    if (monthYearMatch) {
+        const [, month, year] = monthYearMatch;
+        const monthNumber = Number(month);
+        if (monthNumber >= 1 && monthNumber <= 12) {
+            const lastDayOfMonth = new Date(Number(year), monthNumber, 0).getDate();
+            return `${year}-${String(monthNumber).padStart(2, "0")}-${String(lastDayOfMonth).padStart(2, "0")}`;
+        }
+        return null;
+    }
+
+    const parsedDate = new Date(trimmedDate);
+    if (Number.isNaN(parsedDate.getTime())) return null;
+    return parsedDate.toISOString().split("T")[0];
+}
 
 export default function ExpiryTrackerPage() {
     const t = useTranslations("ExpiryTracker");
@@ -298,48 +346,77 @@ export default function ExpiryTrackerPage() {
         }
     };
 
-    const handleBarcodeScan = async (scannedText: string) => {
-        setIsVerifying(true);
+    const handleScannerClose = useCallback(() => {
+        setIsScannerOpen(false);
         setApiError(null);
-        try {
-            const result = await verifyMedicine(scannedText);
-            if (result.verified) {
-                setName(result.medicine.brand_name || "");
-                setBatchNumber(result.medicine.batch_number || scannedText);
-                if (result.medicine.expiry_date) {
-                    try {
-                        const d = new Date(result.medicine.expiry_date);
-                        if (!isNaN(d.getTime())) {
-                            const formattedDate = d.toISOString().split("T")[0];
-                            setExpiryDate(formattedDate);
-                            setDateError("");
+    }, []);
 
-                            const selected = new Date(d);
-                            const today = new Date();
-                            today.setHours(0, 0, 0, 0);
-                            selected.setHours(0, 0, 0, 0);
-                            setIsExpired(selected < today);
-                        }
-                    } catch {
-                        // ignore
+    const updateExpiryState = useCallback((dateInputValue: string) => {
+        setExpiryDate(dateInputValue);
+        setDateError("");
+
+        const selected = parseLocalDate(dateInputValue);
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        selected.setHours(0, 0, 0, 0);
+        setIsExpired(selected < today);
+    }, []);
+
+    const handleBarcodeScan = useCallback(
+        async (scannedText: string) => {
+            setIsVerifying(true);
+            setApiError(null);
+            try {
+                const result = await verifyMedicine(scannedText);
+                if (result.verified) {
+                    const medicine = result.medicine;
+                    const scannedName = medicine.brand_name || medicine.generic_name;
+                    if (scannedName) {
+                        setName(scannedName);
                     }
+                    setBatchNumber(medicine.batch_number || scannedText);
+
+                    const scannedExpiryDate = formatDateInputValue(medicine.expiry_date);
+                    if (scannedExpiryDate) {
+                        updateExpiryState(scannedExpiryDate);
+                    }
+
+                    const scannedDetails = [
+                        medicine.generic_name ? `Generic: ${medicine.generic_name}` : null,
+                        medicine.manufacturer ? `Manufacturer: ${medicine.manufacturer}` : null,
+                        medicine.cdsco_approval_status
+                            ? `CDSCO status: ${medicine.cdsco_approval_status}`
+                            : null,
+                    ]
+                        .filter(Boolean)
+                        .join("\n");
+
+                    if (scannedDetails) {
+                        setNotes((currentNotes) =>
+                            currentNotes.trim() ? currentNotes : scannedDetails
+                        );
+                    }
+
+                    toast.success("Medicine details auto-filled!");
+                    setIsScannerOpen(false);
+                } else {
+                    setBatchNumber(scannedText);
+                    toast.warning("Medicine not found in database. Batch number filled.");
+                    setIsScannerOpen(false);
                 }
-                toast.success("Medicine details auto-filled!");
-                setIsScannerOpen(false);
-            } else {
+            } catch (error: unknown) {
+                console.error("Scan error:", error);
+                const message =
+                    error instanceof Error ? error.message : "Failed to fetch medicine details.";
                 setBatchNumber(scannedText);
-                toast.warning("Medicine not found in database. Batch number filled.");
-                setIsScannerOpen(false);
+                setApiError(message);
+                toast.error("Failed to fetch medicine details. Batch number filled.");
+            } finally {
+                setIsVerifying(false);
             }
-        } catch (error: any) {
-            console.error("Scan error:", error);
-            setBatchNumber(scannedText);
-            setApiError(error.message || "Failed to fetch medicine details.");
-            toast.error("Failed to fetch medicine details. Batch number filled.");
-        } finally {
-            setIsVerifying(false);
-        }
-    };
+        },
+        [updateExpiryState]
+    );
 
     useEffect(() => {
         const loadData = async () => {
@@ -558,22 +635,6 @@ export default function ExpiryTrackerPage() {
             cancelNotificationsForMedicine(id);
         });
         setSelectedIds(new Set());
-    };
-
-    const parseLocalDate = (dateStr: string) => {
-        const [year, month, day] = dateStr.split("-").map(Number);
-        return new Date(year, month - 1, day);
-    };
-
-    const isValidDateString = (dateStr: string): boolean => {
-        if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return false;
-        const [year, month, day] = dateStr.split("-").map(Number);
-        if (month < 1 || month > 12) return false;
-        if (day < 1 || day > 31) return false;
-        const date = new Date(year, month - 1, day);
-        return (
-            date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day
-        );
     };
 
     const getDiffDays = (dateStr: string) => {
@@ -994,17 +1055,23 @@ export default function ExpiryTrackerPage() {
             </main>
 
             {isScannerOpen && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
+                <div
+                    className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="expiry-tracker-scanner-title"
+                >
                     <div className="relative flex h-[80vh] w-full max-w-2xl flex-col rounded-3xl border border-(--color-border-muted) bg-(--color-surface-page) p-6 shadow-2xl dark:bg-slate-900">
                         <div className="mb-4 flex items-center justify-between">
-                            <h3 className="text-xl font-bold text-(--color-text-primary)">
+                            <h3
+                                id="expiry-tracker-scanner-title"
+                                className="text-xl font-bold text-(--color-text-primary)"
+                            >
                                 Scan Medicine Barcode
                             </h3>
                             <button
-                                onClick={() => {
-                                    setIsScannerOpen(false);
-                                    setApiError(null);
-                                }}
+                                type="button"
+                                onClick={handleScannerClose}
                                 className="rounded-full p-1.5 text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800"
                             >
                                 <span className="sr-only">Close</span>

--- a/apps/web/tests/expiry-tracker.test.tsx
+++ b/apps/web/tests/expiry-tracker.test.tsx
@@ -125,33 +125,36 @@ describe("ExpiryTrackerPage", () => {
         ).not.toBeInTheDocument();
     });
 
-    it("uses the last day of the month when scanned expiry only has month and year", async () => {
-        mockedVerifyMedicine.mockResolvedValueOnce({
-            verified: true,
-            medicine: {
-                brand_name: "",
-                generic_name: "Cetirizine",
-                manufacturer: "Acme Pharma",
-                batch_number: "CET-7",
-                expiry_date: "04/2027",
-                cdsco_approval_status: "approved",
-                is_counterfeit_alert: false,
-            },
-        });
+    it.each(["04/2027", "04/27", "2027-04"])(
+        "uses the last day of the month for scanned %s expiry",
+        async (expiryDate) => {
+            mockedVerifyMedicine.mockResolvedValueOnce({
+                verified: true,
+                medicine: {
+                    brand_name: "",
+                    generic_name: "Cetirizine",
+                    manufacturer: "Acme Pharma",
+                    batch_number: "CET-7",
+                    expiry_date: expiryDate,
+                    cdsco_approval_status: "approved",
+                    is_counterfeit_alert: false,
+                },
+            });
 
-        const { container } = render(<ExpiryTrackerPage />);
-        await waitForInitialLoad();
+            const { container } = render(<ExpiryTrackerPage />);
+            await waitForInitialLoad();
 
-        fireEvent.click(screen.getByRole("button", { name: /scan barcode/i }));
-        fireEvent.click(screen.getByRole("button", { name: "Emit scan" }));
+            fireEvent.click(screen.getByRole("button", { name: /scan barcode/i }));
+            fireEvent.click(screen.getByRole("button", { name: "Emit scan" }));
 
-        await waitFor(() => {
-            expect(screen.getByPlaceholderText("namePlaceholder")).toHaveValue("Cetirizine");
-        });
+            await waitFor(() => {
+                expect(screen.getByPlaceholderText("namePlaceholder")).toHaveValue("Cetirizine");
+            });
 
-        expect(screen.getByPlaceholderText("batchPlaceholder")).toHaveValue("CET-7");
-        expect(container.querySelector('input[type="date"]')).toHaveValue("2027-04-30");
-    });
+            expect(screen.getByPlaceholderText("batchPlaceholder")).toHaveValue("CET-7");
+            expect(container.querySelector('input[type="date"]')).toHaveValue("2027-04-30");
+        }
+    );
 
     it("keeps an existing expiry date when verified scan has no expiry", async () => {
         mockedVerifyMedicine.mockResolvedValueOnce({

--- a/apps/web/tests/expiry-tracker.test.tsx
+++ b/apps/web/tests/expiry-tracker.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import userEvent from "@testing-library/user-event";
 
 import ExpiryTrackerPage from "../app/[locale]/expiry-tracker/page";
+import { verifyMedicine } from "@/lib/api";
 
 jest.mock("next-intl", () => ({
     useTranslations: () => (key: string) => key,
@@ -20,20 +21,167 @@ jest.mock("../app/[locale]/components/PageHeader", () => ({
     ),
 }));
 
+jest.mock("@/components/scanner/BarcodeScanner", () => ({
+    BarcodeScanner: ({
+        onScan,
+        apiError,
+        onRetry,
+    }: {
+        onScan: (barcodeText: string) => void;
+        apiError?: string | null;
+        onRetry?: () => void;
+    }) => (
+        <div data-testid="barcode-scanner">
+            <button type="button" onClick={() => onScan("SCAN-123")}>
+                Emit scan
+            </button>
+            {apiError && (
+                <button type="button" onClick={onRetry}>
+                    Retry verification
+                </button>
+            )}
+        </div>
+    ),
+}));
+
+jest.mock("@/lib/api", () => ({
+    verifyMedicine: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+    toast: {
+        success: jest.fn(),
+        warning: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+const mockedVerifyMedicine = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
 const STORAGE_KEY = "sahidawa_expiry_tracker";
+const waitForInitialLoad = async () => {
+    await waitFor(() => {
+        expect(screen.queryByText("loading")).not.toBeInTheDocument();
+    });
+};
 
 describe("ExpiryTrackerPage", () => {
     beforeEach(() => {
         localStorage.clear();
+        jest.clearAllMocks();
     });
 
-    it("renders the add-medicine form with name, expiry and batch inputs", () => {
+    it("renders the add-medicine form with name, expiry and batch inputs", async () => {
         const { container } = render(<ExpiryTrackerPage />);
+        await waitForInitialLoad();
 
         expect(screen.getByPlaceholderText("namePlaceholder")).toBeInTheDocument();
         expect(container.querySelector('input[type="date"]')).toBeInTheDocument();
         expect(screen.getByPlaceholderText("batchPlaceholder")).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "addToTracker" })).toBeInTheDocument();
+    });
+
+    it("opens the barcode scanner from the add-medicine form", async () => {
+        render(<ExpiryTrackerPage />);
+        await waitForInitialLoad();
+
+        fireEvent.click(screen.getByRole("button", { name: /scan barcode/i }));
+
+        expect(screen.getByRole("dialog", { name: /scan medicine barcode/i })).toBeInTheDocument();
+        expect(screen.getByTestId("barcode-scanner")).toBeInTheDocument();
+    });
+
+    it("auto-fills medicine fields after a verified barcode scan", async () => {
+        mockedVerifyMedicine.mockResolvedValueOnce({
+            verified: true,
+            medicine: {
+                brand_name: "Calpol",
+                generic_name: "Paracetamol",
+                manufacturer: "Acme Pharma",
+                batch_number: "BATCH-42",
+                expiry_date: "2027-04-30T00:00:00+05:30",
+                cdsco_approval_status: "approved",
+                is_counterfeit_alert: false,
+            },
+        });
+
+        const { container } = render(<ExpiryTrackerPage />);
+        await waitForInitialLoad();
+
+        fireEvent.click(screen.getByRole("button", { name: /scan barcode/i }));
+        fireEvent.click(screen.getByRole("button", { name: "Emit scan" }));
+
+        await waitFor(() => {
+            expect(screen.getByPlaceholderText("namePlaceholder")).toHaveValue("Calpol");
+        });
+
+        expect(mockedVerifyMedicine).toHaveBeenCalledWith("SCAN-123");
+        expect(screen.getByPlaceholderText("batchPlaceholder")).toHaveValue("BATCH-42");
+        expect(container.querySelector('input[type="date"]')).toHaveValue("2027-04-30");
+        expect(
+            (screen.getByPlaceholderText("notesPlaceholder") as HTMLTextAreaElement).value
+        ).toContain("Generic: Paracetamol");
+        expect(
+            screen.queryByRole("dialog", { name: /scan medicine barcode/i })
+        ).not.toBeInTheDocument();
+    });
+
+    it("uses the last day of the month when scanned expiry only has month and year", async () => {
+        mockedVerifyMedicine.mockResolvedValueOnce({
+            verified: true,
+            medicine: {
+                brand_name: "",
+                generic_name: "Cetirizine",
+                manufacturer: "Acme Pharma",
+                batch_number: "CET-7",
+                expiry_date: "04/2027",
+                cdsco_approval_status: "approved",
+                is_counterfeit_alert: false,
+            },
+        });
+
+        const { container } = render(<ExpiryTrackerPage />);
+        await waitForInitialLoad();
+
+        fireEvent.click(screen.getByRole("button", { name: /scan barcode/i }));
+        fireEvent.click(screen.getByRole("button", { name: "Emit scan" }));
+
+        await waitFor(() => {
+            expect(screen.getByPlaceholderText("namePlaceholder")).toHaveValue("Cetirizine");
+        });
+
+        expect(screen.getByPlaceholderText("batchPlaceholder")).toHaveValue("CET-7");
+        expect(container.querySelector('input[type="date"]')).toHaveValue("2027-04-30");
+    });
+
+    it("keeps an existing expiry date when verified scan has no expiry", async () => {
+        mockedVerifyMedicine.mockResolvedValueOnce({
+            verified: true,
+            medicine: {
+                brand_name: "Crocin",
+                generic_name: "Paracetamol",
+                manufacturer: "Acme Pharma",
+                batch_number: "CRO-9",
+                expiry_date: null,
+                cdsco_approval_status: "approved",
+                is_counterfeit_alert: false,
+            },
+        });
+
+        const { container } = render(<ExpiryTrackerPage />);
+        await waitForInitialLoad();
+
+        fireEvent.change(container.querySelector('input[type="date"]')!, {
+            target: { value: "2027-01-15" },
+        });
+        fireEvent.click(screen.getByRole("button", { name: /scan barcode/i }));
+        fireEvent.click(screen.getByRole("button", { name: "Emit scan" }));
+
+        await waitFor(() => {
+            expect(screen.getByPlaceholderText("namePlaceholder")).toHaveValue("Crocin");
+        });
+
+        expect(screen.getByPlaceholderText("batchPlaceholder")).toHaveValue("CRO-9");
+        expect(container.querySelector('input[type="date"]')).toHaveValue("2027-01-15");
     });
 
     it("adds a submitted medicine to the tracked list and persists it to localStorage", async () => {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1723**
- **Summary:**
  - Adds a reliable Expiry Tracker barcode scan flow using the existing `BarcodeScanner` component.
  - Auto-fills medicine name, batch number, expiry date, and optional notes from verified scan results.
  - Handles month/year expiry values as the last day of the month and keeps user-entered expiry dates when a verified result has no expiry date.
  - Adds dialog semantics for the scanner modal and regression tests for scan open, verified autofill, month/year expiry, and missing-expiry behavior.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

Browser screenshot proof is currently blocked by unrelated build/dev errors on `main`. I filed follow-up #2024 for the web blocker and #2026 for the API blocker. The scanner path is covered by focused UI tests with a mocked scanner emit.

Proof commands run after rebasing onto latest `main`:

```bash
npm run test -w web -- expiry-tracker.test.tsx --runInBand
```

```text
Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
```

```bash
./node_modules/.bin/eslint apps/web/app/[locale]/expiry-tracker/page.tsx apps/web/tests/expiry-tracker.test.tsx
```

```text
# no output
```

```bash
git diff --check main..HEAD
```

```text
# no output
```

Build check attempted:

```bash
NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321 NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key npm run build -w web
```

Blocked by existing upstream issue #2024:

```text
./components/medicine/MedicineSafetyPanel.tsx
Module parse failed: Identifier 't' has already been declared
```

CI also hits existing upstream issue #2026:

```text
src/routes/medicine.ts(4,19): error TS1479: The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'.
```

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [x] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1723`)
- [x] I have pulled the latest `main` and resolved any conflicts
