### PR TITLE
feat(hooks): add usePrevious hook for tracking previous value

### DIFF
--- a/apps/web/hooks/usePrevious.ts
+++ b/apps/web/hooks/usePrevious.ts
@@ -1,0 +1,11 @@
+import { useRef, useEffect } from "react";
+
+export function usePrevious<T>(value: T): T | undefined {
+    const ref = useRef<T | undefined>(undefined);
+
+    useEffect(() => {
+        ref.current = value;
+    });
+
+    return ref.current;
+}


### PR DESCRIPTION
## Summary

Adds `usePrevious` hook to track the previous value of a prop/state. Useful for detecting transitions and conditional animations.

## Changes

- Created `apps/web/hooks/usePrevious.ts`
- Generic type support
- Updates after every render via useEffect

## Related Issue

Closes #2273

---

**GSSoC 2026** — gssoc26