### PR TITLE
feat(hooks): add useInterval hook for declarative setInterval

### DIFF
--- a/apps/web/hooks/useInterval.ts
+++ b/apps/web/hooks/useInterval.ts
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from "react";
+
+export function useInterval(callback: () => void, delay: number | null) {
+    const savedCallback = useRef(callback);
+
+    useEffect(() => {
+        savedCallback.current = callback;
+    }, [callback]);
+
+    useEffect(() => {
+        if (delay === null) return;
+
+        const id = setInterval(() => savedCallback.current(), delay);
+        return () => clearInterval(id);
+    }, [delay]);
+}


### PR DESCRIPTION
## Summary

Adds `useInterval` hook for declarative `setInterval` management. Prevents memory leaks from uncleared intervals by cleaning up on unmount.

## Changes

- Created `apps/web/hooks/useInterval.ts`
- Pauses interval when `null` delay is passed
- Uses mutable ref pattern to avoid re-creating interval on callback change

## Related Issue

Closes #2269

---

**GSSoC 2026** — gssoc26