### PR TITLE
fix(api): add rate limiter to POST /interactions/check

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -94,3 +94,25 @@ export const scanQueryLimiter = rateLimit({
         });
     },
 });
+
+// ── Interaction check limiter ──────────────────────────────────────────────
+// POST /interactions/check accepts up to 20 medicines, generating up to 190
+// DB queries per request. Throttle to prevent DoS via batch interaction checks.
+export const interactionCheckLimiter = rateLimit({
+    windowMs: 60 * 1000, // 1 minute
+    max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: (req) => {
+        return (
+            req.headers["x-forwarded-for"]?.toString().split(",")[0]?.trim() ||
+            req.socket.remoteAddress ||
+            "unknown"
+        );
+    },
+    handler: (_req, res) => {
+        res.status(429).json({
+            error: "Too many interaction check requests. Please try again later.",
+        });
+    },
+});

--- a/apps/api/src/routes/interactions.ts
+++ b/apps/api/src/routes/interactions.ts
@@ -4,6 +4,7 @@ import { supabase, dbConfig } from "../db/client";
 import logger from "../utils/logger";
 import { escapeIlike } from "../utils/db";
 import { escapePostgrest } from "../utils/db";
+import { interactionCheckLimiter } from "../middleware/rateLimit";
 
 const router = Router();
 
@@ -440,7 +441,7 @@ async function resolveToGeneric(input: string): Promise<{ input: string; generic
  *                       source:
  *                         type: string
  */
-router.post("/check", async (req: Request, res: Response) => {
+router.post("/check", interactionCheckLimiter, async (req: Request, res: Response) => {
     const parsed = checkSchema.safeParse(req.body);
 
     if (!parsed.success) {


### PR DESCRIPTION
## Summary

Adds a rate limiter to `POST /api/v1/interactions/check`. This endpoint accepts up to 20 medicines and generates up to 190 DB queries per request, with no rate limiting — allowing trivial DoS by sending rapid batch requests.

## Changes

- **`apps/api/src/middleware/rateLimit.ts`**: Add `interactionCheckLimiter` (10 requests per minute per IP)
- **`apps/api/src/routes/interactions.ts`**: Import and apply `interactionCheckLimiter` to the `/check` route

## Impact

**Before:** Unlimited requests, each generating up to 190 DB queries.

**After:** Max 10 requests per minute per IP, consistent with other POST endpoints.

## Closes

Closes #2375
