### PR TITLE
feat(a11y): add usePrefersReducedMotion hook for accessibility

### DIFF
--- a/apps/web/hooks/usePrefersReducedMotion.ts
+++ b/apps/web/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+export function usePrefersReducedMotion(): boolean {
+    const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+        () => window.matchMedia(QUERY).matches
+    );
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia(QUERY);
+        const handler = (event: MediaQueryListEvent) =>
+            setPrefersReducedMotion(event.matches);
+
+        mediaQuery.addEventListener("change", handler);
+        return () => mediaQuery.removeEventListener("change", handler);
+    }, []);
+
+    return prefersReducedMotion;
+}


### PR DESCRIPTION
## Summary

Adds `usePrefersReducedMotion` hook to detect user's motion accessibility preference. Enables components to disable animations for users with vestibular disorders.

## Changes

- Created `apps/web/hooks/usePrefersReducedMotion.ts`
- Uses window.matchMedia API with reactive updates
- Cleans up event listener on unmount

## Related Issue

Closes #2275

---

**GSSoC 2026** — gssoc26