### PR TITLE
fix: use UTC getters/setters in ICS date export

### DIFF
--- a/apps/web/app/[locale]/vaccine-hub/page.tsx
+++ b/apps/web/app/[locale]/vaccine-hub/page.tsx
@@ -91,9 +91,9 @@ export default function VaccineHubPage() {
 
         const dtstamp = new Date();
         const formatICSDate = (d: Date) =>
-            d.getFullYear().toString() +
-            String(d.getMonth() + 1).padStart(2, "0") +
-            String(d.getDate()).padStart(2, "0");
+            d.getUTCFullYear().toString() +
+            String(d.getUTCMonth() + 1).padStart(2, "0") +
+            String(d.getUTCDate()).padStart(2, "0");
 
         const formatICSDateTime = (d: Date) =>
             d.getUTCFullYear().toString() +
@@ -108,10 +108,10 @@ export default function VaccineHubPage() {
         const events = vaccine.dosing_intervals_weeks
             .map((weeks, index) => {
                 const date = new Date(initialDate);
-                date.setDate(date.getDate() + weeks * 7);
+                date.setUTCDate(date.getUTCDate() + weeks * 7);
 
                 const endDate = new Date(date);
-                endDate.setDate(endDate.getDate() + 1);
+                endDate.setUTCDate(endDate.getUTCDate() + 1);
 
                 const uidKey = selectedVaccine || vaccine.disease_name.replace(/\s+/g, "-");
 


### PR DESCRIPTION
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- Closes #2101 

 **Summary:**

Fixes an off-by-one date bug in the "Export to Calendar" feature on the vaccine hub page. new Date(initialDate) parses date-only strings as UTC midnight, but exportToCalendar() was reading and mutating those dates with local-time methods. For users in timezones behind UTC (e.g. EST), this shifted exported .ics dates back by one day.

**Files changed**

`apps/web/app/[locale]/vaccine-hub/page.tsx`

**Changes made**

- formatICSDate: replaced getFullYear/getMonth/getDate with getUTCFullYear/getUTCMonth/getUTCDate
- Dose date offset calculation: replaced setDate/getDate with setUTCDate/getUTCDate when adding weeks
- End date calculation: replaced setDate/getDate with setUTCDate/getUTCDate when adding one day for the all-day event

## 📸 Proof of Work (Screenshots / Logs)
<img width="720" height="82" alt="Screenshot 2026-06-20 124620" src="https://github.com/user-attachments/assets/a87e2f32-f3ab-4eda-a30e-565e733983c4" />


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2101`)
- [x] I have pulled the latest `main` and resolved any conflicts
