### PR TITLE
fix(ml): handle darwin ru_maxrss units

### DIFF
--- a/apps/ml/services/telemetry.py
+++ b/apps/ml/services/telemetry.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 import time
 import tracemalloc
 from typing import Any
@@ -80,6 +81,8 @@ def get_memory_usage_mb() -> float:
         import resource
 
         usage = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        if sys.platform == "darwin":
+            return usage / (1024 * 1024)
         if os.name == "posix":
             return usage / 1024
         return usage / (1024 * 1024)

--- a/apps/ml/tests/test_telemetry.py
+++ b/apps/ml/tests/test_telemetry.py
@@ -2,12 +2,14 @@ import logging
 import os
 import sys
 import time
+from types import SimpleNamespace
 
 import numpy as np
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+from services import telemetry
 from services.telemetry import (
     get_audio_duration_seconds,
     log_transcription_finished,
@@ -34,3 +36,33 @@ def test_log_transcription_finished_outputs_latency_message(caplog):
     assert "transcription finished in" in caplog.text
     assert "for 2.00 seconds of audio clip" in caplog.text
     assert "memory" in caplog.text
+
+
+def test_get_memory_usage_resource_fallback_converts_darwin_bytes(monkeypatch):
+    usage_bytes = 100 * 1024 * 1024
+    resource_stub = SimpleNamespace(
+        RUSAGE_SELF=object(),
+        getrusage=lambda _: SimpleNamespace(ru_maxrss=usage_bytes),
+    )
+
+    monkeypatch.setitem(sys.modules, "psutil", None)
+    monkeypatch.setitem(sys.modules, "resource", resource_stub)
+    monkeypatch.setattr(telemetry.os, "name", "posix")
+    monkeypatch.setattr(sys, "platform", "darwin")
+
+    assert telemetry.get_memory_usage_mb() == 100
+
+
+def test_get_memory_usage_resource_fallback_keeps_linux_kilobytes(monkeypatch):
+    usage_kb = 100 * 1024
+    resource_stub = SimpleNamespace(
+        RUSAGE_SELF=object(),
+        getrusage=lambda _: SimpleNamespace(ru_maxrss=usage_kb),
+    )
+
+    monkeypatch.setitem(sys.modules, "psutil", None)
+    monkeypatch.setitem(sys.modules, "resource", resource_stub)
+    monkeypatch.setattr(telemetry.os, "name", "posix")
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    assert telemetry.get_memory_usage_mb() == 100


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2096**
- **Summary:**
  Fixes ML telemetry memory reporting on macOS by handling Darwin's `resource.ru_maxrss` byte units separately. Linux and other POSIX platforms keep the existing KB conversion path.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

ML-only change; terminal proof:

```bash
python -m pytest --noconftest apps/ml/tests/test_telemetry.py -q
# 4 passed
```

```bash
python -m py_compile apps/ml/services/telemetry.py apps/ml/tests/test_telemetry.py
# passed
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
