### PR TITLE
refactor: extract shared pharmacy interfaces

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
 import { requireAuth, AuthenticatedRequest } from "../middleware/auth";
+import { PharmacyRpcResult, FormattedPharmacy } from "../types/pharmacy.types";
 
 const router = Router();
 
@@ -25,33 +26,6 @@ interface PharmacyRow {
     district: string | null;
     state: string | null;
     status?: "pending" | "approved" | "rejected";
-}
-
-/** Pharmacy row returned by PostGIS RPC functions */
-interface PharmacyRpcResult {
-    id: string;
-    name: string;
-    address: string;
-    district: string | null;
-    state: string | null;
-    phone_number: string | null;
-    is_verified: boolean;
-    lat: number;
-    lng: number;
-    distance: number;
-}
-
-/** Formatted pharmacy object returned in API responses */
-interface FormattedPharmacy {
-    name: string;
-    address: string;
-    lat: number;
-    lng: number;
-    distance: string;
-    phone_number: string | null;
-    is_verified: boolean;
-    district: string | null;
-    state: string | null;
 }
 
 /** Internal type used during sorting (includes raw numeric distance) */
@@ -84,73 +58,83 @@ const registerPharmacySchema = z.object({
  * Register a new pharmacy. Returns 409 if a pharmacy with the same licenseId
  * already exists to prevent duplicate entries.
  */
-router.post("/", requireAuth, async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-    const parsed = registerPharmacySchema.safeParse(req.body);
-    if (!parsed.success) {
-        res.status(400).json({ error: "Invalid pharmacy payload", issues: parsed.error.issues });
-        return;
-    }
-
-    if (!req.user) {
-        res.status(401).json({ error: "Unauthorized access" });
-        return;
-    }
-
-    const data = {
-        ...parsed.data,
-        created_by: req.user.id
-    };
-    try {
-        // Check for an existing pharmacy with the same licenseId before inserting.
-        // Without this check concurrent or repeated requests can create duplicate
-        // records for the same physical location, corrupting search results and
-        // user-facing data.
-        const { data: existing, error: lookupError } = await supabase
-            .from("pharmacies")
-            .select("id")
-            .eq("license_id", data.licenseId)
-            .maybeSingle();
-
-        if (lookupError) {
-            logger.error("Pharmacy duplicate check failed", { error: lookupError });
-            next(lookupError);
-            return;
-        }
-
-        if (existing) {
-            res.status(409).json({
-                error: "A pharmacy with this license ID is already registered",
+router.post(
+    "/",
+    requireAuth,
+    async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+        const parsed = registerPharmacySchema.safeParse(req.body);
+        if (!parsed.success) {
+            res.status(400).json({
+                error: "Invalid pharmacy payload",
+                issues: parsed.error.issues,
             });
             return;
         }
 
-        const { data: pharmacy, error: insertError } = await supabase
-            .from("pharmacies")
-            .insert({
-                name: data.name,
-                license_id: data.licenseId,
-                address: data.address,
-                district: data.district,
-                state: data.state,
-                phone_number: data.phone_number ?? null,
-                location: data.lat !== undefined && data.lng !== undefined ? `POINT(${data.lng} ${data.lat})` : null,
-                is_verified: false,
-                status: "pending",
-                created_by: data.created_by,
-            })
-            .select()
-            .single();
-
-        if (insertError) {
-            next(insertError);
+        if (!req.user) {
+            res.status(401).json({ error: "Unauthorized access" });
             return;
         }
 
-        res.status(201).json({ pharmacy });
-    } catch (err) {
-        next(err);
+        const data = {
+            ...parsed.data,
+            created_by: req.user.id,
+        };
+        try {
+            // Check for an existing pharmacy with the same licenseId before inserting.
+            // Without this check concurrent or repeated requests can create duplicate
+            // records for the same physical location, corrupting search results and
+            // user-facing data.
+            const { data: existing, error: lookupError } = await supabase
+                .from("pharmacies")
+                .select("id")
+                .eq("license_id", data.licenseId)
+                .maybeSingle();
+
+            if (lookupError) {
+                logger.error("Pharmacy duplicate check failed", { error: lookupError });
+                next(lookupError);
+                return;
+            }
+
+            if (existing) {
+                res.status(409).json({
+                    error: "A pharmacy with this license ID is already registered",
+                });
+                return;
+            }
+
+            const { data: pharmacy, error: insertError } = await supabase
+                .from("pharmacies")
+                .insert({
+                    name: data.name,
+                    license_id: data.licenseId,
+                    address: data.address,
+                    district: data.district,
+                    state: data.state,
+                    phone_number: data.phone_number ?? null,
+                    location:
+                        data.lat !== undefined && data.lng !== undefined
+                            ? `POINT(${data.lng} ${data.lat})`
+                            : null,
+                    is_verified: false,
+                    status: "pending",
+                    created_by: data.created_by,
+                })
+                .select()
+                .single();
+
+            if (insertError) {
+                next(insertError);
+                return;
+            }
+
+            res.status(201).json({ pharmacy });
+        } catch (err) {
+            next(err);
+        }
     }
-});
+);
 
 const nearestQuerySchema = z.object({
     lat: z.coerce.number().min(-90).max(90),

--- a/apps/api/src/routes/triage.ts
+++ b/apps/api/src/routes/triage.ts
@@ -9,37 +9,12 @@ import {
     MEDICINE_RAG_DISCLAIMER,
     type MedicineMatch,
 } from "../services/medicineRag.service";
+import { PharmacyRpcResult, FormattedPharmacy } from "../types/pharmacy.types";
 
 const router = Router();
 
 /** Maximum number of pharmacies returned alongside a recommendation. */
 const MAX_PHARMACY_RESULTS = 5;
-
-/** Pharmacy row as returned by the get_nearest_pharmacies RPC. */
-interface PharmacyRpcResult {
-    name: string;
-    address: string;
-    district: string | null;
-    state: string | null;
-    phone_number: string | null;
-    is_verified: boolean;
-    lat: number;
-    lng: number;
-    distance: number;
-}
-
-/** Formatted pharmacy object returned in triage responses. */
-interface FormattedPharmacy {
-    name: string;
-    address: string;
-    lat: number;
-    lng: number;
-    distance: string;
-    phone_number: string | null;
-    is_verified: boolean;
-    district: string | null;
-    state: string | null;
-}
 
 function formatPharmacy(p: PharmacyRpcResult): FormattedPharmacy {
     return {

--- a/apps/api/src/types/pharmacy.types.ts
+++ b/apps/api/src/types/pharmacy.types.ts
@@ -1,0 +1,25 @@
+/** Pharmacy row as returned by the get_nearest_pharmacies RPC. */
+export interface PharmacyRpcResult {
+    name: string;
+    address: string;
+    district: string | null;
+    state: string | null;
+    phone_number: string | null;
+    is_verified: boolean;
+    lat: number;
+    lng: number;
+    distance: number;
+}
+
+/** Formatted pharmacy object returned in triage responses. */
+export interface FormattedPharmacy {
+    name: string;
+    address: string;
+    lat: number;
+    lng: number;
+    distance: string;
+    phone_number: string | null;
+    is_verified: boolean;
+    district: string | null;
+    state: string | null;
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #1947 **
- **Summary:**
  - Created a `pharmacy.types.ts` file and moved the `PharmacyRpcResult` and `FormattedPharmacy` interfaces into it.
  - Updated `triage.ts` and `pharmacies.ts` to import the shared interfaces.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #1947`)
- [x] I have pulled the latest `main` and resolved any conflicts