### PR TITLE
feat(hooks): add useWindowSize hook for responsive viewport dimensions

### DIFF
--- a/apps/web/hooks/useWindowSize.ts
+++ b/apps/web/hooks/useWindowSize.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from "react";
+
+interface WindowSize {
+    width: number;
+    height: number;
+}
+
+export function useWindowSize(): WindowSize {
+    const [windowSize, setWindowSize] = useState<WindowSize>({
+        width: window.innerWidth,
+        height: window.innerHeight,
+    });
+
+    useEffect(() => {
+        let timeoutId: ReturnType<typeof setTimeout>;
+
+        const handleResize = () => {
+            clearTimeout(timeoutId);
+            timeoutId = setTimeout(() => {
+                setWindowSize({
+                    width: window.innerWidth,
+                    height: window.innerHeight,
+                });
+            }, 150);
+        };
+
+        window.addEventListener("resize", handleResize);
+        return () => {
+            window.removeEventListener("resize", handleResize);
+            clearTimeout(timeoutId);
+        };
+    }, []);
+
+    return windowSize;
+}


### PR DESCRIPTION
## Summary

Adds `useWindowSize` hook for responsive viewport dimensions with debounced resize handling.

## Changes

- Created `apps/web/hooks/useWindowSize.ts`
- Returns `{ width, height }` updating on debounced resize
- Cleans up event listener on unmount
- 150ms debounce to avoid excessive re-renders

## Related Issue

Closes #2279

---

**GSSoC 2026** — gssoc26