### PR TITLE
feat(hooks): add useIdleTimer hook for inactivity detection

### DIFF
--- a/apps/web/hooks/useIdleTimer.ts
+++ b/apps/web/hooks/useIdleTimer.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect, useRef } from "react";
+
+interface UseIdleTimerOptions {
+    timeout?: number;
+    events?: string[];
+    initialState?: boolean;
+}
+
+export function useIdleTimer({
+    timeout = 300000,
+    events = ["mousemove", "mousedown", "keydown", "scroll", "touchstart"],
+    initialState = false,
+}: UseIdleTimerOptions = {}): boolean {
+    const [isIdle, setIsIdle] = useState(initialState);
+    const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+    useEffect(() => {
+        const resetTimer = () => {
+            setIsIdle(false);
+            clearTimeout(timerRef.current);
+            timerRef.current = setTimeout(() => setIsIdle(true), timeout);
+        };
+
+        resetTimer();
+
+        events.forEach((event) => window.addEventListener(event, resetTimer));
+
+        return () => {
+            clearTimeout(timerRef.current);
+            events.forEach((event) =>
+                window.removeEventListener(event, resetTimer)
+            );
+        };
+    }, [timeout, events]);
+
+    return isIdle;
+}


### PR DESCRIPTION
## Summary

Adds `useIdleTimer` hook for detecting user inactivity. Configurable timeout and event types, proper cleanup on unmount.

## Changes

- Created `apps/web/hooks/useIdleTimer.ts`
- Returns boolean idle state
- Configurable timeout (default 5 min) and trigger events
- Cleanup removes all event listeners

## Related Issue

Closes #2281

---

**GSSoC 2026** — gssoc26