### PR TITLE
feat(ui): add Kbd component for keyboard shortcut display

### DIFF
--- a/apps/web/components/ui/Kbd.tsx
+++ b/apps/web/components/ui/Kbd.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { clsx } from "clsx";
+
+interface KbdProps {
+    children: React.ReactNode;
+    className?: string;
+}
+
+export function Kbd({ children, className }: KbdProps) {
+    return (
+        <kbd
+            className={clsx(
+                "inline-flex items-center justify-center rounded-md border border-slate-300 bg-slate-50 px-1.5 py-0.5 font-mono text-xs font-medium text-slate-600 shadow-sm dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300",
+                className,
+            )}
+        >
+            {children}
+        </kbd>
+    );
+}


### PR DESCRIPTION
## Summary
Adds a Kbd component (apps/web/components/ui/Kbd.tsx) for keyboard shortcut display.

### Features
- Styled like native key caps with border and shadow
- Monospace font for clarity
- Dark mode support
- Compact design for inline use

Closes #2207

@gssoc26