### PR TITLE
fix(etl): keep CDSCO local fallback index after RPC sync

### DIFF
--- a/apps/etl/src/validators/cdsco_validator.py
+++ b/apps/etl/src/validators/cdsco_validator.py
@@ -190,8 +190,8 @@ class CDSCOValidator:
                 "norm_m": norm_m
             })
 
-            # First letter map for partitioning search space
-            if not skip_global_cache and norm_p:
+            # First letter map for partitioning search space and RPC fallback.
+            if norm_p:
                 first_char = norm_p[0]
                 if first_char not in self._first_letter_map:
                     self._first_letter_map[first_char] = []

--- a/apps/etl/tests/test_cdsco_validator_optimization.py
+++ b/apps/etl/tests/test_cdsco_validator_optimization.py
@@ -118,7 +118,7 @@ def test_cdsco_validator_syncs_remote_reference_without_retaining_local_referenc
 
     assert validator._cdsco_df is None
     assert validator._exact_product_map != {}
-    assert validator._first_letter_map == {}
+    assert validator._first_letter_map != {}
     assert getattr(validator, "_all_choices_data", []) == []
     assert client.table_calls
     assert client.table_calls[0]["table"] == "cdsco_reference"
@@ -153,6 +153,26 @@ def test_cdsco_validator_does_not_run_local_global_scan_for_empty_rpc_results(mo
     assert client.calls
     assert not bool(validated.loc[0, "is_cdsco_verified"])
     assert validated.loc[0, "matched_cdsco_product"] is None
+
+
+def test_cdsco_validator_uses_local_global_search_after_rpc_failure():
+    cdsco_data = pd.DataFrame([
+        {"brand_name": "Crocin Pain Relief", "firm_name": "GSK"},
+    ])
+    client = FakeSupabaseRpcClient(raises=TimeoutError("rpc timed out"))
+
+    validator = CDSCOValidator(threshold=80, supabase_client=client)
+    validator.load_reference(cdsco_data)
+
+    input_df = pd.DataFrame([
+        {"brand_name": "Krocin Pain Relief", "manufacturer": "GSK"},
+    ])
+    validated = validator.validate(input_df, product_col="brand_name", manufacturer_col="manufacturer")
+
+    assert client.calls
+    assert bool(validated.loc[0, "is_cdsco_verified"])
+    assert validated.loc[0, "matched_cdsco_product"] == "Crocin Pain Relief"
+    assert validated.loc[0, "matched_cdsco_manufacturer"] == "GSK"
 
 
 def test_cdsco_validator_uses_local_global_search_without_rpc_client():


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2099**
- **Summary:**
  Keeps the CDSCO local first-letter fuzzy-match index available after a successful Supabase reference sync. If the RPC later fails or is disabled, the validator can still fall back to local matching instead of returning no matches.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

![issue-2099-pytest-proof.png](https://github.com/user-attachments/assets/f48b43e6-e6ff-4fc6-b7aa-4e3b000335b9)

Verification run:

```bash
python3 -m pytest apps/etl/tests
```

Result: `26 passed, 1 warning`.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2099`)
- [x] I have pulled the latest `main` and resolved any conflicts
