### PR TITLE
feat(hooks): add useCopyToClipboard hook with fallback support

### DIFF
--- a/apps/web/hooks/useCopyToClipboard.ts
+++ b/apps/web/hooks/useCopyToClipboard.ts
@@ -1,0 +1,38 @@
+import { useState, useCallback } from "react";
+
+interface CopyToClipboardState {
+    value: string;
+    success: boolean | null;
+}
+
+export function useCopyToClipboard(): [
+    CopyToClipboardState,
+    (text: string) => Promise<void>
+] {
+    const [state, setState] = useState<CopyToClipboardState>({
+        value: "",
+        success: null,
+    });
+
+    const copy = useCallback(async (text: string) => {
+        try {
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(text);
+            } else {
+                const textarea = document.createElement("textarea");
+                textarea.value = text;
+                textarea.style.position = "fixed";
+                textarea.style.opacity = "0";
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand("copy");
+                document.body.removeChild(textarea);
+            }
+            setState({ value: text, success: true });
+        } catch {
+            setState({ value: text, success: false });
+        }
+    }, []);
+
+    return [state, copy];
+}


### PR DESCRIPTION
## Summary

Adds a reusable `useCopyToClipboard` hook with modern API and legacy fallback. This consolidates clipboard logic that was previously duplicated across components.

## Changes

- Created `apps/web/hooks/useCopyToClipboard.ts` with:
  - `navigator.clipboard.writeText()` for secure contexts
  - `document.execCommand('copy')` fallback for non-HTTPS
  - Success/failure state tracking for toast feedback
  - Proper cleanup of temporary DOM elements

## Related Issue

Closes #2263

---

**GSSoC 2026** — gssoc26
