### PR TITLE
fix(api): escape PostgREST filter and validate ML transcription in me…

### DIFF
--- a/apps/api/src/routes/medicine.ts
+++ b/apps/api/src/routes/medicine.ts
@@ -3,6 +3,7 @@ import multer from "multer";
 import { supabase } from "../db/client";
 import { redisClient } from "../utils/redis";
 import { scanQueryLimiter } from "../middleware/rateLimit";
+import { escapeIlike, escapePostgrest } from "../utils/db";
 
 const router = Router();
 
@@ -61,12 +62,26 @@ router.post(
                 warnings: ["Medicine not found in CDSCO database. Consult a pharmacist."],
             };
 
+            if (transcribedText === "") {
+                verificationResult = {
+                    status: "transcription_failed",
+                    cdsco_registered: false,
+                    medicine_name_english: transcribedText,
+                    medicine_name_regional: transcribedText,
+                    manufacturer: "Unknown",
+                    category: "Unknown",
+                    warnings: ["Audio could not be transcribed. Please try again."],
+                };
+                result.verification = verificationResult;
+                return res.json(result);
+            }
+
             if (transcribedText) {
                 const { data: medicines } = await supabase
                     .from("medicines")
                     .select("brand_name, generic_name, manufacturer, is_cdsco_verified")
                     .or(
-                        `brand_name.ilike.%${transcribedText}%,generic_name.ilike.%${transcribedText}%`
+                        `brand_name.ilike."%${escapePostgrest(escapeIlike(transcribedText))}%",generic_name.ilike."%${escapePostgrest(escapeIlike(transcribedText))}%"`
                     )
                     .limit(1);
 


### PR DESCRIPTION
Closes #2354

### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #2354**
- **Summary:** Fixes two related gaps in `apps/api/src/routes/medicine.ts`'s `POST /verify-voice` route. (1) The PostgREST `.or()` filter previously interpolated the ML-transcribed text with no escaping; now applies `escapeIlike()` + `escapePostgrest()`, wrapped in quotes, mirroring the existing pattern in `interactions.ts`'s `resolveToGeneric`. (2) The route previously had no check for a missing/empty `result.transcribed` from the ML service; an empty transcription would silently fall through to a confident "not found" response. Added an explicit check that returns a distinct `status: "transcription_failed"` result instead.

## 📸 Proof of Work (Screenshots / Logs)
This route requires a live ML service and audio upload to exercise end-to-end, which wasn't available in my local setup. I verified both fixes by tracing the code manually against the exact failure conditions described in the issue:
- Confirmed the new `.or()` filter line matches the escaping pattern already used and trusted in `interactions.ts`.
- Traced `result.transcribed` missing → `undefined` → `String(undefined || "").trim()` → `""` → caught by the new `if (transcribedText === "")` check → returns `status: "transcription_failed"` early, skipping the Redis cache write (intentional — see note below).

## Known Limitation / Follow-up
While investigating, I discovered `apps/api/src/routes/medicine.ts` is not currently imported or mounted in `apps/api/src/app.ts` at all — the `/verify-voice` and `/languages` routes appear to be unreachable in the running app. This is a separate, pre-existing issue unrelated to this fix; I plan to file it separately rather than include it in this PR's scope.

I also deliberately did not cache `transcription_failed` results in Redis, since the cache key is built from `transcribedText`, which is empty in this case — caching under an empty key would risk serving one user's failure response to unrelated future requests.

## 🏷️ PR Type
- [x] 🐛 `type: bug`
- [x] 🔒 `type: security`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts