### PR TITLE
fix: handle unknown websocket control messages

### DIFF
--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -939,6 +939,12 @@ async def stream_transcription(websocket: WebSocket):
                     await websocket.close()
                     return
 
+                await websocket.send_json(
+                    {"type": "error", "error": "Unknown control message type."}
+                )
+                await websocket.close(code=1003)
+                return
+
     except HTTPException as exc:
         await websocket.send_json({"type": "error", "error": exc.detail})
         await websocket.close(code=1011)


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2097 **
- **Summary:**
  - Fixed a WebSocket edge case in `apps/ml/routers/asr.py`.
  - Added handling for unsupported control message types during streaming transcription.
  - The endpoint now returns a structured error response and closes the connection gracefully instead of leaving the session open.
  - Prevents unexpected client messages from causing undefined behavior in the streaming ASR flow.

## 📸 Proof of Work (Screenshots / Logs)

> Backend change (no UI changes).

### Manual Verification
- Started WebSocket streaming session successfully.
- Sent valid `"start"` message → received `"ready"` response.
- Sent valid `"stop"` message → received `"final"` response and connection closed normally.
- Sent unsupported control message type → received:
```json
{
  "type": "error",
  "error": "Unknown control message type."
}
```
- Connection closed with code `1003` as expected.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2097 `)
- [x] I have pulled the latest `main` and resolved any conflicts