### PR TITLE
fix: preserve LASA in-flight request deduplication

### DIFF
--- a/apps/api/src/services/lasa.service.ts
+++ b/apps/api/src/services/lasa.service.ts
@@ -103,9 +103,6 @@ export const detectLasaConflicts = async (medicineName: string): Promise<LasaMat
         }
     })();
 
-    if (inFlight.size >= MAX_INFLIGHT) {
-        inFlight.clear();
-    }
     inFlight.set(cacheKey, promise);
     return promise;
 };


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link

* **Closes #2105**
* **Summary:**

  * Removed unconditional `inFlight.clear()` when `MAX_INFLIGHT` is reached.
  * Preserved active in-flight promise deduplication during concurrency spikes.
  * Existing cleanup remains handled through the `finally` block, allowing entries to be removed naturally after resolution.

## 📸 Proof of Work (Screenshots / Logs)

### Changed File

```text
apps/api/src/services/lasa.service.ts
```
<img width="1149" height="129" alt="image" src="https://github.com/user-attachments/assets/1affd5e1-a391-4fd6-a474-6cebd4b7700d" />

### Diff Summary
<img width="517" height="71" alt="image" src="https://github.com/user-attachments/assets/194d05e9-df84-45a7-825c-fc468dc0d1ea" />

```text
1 file changed, 3 deletions(-)
```

### Behavior

Before:

* Reaching `MAX_INFLIGHT` cleared the entire `inFlight` map.
* Active deduplication entries were removed prematurely.
* Concurrent requests could trigger duplicate RPC calls.

After:

* Active promises remain tracked until completion.
* Deduplication continues to work during high concurrency.
* Cleanup still occurs via the existing `finally` block.

## 🏷️ PR Type

* [x] 🐛 type: bug
* [x] ⚡ type: performance

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2105`)
* [x] I have pulled the latest `main` and resolved any conflicts
