### PR TITLE
Added unit tests for lasa.service.ts in-process cache logic

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
     preset: "ts-jest",
     testEnvironment: "node",
-    testMatch: ["**/tests/**/*.test.ts"],
+    testMatch: ["**/tests/**/*.test.ts", "**/src/services/lasa.service.test.ts"],
     clearMocks: true,
     setupFiles: ["<rootDir>/tests/setup.ts"],
     transform: {

--- a/apps/api/src/services/lasa.service.test.ts
+++ b/apps/api/src/services/lasa.service.test.ts
@@ -1,0 +1,144 @@
+import { detectLasaConflicts, clearLasaCache } from "./lasa.service";
+import { supabase } from "../db/client";
+
+// Mock the Supabase client
+jest.mock("../db/client", () => ({
+    supabase: {
+        rpc: jest.fn(),
+    },
+}));
+
+describe("LASA Cache and Deduplication Service", () => {
+    let nowMock = 1000000;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        clearLasaCache();
+        nowMock = 1000000;
+        jest.spyOn(Date, "now").mockImplementation(() => nowMock);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    // 1. Cache miss: calls Supabase RPC and returns results.
+    it("should fetch from Supabase RPC on a cache miss and return mapped results", async () => {
+        const mockData = [
+            { name: "Lasix", match_type: "sound-alike" as const },
+            { name: "Hydralazine", match_type: "look-alike" as const },
+        ];
+        (supabase.rpc as jest.Mock).mockResolvedValue({
+            data: mockData,
+            error: null,
+        });
+
+        const result = await detectLasaConflicts("Losec");
+
+        expect(supabase.rpc).toHaveBeenCalledTimes(1);
+        expect(supabase.rpc).toHaveBeenCalledWith("find_lasa_conflicts", {
+            target_name: "Losec",
+        });
+        expect(result).toEqual([
+            { name: "Lasix", type: "sound-alike", score: 1.0 },
+            { name: "Hydralazine", type: "look-alike", score: 0.85 },
+        ]);
+    });
+
+    // 2. Cache hit (within TTL): does NOT call Supabase again, returns cached result.
+    it("should return cached results on a cache hit within TTL and not call Supabase again", async () => {
+        const mockData = [{ name: "Lasix", match_type: "sound-alike" as const }];
+        (supabase.rpc as jest.Mock).mockResolvedValue({
+            data: mockData,
+            error: null,
+        });
+
+        // First call - cache miss
+        const result1 = await detectLasaConflicts("Losec");
+        expect(supabase.rpc).toHaveBeenCalledTimes(1);
+
+        // Move time forward by 4 minutes (less than the 5-minute TTL)
+        nowMock += 4 * 60 * 1000;
+
+        // Second call - cache hit
+        const result2 = await detectLasaConflicts("Losec");
+        expect(supabase.rpc).toHaveBeenCalledTimes(1); // Still 1
+
+        expect(result1).toEqual(result2);
+    });
+
+    // 3. Cache expiry: after TTL, calls Supabase again.
+    it("should call Supabase again after the cache TTL has expired", async () => {
+        const mockData = [{ name: "Lasix", match_type: "sound-alike" as const }];
+        (supabase.rpc as jest.Mock).mockResolvedValue({
+            data: mockData,
+            error: null,
+        });
+
+        // First call - cache miss
+        await detectLasaConflicts("Losec");
+        expect(supabase.rpc).toHaveBeenCalledTimes(1);
+
+        // Move time forward by 6 minutes (more than the 5-minute TTL)
+        nowMock += 6 * 60 * 1000;
+
+        // Second call - cache miss due to expiration
+        await detectLasaConflicts("Losec");
+        expect(supabase.rpc).toHaveBeenCalledTimes(2);
+    });
+
+    // 4. In-flight deduplication: two concurrent calls for the same key only issue one Supabase RPC.
+    it("should deduplicate in-flight concurrent requests for the same key", async () => {
+        const mockData = [{ name: "Lasix", match_type: "sound-alike" as const }];
+        let resolveRpc: (value: any) => void = () => {};
+        const rpcPromise = new Promise((resolve) => {
+            resolveRpc = resolve;
+        });
+
+        (supabase.rpc as jest.Mock).mockReturnValue(rpcPromise);
+
+        // Initiate concurrent requests
+        const promise1 = detectLasaConflicts("Losec");
+        const promise2 = detectLasaConflicts("Losec");
+
+        // Resolve the RPC
+        resolveRpc({
+            data: mockData,
+            error: null,
+        });
+
+        const [res1, res2] = await Promise.all([promise1, promise2]);
+
+        expect(supabase.rpc).toHaveBeenCalledTimes(1);
+        expect(res1).toEqual([{ name: "Lasix", type: "sound-alike", score: 1.0 }]);
+        expect(res2).toEqual(res1);
+    });
+
+    // 5. Cache eviction: adding items beyond MAX_CACHE_SIZE does not crash and evicts oldest.
+    it("should evict the oldest cached item when cache size exceeds MAX_CACHE_SIZE", async () => {
+        (supabase.rpc as jest.Mock).mockResolvedValue({
+            data: [],
+            error: null,
+        });
+
+        // Call detectLasaConflicts 1001 times with different names to exceed MAX_CACHE_SIZE (1000)
+        // Since we insert "med_0", "med_1", ..., "med_1000", "med_0" should be the oldest and gets evicted.
+        for (let i = 0; i <= 1000; i++) {
+            await detectLasaConflicts(`med_${i}`);
+        }
+
+        // We expect exactly 1001 calls to supabase.rpc for the initial requests
+        expect(supabase.rpc).toHaveBeenCalledTimes(1001);
+
+        // Reset the mock call tracker to verify subsequent calls
+        (supabase.rpc as jest.Mock).mockClear();
+
+        // Calling "med_1000" (the most recently added) should hit cache (0 RPC calls)
+        await detectLasaConflicts("med_1000");
+        expect(supabase.rpc).toHaveBeenCalledTimes(0);
+
+        // Calling "med_0" (the oldest, which should have been evicted) should miss cache (1 RPC call)
+        await detectLasaConflicts("med_0");
+        expect(supabase.rpc).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1962 **
- **Summary:**
- Created apps/api/src/services/lasa.service.test.ts:
     - Developed a complete unit test suite for lasa.service.ts.
     - Mocked the Supabase client to control database RPC responses and assert correct counts/calls.
     - Wrote 5 test cases covering:
           - Cache Miss: Verified standard fetching and data mapping when the cache does not contain the key.
            - Cache Hit: Verified that subsequent queries within the 5-minute TTL return cached results without hitting the DB.
              - Cache Expiry: Verified that once the TTL expires (simulated via Date.now spying), the DB is queried again.
              - In-flight Deduplication: Verified that concurrent requests for the same key await the same database response promise and result in a single DB RPC call.
              - Cache Eviction: Verified that the oldest cache entry is correctly evicted when adding entries beyond MAX_CACHE_SIZE (1000), ensuring bounded memory usage.
- Updated apps/api/jest.config.js:
Added `**/src/services/lasa.service.test.ts` to `testMatch` to make sure Jest discovers and runs our new tests as part of the overall API test suite execution (npm test).
## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
