### PR TITLE
fix(chat): handle missing GEMINI_API_KEY gracefully

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -159,6 +159,22 @@ export async function POST(req: Request) {
             );
         }
 
+        const geminiKey = process.env.GEMINI_API_KEY?.trim();
+
+        if (!geminiKey || geminiKey === "your_gemini_api_key") {
+            structuredLog({
+                log_level: "warn",
+                route: ROUTE,
+                meta: {
+                    reason: "missing_gemini_api_key",
+                },
+            });
+
+            return NextResponse.json(
+                { error: "AI services are currently unconfigured" },
+                { status: 500 }
+            );
+        }
         const ai = getAiClient();
         const { messages, mode, responseLanguage, locale } = await req.json();
         const latestMessageText = getLatestMessageText(messages);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR *ONLY* touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* *Closes #2339*
* *Summary:*

  * Added validation for GEMINI_API_KEY before initializing the GoogleGenAI client.
  * Added structured warning logging when the API key is missing.
  * Returns a descriptive error response (AI services are currently unconfigured) instead of attempting Gemini initialization and failing later.
  * Ensures the /api/chat endpoint fails gracefully when AI services are not configured.

## 📸 Proof of Work (Screenshots / Logs)

Before
<img width="690" height="280" alt="image" src="https://github.com/user-attachments/assets/a0e7bcb1-b709-40c7-a747-f8149c435666" />

After
<img width="630" height="276" alt="image" src="https://github.com/user-attachments/assets/e6d8e1ff-addf-48dc-87d0-ed25979c7080" />


### Testing Performed

1. Removed GEMINI_API_KEY from the environment configuration.
2. Restarted the Next.js application.
3. Opened the SahiDawa AI chatbot and sent a test message.
4. Verified the API response:

json
{
  "error": "AI services are currently unconfigured"
}


5. Verified the chatbot displays the fallback message instead of crashing.

## 🏷️ PR Type

* [x] 🐛 type: bug


## ✅ Checklist

* [x] My PR has a linked issue (Closes #2339)
* [x] I have pulled the latest main and resolved any conflicts