### PR TITLE
perf(admin): virtualize reports list

### DIFF
--- a/apps/web/app/[locale]/admin/dashboard/page.tsx
+++ b/apps/web/app/[locale]/admin/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useCallback, useId } from "react";
+import React, { useState, useEffect, useCallback, useId, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { createBrowserClient } from "@supabase/ssr";
 import { Link } from "@/i18n/routing";
@@ -20,6 +20,7 @@ import {
     FileText,
     Activity,
 } from "lucide-react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { LiveMessage } from "@/components/ui/LiveMessage";
 import { canMutateAdminData, getAdminRoleFromSession, type AdminRole } from "@/lib/adminAuth";
 import { ADMIN_API_BASE } from "@/lib/adminApi";
@@ -666,6 +667,14 @@ function ReportsTable({
     t: ReturnType<typeof useTranslations>;
 }>) {
     const authErrorMessageId = useId();
+    const listContainerRef = useRef<HTMLDivElement>(null);
+
+    const rowVirtualizer = useVirtualizer({
+        count: reports.length,
+        getScrollElement: () => listContainerRef.current,
+        estimateSize: () => 80,
+        overscan: 5,
+    });
 
     return (
         <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
@@ -710,61 +719,129 @@ function ReportsTable({
             )}
 
             {!loading && !authError && reports.length > 0 && (
-                <table className="w-full text-left">
+                <table className="w-full text-left" style={{ tableLayout: "fixed" }}>
                     <thead>
                         <tr className="bg-slate-50 text-xs font-semibold tracking-wider text-slate-400 uppercase">
-                            <th className="px-6 py-3">{t("reports.columns.medicine")}</th>
-                            <th className="px-6 py-3">{t("reports.columns.district")}</th>
-                            <th className="px-6 py-3">{t("reports.columns.barcode")}</th>
-                            <th className="px-6 py-3">{t("reports.columns.reported")}</th>
+                            <th className="px-6 py-3" style={{ width: "28%" }}>
+                                {t("reports.columns.medicine")}
+                            </th>
+                            <th className="px-6 py-3" style={{ width: "20%" }}>
+                                {t("reports.columns.district")}
+                            </th>
+                            <th className="px-6 py-3" style={{ width: "20%" }}>
+                                {t("reports.columns.barcode")}
+                            </th>
+                            <th className="px-6 py-3" style={{ width: "12%" }}>
+                                {t("reports.columns.reported")}
+                            </th>
                             {canMutate && (
-                                <th className="px-6 py-3">{t("reports.columns.actions")}</th>
+                                <th className="px-6 py-3" style={{ width: "20%" }}>
+                                    {t("reports.columns.actions")}
+                                </th>
                             )}
                         </tr>
                     </thead>
-                    <tbody className="divide-y divide-slate-100">
-                        {reports.map((r) => (
-                            <tr key={r.id} className="transition-colors hover:bg-slate-50/60">
-                                <td className="px-6 py-3 font-medium text-slate-800">
-                                    {r.reported_brand_name ?? r.medicines?.brand_name ?? "—"}
-                                </td>
-                                <td className="px-6 py-3 text-sm text-slate-600">
-                                    {r.district ?? "—"}
-                                </td>
-                                <td className="px-6 py-3">
-                                    <span className="rounded bg-slate-100 px-2 py-0.5 font-mono text-xs">
-                                        {r.scanned_barcode ?? "N/A"}
-                                    </span>
-                                </td>
-                                <td className="px-6 py-3 text-sm text-slate-400">
-                                    {timeAgo(r.created_at)}
-                                </td>
-                                {canMutate && (
-                                    <td className="px-6 py-3">
-                                        <div className="flex gap-2">
-                                            <ActionBtn
-                                                label={t("actions.markFake")}
-                                                icon={XCircle}
-                                                color="red"
-                                                loading={acting === r.id + "verified_fake"}
-                                                disabled={!!acting?.startsWith(r.id)}
-                                                onClick={() => onAction(r.id, "verified_fake")}
-                                            />
-                                            <ActionBtn
-                                                label={t("actions.falseAlarm")}
-                                                icon={CheckCircle}
-                                                color="green"
-                                                loading={acting === r.id + "false_alarm"}
-                                                disabled={!!acting?.startsWith(r.id)}
-                                                onClick={() => onAction(r.id, "false_alarm")}
-                                            />
-                                        </div>
-                                    </td>
-                                )}
-                            </tr>
-                        ))}
-                    </tbody>
                 </table>
+            )}
+
+            {!loading && !authError && reports.length > 0 && (
+                <div ref={listContainerRef} className="overflow-auto" style={{ height: "600px" }}>
+                    <div
+                        style={{
+                            height: `${rowVirtualizer.getTotalSize()}px`,
+                            position: "relative",
+                        }}
+                    >
+                        {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                            const r = reports[virtualRow.index];
+                            return (
+                                <div
+                                    key={r.id}
+                                    style={{
+                                        position: "absolute",
+                                        top: 0,
+                                        left: 0,
+                                        width: "100%",
+                                        transform: `translateY(${virtualRow.start}px)`,
+                                    }}
+                                >
+                                    <table
+                                        className="w-full text-left"
+                                        style={{ tableLayout: "fixed" }}
+                                    >
+                                        <tbody>
+                                            <tr className="border-b border-slate-100 transition-colors hover:bg-slate-50/60">
+                                                <td
+                                                    className="px-6 py-3 font-medium text-slate-800"
+                                                    style={{ width: "28%" }}
+                                                >
+                                                    {r.reported_brand_name ??
+                                                        r.medicines?.brand_name ??
+                                                        "—"}
+                                                </td>
+                                                <td
+                                                    className="px-6 py-3 text-sm text-slate-600"
+                                                    style={{ width: "20%" }}
+                                                >
+                                                    {r.district ?? "—"}
+                                                </td>
+                                                <td className="px-6 py-3" style={{ width: "20%" }}>
+                                                    <span className="rounded bg-slate-100 px-2 py-0.5 font-mono text-xs">
+                                                        {r.scanned_barcode ?? "N/A"}
+                                                    </span>
+                                                </td>
+                                                <td
+                                                    className="px-6 py-3 text-sm text-slate-400"
+                                                    style={{ width: "12%" }}
+                                                >
+                                                    {timeAgo(r.created_at)}
+                                                </td>
+                                                {canMutate && (
+                                                    <td
+                                                        className="px-6 py-3"
+                                                        style={{ width: "20%" }}
+                                                    >
+                                                        <div className="flex gap-2">
+                                                            <ActionBtn
+                                                                label={t("actions.markFake")}
+                                                                icon={XCircle}
+                                                                color="red"
+                                                                loading={
+                                                                    acting ===
+                                                                    r.id + "verified_fake"
+                                                                }
+                                                                disabled={
+                                                                    !!acting?.startsWith(r.id)
+                                                                }
+                                                                onClick={() =>
+                                                                    onAction(r.id, "verified_fake")
+                                                                }
+                                                            />
+                                                            <ActionBtn
+                                                                label={t("actions.falseAlarm")}
+                                                                icon={CheckCircle}
+                                                                color="green"
+                                                                loading={
+                                                                    acting === r.id + "false_alarm"
+                                                                }
+                                                                disabled={
+                                                                    !!acting?.startsWith(r.id)
+                                                                }
+                                                                onClick={() =>
+                                                                    onAction(r.id, "false_alarm")
+                                                                }
+                                                            />
+                                                        </div>
+                                                    </td>
+                                                )}
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
             )}
         </div>
     );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
         "@supabase/auth-helpers-nextjs": "^0.15.0",
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.106.2",
+        "@tanstack/react-virtual": "^3.14.3",
         "@upstash/ratelimit": "^2.0.8",
         "@upstash/redis": "^1.38.0",
         "@zxing/browser": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
                 "@supabase/auth-helpers-nextjs": "^0.15.0",
                 "@supabase/ssr": "^0.10.3",
                 "@supabase/supabase-js": "^2.106.2",
+                "@tanstack/react-virtual": "^3.14.3",
                 "@upstash/ratelimit": "^2.0.8",
                 "@upstash/redis": "^1.38.0",
                 "@zxing/browser": "^0.2.0",
@@ -2873,6 +2874,33 @@
                 "@tailwindcss/oxide": "4.3.0",
                 "postcss": "^8.5.10",
                 "tailwindcss": "4.3.0"
+            }
+        },
+        "node_modules/@tanstack/react-virtual": {
+            "version": "3.14.3",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
+            "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/virtual-core": "3.17.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@tanstack/virtual-core": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
+            "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
         "node_modules/@testing-library/dom": {


### PR DESCRIPTION
Here's your filled-out PR description:

### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #2082**
- **Summary:** Virtualized the reports list in the Admin Dashboard using `@tanstack/react-virtual`. Only visible rows are now rendered in the DOM, preventing layout bloat when hundreds of reports are loaded. Also added explicit column widths (`table-layout: fixed`) on both the header table and each virtual row table to keep columns in sync across the split `<table>` elements.

## 🏷️ PR Type
- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #2082`)
- [x] I have pulled the latest `main` and resolved any conflicts