### PR TITLE
feat(hooks): add useCountdown hook with start/pause/reset controls

### DIFF
--- a/apps/web/hooks/useCountdown.ts
+++ b/apps/web/hooks/useCountdown.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface CountdownResult {
+    seconds: number;
+    isRunning: boolean;
+    isExpired: boolean;
+    start: () => void;
+    pause: () => void;
+    reset: () => void;
+}
+
+export function useCountdown(
+    totalSeconds: number,
+    autoStart = false
+): CountdownResult {
+    const [remaining, setRemaining] = useState(totalSeconds);
+    const [isRunning, setIsRunning] = useState(autoStart);
+
+    useEffect(() => {
+        if (!isRunning || remaining <= 0) return;
+
+        const id = setInterval(() => {
+            setRemaining((prev) => {
+                if (prev <= 1) {
+                    setIsRunning(false);
+                    return 0;
+                }
+                return prev - 1;
+            });
+        }, 1000);
+
+        return () => clearInterval(id);
+    }, [isRunning, remaining]);
+
+    const start = useCallback(() => setIsRunning(true), []);
+    const pause = useCallback(() => setIsRunning(false), []);
+    const reset = useCallback(() => {
+        setIsRunning(false);
+        setRemaining(totalSeconds);
+    }, [totalSeconds]);
+
+    return {
+        seconds: remaining,
+        isRunning,
+        isExpired: remaining <= 0,
+        start,
+        pause,
+        reset,
+    };
+}


### PR DESCRIPTION
## Summary

Adds `useCountdown` hook for countdown timer logic (OTP resend cooldowns, session timeouts). Provides start/pause/reset controls and auto-stops at zero.

## Changes

- Created `apps/web/hooks/useCountdown.ts`
- Returns seconds remaining, running state, expired flag
- Properly cleans up interval on unmount

## Related Issue

Closes #2271

---

**GSSoC 2026** — gssoc26