### PR TITLE
test(web): cover expiry notification permissions

### DIFF
--- a/apps/web/tests/expiry-tracker-notifications.test.tsx
+++ b/apps/web/tests/expiry-tracker-notifications.test.tsx
@@ -1,0 +1,136 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+
+import ExpiryTrackerPage from "../app/[locale]/expiry-tracker/page";
+
+jest.mock("next-intl", () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("../app/[locale]/components/PageHeader", () => ({
+    PageHeader: ({ title, subtitle }: { title?: string; subtitle?: string }) => (
+        <header>
+            <h1>{title}</h1>
+            <p>{subtitle}</p>
+        </header>
+    ),
+}));
+
+jest.mock("@/components/scanner/BarcodeScanner", () => ({
+    BarcodeScanner: () => <div data-testid="barcode-scanner" />,
+}));
+
+jest.mock("@/lib/api", () => ({
+    verifyMedicine: jest.fn(),
+}));
+
+jest.mock("sonner", () => ({
+    toast: {
+        success: jest.fn(),
+        warning: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+const mockedToast = toast as jest.Mocked<typeof toast>;
+
+function defineNotificationMock(permission: NotificationPermission) {
+    const requestPermission = jest.fn<Promise<NotificationPermission>, []>();
+    const notification = jest.fn() as unknown as typeof Notification;
+
+    Object.defineProperty(notification, "permission", {
+        configurable: true,
+        get: () => permission,
+    });
+    Object.defineProperty(notification, "requestPermission", {
+        configurable: true,
+        value: requestPermission,
+    });
+    Object.defineProperty(window, "Notification", {
+        configurable: true,
+        value: notification,
+    });
+    Object.defineProperty(global, "Notification", {
+        configurable: true,
+        value: notification,
+    });
+
+    return requestPermission;
+}
+
+async function waitForInitialLoad() {
+    await waitFor(() => {
+        expect(screen.queryByText("loading")).not.toBeInTheDocument();
+    });
+}
+
+describe("ExpiryTracker notification permission", () => {
+    const originalNotification = window.Notification;
+
+    beforeEach(() => {
+        localStorage.clear();
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        Object.defineProperty(window, "Notification", {
+            configurable: true,
+            value: originalNotification,
+        });
+        Object.defineProperty(global, "Notification", {
+            configurable: true,
+            value: originalNotification,
+        });
+    });
+
+    it("shows a success toast when notification permission is granted", async () => {
+        const requestPermission = defineNotificationMock("default");
+        requestPermission.mockResolvedValueOnce("granted");
+
+        render(<ExpiryTrackerPage />);
+        await waitForInitialLoad();
+
+        fireEvent.click(screen.getByRole("button", { name: /enable notifications/i }));
+
+        await waitFor(() => {
+            expect(mockedToast.success).toHaveBeenCalledWith(
+                "Notifications enabled! You will be alerted before medicines expire."
+            );
+        });
+        expect(requestPermission).toHaveBeenCalledTimes(1);
+        expect(screen.getByText(/expiry alerts enabled/i)).toBeInTheDocument();
+    });
+
+    it("shows a denied-state toast when notification permission is denied", async () => {
+        const requestPermission = defineNotificationMock("default");
+        requestPermission.mockResolvedValueOnce("denied");
+
+        render(<ExpiryTrackerPage />);
+        await waitForInitialLoad();
+
+        fireEvent.click(screen.getByRole("button", { name: /enable notifications/i }));
+
+        await waitFor(() => {
+            expect(mockedToast.error).toHaveBeenCalledWith(
+                "Notification permission denied. Please enable alerts in your browser settings."
+            );
+        });
+        expect(screen.getByRole("button", { name: /enable notifications/i })).toBeInTheDocument();
+    });
+
+    it("handles unavailable Notification API without rendering permission controls", async () => {
+        delete (window as Partial<Window>).Notification;
+        delete (global as { Notification?: typeof Notification }).Notification;
+
+        render(<ExpiryTrackerPage />);
+        await waitForInitialLoad();
+
+        expect(screen.queryByRole("button", { name: /enable notifications/i })).toBeNull();
+        expect(screen.queryByRole("heading", { name: /enable expiry alerts/i })).toBeNull();
+        expect(mockedToast.success).not.toHaveBeenCalled();
+        expect(mockedToast.error).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #1956**
- **Summary:** Adds Jest/jsdom tests for the expiry tracker notification permission flow, covering granted permission, denied permission, and missing Notification API behavior.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

No screenshot needed; this is a test-only change.

```bash
NODE_PATH=/home/user/sahidawa-india/apps/web/node_modules:/home/user/sahidawa-india/node_modules NODE_OPTIONS="--experimental-vm-modules" /home/user/sahidawa-india/node_modules/.bin/jest --config jest.config.cjs --runTestsByPath tests/expiry-tracker-notifications.test.tsx
# Test Suites: 1 passed, 1 total
# Tests: 3 passed, 3 total
```

Full web suite after rebasing onto latest `upstream/main` currently has unrelated upstream failures in `tests/vaccine-hub.test.tsx` and `tests/profile-page.test.tsx`; the new expiry notification tests pass.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts