### PR TITLE
Feat :  Implemented retry logic with exponential backoff for CDSCO Scraper API calls

### DIFF
--- a/apps/etl/src/scrapers/cdsco.py
+++ b/apps/etl/src/scrapers/cdsco.py
@@ -20,6 +20,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import pandas as pd
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from src.utils.logger import logger
 
@@ -54,7 +56,19 @@ class CDSCOScraper:
             return REFERENCE_CSV
 
         logger.info("[CDSCO] Fetching data from portal...")
-        response = requests.get(CDSCO_URL, timeout=30)
+        
+        session = requests.Session()
+        retries = Retry(
+            total=5,
+            backoff_factor=1,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=["GET"]
+        )
+        adapter = HTTPAdapter(max_retries=retries)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        
+        response = session.get(CDSCO_URL, timeout=30)
 
         if response.status_code != 200:
             raise RuntimeError(


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2234 **
- **Summary:**
-  added the retry logic with exponential backoff to apps/etl/src/scrapers/cdsco.py.

The single `requests.get` call is now wrapped in a `requests.Session()` with an `HTTPAdapter` utilizing urllib3.util.Retry. This will automatically retry up to 5 times for HTTP status codes 500, 502, 503, and 504, using an exponential backoff factor to help the pipeline survive temporary blips.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
