### PR TITLE
fix(scan): use translation keys for scan page text

### DIFF
--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -298,8 +298,8 @@ export default function ScanPage() {
             />
 
             <PageHeader
-                title="Scan Medicine"
-                subtitle="Position the Barcode"
+               title={tScan("scanMedicine")}
+               subtitle={tScan("positionBarcode")}
                 backHref="/"
                 variant="light"
             />
@@ -453,7 +453,7 @@ export default function ScanPage() {
                         type="text"
                         value={batchInput}
                         onChange={(e) => setBatchInput(e.target.value)}
-                        placeholder="Enter batch number"
+                       placeholder={tScan("enterBatchNumber")}
                         className="flex-1 rounded-full border border-(--color-border-muted) bg-(--color-surface-muted) px-4 py-3 text-center text-sm font-medium text-(--color-text-primary) placeholder-(--color-text-muted) focus:border-transparent focus:ring-2 focus:ring-emerald-500 focus:outline-none dark:border-white/20 dark:bg-white/10 dark:text-white dark:placeholder-white/40"
                     />
                     <button
@@ -462,20 +462,19 @@ export default function ScanPage() {
                         className="flex items-center justify-center gap-2 rounded-full bg-emerald-500 px-5 py-3 text-sm font-bold text-white shadow-lg transition-colors hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                         <Search size={18} />
-                        {isOffline ? "Offline" : "Verify"}
+                        {isOffline ? tScan("offline") : tScan("verify")}
                     </button>
                 </form>
 
-                <p className="max-w-xs text-center text-sm font-medium text-slate-400">
-                    Enter the batch number from the medicine strip, or upload a photo from your
-                    gallery.
-                </p>
+              <p className="max-w-xs text-center text-sm font-medium text-slate-400">
+              {tScan("batchNumberHelp")}
+              </p>
                 <Link
                     href="/history"
                     className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-bold text-white shadow-sm transition-colors hover:bg-white/20 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-black focus:outline-none dark:border-white/20"
                 >
                     <History size={18} />
-                    View history
+                    tScan("viewHistory")
                 </Link>
                 <div className="flex gap-4">
                     <button
@@ -488,7 +487,7 @@ export default function ScanPage() {
                         }`}
                     >
                         <ScanLine size={18} />
-                        {isCameraActive ? "Stop Scanner" : "Scan Barcode"}
+                        {isCameraActive ? tScan("scanBarcode") : tScan("Scan Barcode")}
                     </button>
                     <label
                         htmlFor={isOffline ? undefined : "medicine-upload"}
@@ -505,7 +504,7 @@ export default function ScanPage() {
                         }`}
                     >
                         <Layers size={18} />
-                        Upload Photo
+                     tScan("uploadPhoto")
                     </label>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Replaced hardcoded text in Scan page with translation keys
- Added localization support for scan page labels
- Improved multilingual compatibility

Fixes #2031