### PR TITLE
fix(web): solve AudioContext and requestAnimationFrame leaks in VoiceVerify, and make skip link global(closes #2181)

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { NextIntlClientProvider } from "next-intl";
-import { getMessages } from "next-intl/server";
+import { getMessages, getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { routing } from "../../i18n/routing";
 
@@ -79,6 +79,7 @@ export default async function LocaleLayout({
     }
 
     const messages = await getMessages();
+    const t = await getTranslations("VoicePage");
     const isRtl = ["ur", "ks"].includes(locale);
 
     return (
@@ -103,9 +104,15 @@ export default async function LocaleLayout({
                     <ThemeProvider>
                         <NextIntlClientProvider messages={messages}>
                             <AuthProvider>
+                                <a
+                                    href="#main-content"
+                                    className="sr-only absolute top-4 left-4 z-[60] rounded-full bg-emerald-600 px-4 py-2 text-sm font-bold text-white shadow-lg focus:not-sr-only focus-visible:ring-[3px] focus-visible:ring-emerald-600 focus-visible:ring-offset-2 focus-visible:outline-[3px] focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+                                >
+                                    {t("skip_to_main_content")}
+                                </a>
                                 <OfflineBanner />
                                 <Navbar />
-                                <main className="flex flex-grow flex-col">
+                                <main id="main-content" className="flex flex-grow flex-col">
                                     <OfflineErrorBoundary>{children}</OfflineErrorBoundary>
                                 </main>
                                 <Footer />

--- a/apps/web/app/[locale]/voice/layout.tsx
+++ b/apps/web/app/[locale]/voice/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
-import { getTranslations } from "next-intl/server";
 
 export const metadata: Metadata = {
     title: "Voice Triage — SahiDawa",
@@ -21,18 +20,6 @@ export const metadata: Metadata = {
     },
 };
 
-export default async function VoiceLayout({ children }: { children: ReactNode }) {
-    const t = await getTranslations("VoicePage");
-
-    return (
-        <>
-            <a
-                href="#main-content"
-                className="sr-only absolute top-4 left-4 z-[60] rounded-full bg-emerald-600 px-4 py-2 text-sm font-bold text-white shadow-lg focus:not-sr-only focus-visible:ring-[3px] focus-visible:ring-emerald-600 focus-visible:ring-offset-2 focus-visible:outline-[3px] focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
-            >
-                {t("skip_to_main_content")}
-            </a>
-            {children}
-        </>
-    );
+export default function VoiceLayout({ children }: { children: ReactNode }) {
+    return <>{children}</>;
 }

--- a/apps/web/components/VoiceVerify.tsx
+++ b/apps/web/components/VoiceVerify.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useEffect } from "react";
 import { useTranslations } from "next-intl";
 
 type VerificationResult = {
@@ -62,6 +62,51 @@ export default function VoiceVerify() {
     const chunksRef = useRef<Blob[]>([]);
     const animFrameRef = useRef<number | null>(null);
     const analyserRef = useRef<AnalyserNode | null>(null);
+    const audioContextRef = useRef<AudioContext | null>(null);
+    const streamRef = useRef<MediaStream | null>(null);
+    const isMountedRef = useRef(true);
+
+    const cleanupRecording = useCallback(() => {
+        // Stop animation frame
+        if (animFrameRef.current !== null) {
+            cancelAnimationFrame(animFrameRef.current);
+            animFrameRef.current = null;
+        }
+
+        // Close AudioContext
+        if (audioContextRef.current) {
+            if (audioContextRef.current.state !== "closed") {
+                audioContextRef.current.close().catch((err) => {
+                    console.error("Failed to close AudioContext:", err);
+                });
+            }
+            audioContextRef.current = null;
+        }
+
+        // Stop stream tracks
+        if (streamRef.current) {
+            streamRef.current.getTracks().forEach((track) => {
+                if (track.readyState === "live") {
+                    track.stop();
+                }
+            });
+            streamRef.current = null;
+        }
+
+        // Reset level
+        setAudioLevel(0);
+    }, []);
+
+    useEffect(() => {
+        isMountedRef.current = true;
+        return () => {
+            isMountedRef.current = false;
+            cleanupRecording();
+            if (mediaRecorderRef.current && mediaRecorderRef.current.state !== "inactive") {
+                mediaRecorderRef.current.stop();
+            }
+        };
+    }, [cleanupRecording]);
 
     const startRecording = useCallback(async () => {
         setError(null);
@@ -69,9 +114,11 @@ export default function VoiceVerify() {
 
         try {
             const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            streamRef.current = stream;
 
             // Visualize audio level
-            const audioCtx = new AudioContext();
+            const audioCtx = new (window.AudioContext || (window as any).webkitAudioContext)();
+            audioContextRef.current = audioCtx;
             const source = audioCtx.createMediaStreamSource(stream);
             const analyser = audioCtx.createAnalyser();
             analyser.fftSize = 256;
@@ -79,6 +126,12 @@ export default function VoiceVerify() {
             analyserRef.current = analyser;
 
             const draw = () => {
+                if (
+                    !isMountedRef.current ||
+                    !audioContextRef.current ||
+                    audioContextRef.current.state === "closed"
+                )
+                    return;
                 const data = new Uint8Array(analyser.frequencyBinCount);
                 analyser.getByteFrequencyData(data);
                 const avg = data.reduce((a, b) => a + b, 0) / data.length;
@@ -96,10 +149,7 @@ export default function VoiceVerify() {
             };
 
             recorder.onstop = async () => {
-                stream.getTracks().forEach((t) => t.stop());
-                if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
-                setAudioLevel(0);
-
+                cleanupRecording();
                 const blob = new Blob(chunksRef.current, { type: "audio/webm" });
                 await sendAudioToApi(blob);
             };
@@ -110,7 +160,7 @@ export default function VoiceVerify() {
         } catch {
             setError(t("errorMicDenied"));
         }
-    }, [t]);
+    }, [cleanupRecording, t]);
 
     const stopRecording = useCallback(() => {
         if (mediaRecorderRef.current && isRecording) {
@@ -120,6 +170,7 @@ export default function VoiceVerify() {
     }, [isRecording]);
 
     const sendAudioToApi = async (blob: Blob) => {
+        if (!isMountedRef.current) return;
         setIsLoading(true);
         try {
             const form = new FormData();
@@ -132,15 +183,20 @@ export default function VoiceVerify() {
 
             const data: ApiResponse = await res.json();
 
+            if (!isMountedRef.current) return;
+
             if (!res.ok || !data.success) {
                 setError(data.error || t("errorNetwork"));
             } else {
                 setResult(data);
             }
         } catch {
+            if (!isMountedRef.current) return;
             setError(t("errorNetwork"));
         } finally {
-            setIsLoading(false);
+            if (isMountedRef.current) {
+                setIsLoading(false);
+            }
         }
     };
 

--- a/apps/web/jest.config.cjs
+++ b/apps/web/jest.config.cjs
@@ -10,6 +10,7 @@ module.exports = {
     setupFiles: ["<rootDir>/jest.env.cjs"],
     roots: ["<rootDir>/tests"],
     moduleNameMapper: {
+        "\\.css$": "<rootDir>/tests/mocks/styleMock.ts",
         "^leaflet$": "<rootDir>/tests/mocks/leaflet.ts",
         "^react-leaflet$": "<rootDir>/tests/mocks/react-leaflet.ts",
         "^leaflet/dist/leaflet.css$": "<rootDir>/tests/mocks/leaflet.ts",

--- a/apps/web/scripts/voice-a11y-audit.mjs
+++ b/apps/web/scripts/voice-a11y-audit.mjs
@@ -32,11 +32,12 @@ async function waitForUrl(url) {
 
 function startDevServer() {
     const server = spawn(
-        "npm",
+        process.platform === "win32" ? "npm.cmd" : "npm",
         ["run", "dev", "-w", "web", "--", "--hostname", auditUrl.hostname, "--port", auditUrl.port],
         {
             cwd: repoRoot,
             stdio: "inherit",
+            shell: process.platform === "win32",
         }
     );
 

--- a/apps/web/tests/mocks/styleMock.ts
+++ b/apps/web/tests/mocks/styleMock.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/apps/web/tests/voice-page-accessibility.test.tsx
+++ b/apps/web/tests/voice-page-accessibility.test.tsx
@@ -1,15 +1,20 @@
+/**
+ * @jest-environment jsdom
+ */
 import { renderToStaticMarkup } from "react-dom/server";
-
+import LocaleLayout from "../app/[locale]/layout";
 import VoiceLayout from "../app/[locale]/voice/layout";
 import VoiceTriagePage from "../app/[locale]/voice/page";
 
 jest.mock("next-intl", () => ({
     useLocale: () => "en",
     useTranslations: () => (key: string) => key,
+    NextIntlClientProvider: ({ children }: any) => children,
 }));
 
 jest.mock("next-intl/server", () => ({
     getTranslations: async () => (key: string) => key,
+    getMessages: async () => ({}),
 }));
 
 jest.mock("next/navigation", () => ({
@@ -19,6 +24,7 @@ jest.mock("next/navigation", () => ({
     useParams: () => ({
         locale: "en",
     }),
+    notFound: () => {},
 }));
 
 jest.mock("sonner", () => ({
@@ -26,6 +32,7 @@ jest.mock("sonner", () => ({
         error: jest.fn(),
         success: jest.fn(),
     },
+    Toaster: () => null,
 }));
 
 jest.mock("../app/[locale]/components/PageHeader", () => ({
@@ -38,11 +45,41 @@ jest.mock("../app/[locale]/components/PageHeader", () => ({
     ),
 }));
 
+// Mock layout sub-components to prevent rendering complex/nested structures
+jest.mock("../app/[locale]/components/ThemeProvider", () => ({
+    ThemeProvider: ({ children }: any) => children,
+}));
+jest.mock("@/components/OfflineBanner", () => ({
+    OfflineBanner: () => null,
+}));
+jest.mock("@/components/OfflineErrorBoundary", () => ({
+    OfflineErrorBoundary: ({ children }: any) => children,
+}));
+jest.mock("@/components/ServiceWorkerProvider", () => ({
+    ServiceWorkerProvider: ({ children }: any) => children,
+}));
+jest.mock("../app/[locale]/components/BackToTopButton", () => () => null);
+jest.mock("../app/[locale]/components/Chatbot", () => () => null);
+jest.mock("../app/[locale]/components/Navbar", () => () => null);
+jest.mock("../app/[locale]/components/Footer", () => () => null);
+jest.mock("@/src/components/AuthProvider", () => ({
+    AuthProvider: ({ children }: any) => children,
+}));
+jest.mock("../app/[locale]/components/CommandPalette", () => () => null);
+jest.mock("@/components/TracingInitializer", () => ({
+    TracingInitializer: () => null,
+}));
+
 describe("VoiceTriagePage accessibility shell", () => {
-    it("renders a skip link before a focusable main landmark target", async () => {
+    it("renders a skip link before a focusable main landmark target in the page shell", async () => {
         const layoutMarkup = renderToStaticMarkup(
-            await VoiceLayout({
-                children: <VoiceTriagePage />,
+            await LocaleLayout({
+                children: (
+                    <VoiceLayout>
+                        <VoiceTriagePage />
+                    </VoiceLayout>
+                ),
+                params: Promise.resolve({ locale: "en" }),
             })
         );
         const skipLinkIndex = layoutMarkup.indexOf('href="#main-content"');


### PR DESCRIPTION
 
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2181**
- **Summary:**
  - Fixed memory leaks in `VoiceVerify` component by properly closing the browser `AudioContext`, cancelling visualizer `requestAnimationFrame` loops, and stopping all active `MediaStream` tracks when a recording completes or on component unmount.
  - Added a mounting ref (`isMountedRef`) to guard async API state updates and prevent React unmounted set-state warnings.
  - Relocated the "Skip to main content" link to the global `LocaleLayout` before the `Navbar` so it is structurally the first tabbable element in the page shell, resolving a voice page accessibility failure.
  - Made the accessibility test runner script `voice-a11y-audit.mjs` compatible with Windows systems by spawning `npm.cmd` inside shell.

## 📸 Proof of Work (Screenshots / Logs)

### Automated Test Runs
The voice accessibility audit passes successfully:
```text
▲ Next.js 16.2.9 (Turbopack)
- Local:         http://127.0.0.1:3000
- Network:       http://127.0.0.1:3000
- Environments: .env
✓ Ready in 636ms

 GET /en/voice 200 in 3.7s (next.js: 2.2s, proxy.ts: 235ms, application-code: 1188ms)
 GET /en/voice 200 in 283ms (next.js: 62ms, proxy.ts: 35ms, application-code: 186ms)
Voice accessibility audit passed for http://127.0.0.1:3000/en/voice
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [x] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2181`)
- [x] I have pulled the latest `main` and resolved any conflicts