### PR TITLE
feat(ui): add VisuallyHidden component for screen reader accessibility

### DIFF
--- a/apps/web/components/ui/VisuallyHidden.tsx
+++ b/apps/web/components/ui/VisuallyHidden.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { clsx } from "clsx";
+
+interface VisuallyHiddenProps {
+    as?: "span" | "div" | "label";
+    children: React.ReactNode;
+    className?: string;
+}
+
+export function VisuallyHidden({ as: Component = "span", children, className }: VisuallyHiddenProps) {
+    return (
+        <Component
+            className={clsx(
+                "absolute -m-px h-px w-px overflow-hidden border-0 p-0 whitespace-nowrap",
+                "clip-[rect(0,0,0,0)]",
+                className,
+            )}
+            style={{ clip: "rect(0,0,0,0)" }}
+        >
+            {children}
+        </Component>
+    );
+}


### PR DESCRIPTION
## Summary
Adds a reusable VisuallyHidden component (apps/web/components/ui/VisuallyHidden.tsx) for screen-reader-only content.

### Why?
- Provides semantic, self-documenting alternative to inline sr-only classes
- Polymorphic as prop (span, div, label)
- Follows Tailwind sr-only implementation pattern
- Improves accessibility discoverability

Closes #2188

@gssoc26