### PR TITLE
feat(ui): add reusable Button component with variants and loading state

### DIFF
--- a/apps/web/components/ui/Button.tsx
+++ b/apps/web/components/ui/Button.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { clsx } from "clsx";
+
+const variants = {
+    primary:
+        "bg-emerald-600 text-white hover:bg-emerald-700 focus:ring-emerald-500 dark:bg-emerald-500 dark:hover:bg-emerald-600",
+    secondary:
+        "bg-slate-100 text-slate-900 hover:bg-slate-200 focus:ring-slate-400 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700",
+    ghost:
+        "bg-transparent text-slate-700 hover:bg-slate-100 focus:ring-slate-400 dark:text-slate-300 dark:hover:bg-slate-800",
+    danger:
+        "bg-red-600 text-white hover:bg-red-700 focus:ring-red-500 dark:bg-red-500 dark:hover:bg-red-600",
+    outline:
+        "border border-slate-300 text-slate-700 hover:bg-slate-50 focus:ring-slate-400 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800",
+};
+
+const sizes = {
+    sm: "px-3 py-1.5 text-xs",
+    md: "px-4 py-2 text-sm",
+    lg: "px-6 py-3 text-base",
+};
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: keyof typeof variants;
+    size?: keyof typeof sizes;
+    loading?: boolean;
+}
+
+export function Button({
+    variant = "primary",
+    size = "md",
+    loading = false,
+    className,
+    disabled,
+    children,
+    ...props
+}: ButtonProps) {
+    return (
+        <button
+            className={clsx(
+                "inline-flex items-center justify-center gap-2 rounded-full font-semibold transition focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+                variants[variant],
+                sizes[size],
+                className,
+            )}
+            disabled={disabled || loading}
+            {...props}
+        >
+            {loading && (
+                <svg
+                    className="h-4 w-4 animate-spin"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                >
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+            )}
+            {children}
+        </button>
+    );
+}


### PR DESCRIPTION
## Summary

Adds a reusable  component to the UI library () with multiple variants, sizes, and built-in loading state support.

### Features
- 5 variants: primary, secondary, ghost, danger, outline
- 3 sizes: sm, md, lg
- Loading spinner state
- Dark mode support
- Proper disabled state handling

Closes #2182

@gssoc26