### PR TITLE
fix(web): escape double quotes in calculator search to prevent PostgREST injection(closes #2201)

### DIFF
--- a/apps/web/app/[locale]/calculator/page.tsx
+++ b/apps/web/app/[locale]/calculator/page.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from "../components/PageHeader";
 import MedicineSearchSelect from "@/src/components/MedicineSearchSelect";
 import { fetchGenericAlternatives, type GenericAlternative } from "@/lib/api/alternatives";
 import { supabase } from "@/lib/supabase";
+import { escapePostgrest } from "@/lib/supabase/utils";
 import type { Medicine } from "@/src/components/ComparisonGrid";
 import { useRouter, useParams, useSearchParams } from "next/navigation";
 import {
@@ -23,13 +24,13 @@ async function searchMedicines(query: string): Promise<Medicine[]> {
     const q = query.trim();
     if (q.length < 2) return [];
 
-    const pattern = `%${q.replace(/[%_\\]/g, "\\$&")}%`;
+    const escaped = escapePostgrest(q);
     const { data, error } = await supabase
         .from("medicines")
         .select(
             "id, brand_name, generic_name, manufacturer, mrp, jan_aushadhi_price, composition, cdsco_approval_status"
         )
-        .or(`brand_name.ilike."${pattern}",generic_name.ilike."${pattern}"`)
+        .or(`brand_name.ilike."%${escaped}%",generic_name.ilike."%${escaped}%"`)
         .limit(20);
 
     if (error) {

--- a/apps/web/tests/calculator-search.test.tsx
+++ b/apps/web/tests/calculator-search.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import CalculatorPage from "../app/[locale]/calculator/page";
+import { supabase } from "@/lib/supabase";
+
+// Mock supabase client
+jest.mock("@/lib/supabase", () => {
+    const mockLimit = jest.fn().mockResolvedValue({ data: [], error: null });
+    const mockOr = jest.fn().mockReturnValue({ limit: mockLimit });
+    const mockSelect = jest.fn().mockReturnValue({ or: mockOr });
+    const mockFrom = jest.fn().mockReturnValue({ select: mockSelect });
+
+    return {
+        supabase: {
+            from: mockFrom,
+            _mockOr: mockOr, // expose mock for checking calls
+        },
+    };
+});
+
+jest.mock("next-intl", () => ({
+    useLocale: () => "en",
+    useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+}));
+
+jest.mock("next/navigation", () => ({
+    useRouter: () => ({
+        push: jest.fn(),
+    }),
+    useParams: () => ({ locale: "en" }),
+    useSearchParams: () => ({
+        get: jest.fn(),
+    }),
+}));
+
+describe("CalculatorPage search safety", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("should escape double quotes in search query to prevent PostgREST injection", async () => {
+        render(<CalculatorPage />);
+
+        // Find the medicine search select input
+        const searchInput = screen.getByRole("combobox");
+
+        // Type a query with double quotes: Crocin" OR "Paracetamol
+        fireEvent.change(searchInput, { target: { value: 'Crocin" OR "Paracetamol' } });
+
+        // Wait for debounced search to trigger the database query (MedicineSearchSelect has 300ms debounce)
+        await waitFor(
+            () => {
+                expect(supabase.from).toHaveBeenCalledWith("medicines");
+            },
+            { timeout: 1000 }
+        );
+
+        // Verify the argument passed to .or()
+        const mockOr = (supabase as any)._mockOr;
+        expect(mockOr).toHaveBeenCalled();
+        const callArg = mockOr.mock.calls[0][0];
+
+        // It should contain properly escaped double quotes '""' instead of '"'
+        expect(callArg).toContain('brand_name.ilike."%Crocin"" OR ""Paracetamol%"');
+        expect(callArg).toContain('generic_name.ilike."%Crocin"" OR ""Paracetamol%"');
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2201**
- **Summary:**
  - Integrated the `escapePostgrest` utility inside the `searchMedicines` handler of the Medicine Calculator search page ([page.tsx](file:///d:/sahidawa-india/apps/web/app/[locale]/calculator/page.tsx)).
  - Double quotes (`"`) inside search queries are now correctly escaped (doubled to `""`) inside raw Supabase `.or()` PostgREST filter strings to prevent injection or query breaking.
  - Added a dedicated JSDOM unit test in [calculator-search.test.tsx](file:///d:/sahidawa-india/apps/web/tests/calculator-search.test.tsx) to verify that queries with quotes are correctly escaped and passed safely to the Supabase client.

## 📸 Proof of Work (Screenshots / Logs)

### Automated Test Runs
The new safety unit test passes successfully:
```text
PASS tests/calculator-search.test.tsx
  CalculatorPage search safety
    √ should escape double quotes in search query to prevent PostgREST injection (399 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        2.489 s
Ran all test suites matching tests/calculator-search.test.tsx.
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2201`)
- [x] I have pulled the latest `main` and resolved any conflicts