### PR TITLE
fix(api): build single .or() expression for scan/match fallback

### DIFF
--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -673,15 +673,18 @@ router.post("/match", scanQueryLimiter, async (req: Request, res: Response) => {
                 .split(/\s+/)
                 .filter((w: string) => w.length > 2);
             if (words.length > 1) {
-                let fallbackQuery = supabase.from("medicines").select("brand_name, generic_name");
+                const orConditions = words
+                    .map(
+                        (w: string) =>
+                            `brand_name.ilike.%${escapePostgrest(w)}%,generic_name.ilike.%${escapePostgrest(w)}%`
+                    )
+                    .join(",");
 
-                for (const word of words) {
-                    fallbackQuery = fallbackQuery.or(
-                        `brand_name.ilike.%${escapePostgrest(word)}%,generic_name.ilike.%${escapePostgrest(word)}%`
-                    );
-                }
-
-                const { data: fallback } = await (fallbackQuery as any).limit(3);
+                const { data: fallback } = await supabase
+                    .from("medicines")
+                    .select("brand_name, generic_name")
+                    .or(orConditions)
+                    .limit(3);
                 if (fallback && fallback.length > 0) {
                     const fallbackResult = fallback.map(
                         (m: { brand_name: string | null; generic_name: string }) => ({


### PR DESCRIPTION
## Summary

Fixes a bug in `POST /api/v1/scan/match` where the fallback database search called `.or()` in a loop. Each call overwrites the previous filter in the Supabase JS client, so multi-word queries silently only matched the last word.

## Changes

- **`apps/api/src/routes/scan.ts`**: Build the full OR expression as a single string before passing it to Supabase, instead of calling `.or()` in a loop.

## Impact

**Before:** Searching "paracetamol 500mg" would only search for medicines matching "500mg".

**After:** Searching "paracetamol 500mg" searches for medicines matching either "paracetamol" OR "500mg".

## Closes

Closes #2374
