### PR TITLE
feat(hooks): add useSpeechRecognition hook for voice input

### DIFF
--- a/apps/web/hooks/useSpeechRecognition.ts
+++ b/apps/web/hooks/useSpeechRecognition.ts
@@ -1,0 +1,73 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+
+interface SpeechRecognitionResult {
+    transcript: string;
+    isListening: boolean;
+    isSupported: boolean;
+    error: string | null;
+}
+
+export function useSpeechRecognition(): SpeechRecognitionResult & {
+    start: () => void;
+    stop: () => void;
+} {
+    const [transcript, setTranscript] = useState("");
+    const [isListening, setIsListening] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const recognitionRef = useRef<any>(null);
+
+    const SpeechRecognitionAPI =
+        (window as any).SpeechRecognition ||
+        (window as any).webkitSpeechRecognition;
+
+    const isSupported = !!SpeechRecognitionAPI;
+
+    const start = useCallback(() => {
+        if (!SpeechRecognitionAPI) {
+            setError("Speech recognition not supported");
+            return;
+        }
+
+        const recognition = new SpeechRecognitionAPI();
+        recognition.continuous = false;
+        recognition.interimResults = true;
+        recognition.lang = "hi-IN";
+
+        recognition.onresult = (event: any) => {
+            const current = event.resultIndex;
+            const result = event.results[current];
+            setTranscript(result[0].transcript);
+        };
+
+        recognition.onerror = (event: any) => {
+            setError(event.error);
+            setIsListening(false);
+        };
+
+        recognition.onend = () => {
+            setIsListening(false);
+        };
+
+        recognitionRef.current = recognition;
+        recognition.start();
+        setIsListening(true);
+        setError(null);
+    }, [SpeechRecognitionAPI]);
+
+    const stop = useCallback(() => {
+        if (recognitionRef.current) {
+            recognitionRef.current.stop();
+            setIsListening(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            if (recognitionRef.current) {
+                recognitionRef.current.abort();
+            }
+        };
+    }, []);
+
+    return { transcript, isListening, isSupported, error, start, stop };
+}


### PR DESCRIPTION
## Summary

Adds `useSpeechRecognition` hook for voice input using the Web Speech API. Supports start/stop controls, interim results, and error handling.

## Changes

- Created `apps/web/hooks/useSpeechRecognition.ts`
- Returns transcript, isListening, isSupported, error states
- start()/stop() control functions
- Cleans up recognition instance on unmount
- Supports both standard and webkit prefixed APIs

## Related Issue

Closes #2289

---

**GSSoC 2026** — gssoc26