### PR TITLE
fix(api): add max length validation to medicines/ids in interactions.ts

### DIFF
--- a/apps/api/src/routes/interactions.ts
+++ b/apps/api/src/routes/interactions.ts
@@ -20,7 +20,8 @@ type InteractionRecord = LocalInteraction & { id?: string };
 const checkSchema = z.object({
     medicines: z
         .array(z.string())
-        .min(2, "At least two medicines are required to check interactions"),
+        .min(2, "At least two medicines are required to check interactions")
+        .max(20, "A maximum of 20 medicines can be checked at once"),
 });
 
 // Brand name to generic name static mapping for local offline fallback
@@ -243,6 +244,11 @@ router.get("/", async (req: Request, res: Response) => {
 
     if (ids.length < 2) {
         res.status(400).json({ error: "At least two medicine ids are required" });
+        return;
+    }
+
+    if (ids.length > 20) {
+        res.status(400).json({ error: "At most 20 medicine ids are allowed" });
         return;
     }
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #2163**
- **Summary:** Adds maximum-length validation to the `medicines` array in `checkSchema` (`POST /api/v1/interactions/check`) and to the parsed `ids` array in `GET /api/v1/interactions`. Both endpoints previously enforced a minimum input size but had no upper bound, so a request with an arbitrarily large `medicines`/`ids` list would be accepted and generate a quadratically growing number of pairwise interaction checks. Added `.max(20, ...)` to the Zod schema for the POST route, and a matching `ids.length > 20` check (mirroring the existing `ids.length < 2` check) for the GET route.

## 📸 Proof of Work (Screenshots / Logs)

Tested manually against a local dev server (Supabase running in offline fallback mode):

**GET /api/v1/interactions — 1 id (existing lower bound, unchanged):**
curl.exe "http://localhost:4000/api/v1/interactions?ids=a"

{"error":"At least two medicine ids are required"}

**GET /api/v1/interactions — 20 ids (boundary, should pass validation):**
curl.exe "http://localhost:4000/api/v1/interactions?ids=a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t"

{"error":"Failed to check medicine interactions","details":"Unknown error"}
(Passes the new max check and proceeds to the DB lookup, as expected — the downstream 500 is due to the ids not matching real records, unrelated to this fix.)

**GET /api/v1/interactions — 21 ids (new upper bound):**
curl.exe "http://localhost:4000/api/v1/interactions?ids=a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u"

{"error":"At most 20 medicine ids are allowed"}

**POST /api/v1/interactions/check — 21 medicines (new upper bound):**
curl.exe -X POST "http://localhost:4000/api/v1/interactions/check" -H "Content-Type: application/json" -d "@test21.json"

{"error":"Invalid request body","details":[{"origin":"array","code":"too_big","maximum":20,"inclusive":true,"path":["medicines"],"message":"A maximum of 20 medicines can be checked at once"}]}

## 🏷️ PR Type
- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts