### PR TITLE
fix(api): add verified flag to flag offline-fallback interaction results

### DIFF
--- a/apps/api/src/routes/interactions.ts
+++ b/apps/api/src/routes/interactions.ts
@@ -276,6 +276,7 @@ router.get("/", async (req: Request, res: Response) => {
         const interactionByPair = indexInteractions(
             await loadInteractionsForGenerics(selectedGenerics)
         );
+        const isFallback = dbConfig?.isSupabaseOffline ?? true;
         const interactions = [];
 
         for (let i = 0; i < medicines.length; i++) {
@@ -306,6 +307,7 @@ router.get("/", async (req: Request, res: Response) => {
                         "Follow the prescribed dosage and consult a clinician if symptoms change.",
                     mechanism: match?.mechanism || "No interaction mechanism is documented.",
                     source: match?.source || "SahiDawa interaction checker",
+                    verified: !isFallback,
                 });
             }
         }
@@ -324,7 +326,6 @@ router.get("/", async (req: Request, res: Response) => {
 async function resolveToGeneric(input: string): Promise<{ input: string; generic: string }> {
     const cleanInput = input.trim();
     const lowerInput = cleanInput.toLowerCase();
-
     let dbFailed = dbConfig?.isSupabaseOffline;
     let genericName = cleanInput;
 
@@ -475,6 +476,7 @@ router.post("/check", async (req: Request, res: Response) => {
         await Promise.all(
             pairs.map(async ([a, b]) => {
                 let match = null;
+                let isFallback = false;
 
                 if (!dbFailed) {
                     try {
@@ -520,6 +522,7 @@ router.post("/check", async (req: Request, res: Response) => {
                     );
                     if (found) {
                         match = found;
+                        isFallback = true;
                     }
                 }
 
@@ -540,6 +543,7 @@ router.post("/check", async (req: Request, res: Response) => {
                             match.clinical_recommendation ||
                             "Consult a physician before combining.",
                         source: match.source || "Clinical Literature",
+                        verified: !isFallback,
                     });
                 }
             })


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #<2245>**
- **Summary:** Adds a `verified` boolean to each interaction result in both `GET /api/v1/interactions` and `POST /api/v1/interactions/check`. `verified` is `true` when the result came from the live `drug_interactions` table, and `false` when it came from the static 4-entry `localInteractions` offline fallback list (or when the offline/online state is unknown, defaulting to the cautious `false`). Previously, fallback-sourced results were indistinguishable from live-verified ones in the API response.

## 📸 Proof of Work (Screenshots / Logs)

**POST /check — known offline-fallback pair (paracetamol/warfarin via "Crocin"/"Warfarin"):**
curl.exe -X POST ".../interactions/check" -d '{"medicines": ["Crocin", "Warfarin"]}'

→ {"interactions":[{... "verified":false}]}

**POST /check — pair not in the fallback list ("Crocin"/"Brufen" → paracetamol/ibuprofen):**
curl.exe -X POST ".../interactions/check" -d '{"medicines": ["Crocin", "Brufen"]}'

→ {"interactions":[]}

## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts

## Known Limitation / Follow-up
While testing, I confirmed that `POST /check` returns an **empty** `interactions` array (not an unverified placeholder) when a pair has no match in either the live DB or the fallback list — e.g. paracetamol + ibuprofen while offline. This means a caller could see an empty array and read it as "confirmed no interaction" rather than "we couldn't check most things while offline." I scoped this PR to adding the `verified` flag on results that do have a match, but flagging this as a possible follow-up issue, since fixing it would mean restructuring `POST /check` to always emit a result entry per pair (matched or not) — a larger change than this fix.