### PR TITLE
fix(asr): enforce stream duration limit and wall-clock timeout

### DIFF
--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -1,9 +1,11 @@
 from __future__ import annotations  # MUST BE LINE 1
 
+import asyncio
 import io
 import json
 import logging
 import os
+import time
 import subprocess
 import tempfile
 import threading
@@ -863,7 +865,10 @@ async def stream_transcription(websocket: WebSocket):
 
     try:
         # ---- handshake ----
-        start_message = await websocket.receive()
+        session_start = time.monotonic()
+        MAX_SESSION_WALL_SECONDS = 120.0
+
+        start_message = await asyncio.wait_for(websocket.receive(), timeout=5.0)
 
         if "text" not in start_message or not start_message["text"]:
             await websocket.send_json(
@@ -901,7 +906,24 @@ async def stream_transcription(websocket: WebSocket):
 
         # ---- main loop ----
         while True:
-            message = await websocket.receive()
+            time_left = max(0.0, MAX_SESSION_WALL_SECONDS - (time.monotonic() - session_start))
+            if time_left <= 0:
+                await websocket.send_json({
+                    "type": "error",
+                    "error": "Streaming session timed out."
+                })
+                await websocket.close(code=1008)
+                return
+
+            try:
+                message = await asyncio.wait_for(websocket.receive(), timeout=time_left)
+            except asyncio.TimeoutError:
+                await websocket.send_json({
+                    "type": "error",
+                    "error": "Streaming session timed out."
+                })
+                await websocket.close(code=1008)
+                return
 
             if message.get("type") == "websocket.disconnect":
                 return
@@ -912,6 +934,17 @@ async def stream_transcription(websocket: WebSocket):
                     mime_type=mime_type,
                     language=language,
                 )
+
+                if session.total_audio_seconds > MAX_TRANSCRIPTION_DURATION_SECONDS:
+                    final = session.finalize(mime_type=mime_type, language=language)
+                    await websocket.send_json({
+                        "type": "error",
+                        "error": f"Streaming session exceeded maximum duration of {MAX_TRANSCRIPTION_DURATION_SECONDS}s.",
+                        **final,
+                    })
+                    await websocket.close(code=1009)
+                    return
+
                 if partial:
                     await websocket.send_json({"type": "partial", **partial})
                 continue

--- a/apps/ml/tests/test_asr_duration.py
+++ b/apps/ml/tests/test_asr_duration.py
@@ -142,3 +142,48 @@ def test_post_transcode_duration_guard_rejects_over_limit_non_wav(monkeypatch):
     assert exc.value.status_code == 400
     assert exc.value.detail == "Uploaded audio must be 60 seconds or shorter."
     assert model_loaded is False
+
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+def test_stream_duration_guard_rejects_over_limit_audio(monkeypatch):
+    from main import app
+    client = TestClient(app)
+
+    class FakeStreamingSession:
+        def __init__(self):
+            self.total_audio_seconds = 0.0
+
+        def append_and_maybe_transcribe(self, chunk, *, mime_type, language):
+            self.total_audio_seconds += 61.0
+            return None
+
+        def finalize(self, *, mime_type, language):
+            return {
+                "transcript": "Partial text",
+                "corrected_name": "",
+                "suggestion_applied": False,
+                "message": None,
+                "language": "en",
+                "languageConfidence": 0.99,
+            }
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(asr_router, "StreamingAsrSession", FakeStreamingSession)
+
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/asr/stream") as websocket:
+            websocket.send_text('{"type": "start", "mimeType": "audio/webm"}')
+            assert websocket.receive_json() == {"type": "ready"}
+
+            websocket.send_bytes(b"dummy audio data")
+
+            response = websocket.receive_json()
+            assert response["type"] == "error"
+            assert "exceeded maximum duration" in response["error"]
+            
+            websocket.receive_json()
+    
+    assert exc.value.code == 1009

--- a/apps/ml/tests/test_asr_stream.py
+++ b/apps/ml/tests/test_asr_stream.py
@@ -52,6 +52,7 @@ def test_stream_returns_partial_and_final_events(monkeypatch):
     class FakeStreamingSession:
         def __init__(self):
             self.chunk_count = 0
+            self.total_audio_seconds = 0.0
 
         def append_and_maybe_transcribe(self, chunk, *, mime_type, language):
             self.chunk_count += 1


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

##  PR Summary & Link

- **Closes #2158**
- **Summary:** Addresses the unbounded Whisper inference vulnerability on the `/asr/stream` endpoint by enforcing the existing audio limits. Adds a strict absolute timeout using `asyncio.wait_for` to disconnect idle clients, and enforces `MAX_TRANSCRIPTION_DURATION_SECONDS` against `session.total_audio_seconds` to close over-limit connections with code 1009.

##  Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

_Note: This is a backend ML service fix. The behavior was verified via unit tests ensuring the WebSocket connection gracefully rejects over-limit streams._

    apps/ml/tests/test_asr_duration.py::test_stream_duration_guard_rejects_over_limit_audio PASSED

##  PR Type

- [x] `type: bug`
- [ ]  `type: feature`
- [ ]  `type: docs`
- [x]  `type: testing`
- [x]  `type: security`
- [ ]  `type: performance`
- [ ]  `type: design`
- [ ]  `type: refactor`
- [ ]  `type: devops`
- [ ]  `type: accessibility`

##  Checklist

- [x] My PR has a linked issue (`Closes #2158`)
- [x] I have pulled the latest `main` and resolved any conflicts