### PR TITLE
[BUG] Report City/State Auto-Population from Pincode Silently Broken — geocodePincode Does Not Return Address Fields

### DIFF
--- a/apps/web/components/reports/ReportWizard.tsx
+++ b/apps/web/components/reports/ReportWizard.tsx
@@ -651,10 +651,8 @@ function Step3() {
         // Step 2: Debouncing - Wait 500ms after last keystroke
         const timer = setTimeout(async () => {
             try {
-                // Cast to any to access optional address fields (city, state) returned by the API
-                const geo = (await geocodePincode(pincode)) as any;
+                const geo = await geocodePincode(pincode);
                 if (geo) {
-                    // Auto-populate City and State
                     if (geo.city) setValue("city", geo.city, { shouldValidate: true });
                     if (geo.state) setValue("state", geo.state, { shouldValidate: true });
                 }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -120,17 +120,24 @@ export async function submitReport(
     });
 }
 
+type GeocodeResult = {
+    latitude: number;
+    longitude: number;
+    city?: string;
+    state?: string;
+};
+
 export async function geocodePincode(
     pincode: string,
     signal?: AbortSignal
-): Promise<{ latitude: number; longitude: number } | null> {
+): Promise<GeocodeResult | null> {
     if (typeof window !== "undefined" && !window.navigator.onLine) {
         return null;
     }
     try {
         const url =
             `https://nominatim.openstreetmap.org/search?postalcode=${encodeURIComponent(pincode)}` +
-            `&country=IN&format=json&limit=1`;
+            `&country=IN&format=json&addressdetails=1&limit=1`;
 
         let abortSignal = signal;
         if (!abortSignal) {
@@ -142,15 +149,27 @@ export async function geocodePincode(
             signal: abortSignal,
         });
         if (!r.ok) return null;
-        const arr = (await r.json()) as Array<{
+        type NominatimResult = {
             lat: string;
             lon: string;
-        }>;
+            address: {
+                city?: string;
+                town?: string;
+                village?: string;
+                municipality?: string;
+                county?: string;
+                state?: string;
+            };
+        };
+        const arr = (await r.json()) as NominatimResult[];
         if (!arr.length) return null;
-        const lat = parseFloat(arr[0].lat);
-        const lng = parseFloat(arr[0].lon);
+        const entry = arr[0];
+        const lat = parseFloat(entry.lat);
+        const lng = parseFloat(entry.lon);
         if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
-        return { latitude: lat, longitude: lng };
+        const city = entry.address?.city ?? entry.address?.town ?? entry.address?.village ?? entry.address?.municipality ?? entry.address?.county;
+        const state = entry.address?.state;
+        return { latitude: lat, longitude: lng, city, state };
     } catch (error) {
         if (typeof window !== "undefined") {
             console.warn(


### PR DESCRIPTION
## Description

Fix `geocodePincode` to return `city` and `state` from Nominatim response so the ReportWizard can auto-populate City and State fields when a user enters a valid 6-digit Indian pincode.

### Changes
- **apps/web/lib/api.ts**: Add `addressdetails=1` param to Nominatim API call so address breakdown is returned. Parse `address` object extracting `city` (with fallback to `town`/`village`/`municipality`/`county`) and `state`. Update return type accordingly.
- **apps/web/components/reports/ReportWizard.tsx**: Remove `as any` cast on `geocodePincode` result since the return type now properly includes `city` and `state`.

Fixes #2410