### PR TITLE
refactor(web): extract chat role strings to shared constants

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -4,6 +4,7 @@ import { detectEmergencyKeywords } from "@/lib/voice/emergency";
 import { rateLimit } from "@/lib/rateLimit";
 import { BASE_PROMPT } from "@/lib/chatPrompts";
 import { structuredLog } from "@/lib/structuredLogger";
+import { ChatRoles, ChatRole } from "@/lib/constants";
 
 const DEFAULT_DISCLAIMER =
     "This guidance is for informational use only and is not a diagnosis. Consult a doctor or pharmacist, especially for severe or persistent symptoms.";
@@ -11,7 +12,7 @@ const DEFAULT_DISCLAIMER =
 type ChatMessage = {
     text?: string;
     content?: string;
-    role?: string;
+    role?: ChatRole | string;
 };
 
 type VoiceTriageResponse = {
@@ -41,7 +42,7 @@ function getLatestMessageText(messages: ChatMessage[] | undefined) {
 function mapMessagesToGeminiContents(messages: ChatMessage[]) {
     return messages.map((msg) => {
         const text = msg.text || msg.content || "";
-        const role = msg.role === "assistant" ? "model" : "user";
+        const role = msg.role === ChatRoles.ASSISTANT ? ChatRoles.MODEL : ChatRoles.USER;
         return { role, parts: [{ text }] };
     });
 }
@@ -183,13 +184,16 @@ export async function POST(req: Request) {
                     process.env.NEXT_PUBLIC_ML_SERVICE_URL?.trim() ||
                     "http://localhost:8000";
                 const formattedMessages = (messages || []).map((m: any) => ({
-                    role: m.role === "assistant" || m.role === "model" ? "assistant" : "user",
+                    role:
+                        m.role === ChatRoles.ASSISTANT || m.role === ChatRoles.MODEL
+                            ? ChatRoles.ASSISTANT
+                            : ChatRoles.USER,
                     content: m.text || m.content || "",
                 }));
 
                 // If there's no history, initialize with the current message
                 if (formattedMessages.length === 0) {
-                    formattedMessages.push({ role: "user", content: latestMessageText });
+                    formattedMessages.push({ role: ChatRoles.USER, content: latestMessageText });
                 }
 
                 const mlResponse = await fetch(`${mlServiceUrl}/triage/chat`, {

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -1,0 +1,7 @@
+export const ChatRoles = {
+    USER: "user",
+    MODEL: "model",
+    ASSISTANT: "assistant",
+} as const;
+
+export type ChatRole = typeof ChatRoles[keyof typeof ChatRoles];


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #** [2342]
- **Summary:**
  Refactored `apps/web/app/api/chat/route.ts` to eliminate hardcoded string literals for chat roles (`"user"`, `"model"`, and `"assistant"`). 
  - Extracted these roles into a centralized `ChatRoles` constant object and `ChatRole` type definition inside a new `apps/web/lib/constants.ts` file.
  - Replaced all raw inline string occurrences within the route handler and helper functions with reference to `ChatRoles` constants.
  - Updated the `ChatMessage` type signature to reference `ChatRole` to ensure type safety.

## 📸 Proof of Work (Screenshots / Logs)
<img width="1098" height="455" alt="image" src="https://github.com/user-attachments/assets/a46659db-3bed-4a2c-b2bd-b4197de8e308" />

Chatbot is working fine and well , After the changes