### PR TITLE
feat(hooks): add useDocumentTitle hook for reactive document.title

### DIFF
--- a/apps/web/hooks/useDocumentTitle.ts
+++ b/apps/web/hooks/useDocumentTitle.ts
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from "react";
+
+export function useDocumentTitle(title: string, retainOnUnmount = false) {
+    const previousTitle = useRef(document.title);
+
+    useEffect(() => {
+        document.title = title;
+    }, [title]);
+
+    useEffect(() => {
+        return () => {
+            if (!retainOnUnmount) {
+                document.title = previousTitle.current;
+            }
+        };
+    }, [retainOnUnmount]);
+}


### PR DESCRIPTION
## Summary

Adds `useDocumentTitle` hook for managing `document.title` reactively. Restores the previous title on unmount to prevent stale tab labels.

## Changes

- Created `apps/web/hooks/useDocumentTitle.ts` (17 lines)
- Reactively updates title on prop change
- Restores previous title on unmount (opt-out via `retainOnUnmount`)

## Related Issue

Closes #2267

---

**GSSoC 2026** — gssoc26