### PR TITLE
feat: add medicine info copy action

### DIFF
--- a/apps/web/components/ExpandableDetails.tsx
+++ b/apps/web/components/ExpandableDetails.tsx
@@ -3,10 +3,21 @@ import { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { VerifiedMedicine } from "@/lib/api";
+import { CopyButton } from "@/components/ui/CopyButton";
 
 export function ExpandableDetails({ medicine }: { medicine: VerifiedMedicine }) {
     const [expanded, setExpanded] = useState(false);
     const tScan = useTranslations("Scan");
+    const copyText = [
+        `Brand: ${medicine.brand_name}`,
+        `Generic: ${medicine.generic_name}`,
+        `Manufacturer: ${medicine.manufacturer}`,
+        `Batch: ${medicine.batch_number}`,
+        medicine.dosage_form ? `Dosage Form: ${medicine.dosage_form}` : null,
+        medicine.composition ? `Composition: ${medicine.composition}` : null,
+    ]
+        .filter(Boolean)
+        .join("\n");
 
     return (
         <div className="w-full">
@@ -22,30 +33,38 @@ export function ExpandableDetails({ medicine }: { medicine: VerifiedMedicine }) 
             </button>
 
             {expanded && (
-                <div className="mt-3 grid w-full grid-cols-2 gap-3">
-                    <div className="rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) p-3">
-                        <span className="block text-[10px] font-bold tracking-wider text-(--color-text-muted) uppercase">
-                            {tScan("genericName")}
+                <div className="mt-3 space-y-3">
+                    <div className="flex items-center justify-between rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) px-3 py-2">
+                        <span className="text-[10px] font-bold tracking-wider text-(--color-text-muted) uppercase">
+                            Medicine Info
                         </span>
-                        <span className="text-sm font-bold text-(--color-text-primary)">
-                            {medicine.generic_name}
-                        </span>
+                        <CopyButton text={copyText} toastMessage="Medicine info copied!" />
                     </div>
-                    <div className="rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) p-3">
-                        <span className="block text-[10px] font-bold tracking-wider text-(--color-text-muted) uppercase">
-                            {tScan("dosageForm")}
-                        </span>
-                        <span className="text-sm font-bold text-(--color-text-primary)">
-                            {medicine.dosage_form ?? "N/A"}
-                        </span>
-                    </div>
-                    <div className="col-span-2 rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) p-3">
-                        <span className="block text-[10px] font-bold tracking-wider text-(--color-text-muted) uppercase">
-                            {tScan("composition")}
-                        </span>
-                        <span className="text-sm font-bold text-(--color-text-primary)">
-                            {medicine.composition ?? "N/A"}
-                        </span>
+                    <div className="grid w-full grid-cols-2 gap-3">
+                        <div className="rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) p-3">
+                            <span className="block text-[10px] font-bold tracking-wider text-(--color-text-muted) uppercase">
+                                {tScan("genericName")}
+                            </span>
+                            <span className="text-sm font-bold text-(--color-text-primary)">
+                                {medicine.generic_name}
+                            </span>
+                        </div>
+                        <div className="rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) p-3">
+                            <span className="block text-[10px] font-bold tracking-wider text-(--color-text-muted) uppercase">
+                                {tScan("dosageForm")}
+                            </span>
+                            <span className="text-sm font-bold text-(--color-text-primary)">
+                                {medicine.dosage_form ?? "N/A"}
+                            </span>
+                        </div>
+                        <div className="col-span-2 rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) p-3">
+                            <span className="block text-[10px] font-bold tracking-wider text-(--color-text-muted) uppercase">
+                                {tScan("composition")}
+                            </span>
+                            <span className="text-sm font-bold text-(--color-text-primary)">
+                                {medicine.composition ?? "N/A"}
+                            </span>
+                        </div>
                     </div>
                 </div>
             )}

--- a/apps/web/tests/expandable-details.test.tsx
+++ b/apps/web/tests/expandable-details.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ExpandableDetails } from "../components/ExpandableDetails";
+
+jest.mock("next-intl", () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+describe("ExpandableDetails", () => {
+    const medicine = {
+        brand_name: "Crocin",
+        generic_name: "Paracetamol",
+        manufacturer: "GSK",
+        batch_number: "BATCH-001",
+        dosage_form: "Tablet",
+        composition: "Paracetamol 500mg",
+    } as any;
+
+    it("shows a medicine info copy button when expanded", async () => {
+        const user = userEvent.setup();
+        render(<ExpandableDetails medicine={medicine} />);
+
+        await user.click(screen.getByRole("button", { name: "showMoreDetails" }));
+
+        expect(screen.getByRole("button", { name: /copy to clipboard/i })).toBeInTheDocument();
+        expect(screen.getByText("Paracetamol")).toBeInTheDocument();
+        expect(screen.getByText("Paracetamol 500mg")).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary\n- Add a medicine info copy control to the expanded scan details panel\n- Reuse the existing CopyButton component to copy a formatted summary\n- Add a focused test covering the expanded copy action\n\n## Validation\n- git diff --check\n- npm test -w web -- --runInBand apps/web/tests/expandable-details.test.tsx