### PR TITLE
fix: strictly type sub and data parameters in alert-broadcaster.ts (#1976)

### DIFF
--- a/apps/api/src/cron/alert-broadcaster.ts
+++ b/apps/api/src/cron/alert-broadcaster.ts
@@ -2,13 +2,14 @@ import { supabase, dbConfig } from "../db/client";
 import { smsService } from "../services/sms-service";
 import { whatsappService } from "../services/whatsapp-service";
 import logger from "../utils/logger";
+import { NotificationSubscriber, NotificationAlertData } from "../types/notification.types";
 
 let intervalId: NodeJS.Timeout | null = null;
 const CHECK_INTERVAL_MS = process.env.NODE_ENV === "test" ? 1000 : 30000; // 30 seconds
 
 export function getLocalizedMessage(
     type: "counterfeit" | "recall" | "expiry",
-    data: { medicineName: string; batchNumber?: string; district?: string; expiryDate?: string },
+    data: NotificationAlertData,
     language: string
 ): { title: string; body: string } {
     const lang = language.toLowerCase();
@@ -74,9 +75,9 @@ export function getLocalizedMessage(
 }
 
 async function sendNotificationToSubscriber(
-    sub: any,
+    sub: NotificationSubscriber,
     type: "counterfeit" | "recall" | "expiry",
-    data: any
+    data: NotificationAlertData
 ): Promise<void> {
     const { title, body } = getLocalizedMessage(type, data, sub.language);
     const fullMessage = `${title}\n\n${body}`;

--- a/apps/api/src/types/notification.types.ts
+++ b/apps/api/src/types/notification.types.ts
@@ -1,0 +1,15 @@
+export interface NotificationSubscriber {
+    id: string;
+    phone: string;
+    language: string;
+    channels: ("sms" | "whatsapp")[];
+    district?: string;
+    is_active: boolean;
+}
+
+export interface NotificationAlertData {
+    medicineName: string;
+    batchNumber?: string;
+    district?: string;
+    expiryDate?: string;
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #1976**
- **Summary:** Replaces `any` types for the `sub` and `data` parameters in `apps/api/src/cron/alert-broadcaster.ts` with strict interfaces. Created a new `apps/api/src/types/notification.types.ts` file containing `NotificationSubscriber` (matching the actual shape of rows from the `notification_subscribers` table — `id`, `phone`, `language`, `channels`, `district`, `is_active`) and `NotificationAlertData` (covering `medicineName`, `batchNumber`, `district`, `expiryDate` as used across counterfeit, recall, and expiry alert types). Note: this cron job broadcasts via SMS/WhatsApp rather than browser Web Push, so the types reflect the actual subscriber/payload shape used in the code rather than the `web-push` library's `PushSubscription` type.

## 📸 Proof of Work (Screenshots / Logs)
<img width="697" height="136" alt="image" src="https://github.com/user-attachments/assets/553d26df-de31-4012-a6f9-3226f2937394" />

## 🏷️ PR Type
- [x] ♻️ `type: refactor`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #1976`)
- [x] I have pulled the latest `main` and resolved any conflicts

---

**Files changed:**
- `apps/api/src/cron/alert-broadcaster.ts` — replaced `sub: any` → `sub: NotificationSubscriber`, `data: any` → `data: NotificationAlertData` in `sendNotificationToSubscriber`, and updated `getLocalizedMessage`'s `data` parameter to use `NotificationAlertData`
- `apps/api/src/types/notification.types.ts` — new file with `NotificationSubscriber` and `NotificationAlertData` interfaces