### PR TITLE
refactor: remove custom ArrowLeft back button in schedule/new/page.tsx

### DIFF
--- a/apps/web/app/[locale]/schedule/new/page.tsx
+++ b/apps/web/app/[locale]/schedule/new/page.tsx
@@ -2,8 +2,7 @@
 
 import { useRouter } from "@/i18n/routing";
 import { useState } from "react";
-import { ArrowLeft, Plus, Trash2 } from "lucide-react";
-import { Link } from "@/i18n/routing";
+import { Plus, Trash2 } from "lucide-react";
 import { PageHeader } from "../../components/PageHeader";
 import Card from "@/components/Card";
 import { createSchedule } from "@/lib/scheduleApi";
@@ -217,13 +216,6 @@ export default function NewSchedulePage() {
                         </div>
 
                         <div className="flex items-center gap-3 pt-2">
-                            <Link
-                                href="/schedule"
-                                className="inline-flex items-center gap-1.5 rounded-lg border border-(--color-border-muted) px-4 py-2.5 text-sm font-semibold text-(--color-text-secondary) transition hover:bg-(--color-surface-muted)"
-                            >
-                                <ArrowLeft size={16} />
-                                Cancel
-                            </Link>
                             <button
                                 type="submit"
                                 disabled={saving}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1942**
- **Summary:**
This PR removes the redundant custom back button from the `schedule/new/page.tsx` and standardizes navigation by relying on the existing `PageHeader` . 

**Changes Made:**

- Removed the unused **ArrowLeft** import from `schedule/new/page.tsx`
- Removed the inline Cancel button at the bottom of the form.
- Remove the unused `Link` import from `schedule/new/page.tsx`
- Kept `PageHeader` with `backHref="/schedule" ` as the single back navigation component.

**File changed**
- `apps/web/app/[locale]/schedule/new/page.tsx`

**Testing**

- Verified that the Back button in the `PageHeader` navigates correctly to the Schedule page.
- Confirmed the redundant Cancel button is removed.
- Ensured no navigation functionality was affected.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1942`)
- [x] I have pulled the latest `main` and resolved any conflicts
