### PR TITLE
fix(chat): cap maximum message count and per-message length to preven…

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -161,7 +161,29 @@ export async function POST(req: Request) {
 
         const ai = getAiClient();
         const { messages, mode, responseLanguage, locale } = await req.json();
-        const latestMessageText = getLatestMessageText(messages);
+
+        if (!Array.isArray(messages) || messages.length === 0) {
+            return NextResponse.json({ error: "Messages are required" }, { status: 400 });
+        }
+
+        const MAX_MESSAGES = 50;
+        const MAX_MESSAGE_CHARS = 2000;
+        const trimmedMessages = messages.slice(-MAX_MESSAGES);
+
+        for (const msg of trimmedMessages) {
+            const text = msg.text || msg.content || "";
+            if (typeof text !== "string" || text.length > MAX_MESSAGE_CHARS) {
+                const isVoiceTriage =
+                    mode === "voice-triage" && msg === trimmedMessages[trimmedMessages.length - 1];
+                const errorMsg = isVoiceTriage
+                    ? `Transcript exceeds maximum allowed length of ${MAX_MESSAGE_CHARS} characters.`
+                    : `Each message must be under ${MAX_MESSAGE_CHARS} characters.`;
+
+                return NextResponse.json({ error: errorMsg }, { status: 400 });
+            }
+        }
+
+        const latestMessageText = getLatestMessageText(trimmedMessages);
 
         if (!latestMessageText) {
             structuredLog({
@@ -183,7 +205,7 @@ export async function POST(req: Request) {
                     process.env.ML_SERVICE_URL?.trim() ||
                     process.env.NEXT_PUBLIC_ML_SERVICE_URL?.trim() ||
                     "http://localhost:8000";
-                const formattedMessages = (messages || []).map((m: any) => ({
+                const formattedMessages = trimmedMessages.map((m: any) => ({
                     role:
                         m.role === ChatRoles.ASSISTANT || m.role === ChatRoles.MODEL
                             ? ChatRoles.ASSISTANT
@@ -267,7 +289,7 @@ export async function POST(req: Request) {
             });
         }
 
-        const formattedContents = mapMessagesToGeminiContents(messages || []);
+        const formattedContents = mapMessagesToGeminiContents(trimmedMessages);
 
         const supportedLocales = ["en", "gu", "bn", "te", "ta", "mr", "ur", "kn", "pa", "or", "hi"];
         const finalLocale = supportedLocales.includes(locale) ? locale : "en";
@@ -332,7 +354,7 @@ export async function POST(req: Request) {
                             input_tokens: usageMetadata?.promptTokenCount,
                             output_tokens: usageMetadata?.candidatesTokenCount,
                         },
-                        meta: { mode: "chat", messageCount: (messages || []).length },
+                        meta: { mode: "chat", messageCount: trimmedMessages.length },
                     });
                     controller.close();
                 } catch (streamError) {
@@ -346,7 +368,7 @@ export async function POST(req: Request) {
                             code: 500,
                             stack: streamError instanceof Error ? streamError.stack : undefined,
                         },
-                        meta: { mode: "chat", messageCount: (messages || []).length },
+                        meta: { mode: "chat", messageCount: trimmedMessages.length },
                     });
                     controller.error(streamError);
                 }


### PR DESCRIPTION
###  STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

##  PR Summary & Link

- **Closes #2418**
- **Summary:** Addresses the unbounded token volume vulnerability on the `/api/chat` endpoint by capping the message history to the most recent 50 messages (`MAX_MESSAGES`) and enforcing a strict 2000-character limit per message (`MAX_MESSAGE_CHARS`). It ensures large requests are rejected with a 400 status before reaching the Gemini API, effectively preventing token exhaustion and unexpected billing spikes.

##  Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

*Note: This is a backend security fix. Using the reproduction Python script provided in the original issue now correctly yields a `400 Bad Request` instead of a `200 OK`, protecting the Gemini API.*

##  PR Type

- [x]  `type: bug`
- [ ]  `type: feature`
- [ ]  `type: docs`
- [ ]  `type: testing`
- [x]  `type: security`
- [ ]  `type: performance`
- [ ]  `type: design`
- [ ]  `type: refactor`
- [ ]  `type: devops`
- [ ]  `type: accessibility`

##  Checklist

- [x] My PR has a linked issue (`Closes #2418`)
- [x] I have pulled the latest `main` and resolved any conflicts