### PR TITLE
Fix : Background sync listener unregistered prematurely on Report Wizard unmount

### DIFF
--- a/apps/web/components/ServiceWorkerProvider.tsx
+++ b/apps/web/components/ServiceWorkerProvider.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { toast } from "sonner";
+import { initBackgroundSync } from "@/lib/backgroundSync";
 
 /**
  * ServiceWorkerProvider
@@ -69,6 +70,19 @@ export function ServiceWorkerProvider({ children }: { children: React.ReactNode 
         return () => {
             if (updateInterval) clearInterval(updateInterval);
         };
+    }, []);
+
+    // Global background sync for offline reports
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const cleanup = initBackgroundSync((count) => {
+            toast.success(
+                `${count} pending report${count > 1 ? "s" : ""} submitted now that you're back online.`
+            );
+            // Dispatch a custom event so active pages (like ReportWizard) can update their UI
+            window.dispatchEvent(new CustomEvent("reports-synced", { detail: { count } }));
+        });
+        return cleanup;
     }, []);
 
     return <>{children}</>;

--- a/apps/web/components/reports/ReportWizard.tsx
+++ b/apps/web/components/reports/ReportWizard.tsx
@@ -32,7 +32,6 @@ import {
     queueReport,
     getPendingCount,
 } from "@/lib/offlineStorage";
-import { initBackgroundSync } from "@/lib/backgroundSync";
 
 // ─── Cloudinary env ────────────────────────────────────────────────────────────
 // Uploads are now securely routed through our backend API (/api/upload),
@@ -875,16 +874,16 @@ export default function ReportWizard() {
         if (medicineId) setValue("medicineId", medicineId);
     }, [searchParams, setValue]);
 
-    // Background sync of queued offline reports
+    // Initialize pending count and listen for global sync events
     useEffect(() => {
-        const cleanup = initBackgroundSync((count) => {
-            toast.success(
-                `${count} pending report${count > 1 ? "s" : ""} submitted now that you're back online.`
-            );
-            setPendingCount((c) => Math.max(0, c - count));
-        });
         void getPendingCount().then(setPendingCount);
-        return cleanup;
+
+        const handleSynced = (e: Event) => {
+            const count = (e as CustomEvent).detail?.count || 0;
+            setPendingCount((c) => Math.max(0, c - count));
+        };
+        window.addEventListener("reports-synced", handleSynced);
+        return () => window.removeEventListener("reports-synced", handleSynced);
     }, []);
 
     // Autosave draft as the user fills the form (skip until initial restore is done)


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2108 **
- **Summary:**
-  Global Syncing `(ServiceWorkerProvider.tsx)`: The `initBackgroundSync` hook is now initialized when the Service Worker provider mounts on the root layout. This ensures that whenever the user regains internet connectivity—regardless of which page they are on—any pending reports saved locally will auto-sync and they will be notified with a success toast.
- Local UI Fallback (`ReportWizard.tsx`): I removed `initBackgroundSync` from the wizard component. However, the wizard still loads the pending count locally, and it now listens for a new "reports-synced" custom event dispatched by the global provider so that the "pending sync" UI badge instantly reflects changes if the user happens to have the wizard page open while coming back online.
## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
