### PR TITLE
feat(api): integrate ABDM sandbox ABHA OTP flow

### DIFF
--- a/apps/api/src/services/abha.service.ts
+++ b/apps/api/src/services/abha.service.ts
@@ -1,5 +1,13 @@
+import { constants, publicEncrypt } from "node:crypto";
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
+
+const DEFAULT_ABDM_BASE_URL = "https://abhasbx.abdm.gov.in/abha/api";
+const DEFAULT_ABDM_SESSION_URL = "https://dev.abdm.gov.in/api/hiecm/gateway/v3/sessions";
+const ABDM_REQUEST_TIMEOUT_MS = 10000;
+const ABHA_LOGIN_SCOPE = ["abha-address-login", "mobile-verify"];
+const ABHA_ADDRESS_LOGIN_PATH = "/v3/phr/web/login/abha";
+const ABDM_PUBLIC_CERTIFICATE_PATH = "/v3/profile/public/certificate";
 
 export interface ABHALinkResponse {
     txnId: string;
@@ -17,16 +25,45 @@ export interface ABHAVerificationData {
     scannedAt: string;
 }
 
+interface AbdmSessionResponse {
+    accessToken?: string;
+}
+
+interface AbdmPublicCertificateResponse {
+    publicKey?: string;
+}
+
+interface AbdmOtpResponse {
+    txnId?: string;
+}
+
+interface AbdmVerifyResponse {
+    token?: string;
+    authToken?: string;
+}
+
 export const generateOTP = async (abhaAddress: string): Promise<ABHALinkResponse> => {
     logger.info("ABHA OTP generation requested", { abhaAddress });
 
-    /**
-     * Future Integration Point:
-     * This method is a stub. It should be replaced with the actual
-     * ABDM Sandbox API call for generating ABHA OTPs.
-     */
+    const accessToken = await getAbdmSessionToken();
+    const publicKey = await getAbdmPublicKey(accessToken);
+    const response = await postToAbdm<AbdmOtpResponse>(
+        `${getAbdmBaseUrl()}${ABHA_ADDRESS_LOGIN_PATH}/request/otp`,
+        {
+            scope: ABHA_LOGIN_SCOPE,
+            loginHint: "abha-address",
+            loginId: encryptWithAbdmPublicKey(abhaAddress, publicKey),
+            otpSystem: "abdm",
+        },
+        accessToken
+    );
+
+    if (!response.txnId) {
+        throw new Error("ABDM sandbox returned an invalid OTP response");
+    }
+
     return {
-        txnId: crypto.randomUUID(),
+        txnId: response.txnId,
     };
 };
 
@@ -36,15 +73,189 @@ export const verifyOTP = async (txnId: string, otp: string): Promise<{ token: st
         otpProvided: Boolean(otp),
     });
 
-    /**
-     * Future Integration Point:
-     * This method is a stub. It should be replaced with the actual
-     * ABDM Sandbox API call for verifying ABHA OTPs.
-     */
+    const accessToken = await getAbdmSessionToken();
+    const publicKey = await getAbdmPublicKey(accessToken);
+    const response = await postToAbdm<AbdmVerifyResponse>(
+        `${getAbdmBaseUrl()}${ABHA_ADDRESS_LOGIN_PATH}/verify`,
+        {
+            scope: ABHA_LOGIN_SCOPE,
+            authData: {
+                authMethods: ["otp"],
+                otp: {
+                    txnId,
+                    otpValue: encryptWithAbdmPublicKey(otp, publicKey),
+                },
+            },
+        },
+        accessToken
+    );
+
+    const token = response.token ?? response.authToken;
+    if (!token) {
+        throw new Error("ABDM sandbox returned an invalid OTP verification response");
+    }
+
     return {
-        token: "mock-abha-token",
+        token,
     };
 };
