### PR TITLE
fix(api): prevent escapePostgrest from escaping ILIKE wildcards in medicine RAG fallback

### DIFF
--- a/apps/api/src/services/medicineRag.service.ts
+++ b/apps/api/src/services/medicineRag.service.ts
@@ -283,14 +283,15 @@ export async function retrieveRelevantMedicines(
     });
 
     // Tier 3 — in-memory ILIKE filter over the table.
-    const pattern = `%${escapeIlike(query)}%`;
+    const safe = escapePostgrest(escapeIlike(query));
+    const pattern = `%${safe}%`;
     const { data: tableData, error: tableError } = await anonSupabase
         .from("medicines")
         .select(
             "id, brand_name, generic_name, manufacturer, composition, strength, dosage_form, schedule, mrp, jan_aushadhi_price"
         )
         .or(
-            `generic_name.ilike."${escapePostgrest(pattern)}",brand_name.ilike."${escapePostgrest(pattern)}",composition.ilike."${escapePostgrest(pattern)}"`
+            `generic_name.ilike."${pattern}",brand_name.ilike."${pattern}",composition.ilike."${pattern}"`
         )
         .limit(limit);
 


### PR DESCRIPTION
## Summary

Fixes #2395 — medicineRag.service.ts Tier-3 fallback search returns 0 results because `escapePostgrest()` double-escapes the outer ILIKE `%` wildcards.

## Root Cause

The `pattern` variable was built with outer `%` wildcards first, then `escapePostgrest()` was applied — which escapes `%` globally, turning the wildcards into literal `\%` characters.

```ts
// Before (broken)
const pattern = `%${escapeIlike(query)}%`;
.or(`...ilike."${escapePostgrest(pattern)}"...`)  // outer % escaped too!
```

## Fix

Escape the value `before` wrapping with outer `%` wildcards:

```ts
// After (fixed)
const safe = escapePostgrest(escapeIlike(query));
const pattern = `%${safe}%`;
.or(`...ilike."${pattern}"...`)
```

This matches the pattern used by `alternatives.ts` and `scan.ts`.