### PR TITLE
fix: restore missing back button on how it works page

### DIFF
--- a/apps/web/app/[locale]/how-it-works/page.tsx
+++ b/apps/web/app/[locale]/how-it-works/page.tsx
@@ -128,7 +128,7 @@ export default function HowItWorksPage() {
     const t = useTranslations("howItWorks");
     return (
         <main className="min-h-screen overflow-x-hidden bg-gradient-to-b from-(--color-surface-page) via-emerald-500/[0.03] to-(--color-surface-page) text-(--color-text-primary)">
-            <PageHeader backHref="/" variant="light" hideBackButton />
+            <PageHeader backHref="/" variant="light" />
             {/* Hero Section */}
             <section className="relative px-6 pt-24 pb-20">
                 {/* Glow Effects */}
@@ -180,7 +180,7 @@ export default function HowItWorksPage() {
                 <div className="relative mx-auto max-w-6xl">
                     {/* Desktop Connected Path */}
                     <motion.div
-                        className="no-scrollbar relative z-10 flex snap-x snap-mandatory flex-row gap-6 overflow-x-auto pb-6 md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-6 md:overflow-x-visible md:pb-0"
+                        className="no-scrollbar relative z-10 flex snap-x snap-mandatory flex-row gap-6 overflow-x-auto pb-6 md:grid md:grid-cols-2 md:gap-6 md:overflow-x-visible md:pb-0 lg:grid-cols-3"
                         variants={timelineContainerVariants}
                         initial="hidden"
                         whileInView="visible"
@@ -193,7 +193,7 @@ export default function HowItWorksPage() {
                                 className="w-[calc(100%-3rem)] max-w-sm flex-shrink-0 snap-center md:w-auto md:max-w-none"
                             >
                                 <div
-                                    className={`flex h-full flex-col items-center rounded-3xl border border-(--color-border-muted) bg-(--color-surface-page) p-8 mt-2 md:mt-0 text-center shadow-xs transition-all duration-500 hover:-translate-y-2 hover:shadow-xl active:scale-[0.99] ${step.borderClass}`}
+                                    className={`mt-2 flex h-full flex-col items-center rounded-3xl border border-(--color-border-muted) bg-(--color-surface-page) p-8 text-center shadow-xs transition-all duration-500 hover:-translate-y-2 hover:shadow-xl active:scale-[0.99] md:mt-0 ${step.borderClass}`}
                                 >
                                     {/* Icon Container with Floating Number Badge */}
                                     <div


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #2069 **
- **Summary:** Restored the missing back button on the "How it Works" page to maintain a consistent navigation experience across secondary pages.

## 📸 Proof of Work (Screenshots / Logs)

<img width="959" height="414" alt="Screenshot 2026-06-19 211449" src="https://github.com/user-attachments/assets/81c972c2-5aa3-4716-9b45-8cc581f941be" />

<img width="380" height="370" alt="Screenshot 2026-06-19 211501" src="https://github.com/user-attachments/assets/38e32fbd-3813-42a9-adb0-be510509caa9" />


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [x] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue 
- [x] I have pulled the latest `main` and resolved any conflicts
