### PR TITLE
feat(hooks): add useLockedBody hook for scroll lock on modals

### DIFF
--- a/apps/web/hooks/useLockedBody.ts
+++ b/apps/web/hooks/useLockedBody.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from "react";
+
+export function useLockedBody(locked: boolean) {
+    const originalOverflow = useRef<string>("");
+
+    useEffect(() => {
+        if (locked) {
+            originalOverflow.current = document.body.style.overflow;
+            document.body.style.overflow = "hidden";
+        } else {
+            document.body.style.overflow = originalOverflow.current;
+        }
+
+        return () => {
+            document.body.style.overflow = originalOverflow.current;
+        };
+    }, [locked]);
+}


### PR DESCRIPTION
## Summary

Adds `useLockedBody` hook for preventing background scroll when modals/overlays are open. Restores original overflow state on unmount.

## Changes

- Created `apps/web/hooks/useLockedBody.ts`
- Stores and restores original overflow value
- Cleans up on unmount to prevent stuck scroll locks

## Related Issue

Closes #2285

---

**GSSoC 2026** — gssoc26