### PR TITLE
Fix : drugLookup.service.ts Looks Up Drugs Purely by batch_number #2330

### DIFF
--- a/apps/api/src/routes/batch.ts
+++ b/apps/api/src/routes/batch.ts
@@ -38,15 +38,21 @@ const batchParamSchema = z.object({
     batchNumber: BATCH_NUMBER_SCHEMA,
 });
 
-const reportBatchSchema = z.object({
-    batchNumber: BATCH_NUMBER_SCHEMA,
-    description: z.string().min(10, "Description must be at least 10 characters"),
-    reporterName: z.string().optional(),
-    city: z.string().optional(),
-    state: z.string().optional(),
-    pincode: z.string().optional(),
-    pharmacyName: z.string().optional(),
-});
+const reportBatchSchema = z
+    .object({
+        batchNumber: BATCH_NUMBER_SCHEMA,
+        brandName: z.string().optional(),
+        barcodeId: z.string().optional(),
+        description: z.string().min(10, "Description must be at least 10 characters"),
+        reporterName: z.string().optional(),
+        city: z.string().optional(),
+        state: z.string().optional(),
+        pincode: z.string().optional(),
+        pharmacyName: z.string().optional(),
+    })
+    .refine((data) => data.brandName || data.barcodeId, {
+        message: "Either brandName or barcodeId must be provided alongside batchNumber",
+    });
 
 // ── GET /api/verify/batch/:batchNumber ────────────────────────────────────────
 
