### PR TITLE
fix(ml): register voice_verify router and add openai-whisper dep

### DIFF
--- a/apps/ml/main.py
+++ b/apps/ml/main.py
@@ -53,6 +53,7 @@ if not ocr_loaded:
 tts_loaded = include_router_if_available(app, "routers.tts", required=False)
 if not tts_loaded:
     logger.warning("TTS routes are disabled. Install google-cloud-texttospeech or configure Azure TTS.")
+include_router_if_available(app, "routers.voice_verify", required=True)
 
 @app.get("/")
 def read_root():

--- a/apps/ml/requirements.txt
+++ b/apps/ml/requirements.txt
@@ -27,6 +27,7 @@ thefuzz==0.22.1
 
 # ASR (Speech-to-Text)
 faster-whisper>=1.1.0
+openai-whisper>=20240930
 soundfile>=0.12.1
 noisereduce>=3.0.0
 numpy>=1.26.0


### PR DESCRIPTION
## Summary

Fixes #2394 — Voice Verification ML endpoint never registered + missing dependency.

## Changes

1. **apps/ml/main.py**: Added `include_router_if_available(app, "routers.voice_verify", required=True)` after the TTS router registration.

2. **apps/ml/requirements.txt**: Added `openai-whisper>=20240930` — voice_verify.py imports `whisper` (the original OpenAI Whisper library), which was missing from the requirements.

## Impact

- `POST /voice/verify` and `GET /voice/languages` are now reachable
- The entire voice-medicine-verification feature works end-to-end