### PR TITLE
fix: prevent negative savings display in generic alternative card

### DIFF
--- a/apps/web/components/GenericAlternativeCard.tsx
+++ b/apps/web/components/GenericAlternativeCard.tsx
@@ -48,9 +48,13 @@ export default function GenericAlternativeCard({ alternative }: GenericAlternati
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2 rounded-full bg-emerald-100 px-3.5 py-1 text-xs font-black text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-400">
                         <Sparkles size={12} className="animate-pulse" />
-                        <span>Cheaper Alternative Available</span>
+                        <span>
+                            {savingsAmount > 0
+                                ? "Cheaper Alternative Available"
+                                : "Alternative Available"}
+                        </span>
                     </div>
-                    {savingsPct > 0 && (
+                    {savingsAmount > 0 && (
                         <div className="flex items-center gap-1 text-sm font-black text-emerald-600 dark:text-emerald-400">
                             <TrendingDown size={16} />
                             <span>Save {savingsPct}%</span>


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2292 **
- **Summary:**
  - Fixed an edge case in `GenericAlternativeCard` where negative savings values could be displayed when the Jan Aushadhi price was greater than or equal to the brand price.
  - Updated the badge text to display **"Alternative Available"** when no savings exist.
  - Conditionally rendered the **"Save X%"** indicator only when `savingsAmount > 0`.
  - Ensured the savings summary banner is hidden when savings are zero or negative.
  - Prevented negative currency and percentage values from being shown in the UI.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** Attach screenshots or a screen recording showing:
>   - Positive savings scenario (badge + savings banner visible)
>   - Zero/negative savings scenario (no savings banner, no save percentage, "Alternative Available" badge shown)

_Please drag & drop your screenshots/GIFs here._

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2292 `)
- [x] I have pulled the latest `main` and resolved any conflicts