@@ -134,14 +140,32 @@ router.get("/:batchNumber", batchLimiter, async (req: Request, res: Response) =>
 
         // ── Fall back to medicines table if no dedicated batch record ─────────
         if (!batchData) {
-            const { data: medicineData, error: medicineError } = await supabase
+            const { brandName, barcodeId } = req.query as {
+                brandName?: string;
+                barcodeId?: string;
+            };
+
+            if (!brandName && !barcodeId) {
+                res.status(400).json({
+                    error: "Missing required composite identifier (brandName or barcodeId query parameter)",
+                });
+                return;
+            }
+
+            let query = supabase
                 .from("medicines")
                 .select(
                     "id, brand_name, generic_name, manufacturer, batch_number, manufacturing_date, expiry_date, cdsco_approval_status, is_counterfeit_alert, is_cdsco_verified, cdsco_match_score, matched_cdsco_product, matched_cdsco_manufacturer, product_match_score, manufacturer_match_score, manufacturer_id"
                 )
-                .eq("batch_number", batchNumber)
-                .limit(1)
-                .maybeSingle();
+                .eq("batch_number", batchNumber);
+
+            if (barcodeId) {
+                query = query.eq("barcode_id", barcodeId);
+            } else if (brandName) {
+                query = query.eq("brand_name", brandName);
+            }
+
+            const { data: medicineData, error: medicineError } = await query.limit(1).maybeSingle();
 
             if (medicineError) {
                 logger.error({
@@ -351,11 +375,12 @@ router.post("/report", batchLimiter, async (req: Request, res: Response) => {
         return;
     }
 
-    const { batchNumber, description, city, state, pincode, pharmacyName } = parsed.data;
+    const { batchNumber, brandName, barcodeId, description, city, state, pincode, pharmacyName } =
+        parsed.data;
     const hashedIp = anonymizeIp(req.ip);
 
     const reportPayload = {
-        medicineName: batchNumber,
+        medicineName: brandName || batchNumber,
         manufacturer: "",
         description,
         pharmacyName: pharmacyName ?? "",
@@ -387,12 +412,15 @@ router.post("/report", batchLimiter, async (req: Request, res: Response) => {
     try {
         // Use .eq() instead of .ilike() — exact match, no wildcard risk
         let medicine_id: string | null = null;
-        const { data: medicineMatch } = await supabase
-            .from("medicines")
-            .select("id")
-            .eq("batch_number", batchNumber)
-            .limit(1)
-            .maybeSingle();
+        let query = supabase.from("medicines").select("id").eq("batch_number", batchNumber);
+
+        if (barcodeId) {
+            query = query.eq("barcode_id", barcodeId);
+        } else if (brandName) {
+            query = query.eq("brand_name", brandName);
+        }
+
+        const { data: medicineMatch } = await query.limit(1).maybeSingle();
 
         if (medicineMatch) {
             medicine_id = medicineMatch.id;
@@ -400,8 +428,8 @@ router.post("/report", batchLimiter, async (req: Request, res: Response) => {
 
         const { error } = await supabase.from("counterfeit_reports").insert({
             medicine_id,
-            scanned_barcode: batchNumber,
-            reported_brand_name: batchNumber,
+            scanned_barcode: barcodeId ?? batchNumber,
+            reported_brand_name: brandName ?? batchNumber,
             description,
             city: city ?? null,
             state: state ?? null,

--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -39,21 +39,28 @@ function maskClientIp(ip: string | undefined): string | null {
 
 const router = Router();
 
-const verifySchema = z.object({
-    batchNumber: z
-        .string({ message: "batchNumber is required and must be a string" })
-        .min(3, "batchNumber must be at least 3 characters long"),
-    latitude: z
-        .number()
-        .min(-90, "Latitude must be between -90 and 90")
-        .max(90, "Latitude must be between -90 and 90")
-        .optional(),
-    longitude: z
-        .number()
-        .min(-180, "Longitude must be between -180 and 180")
-        .max(180, "Longitude must be between -180 and 180")
-        .optional(),
-});
+const verifySchema = z
+    .object({
+        batchNumber: z
+            .string({ message: "batchNumber is required and must be a string" })
+            .min(3, "batchNumber must be at least 3 characters long"),
+        brandName: z.string().optional(),
+        barcodeId: z.string().optional(),
+        latitude: z
+            .number()
+            .min(-90, "Latitude must be between -90 and 90")
+            .max(90, "Latitude must be between -90 and 90")
+            .optional(),
+        longitude: z
+            .number()
+            .min(-180, "Longitude must be between -180 and 180")
+            .max(180, "Longitude must be between -180 and 180")
+            .optional(),
+    })
+    .refine((data) => data.brandName || data.barcodeId, {
+        message: "Either brandName or barcodeId must be provided",
+        path: ["brandName", "barcodeId"],
+    });
 
 /**
  * @openapi
@@ -175,7 +182,7 @@ router.post(
             return;
         }
 
-        const { batchNumber, latitude, longitude } = parsed.data;
+        const { batchNumber, brandName, barcodeId, latitude, longitude } = parsed.data;
 
         const upperBatch = batchNumber.toUpperCase();
         const ALLOWED_MOCK_BATCHES = new Set([
@@ -228,7 +235,10 @@ router.post(
             return;
         }
         try {
-            const data = await lookupDrugByBatch(batchNumber);
+            const data = await lookupDrugByBatch(batchNumber, {
+                brand_name: brandName,
+                barcode_id: barcodeId,
+            });
 
             if (!data) {
                 res.status(404).json({

--- a/apps/api/src/services/drugLookup.service.ts
+++ b/apps/api/src/services/drugLookup.service.ts
@@ -8,34 +8,54 @@ import {
 import logger from "../utils/logger";
 
 /**
- * Looks up a drug by its batch number.
+ * Looks up a drug by its batch number and an identifier (barcode or brand name).
  * It first checks the Redis cache. If missed, it queries the database and caches the result.
  */
-export async function lookupDrugByBatch(batchNumber: string): Promise<any | null> {
+export interface DrugLookupIdentifier {
+    brand_name?: string;
+    barcode_id?: string;
+}
+
+export async function lookupDrugByBatch(
+    batchNumber: string,
+    identifier: DrugLookupIdentifier
+): Promise<any | null> {
+    if (!identifier.brand_name && !identifier.barcode_id) {
+        throw new Error("Either brand_name or barcode_id must be provided alongside batch_number");
+    }
+
+    const cacheKey = `${batchNumber}|${identifier.barcode_id || ""}|${identifier.brand_name || ""}`;
+
     // 1. Try to fetch from Redis cache
     try {
-        const cachedDrug = await getCachedDrug(batchNumber);
+        const cachedDrug = await getCachedDrug(cacheKey);
         if (cachedDrug) {
-            logger.info(`Cache HIT for drug batch: ${batchNumber}`);
+            logger.info(`Cache HIT for drug batch: ${cacheKey}`);
             return cachedDrug;
         }
     } catch (err) {
-        logger.error(`Error checking cache for batch: ${batchNumber}`, err);
+        logger.error(`Error checking cache for batch: ${cacheKey}`, err);
     }
 
     // 2. Cache miss, query PostgreSQL database
-    logger.info(`Cache MISS for drug batch: ${batchNumber}. Querying database...`);
+    logger.info(`Cache MISS for drug batch: ${cacheKey}. Querying database...`);
     await incrementMissCount();
 
     try {
-        const { data, error } = await supabase
+        let query = supabase
             .from("medicines")
             .select(
                 "id, barcode_id, brand_name, generic_name, manufacturer, batch_number, manufacturing_date, expiry_date, cdsco_approval_status, is_counterfeit_alert, is_cdsco_verified, cdsco_match_score, matched_cdsco_product, matched_cdsco_manufacturer, product_match_score, manufacturer_match_score, manufacturer_id"
             )
-            .eq("batch_number", batchNumber)
-            .limit(1)
-            .maybeSingle();
+            .eq("batch_number", batchNumber);
+
+        if (identifier.barcode_id) {
+            query = query.eq("barcode_id", identifier.barcode_id);
+        } else if (identifier.brand_name) {
+            query = query.eq("brand_name", identifier.brand_name);
+        }
+
+        const { data, error } = await query.limit(1).maybeSingle();
 
         if (error) {
             logger.error({
@@ -50,7 +70,7 @@ export async function lookupDrugByBatch(batchNumber: string): Promise<any | null
             // Increment the hit count for the drug ID so that its TTL tier increases and update the top drugs sorted set
             await incrementHitCount(data.id, data.brand_name || data.generic_name);
             // Save the drug to cache with a tiered TTL determined dynamically
-            await setCachedDrug(batchNumber, data);
+            await setCachedDrug(cacheKey, data);
         }
 
         return data;

--- a/apps/api/src/services/drugLookup.test.ts
+++ b/apps/api/src/services/drugLookup.test.ts
@@ -68,10 +68,10 @@ describe("drugLookup Service - lookupDrugByBatch", () => {
     it("should return cached drug immediately on cache hit", async () => {
         (getCachedDrug as jest.Mock).mockResolvedValue(mockDrug);
 
-        const result = await lookupDrugByBatch(batchNumber);
+        const result = await lookupDrugByBatch(batchNumber, { brand_name: "Dolo 650" });
 
         expect(result).toEqual(mockDrug);
-        expect(getCachedDrug).toHaveBeenCalledWith(batchNumber);
+        expect(getCachedDrug).toHaveBeenCalledWith("B12345||Dolo 650");
         // Verify database was NOT queried
         expect(supabase.from).not.toHaveBeenCalled();
         expect(incrementMissCount).not.toHaveBeenCalled();
@@ -81,29 +81,30 @@ describe("drugLookup Service - lookupDrugByBatch", () => {
         (getCachedDrug as jest.Mock).mockResolvedValue(null);
         mockMaybeSingle.mockResolvedValue({ data: mockDrug, error: null });
 
-        const result = await lookupDrugByBatch(batchNumber);
+        const result = await lookupDrugByBatch(batchNumber, { brand_name: "Dolo 650" });
 
         expect(result).toEqual(mockDrug);
-        expect(getCachedDrug).toHaveBeenCalledWith(batchNumber);
+        expect(getCachedDrug).toHaveBeenCalledWith("B12345||Dolo 650");
         expect(incrementMissCount).toHaveBeenCalled();
         expect(supabase.from).toHaveBeenCalledWith("medicines");
-        expect(supabase.select).toHaveBeenCalled();
-        expect(supabase.eq).toHaveBeenCalledWith("batch_number", batchNumber);
-        expect(supabase.limit).toHaveBeenCalledWith(1);
+        expect((supabase as any).select).toHaveBeenCalled();
+        expect((supabase as any).eq).toHaveBeenCalledWith("batch_number", batchNumber);
+        expect((supabase as any).eq).toHaveBeenCalledWith("brand_name", "Dolo 650");
+        expect((supabase as any).limit).toHaveBeenCalledWith(1);
 
         // Cache updates should be triggered
         expect(incrementHitCount).toHaveBeenCalledWith(mockDrug.id, mockDrug.brand_name);
-        expect(setCachedDrug).toHaveBeenCalledWith(batchNumber, mockDrug);
+        expect(setCachedDrug).toHaveBeenCalledWith("B12345||Dolo 650", mockDrug);
     });
 
     it("should return null and not update cache if drug is not found in database", async () => {
         (getCachedDrug as jest.Mock).mockResolvedValue(null);
         mockMaybeSingle.mockResolvedValue({ data: null, error: null });
 
-        const result = await lookupDrugByBatch(batchNumber);
+        const result = await lookupDrugByBatch(batchNumber, { barcode_id: "8901148220042" });
 
         expect(result).toBeNull();
-        expect(getCachedDrug).toHaveBeenCalledWith(batchNumber);
+        expect(getCachedDrug).toHaveBeenCalledWith("B12345|8901148220042|");
         expect(incrementMissCount).toHaveBeenCalled();
         expect(supabase.from).toHaveBeenCalledWith("medicines");
 
@@ -117,9 +118,11 @@ describe("drugLookup Service - lookupDrugByBatch", () => {
         (getCachedDrug as jest.Mock).mockResolvedValue(null);
         mockMaybeSingle.mockResolvedValue({ data: null, error: dbError });
 
-        await expect(lookupDrugByBatch(batchNumber)).rejects.toThrow(dbError);
+        await expect(lookupDrugByBatch(batchNumber, { brand_name: "Dolo 650" })).rejects.toThrow(
+            dbError
+        );
 
-        expect(getCachedDrug).toHaveBeenCalledWith(batchNumber);
+        expect(getCachedDrug).toHaveBeenCalledWith("B12345||Dolo 650");
         expect(incrementMissCount).toHaveBeenCalled();
         expect(supabase.from).toHaveBeenCalledWith("medicines");
 
@@ -133,14 +136,14 @@ describe("drugLookup Service - lookupDrugByBatch", () => {
         (getCachedDrug as jest.Mock).mockRejectedValue(cacheError);
         mockMaybeSingle.mockResolvedValue({ data: mockDrug, error: null });
 
-        const result = await lookupDrugByBatch(batchNumber);
+        const result = await lookupDrugByBatch(batchNumber, { brand_name: "Dolo 650" });
 
         expect(result).toEqual(mockDrug);
-        expect(getCachedDrug).toHaveBeenCalledWith(batchNumber);
+        expect(getCachedDrug).toHaveBeenCalledWith("B12345||Dolo 650");
         // Verify it still queried the database
         expect(supabase.from).toHaveBeenCalledWith("medicines");
         expect(incrementMissCount).toHaveBeenCalled();
         expect(incrementHitCount).toHaveBeenCalledWith(mockDrug.id, mockDrug.brand_name);
-        expect(setCachedDrug).toHaveBeenCalledWith(batchNumber, mockDrug);
+        expect(setCachedDrug).toHaveBeenCalledWith("B12345||Dolo 650", mockDrug);
     });
 });

--- a/apps/api/tests/cache.service.test.ts
+++ b/apps/api/tests/cache.service.test.ts
@@ -207,7 +207,7 @@ describe("Redis Caching and Drug Lookup Services", () => {
             };
             mockRedis.get.mockResolvedValueOnce(JSON.stringify(mockMed));
 
-            const result = await lookupDrugByBatch("BATCH-1");
+            const result = await lookupDrugByBatch("BATCH-1", { brand_name: "Crocin" });
 
             expect(result).toEqual(mockMed);
             expect(mockSupabase.from).not.toHaveBeenCalled();
@@ -225,7 +225,7 @@ describe("Redis Caching and Drug Lookup Services", () => {
             mockRedis.incr.mockResolvedValue(1);
             mockRedis.zIncrBy.mockResolvedValue(1);
 
-            const result = await lookupDrugByBatch("BATCH-1");
+            const result = await lookupDrugByBatch("BATCH-1", { brand_name: "Crocin" });
 
             expect(result).toEqual(mockMed);
             expect(mockSupabase.from).toHaveBeenCalledWith("medicines");
@@ -233,7 +233,7 @@ describe("Redis Caching and Drug Lookup Services", () => {
             expect(mockRedis.incr).toHaveBeenCalledWith("hits:drug:med-1");
             expect(mockRedis.zIncrBy).toHaveBeenCalledWith("stats:top_drugs", 1, "Crocin");
             expect(mockRedis.set).toHaveBeenCalledWith(
-                "drug:batch:BATCH-1",
+                "drug:batch:BATCH-1||Crocin",
                 JSON.stringify(mockMed),
                 { EX: TTL_TIERS.COLD }
             );


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2330**
- **Summary:**
- Updated the `lookupDrugByBatch` function signature to require a `DrugLookupIdentifier` containing brand_name or barcode_id.
- Updated the `Supabase` query to filter by both the batch number and the provided identifier.
- Changed the Redis cache key format to use a composite key `(batchNumber|barcode_id|brand_name)` to prevent cache collisions between different medicines sharing a batch number.
- `GET /api/verify/batch/:batchNumber`: Updated to accept and require brandName or barcodeId as query parameters when executing the fallback query against the medicines table.
- `POST /api/verify/batch/report`: Updated the `reportBatchSchema` to require `brandName or barcodeId` in the request body to accurately link the report to the correct medicine ID.
- Updated all function calls to lookupDrugByBatch to match the new signature with mock identifiers.
- Updated cache key assertions to match the new composite format (e.g., "B12345||Dolo 650").


## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
