### PR TITLE
fix: preserve locale in offline error boundary home link

### DIFF
--- a/apps/web/components/OfflineErrorBoundary.tsx
+++ b/apps/web/components/OfflineErrorBoundary.tsx
@@ -82,6 +82,10 @@ export class OfflineErrorBoundary extends React.Component<
     };
 
     render() {
+        const homeHref =
+            typeof window !== "undefined"
+                ? `/${window.location.pathname.split("/")[1] || "en"}`
+                : "/";
         if (this.state.hasError) {
             return (
                 <>
@@ -89,7 +93,10 @@ export class OfflineErrorBoundary extends React.Component<
                         <div className="max-w-md rounded-2xl border border-slate-200 bg-white p-8 text-center shadow-lg dark:border-slate-700 dark:bg-slate-900">
                             <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-amber-100 ring-4 ring-amber-50 dark:bg-amber-900/20 dark:ring-amber-900/10">
                                 {this.state.isOfflineError ? (
-                                    <Wifi size={32} className="text-amber-600 dark:text-amber-400" />
+                                    <Wifi
+                                        size={32}
+                                        className="text-amber-600 dark:text-amber-400"
+                                    />
                                 ) : (
                                     <AlertTriangle
                                         size={32}
@@ -99,7 +106,9 @@ export class OfflineErrorBoundary extends React.Component<
                             </div>
 
                             <h2 className="mb-2 text-lg font-bold text-slate-900 dark:text-white">
-                                {this.state.isOfflineError ? "Connection Lost" : "Something Went Wrong"}
+                                {this.state.isOfflineError
+                                    ? "Connection Lost"
+                                    : "Something Went Wrong"}
                             </h2>
 
                             <p
@@ -122,7 +131,7 @@ export class OfflineErrorBoundary extends React.Component<
                                 </button>
 
                                 <a
-                                    href="/"
+                                    href={homeHref}
                                     className="flex-1 rounded-lg bg-slate-200 px-4 py-2 text-center font-semibold text-slate-900 transition-colors hover:bg-slate-300 dark:bg-slate-700 dark:text-white dark:hover:bg-slate-600"
                                 >
                                     Go Home
@@ -131,17 +140,16 @@ export class OfflineErrorBoundary extends React.Component<
                         </div>
                     </div>
 
-                    {process.env.NODE_ENV === "development" &&
-                        this.state.componentStack && (
-                            <details className="mt-6 text-left">
-                                <summary className="cursor-pointer text-sm font-semibold text-slate-700 dark:text-slate-300">
-                                    Developer Error Details
-                                </summary>
+                    {process.env.NODE_ENV === "development" && this.state.componentStack && (
+                        <details className="mt-6 text-left">
+                            <summary className="cursor-pointer text-sm font-semibold text-slate-700 dark:text-slate-300">
+                                Developer Error Details
+                            </summary>
 
-                                <pre className="mt-2 max-h-40 overflow-auto rounded bg-slate-100 p-3 text-xs dark:bg-slate-800">
-                                    {this.state.componentStack}
-                                </pre>
-                            </details>
+                            <pre className="mt-2 max-h-40 overflow-auto rounded bg-slate-100 p-3 text-xs dark:bg-slate-800">
+                                {this.state.componentStack}
+                            </pre>
+                        </details>
                     )}
                 </>
             );


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2103 **
- **Summary:**
  - Fixed locale-aware navigation in `OfflineErrorBoundary`.
  - Replaced the hardcoded home link (`/`) with a dynamically generated localized home route based on the current pathname.
  - Preserves the user's active locale when navigating from the error fallback screen.

## 📸 Proof of Work (Screenshots / Logs)

### Test Cases

| Current Page | Go Home Result |
|-------------|---------------|
| `/hi/offline` | `/hi` |
| `/ta/offline` | `/ta` |
| `/en/offline` | `/en` |

### Verification

```bash
npm run lint
```

Output:

```text
✓ No lint errors
```

### Files Changed

```text
apps/web/components/OfflineErrorBoundary.tsx
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2103 `)
- [x] I have pulled the latest `main` and resolved any conflicts