### PR TITLE
feat(hooks): add useHover hook for declarative hover detection

### DIFF
--- a/apps/web/hooks/useHover.ts
+++ b/apps/web/hooks/useHover.ts
@@ -1,0 +1,24 @@
+import { useState, useRef, useEffect, RefObject } from "react";
+
+export function useHover<T extends HTMLElement>(): [RefObject<T | null>, boolean] {
+    const [isHovered, setIsHovered] = useState(false);
+    const ref = useRef<T | null>(null);
+
+    useEffect(() => {
+        const element = ref.current;
+        if (!element) return;
+
+        const handleMouseEnter = () => setIsHovered(true);
+        const handleMouseLeave = () => setIsHovered(false);
+
+        element.addEventListener("mouseenter", handleMouseEnter);
+        element.addEventListener("mouseleave", handleMouseLeave);
+
+        return () => {
+            element.removeEventListener("mouseenter", handleMouseEnter);
+            element.removeEventListener("mouseleave", handleMouseLeave);
+        };
+    }, []);
+
+    return [ref, isHovered];
+}


### PR DESCRIPTION
## Summary

Adds `useHover` hook for declarative hover state detection using DOM event listeners. Returns a ref to attach and a boolean hover state.

## Changes

- Created `apps/web/hooks/useHover.ts`
- Generic HTMLElement type support
- Properly cleans up event listeners

## Related Issue

Closes #2277

---

**GSSoC 2026** — gssoc26