### PR TITLE
feat(web): enforce keyboard focus trapping in custom modals(closes #2090)

### DIFF
--- a/apps/web/app/[locale]/expiry-tracker/components/ExpiryModal.tsx
+++ b/apps/web/app/[locale]/expiry-tracker/components/ExpiryModal.tsx
@@ -1,5 +1,7 @@
 import { BarcodeScanner } from "@/components/scanner/BarcodeScanner";
 import { X } from "lucide-react";
+import { useRef } from "react";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 
 interface ExpiryModalProps {
     isOpen: boolean;
@@ -18,10 +20,14 @@ export function ExpiryModal({
     onScan,
     onRetry,
 }: ExpiryModalProps) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    useFocusTrap(containerRef, isOpen);
+
     if (!isOpen) return null;
 
     return (
         <div
+            ref={containerRef}
             className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
             role="dialog"
             aria-modal="true"

--- a/apps/web/app/[locale]/history/ExportModal.tsx
+++ b/apps/web/app/[locale]/history/ExportModal.tsx
@@ -2,6 +2,7 @@
 
 import { useRef, useState } from "react";
 import { useOnClickOutside } from "@/hooks/useOnClickOutside";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { ScanHistoryEntry } from "@/lib/db/scanHistory";
 import { Download, Loader, X } from "lucide-react";
 
@@ -19,6 +20,7 @@ export default function ExportModal({ isOpen, onClose, history, t }: ExportModal
     const modalRef = useRef<HTMLDivElement>(null);
 
     useOnClickOutside(modalRef, onClose, isOpen);
+    useFocusTrap(modalRef, isOpen);
 
     if (!isOpen) return null;
 

--- a/apps/web/hooks/useFocusTrap.ts
+++ b/apps/web/hooks/useFocusTrap.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef, RefObject } from "react";
+
+/**
+ * A custom React hook to trap keyboard focus within a specific container (e.g., a modal or dialog).
+ *
+ * @param ref - React ref of the container element containing focusable children.
+ * @param enabled - Boolean indicating whether the focus trap is currently active.
+ */
+export function useFocusTrap<T extends HTMLElement>(
+    ref: RefObject<T | null>,
+    enabled: boolean = true
+) {
+    const previousActiveElement = useRef<HTMLElement | null>(null);
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        // Save the element that currently has focus, so we can restore it when the trap is disabled or unmounted
+        if (typeof document !== "undefined") {
+            previousActiveElement.current = document.activeElement as HTMLElement;
+        }
+
+        const container = ref.current;
+        if (!container) return;
+
+        // Focusable elements selector
+        const FOCUSABLE_SELECTOR =
+            'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable], [tabindex]:not([tabindex="-1"])';
+
+        // Find focusable elements
+        const getFocusableElements = (): HTMLElement[] => {
+            if (!ref.current) return [];
+            return Array.from(ref.current.querySelectorAll(FOCUSABLE_SELECTOR)) as HTMLElement[];
+        };
+
+        // Focus the first focusable element initially
+        const focusable = getFocusableElements();
+        if (focusable.length > 0) {
+            focusable[0].focus();
+        } else {
+            // Fallback: focus the container itself (should have tabindex="-1" or similar)
+            container.focus();
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== "Tab") return;
+
+            const focusableElements = getFocusableElements();
+            if (focusableElements.length === 0) {
+                event.preventDefault();
+                return;
+            }
+
+            const firstElement = focusableElements[0];
+            const lastElement = focusableElements[focusableElements.length - 1];
+            const activeElement = document.activeElement;
+
+            if (event.shiftKey) {
+                // Shift + Tab: trap focus backward
+                if (activeElement === firstElement || !container.contains(activeElement)) {
+                    lastElement.focus();
+                    event.preventDefault();
+                }
+            } else {
+                // Tab: trap focus forward
+                if (activeElement === lastElement || !container.contains(activeElement)) {
+                    firstElement.focus();
+                    event.preventDefault();
+                }
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            // Restore focus
+            if (
+                previousActiveElement.current &&
+                typeof previousActiveElement.current.focus === "function"
+            ) {
+                previousActiveElement.current.focus();
+            }
+        };
+    }, [ref, enabled]);
+}

--- a/apps/web/tests/useFocusTrap.test.tsx
+++ b/apps/web/tests/useFocusTrap.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act } from "react";
+import { createElement, createRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import { useFocusTrap } from "../hooks/useFocusTrap";
+
+interface HarnessProps {
+    enabled?: boolean;
+    targetRef: React.RefObject<HTMLDivElement | null>;
+}
+
+function Harness({ enabled = true, targetRef }: HarnessProps) {
+    useFocusTrap(targetRef, enabled);
+
+    return createElement(
+        "div",
+        { ref: targetRef, tabIndex: -1 },
+        createElement("button", { "data-testid": "btn-first" }, "First Button"),
+        createElement("input", { "data-testid": "input-middle" }),
+        createElement("button", { "data-testid": "btn-last" }, "Last Button")
+    );
+}
+
+describe("useFocusTrap", () => {
+    let root: Root;
+    let container: HTMLDivElement;
+    let fallbackButton: HTMLButtonElement;
+
+    beforeEach(() => {
+        // Set up DOM container
+        container = document.createElement("div");
+        document.body.appendChild(container);
+
+        // Add a focus target outside the trap to mock active element restoration
+        fallbackButton = document.createElement("button");
+        fallbackButton.id = "outside-button";
+        document.body.appendChild(fallbackButton);
+        fallbackButton.focus();
+
+        root = createRoot(container);
+    });
+
+    afterEach(() => {
+        act(() => {
+            root.unmount();
+        });
+        container.remove();
+        fallbackButton.remove();
+        jest.clearAllMocks();
+    });
+
+    async function renderHarness(enabled = true) {
+        const targetRef = createRef<HTMLDivElement>();
+
+        await act(async () => {
+            root.render(
+                createElement(Harness, {
+                    enabled,
+                    targetRef,
+                })
+            );
+        });
+
+        return {
+            targetRef,
+        };
+    }
+
+    it("automatically focuses the first focusable element inside the ref container on mount when enabled", async () => {
+        await renderHarness();
+
+        const firstButton = document.querySelector('[data-testid="btn-first"]') as HTMLElement;
+        expect(document.activeElement).toBe(firstButton);
+    });
+
+    it("traps Tab key so that pressing Tab on the last element wraps focus back to the first", async () => {
+        await renderHarness();
+
+        const firstButton = document.querySelector('[data-testid="btn-first"]') as HTMLElement;
+        const lastButton = document.querySelector('[data-testid="btn-last"]') as HTMLElement;
+
+        // Manually focus the last element
+        act(() => {
+            lastButton.focus();
+        });
+        expect(document.activeElement).toBe(lastButton);
+
+        // Simulate Tab key down
+        act(() => {
+            document.dispatchEvent(
+                new KeyboardEvent("keydown", {
+                    key: "Tab",
+                    bubbles: true,
+                })
+            );
+        });
+
+        expect(document.activeElement).toBe(firstButton);
+    });
+
+    it("traps Shift+Tab key so that pressing Shift+Tab on the first element wraps focus to the last", async () => {
+        await renderHarness();
+
+        const firstButton = document.querySelector('[data-testid="btn-first"]') as HTMLElement;
+        const lastButton = document.querySelector('[data-testid="btn-last"]') as HTMLElement;
+
+        // Manually focus the first element
+        act(() => {
+            firstButton.focus();
+        });
+        expect(document.activeElement).toBe(firstButton);
+
+        // Simulate Shift+Tab key down
+        act(() => {
+            document.dispatchEvent(
+                new KeyboardEvent("keydown", {
+                    key: "Tab",
+                    shiftKey: true,
+                    bubbles: true,
+                })
+            );
+        });
+
+        expect(document.activeElement).toBe(lastButton);
+    });
+
+    it("restores focus to the previously focused element when unmounted", async () => {
+        // Step 1: Focus fallbackButton outside the modal
+        act(() => {
+            fallbackButton.focus();
+        });
+        expect(document.activeElement).toBe(fallbackButton);
+
+        // Step 2: Render focus trap (should auto-focus first button)
+        await renderHarness();
+        const firstButton = document.querySelector('[data-testid="btn-first"]') as HTMLElement;
+        expect(document.activeElement).toBe(firstButton);
+
+        // Step 3: Unmount focus trap (should restore focus to fallbackButton)
+        await act(async () => {
+            root.unmount();
+        });
+
+        expect(document.activeElement).toBe(fallbackButton);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2090**
- **Summary:** Implemented keyboard focus trapping inside custom modals (`ExpiryModal` and `ExportModal`) to meet WCAG accessibility standards for dialogs. Added a reusable custom React hook `useFocusTrap` to handle focus cycle and restoration without external package dependencies.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.

**Note:** This is an accessibility behavior change for keyboard navigation (focus trapping/restoration) with no visual UI style changes. Programmatic verification logs are attached below:

### Unit Test Execution Logs
```bash
PASS tests/useFocusTrap.test.tsx
  useFocusTrap
    √ automatically focuses the first focusable element inside the ref container on mount when enabled (50 ms)
    √ traps Tab key so that pressing Tab on the last element wraps focus back to the first (13 ms)
    √ traps Shift+Tab key so that pressing Shift+Tab on the first element wraps focus to the last (7 ms)
    √ restores focus to the previously focused element when unmounted (6 ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        1.562 s
Ran all test suites matching tests/useFocusTrap.test.tsx.
```

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [x] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2090`)
- [x] I have pulled the latest `main` and resolved any conflicts

