### PR TITLE
feat(hooks): add useNetworkStatus hook for connectivity detection

### DIFF
--- a/apps/web/hooks/useNetworkStatus.ts
+++ b/apps/web/hooks/useNetworkStatus.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from "react";
+
+interface NetworkStatus {
+    isOnline: boolean;
+    effectiveType: string | null;
+    downlink: number | null;
+}
+
+export function useNetworkStatus(): NetworkStatus {
+    const [status, setStatus] = useState<NetworkStatus>(() => ({
+        isOnline: navigator.onLine,
+        effectiveType: null,
+        downlink: null,
+    }));
+
+    useEffect(() => {
+        const updateStatus = () => {
+            const connection = (navigator as any).connection;
+            setStatus({
+                isOnline: navigator.onLine,
+                effectiveType: connection?.effectiveType ?? null,
+                downlink: connection?.downlink ?? null,
+            });
+        };
+
+        window.addEventListener("online", updateStatus);
+        window.addEventListener("offline", updateStatus);
+
+        const connection = (navigator as any).connection;
+        if (connection) {
+            connection.addEventListener("change", updateStatus);
+        }
+
+        updateStatus();
+
+        return () => {
+            window.removeEventListener("online", updateStatus);
+            window.removeEventListener("offline", updateStatus);
+            if (connection) {
+                connection.removeEventListener("change", updateStatus);
+            }
+        };
+    }, []);
+
+    return status;
+}


### PR DESCRIPTION
## Summary

Adds `useNetworkStatus` hook for raw network connectivity detection (online/offline + Network Information API).

## Changes

- Created `apps/web/hooks/useNetworkStatus.ts`
- Returns `isOnline`, `effectiveType`, `downlink`
- Listens to online/offline events and connection changes
- Complementary to existing useOfflineStatus (which focuses on retry queue)

## Related Issue

Closes #2283

---

**GSSoC 2026** — gssoc26