### PR TITLE
fix: add ARIA attributes to ExpandableDetails toggle

### DIFF
--- a/apps/web/components/ExpandableDetails.tsx
+++ b/apps/web/components/ExpandableDetails.tsx
@@ -23,6 +23,8 @@ export function ExpandableDetails({ medicine }: { medicine: VerifiedMedicine }) 
         <div className="w-full">
             <button
                 onClick={() => setExpanded(!expanded)}
+                aria-expanded={expanded}
+                aria-controls="medicine-details-panel"
                 className="flex items-center gap-1 text-sm text-(--color-text-muted) transition-colors hover:text-(--color-text-primary)"
             >
                 {expanded ? tScan("showLess") : tScan("showMoreDetails")}
@@ -33,7 +35,7 @@ export function ExpandableDetails({ medicine }: { medicine: VerifiedMedicine }) 
             </button>
 
             {expanded && (
-                <div className="mt-3 space-y-3">
+                <div id="medicine-details-panel" className="mt-3 space-y-3">
                     <div className="flex items-center justify-between rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) px-3 py-2">
                         <span className="text-[10px] font-bold tracking-wider text-(--color-text-muted) uppercase">
                             Medicine Info


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2291 **
- **Summary:**
  - Added `aria-expanded={expanded}` to the toggle button.
  - Added `aria-controls="medicine-details-panel"` to explicitly associate the button with the expandable content.
  - Added `id="medicine-details-panel"` to the expandable details container.
  - Improved accessibility for screen reader users without changing UI behavior or styling.

## 📸 Proof of Work (Screenshots / Logs)

**Testing Performed**
- Verified `aria-expanded` updates correctly when expanding/collapsing details.
- Verified button is linked to the details panel through `aria-controls`.
- Verified no visual changes to the component.

_Please drag & drop screenshots/GIFs here if required._

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [x] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2291 `)
- [x] I have pulled the latest `main` and resolved any conflicts