### PR TITLE
[BUG] ML Service Tracing Config from .env Silently Ignored — setup_tracing() Called Before load_dotenv()

### DIFF
--- a/apps/ml/main.py
+++ b/apps/ml/main.py
@@ -8,13 +8,14 @@ from tracing import setup_tracing
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
 
+load_dotenv()
+
 setup_tracing()
 RequestsInstrumentor().instrument()
 
 from services.telemetry import configure_telemetry_logging
 from services.router_loader import include_router_if_available
 
-load_dotenv()
 configure_telemetry_logging()
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

Reorder startup sequence so `load_dotenv()` runs before `setup_tracing()`. The tracing function reads `OTEL_EXPORTER_OTLP_ENDPOINT` from environment, but if the value is set in `.env` it was silently ignored because `load_dotenv()` hadn't run yet.

### Changes
- Move `load_dotenv()` call to before `setup_tracing()` in `apps/ml/main.py`

Fixes #2409