### PR TITLE
fix  : medicine.ts API route that creates an isolated Redis client connection leak risk

### DIFF
--- a/apps/api/src/routes/medicine.ts
+++ b/apps/api/src/routes/medicine.ts
@@ -2,8 +2,8 @@ import { Router, Request, Response } from "express";
 import multer from "multer";
 import FormData from "form-data";
 import fetch from "node-fetch";
-import { createClient } from "redis";
 import { supabase } from "../db/client";
+import { redisClient } from "../utils/redis";
 import { scanQueryLimiter } from "../middleware/rateLimit";
 
 const router = Router();
@@ -19,19 +19,6 @@ const upload = multer({
 });
 
 const ML_SERVICE_URL = process.env.ML_SERVICE_URL || "http://localhost:8000";
-const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
-
-// Redis client for caching - lazy singleton
-let redis: ReturnType<typeof createClient> | null = null;
-
-async function getRedisClient() {
-    if (!redis) {
-        redis = createClient({ url: REDIS_URL });
-        redis.on("error", (err) => console.error("Redis error:", err));
-        await redis.connect();
-    }
-    return redis;
-}
 /**
  * POST /api/medicine/verify-voice
  * Accepts audio blob from frontend, forwards to Python ML service,
@@ -107,7 +94,7 @@ router.post(
 
             // Cache result in Redis (key: transcribed medicine name, TTL: 1 hour)
             try {
-                const redisClient = await getRedisClient();
+                // Use the shared redisClient
                 if (transcribedText) {
                     const cacheKey = `medicine:voice:${transcribedText.toLowerCase().replace(/\s+/g, "_")}`;
                     await redisClient.setEx(cacheKey, 3600, JSON.stringify(result));


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1946 **
- **Summary:**
- The let redis singleton and the getRedisClient() initialization function were deleted. This ensures [`medicine.ts`] is no longer responsible for managing its own TCP connection lifecycle.
- The direct dependency on the redis npm package (import { createClient } ...) was removed, reducing the file's complexity.
- The shared redisClient from ../utils/redis is now imported and used. By removing the local const redisClient = await getRedisClient() line inside the route handler, the code now correctly references the shared instance.
-  Since the shared redisClient typically exports the same RedisClientType, and the local variable name matched the import name, the existing calls to .setEx() remain type-compatible, ensuring npx tsc --noEmit passes.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [x] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
