### PR TITLE
feat(hooks): add useLocalStorage hook for persistent client-side state

### DIFF
--- a/apps/web/hooks/useLocalStorage.ts
+++ b/apps/web/hooks/useLocalStorage.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect, useCallback } from "react";
+
+export function useLocalStorage<T>(
+    key: string,
+    initialValue: T
+): [T, (value: T | ((prev: T) => T)) => void, () => void] {
+    const [storedValue, setStoredValue] = useState<T>(initialValue);
+
+    useEffect(() => {
+        try {
+            const item = window.localStorage.getItem(key);
+            if (item !== null) {
+                setStoredValue(JSON.parse(item) as T);
+            }
+        } catch {
+            console.warn(`useLocalStorage: Error reading key "${key}"`);
+        }
+    }, [key]);
+
+    const setValue = useCallback(
+        (value: T | ((prev: T) => T)) => {
+            try {
+                setStoredValue((prev) => {
+                    const nextValue = value instanceof Function ? value(prev) : value;
+                    window.localStorage.setItem(key, JSON.stringify(nextValue));
+                    return nextValue;
+                });
+            } catch {
+                console.warn(`useLocalStorage: Error setting key "${key}"`);
+            }
+        },
+        [key]
+    );
+
+    const removeValue = useCallback(() => {
+        try {
+            window.localStorage.removeItem(key);
+            setStoredValue(initialValue);
+        } catch {
+            console.warn(`useLocalStorage: Error removing key "${key}"`);
+        }
+    }, [key, initialValue]);
+
+    return [storedValue, setValue, removeValue];
+}


### PR DESCRIPTION
## Summary

Adds a reusable `useLocalStorage` hook for persisting React state to localStorage with SSR safety. Follows the same pattern as existing hooks in `apps/web/hooks/`.

## Changes

- Created `apps/web/hooks/useLocalStorage.ts` — generic hook with:
  - SSR-safe initialization (reads from localStorage on mount only)
  - JSON serialization/deserialization
  - Functional updates (`setValue(prev => prev + 1)`)
  - `removeValue` helper for clearing stored keys
  - Graceful error handling (console.warn on quota/storage errors)

## Related Issue

Closes #2261

---

**GSSoC 2026** — gssoc26
