### PR TITLE
(fix) add missing reported_brand_name field in counterfeit_reports in…

### DIFF
--- a/apps/api/src/routes/batch.ts
+++ b/apps/api/src/routes/batch.ts
@@ -401,6 +401,7 @@ router.post("/report", batchLimiter, async (req: Request, res: Response) => {
         const { error } = await supabase.from("counterfeit_reports").insert({
             medicine_id,
             scanned_barcode: batchNumber,
+            reported_brand_name: batchNumber,
             description,
             city: city ?? null,
             state: state ?? null,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #2098**
* **Summary:**
  Added the missing `reported_brand_name` field to the `counterfeit_reports` insertion payload in `apps/api/src/routes/batch.ts`.

  The duplicate/fuzzy-match validation logic in `reportValidation.service.ts` relies on `reported_brand_name` when identifying previously submitted reports. Batch reports created through `/api/verify/batch/report` were not populating this field, preventing future duplicate detection from matching those reports correctly.

  This PR stores:

  ```ts
  reported_brand_name: batchNumber
  ```

  alongside the existing batch report data.

## 📸 Proof of Work (Screenshots / Logs)

### Code Change

<img width="548" height="303" alt="image" src="https://github.com/user-attachments/assets/a9e455c8-9f4a-42c0-9173-cfc454bd1105" />

* Screenshot showing the added line:

  ```ts
  reported_brand_name: batchNumber,
  ```

### Validation
<img width="488" height="76" alt="image" src="https://github.com/user-attachments/assets/47861a28-2e7a-488c-96f4-ae3b05e46b1c" />

* API starts successfully using:

  ```bash
  npm run dev -w sahidawa-api
  ```

* Tested `/api/verify/batch/report` endpoint via Swagger.

* Local database testing is currently blocked because the configured Supabase environment returns:

  ```text
  PGRST205:
  Could not find the table 'public.counterfeit_reports' in the schema cache
  ```

  This environment issue is unrelated to the code change introduced in this PR.

## 🏷️ PR Type

* [x] 🐛 `type: bug`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2098`)
* [x] I have pulled the latest `main` and resolved any conflicts
