### PR TITLE
perf(web): lazy load history export modal

### DIFF
--- a/apps/web/app/[locale]/history/page.tsx
+++ b/apps/web/app/[locale]/history/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 
 import {
@@ -11,10 +12,13 @@ import {
 } from "@/lib/db/scanHistory";
 import { CopyButton } from "@/components/ui/CopyButton";
 import { ClipboardList, Download, RefreshCw, Trash2 } from "lucide-react";
-import ExportModal from "./ExportModal";
 import { syncScanHistoryWithCloud } from "@/lib/scanHistoryCloudSync";
 import { EmptyState } from "@/components/ui/EmptyState";
 
+const ExportModal = dynamic(() => import("./ExportModal"), {
+    loading: () => null,
+    ssr: false,
+});
 
 export default function HistoryPage() {
     const [history, setHistory] = useState<ScanHistoryEntry[]>([]);

--- a/apps/web/tests/history-dynamic-export-modal.test.ts
+++ b/apps/web/tests/history-dynamic-export-modal.test.ts
@@ -1,0 +1,16 @@
+/** @jest-environment node */
+
+import fs from "node:fs";
+import path from "node:path";
+
+const historyPagePath = path.join(process.cwd(), "app", "[locale]", "history", "page.tsx");
+
+describe("HistoryPage export modal loading", () => {
+    it("lazy loads ExportModal instead of importing it in the initial bundle", () => {
+        const pageSource = fs.readFileSync(historyPagePath, "utf8");
+
+        expect(pageSource).toContain('import dynamic from "next/dynamic"');
+        expect(pageSource).not.toContain('import ExportModal from "./ExportModal"');
+        expect(pageSource).toContain('dynamic(() => import("./ExportModal")');
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2088**
- **Summary:**
  Moves the history page export modal behind `next/dynamic` so the modal code is split out of the initial page bundle and still opens normally when the user clicks Export to CSV.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

![issue-2088-export-modal.png](https://github.com/user-attachments/assets/5370fff2-ef2f-481b-83ea-21a0bd806abd)

Verification run:

```bash
npm run test -w web -- history-dynamic-export-modal.test.ts
npx tsc --noEmit -p apps/web/tsconfig.json
npx eslint 'apps/web/app/[locale]/history/page.tsx' apps/web/tests/history-dynamic-export-modal.test.ts
```

Browser proof: seeded one local scan-history entry, opened `/en/history`, clicked Export to CSV, and verified the export modal rendered.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2088`)
- [x] I have pulled the latest `main` and resolved any conflicts
