### PR TITLE
refactor(lasa): replace any with typed database row interface

### DIFF
--- a/apps/api/src/services/lasa.service.ts
+++ b/apps/api/src/services/lasa.service.ts
@@ -34,6 +34,11 @@ interface CacheEntry {
     expiresAt: number;
 }
 
+interface LasaConflictRow {
+    name: string;
+    match_type: LasaMatchType;
+}
+
 const cache = new Map<string, CacheEntry>();
 const inFlight = new Map<string, Promise<LasaMatch[]>>();
 
@@ -85,9 +90,9 @@ export const detectLasaConflicts = async (medicineName: string): Promise<LasaMat
                 throw new Error(`Failed to check LASA conflicts: ${error.message}`);
             }
 
-            const result: LasaMatch[] = (data || []).map((row: any) => ({
+            const result: LasaMatch[] = (data || []).map((row: LasaConflictRow) => ({
                 name: row.name,
-                type: row.match_type as LasaMatchType,
+                type: row.match_type,
                 score: row.match_type === "sound-alike" ? 1.0 : 0.85,
             }));
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #1975**
* **Summary:**

  * Added a strongly typed `LasaConflictRow` interface for LASA RPC response rows.
  * Replaced `row: any` with `row: LasaConflictRow` in the mapping function.
  * Removed the unnecessary `as LasaMatchType` type assertion and used the strongly typed field directly.
  * No runtime behavior changes; this is a type-safety improvement only.

## 📸 Proof of Work (Screenshots / Logs)

### Type Safety Verification

Before:
<img width="1110" height="483" alt="image" src="https://github.com/user-attachments/assets/34f615d2-e6b3-4e9b-8296-f86fcb0a2584" />

* `row` was typed as `any`.
* Invalid property access such as `row.abcdef` was accepted by TypeScript.

After:
<img width="1207" height="577" alt="image" src="https://github.com/user-attachments/assets/c10ec68b-ec8b-40f5-9b54-fc8d23f88aaf" />

* `row` is typed as `LasaConflictRow`.
* TypeScript correctly reports:
  `Property 'abcdef' does not exist on type 'LasaConflictRow'.`

<img width="1162" height="562" alt="image" src="https://github.com/user-attachments/assets/b062aa52-f1ff-49ea-b82a-4efc7ae9aaa5" />
Runs for valid property 'name'

### Build Verification

```bash
npm run build
```

The LASA mapping compiles correctly with the new interface and no type errors are introduced by this change.

## 🏷️ PR Type

* [ ] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [x] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #1975`)
* [x] I have pulled the latest `main` and resolved any conflicts
