### PR TITLE
feat(hooks): add useGeolocation hook for browser location

### DIFF
--- a/apps/web/hooks/useGeolocation.ts
+++ b/apps/web/hooks/useGeolocation.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface GeolocationState {
+    latitude: number | null;
+    longitude: number | null;
+    error: string | null;
+    loading: boolean;
+}
+
+export function useGeolocation(): GeolocationState & { refresh: () => void } {
+    const [state, setState] = useState<GeolocationState>({
+        latitude: null,
+        longitude: null,
+        error: null,
+        loading: true,
+    });
+
+    const query = useCallback(() => {
+        if (!navigator.geolocation) {
+            setState((prev) => ({
+                ...prev,
+                error: "Geolocation not supported",
+                loading: false,
+            }));
+            return;
+        }
+
+        navigator.geolocation.getCurrentPosition(
+            (position) => {
+                setState({
+                    latitude: position.coords.latitude,
+                    longitude: position.coords.longitude,
+                    error: null,
+                    loading: false,
+                });
+            },
+            (error) => {
+                setState((prev) => ({
+                    ...prev,
+                    error: error.message,
+                    loading: false,
+                }));
+            },
+            { enableHighAccuracy: false, timeout: 10000, maximumAge: 300000 }
+        );
+    }, []);
+
+    useEffect(() => {
+        query();
+    }, [query]);
+
+    return { ...state, refresh: query };
+}


### PR DESCRIPTION
## Summary

Adds `useGeolocation` hook for requesting and tracking browser location. Essential for the pharmacy map and nearby medicine features.

## Changes

- Created `apps/web/hooks/useGeolocation.ts`
- Returns latitude, longitude, error, loading state
- Includes `refresh` function for re-querying location
- Handles unsupported browsers and permission errors
- Uses sensible defaults (cached up to 5 min, 10s timeout)

## Related Issue

Closes #2287

---

**GSSoC 2026** — gssoc26