### PR TITLE
fix(web): memoize Supabase client in LoginPage to prevent instantiation leak on every render(closes #2192)

### DIFF
--- a/apps/web/app/[locale]/login/page.tsx
+++ b/apps/web/app/[locale]/login/page.tsx
@@ -11,7 +11,7 @@ import {
     EyeOff,
 } from "lucide-react";
 import { FcGoogle } from "react-icons/fc";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Link, useRouter } from "@/i18n/routing";
 import { createBrowserClient } from "@supabase/ssr";
@@ -22,10 +22,32 @@ export default function LoginPage() {
     const router = useRouter();
     const locale = useLocale();
     const t = useTranslations("Login");
-    const supabaseUrl = getSupabaseUrl();
-    const supabaseKey = getSupabaseAnonKey();
-    const isMissingEnvVars = !supabaseUrl || !supabaseKey;
-    const supabase = createBrowserClient(supabaseUrl, supabaseKey);
+
+    // Safely retrieve Supabase configurations without crashing during SSR or when missing
+    const { supabaseUrl, supabaseKey, isMissingEnvVars } = useMemo(() => {
+        try {
+            const url = getSupabaseUrl();
+            const key = getSupabaseAnonKey();
+            return {
+                supabaseUrl: url,
+                supabaseKey: key,
+                isMissingEnvVars: !url || !key,
+            };
+        } catch {
+            return {
+                supabaseUrl: "",
+                supabaseKey: "",
+                isMissingEnvVars: true,
+            };
+        }
+    }, []);
+
+    // Memoize the browser client so it is created once and persists across renders
+    const supabase = useMemo(() => {
+        if (isMissingEnvVars) return null;
+        return createBrowserClient(supabaseUrl, supabaseKey);
+    }, [isMissingEnvVars, supabaseUrl, supabaseKey]);
+
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [loading, setLoading] = useState(false);
@@ -38,7 +60,7 @@ export default function LoginPage() {
         setLoading(true);
         setError("");
 
-        if (isMissingEnvVars) {
+        if (isMissingEnvVars || !supabase) {
             setError(t("errors.databaseNotConfigured"));
             setLoading(false);
             return;
@@ -70,7 +92,7 @@ export default function LoginPage() {
         setLoading(true);
         setError("");
 
-        if (isMissingEnvVars) {
+        if (isMissingEnvVars || !supabase) {
             setError(t("errors.databaseNotConfigured"));
             setLoading(false);
             return;
@@ -97,7 +119,7 @@ export default function LoginPage() {
         setLoading(true);
         setError("");
 
-        if (isMissingEnvVars) {
+        if (isMissingEnvVars || !supabase) {
             setError(t("errors.databaseNotConfigured"));
             setLoading(false);
             return;

--- a/apps/web/tests/login-page.test.tsx
+++ b/apps/web/tests/login-page.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import LoginPage from "../app/[locale]/login/page";
+import { createBrowserClient } from "@supabase/ssr";
+
+jest.mock("@supabase/ssr", () => ({
+    createBrowserClient: jest.fn(() => ({
+        auth: {
+            signInWithPassword: jest.fn(),
+            signInWithOAuth: jest.fn(),
+        },
+    })),
+}));
+
+jest.mock("@/lib/env", () => ({
+    getSupabaseUrl: () => "https://example.supabase.co",
+    getSupabaseAnonKey: () => "anon-key-123",
+}));
+
+jest.mock("next-intl", () => ({
+    useLocale: () => "en",
+    useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+}));
+
+jest.mock("@/i18n/routing", () => ({
+    Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+        <a href={href}>{children}</a>
+    ),
+    useRouter: () => ({
+        push: jest.fn(),
+    }),
+}));
+
+describe("LoginPage Supabase client creation", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should instantiate the Supabase client only once on initial render and reuse it across state updates", () => {
+        render(<LoginPage />);
+
+        // createBrowserClient should have been called once on initial render
+        expect(createBrowserClient).toHaveBeenCalledTimes(1);
+
+        // Find the email input field and type in it to trigger state updates/re-renders
+        const emailInput = screen.getByPlaceholderText("Login.emailPlaceholder");
+        fireEvent.change(emailInput, { target: { value: "test@example.com" } });
+
+        // Type in the password input to trigger another state update/re-render
+        const passwordInput = screen.getByPlaceholderText("Login.passwordPlaceholder");
+        fireEvent.change(passwordInput, { target: { value: "password123" } });
+
+        // createBrowserClient should STILL have been called only once, demonstrating useMemo is successfully keeping it cached/singleton
+        expect(createBrowserClient).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2192**
- **Summary:**
  - Memoized the Supabase browser client creation in the `LoginPage` component body using a `useMemo` hook, ensuring the client persists across component renders when user inputs update state.
  - Wrapped environment configuration retrieval in a safe `useMemo` block with try-catch logic, avoiding page-wide server-side rendering (SSR) crashes if environment variables are missing and displaying a helpful warning box instead.
  - Added checks to `handleLogin`, `handleGoogleLogin`, and `handleGithubLogin` to ensure the Supabase client is properly defined before access.
  - Created a dedicated unit test in `apps/web/tests/login-page.test.tsx` verifying that client instantiation is executed only once on mount and not on state changes or typing re-renders.

## 📸 Proof of Work (Screenshots / Logs)

### Automated Test Runs
The new unit tests verifying memoization and singleton persistence pass successfully:
```text
PASS tests/login-page.test.tsx
  LoginPage Supabase client creation
    √ should instantiate the Supabase client only once on initial render and reuse it across state updates (41 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.549 s
Ran all test suites matching tests/login-page.test.tsx.
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2192`)
- [x] I have pulled the latest `main` and resolved any conflicts