### PR TITLE
feat(ui): add reusable Spinner component for loading states

### DIFF
--- a/apps/web/components/ui/Spinner.tsx
+++ b/apps/web/components/ui/Spinner.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { clsx } from "clsx";
+
+const sizes = {
+    sm: "h-4 w-4 border-2",
+    md: "h-6 w-6 border-2",
+    lg: "h-10 w-10 border-3",
+};
+
+const variants = {
+    primary: "border-emerald-500 border-t-transparent",
+    secondary: "border-slate-300 border-t-slate-600 dark:border-slate-600 dark:border-t-slate-300",
+    white: "border-white/30 border-t-white",
+};
+
+interface SpinnerProps {
+    size?: keyof typeof sizes;
+    variant?: keyof typeof variants;
+    label?: string;
+    className?: string;
+}
+
+export function Spinner({ size = "md", variant = "primary", label, className }: SpinnerProps) {
+    return (
+        <div
+            role="status"
+            aria-label={label || "Loading"}
+            className={clsx(
+                "inline-block animate-spin rounded-full",
+                sizes[size],
+                variants[variant],
+                className,
+            )}
+        >
+            <span className="sr-only">{label || "Loading..."}</span>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Adds a reusable  component to the UI library () for consistent loading indicators across the app.

### Features
- 3 sizes: sm, md, lg
- 3 variants: primary (emerald), secondary (slate), white (for dark backgrounds)
- Accessible: uses `role=\"status\"` and `sr-only` label
- Lightweight: just 38 lines

This replaces inline spinner implementations found in scan page, chatbot, and voice triage components.

Closes #2184

@gssoc26