### PR TITLE
test: align profile page back navigation test with current UI

### DIFF
--- a/apps/web/tests/profile-page.test.tsx
+++ b/apps/web/tests/profile-page.test.tsx
@@ -21,7 +21,7 @@ describe("ProfilePage navigation and guest state", () => {
     it("renders a back-to-home link pointing at the localized home route", () => {
         render(<ProfilePage />);
 
-        const backLink = screen.getByRole("link", { name: /go back to previous page/i });
+        const backLink = screen.getByRole("link", { name: /back to home/i });
         expect(backLink).toHaveAttribute("href", "/");
     });
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #2175**
* **Summary:**

  * Updated `apps/web/tests/profile-page.test.tsx` to match the current Profile page implementation.
  * Replaced the outdated accessibility query (`Go back to previous page`) with the actual rendered link text (`Back to Home`).
  * Continued verifying that the link points to the home route (`/`).
  * No production code changes were made.

## 📸 Proof of Work (Screenshots / Logs)

Executed:

```bash
npm test -- profile-page
```

### Before
<img width="594" height="316" alt="image" src="https://github.com/user-attachments/assets/0ce4ad5e-2806-44d4-9460-5b952039a0f3" />

### After

<img width="1128" height="394" alt="image" src="https://github.com/user-attachments/assets/d5a662bc-2b0f-42c4-b72d-af9af0ca4515" />

```text
PASS tests/profile-page.test.tsx

✓ renders a back-to-home link pointing at the localized home route
✓ renders guest information on initial load when no session token exists

Test Suites: 1 passed, 1 total
Tests: 2 passed, 2 total
```


## 🏷️ PR Type

* [x] 🧪 `type: testing`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2175`)
* [x] I have pulled the latest `main` and resolved any conflicts