+
+const getAbdmSessionToken = async (): Promise<string> => {
+    const clientId = getRequiredEnv("ABDM_SANDBOX_CLIENT_ID");
+    const clientSecret = getRequiredEnv("ABDM_SANDBOX_CLIENT_SECRET");
+    const sessionUrl = process.env.ABDM_SANDBOX_SESSION_URL?.trim() || DEFAULT_ABDM_SESSION_URL;
+
+    const response = await postToAbdm<AbdmSessionResponse>(sessionUrl, {
+        clientId,
+        clientSecret,
+    });
+
+    if (!response.accessToken) {
+        throw new Error("ABDM sandbox returned an invalid session response");
+    }
+
+    return response.accessToken;
+};
+
+const getAbdmPublicKey = async (accessToken: string): Promise<string> => {
+    const response = await getFromAbdm<AbdmPublicCertificateResponse>(
+        `${getAbdmBaseUrl()}${ABDM_PUBLIC_CERTIFICATE_PATH}`,
+        accessToken
+    );
+
+    if (!response.publicKey) {
+        throw new Error("ABDM sandbox returned an invalid public certificate response");
+    }
+
+    return response.publicKey;
+};
+
+const postToAbdm = async <T>(url: string, body: unknown, accessToken?: string): Promise<T> => {
+    return requestAbdm<T>(url, {
+        method: "POST",
+        accessToken,
+        body,
+    });
+};
+
+const getFromAbdm = async <T>(url: string, accessToken?: string): Promise<T> => {
+    return requestAbdm<T>(url, {
+        method: "GET",
+        accessToken,
+    });
+};
+
+const requestAbdm = async <T>(
+    url: string,
+    options: { method: "GET" | "POST"; accessToken?: string; body?: unknown }
+): Promise<T> => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), ABDM_REQUEST_TIMEOUT_MS);
+
+    try {
+        const response = await fetch(url, {
+            method: options.method,
+            headers: {
+                "Content-Type": "application/json",
+                "REQUEST-ID": crypto.randomUUID(),
+                TIMESTAMP: new Date().toISOString(),
+                ...(options.accessToken ? { Authorization: `Bearer ${options.accessToken}` } : {}),
+            },
+            ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
+            signal: controller.signal,
+        });
+
+        const responseBody = await parseAbdmResponse(response);
+
+        if (!response.ok) {
+            throw createAbdmError(response.status, responseBody);
+        }
+
+        return responseBody as T;
+    } catch (error) {
+        if (error instanceof Error && isMappedAbdmError(error.message)) {
+            throw error;
+        }
+
+        const message =
+            error instanceof Error && error.name === "AbortError"
+                ? "request timed out"
+                : error instanceof Error
+                  ? error.message
+                  : "unknown network error";
+        throw new Error(`ABDM sandbox request failed: ${message}`);
+    } finally {
+        clearTimeout(timeout);
+    }
+};
+
+const encryptWithAbdmPublicKey = (value: string, publicKey: string): string => {
+    const normalizedPublicKey = publicKey.includes("BEGIN PUBLIC KEY")
+        ? publicKey
+        : `-----BEGIN PUBLIC KEY-----\n${publicKey.match(/.{1,64}/g)?.join("\n")}\n-----END PUBLIC KEY-----`;
+
+    return publicEncrypt(
+        {
+            key: normalizedPublicKey,
+            padding: constants.RSA_PKCS1_OAEP_PADDING,
+            oaepHash: "sha1",
+        },
+        Buffer.from(value, "utf8")
+    ).toString("base64");
+};
+
+const isMappedAbdmError = (message: string): boolean =>
+    message.startsWith("Invalid ABHA address:") || message.startsWith("ABDM ");
+
+const parseAbdmResponse = async (response: Response): Promise<unknown> => {
+    try {
+        return await response.json();
+    } catch {
+        return {};
+    }
+};
+
+const createAbdmError = (status: number, body: unknown): Error => {
+    const detail = extractAbdmErrorMessage(body);
+
+    if (status === 400) {
+        return new Error(`Invalid ABHA address: ${detail}`);
+    }
+
+    if (status === 401 || status === 403) {
+        return new Error(`ABDM sandbox authorization failed: ${detail}`);
+    }
+
+    if (status >= 500) {
+        return new Error(`ABDM sandbox service failed: ${detail}`);
+    }
+
+    return new Error(`ABDM sandbox request failed with status ${status}: ${detail}`);
+};
+
+const extractAbdmErrorMessage = (body: unknown): string => {
+    if (typeof body === "object" && body !== null) {
+        const record = body as Record<string, unknown>;
+        const message = record.message ?? record.error ?? record.details;
+        if (typeof message === "string" && message.trim()) {
+            return message;
+        }
+    }
+
+    return "Unexpected ABDM sandbox response";
+};
+
+const getRequiredEnv = (name: string): string => {
+    const value = process.env[name]?.trim();
+    if (!value) {
+        throw new Error(`${name} is required for ABDM sandbox integration`);
+    }
+
+    return value;
+};
+
+const getAbdmBaseUrl = (): string =>
+    (process.env.ABDM_SANDBOX_BASE_URL?.trim() || DEFAULT_ABDM_BASE_URL).replace(/\/$/, "");
 
 export const uploadVerification = async (
     userId: string,

--- a/apps/api/tests/abha.service.test.ts
+++ b/apps/api/tests/abha.service.test.ts
@@ -1,0 +1,207 @@
+import { generateKeyPairSync } from "node:crypto";
+import { generateOTP, verifyOTP } from "../src/services/abha.service";
+
+jest.mock("../src/utils/logger", () => ({
+    __esModule: true,
+    default: {
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+    },
+}));
+
+const fetchMock = jest.fn();
+const { publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const testPublicKey = publicKey
+    .export({ type: "spki", format: "pem" })
+    .toString()
+    .replace("-----BEGIN PUBLIC KEY-----", "")
+    .replace("-----END PUBLIC KEY-----", "")
+    .replace(/\s/g, "");
+
+describe("ABHA service ABDM sandbox integration", () => {
+    const originalFetch = global.fetch;
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        process.env = {
+            ...originalEnv,
+            ABDM_SANDBOX_BASE_URL: "https://abha-sandbox.test/abha/api",
+            ABDM_SANDBOX_SESSION_URL: "https://gateway-sandbox.test/api/hiecm/gateway/v3/sessions",
+            ABDM_SANDBOX_CLIENT_ID: "sandbox-client-id",
+            ABDM_SANDBOX_CLIENT_SECRET: "sandbox-client-secret",
+        };
+        global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+        global.fetch = originalFetch;
+    });
+
+    it("generates an ABHA address OTP with ABDM session credentials and returns txnId", async () => {
+        fetchMock
+            .mockResolvedValueOnce(
+                jsonResponse(200, {
+                    accessToken: "session-access-token",
+                })
+            )
+            .mockResolvedValueOnce(
+                jsonResponse(200, {
+                    publicKey: testPublicKey,
+                    encryptionAlgorithm: "RSA/ECB/OAEPWithSHA-1AndMGF1Padding",
+                })
+            )
+            .mockResolvedValueOnce(
+                jsonResponse(200, {
+                    txnId: "otp-txn-id",
+                })
+            );
+
+        await expect(generateOTP("deepak@sbx")).resolves.toEqual({
+            txnId: "otp-txn-id",
+        });
+
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            1,
+            "https://gateway-sandbox.test/api/hiecm/gateway/v3/sessions",
+            expect.objectContaining({
+                method: "POST",
+                body: JSON.stringify({
+                    clientId: "sandbox-client-id",
+                    clientSecret: "sandbox-client-secret",
+                }),
+            })
+        );
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            2,
+            "https://abha-sandbox.test/abha/api/v3/profile/public/certificate",
+            expect.objectContaining({
+                method: "GET",
+                headers: expect.objectContaining({
+                    Authorization: "Bearer session-access-token",
+                }),
+            })
+        );
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            3,
+            "https://abha-sandbox.test/abha/api/v3/phr/web/login/abha/request/otp",
+            expect.objectContaining({
+                method: "POST",
+                headers: expect.objectContaining({
+                    Authorization: "Bearer session-access-token",
+                    "REQUEST-ID": expect.any(String),
+                    TIMESTAMP: expect.any(String),
+                }),
+                body: expect.any(String),
+            })
+        );
+
+        const otpRequestBody = parseFetchBody(3);
+        expect(otpRequestBody).toMatchObject({
+            scope: ["abha-address-login", "mobile-verify"],
+            loginHint: "abha-address",
+            otpSystem: "abdm",
+        });
+        expect(otpRequestBody.loginId).toEqual(expect.any(String));
+        expect(otpRequestBody.loginId).not.toBe("deepak@sbx");
+        expect(otpRequestBody.loginId.length).toBeGreaterThan(100);
+    });
+
+    it("verifies an ABHA OTP and keeps the token response contract stable", async () => {
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse(200, { accessToken: "session-access-token" }))
+            .mockResolvedValueOnce(
+                jsonResponse(200, {
+                    publicKey: testPublicKey,
+                    encryptionAlgorithm: "RSA/ECB/OAEPWithSHA-1AndMGF1Padding",
+                })
+            )
+            .mockResolvedValueOnce(jsonResponse(200, { token: "abha-login-token" }));
+
+        await expect(verifyOTP("otp-txn-id", "123456")).resolves.toEqual({
+            token: "abha-login-token",
+        });
+
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            3,
+            "https://abha-sandbox.test/abha/api/v3/phr/web/login/abha/verify",
+            expect.objectContaining({
+                method: "POST",
+                headers: expect.objectContaining({
+                    Authorization: "Bearer session-access-token",
+                }),
+                body: expect.any(String),
+            })
+        );
+
+        const verifyRequestBody = parseFetchBody(3);
+        expect(verifyRequestBody).toMatchObject({
+            scope: ["abha-address-login", "mobile-verify"],
+            authData: {
+                authMethods: ["otp"],
+                otp: {
+                    txnId: "otp-txn-id",
+                },
+            },
+        });
+        expect(verifyRequestBody.authData.otp.otpValue).toEqual(expect.any(String));
+        expect(verifyRequestBody.authData.otp.otpValue).not.toBe("123456");
+        expect(verifyRequestBody.authData.otp.otpValue.length).toBeGreaterThan(100);
+    });
+
+    it("maps ABDM 400 responses to an invalid ABHA error", async () => {
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse(200, { accessToken: "session-access-token" }))
+            .mockResolvedValueOnce(jsonResponse(200, { publicKey: testPublicKey }))
+            .mockResolvedValueOnce(jsonResponse(400, { message: "Invalid ABHA address" }));
+
+        await expect(generateOTP("bad-abha")).rejects.toThrow(
+            "Invalid ABHA address: Invalid ABHA address"
+        );
+    });
+
+    it("maps ABDM 401 responses to an unauthorized sandbox error", async () => {
+        fetchMock.mockResolvedValueOnce(
+            jsonResponse(401, { message: "Invalid client credentials" })
+        );
+
+        await expect(generateOTP("deepak@sbx")).rejects.toThrow(
+            "ABDM sandbox authorization failed: Invalid client credentials"
+        );
+    });
+
+    it("maps ABDM 500 responses to a sandbox service error", async () => {
+        fetchMock
+            .mockResolvedValueOnce(jsonResponse(200, { accessToken: "session-access-token" }))
+            .mockResolvedValueOnce(jsonResponse(200, { publicKey: testPublicKey }))
+            .mockResolvedValueOnce(jsonResponse(500, { message: "Sandbox unavailable" }));
+
+        await expect(generateOTP("deepak@sbx")).rejects.toThrow(
+            "ABDM sandbox service failed: Sandbox unavailable"
+        );
+    });
+
+    it("maps network failures to a sandbox connectivity error", async () => {
+        fetchMock.mockRejectedValueOnce(new Error("getaddrinfo ENOTFOUND"));
+
+        await expect(generateOTP("deepak@sbx")).rejects.toThrow(
+            "ABDM sandbox request failed: getaddrinfo ENOTFOUND"
+        );
+    });
+});
+
+function parseFetchBody(callNumber: number): Record<string, any> {
+    const [, init] = fetchMock.mock.calls[callNumber - 1] as [string, RequestInit];
+    return JSON.parse(init.body as string);
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: jest.fn().mockResolvedValue(body),
+        text: jest.fn().mockResolvedValue(JSON.stringify(body)),
+    } as unknown as Response;
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2226**
- **Summary:** Replaces the ABHA OTP stubs with ABDM sandbox calls for session creation, public certificate fetch, OTP request, and OTP verification. ABHA address and OTP values are encrypted with the ABDM public key before they are sent. Sandbox credentials are read from environment variables.

## 📸 Proof of Work (Screenshots / Logs)

Terminal proof:

```bash
npm test -w sahidawa-api -- abha.service.test.ts --runInBand
```

Result: 1 suite passed, 6 tests passed.

Build check:

```bash
npm run build -w sahidawa-api
```

Result: blocked by an unrelated latest-`main` TypeScript syntax error in `apps/api/src/routes/pharmacies.ts`. This PR does not touch that file.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2226`)
- [x] I have pulled the latest `main` and resolved any conflicts
