### PR TITLE
Ref :  Memoized Supabase Browser Client Instantiation to Prevent Memoy Leaks #2363

### DIFF
--- a/apps/web/app/[locale]/components/Navbar.tsx
+++ b/apps/web/app/[locale]/components/Navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useMemo } from "react";
 import Image from "next/image";
 import { MessageCircle } from "lucide-react";
 import { Link, usePathname } from "@/i18n/routing";
@@ -21,6 +21,8 @@ export default function Navbar() {
     const pathname = usePathname();
     const tHome = useTranslations("Home");
     const { session, isLoading: authLoading } = useSession();
+
+    const supabase = useMemo(() => createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey()), []);
 
     // UI States
     const [isNavVisible, setIsNavVisible] = useState(true);
@@ -55,7 +57,6 @@ export default function Navbar() {
         setIsMenuOpen(false);
         try {
             await fetch("/api/auth/signout", { method: "POST" });
-            const supabase = createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey());
             await supabase.auth.signOut();
         } catch (error) {
             console.error("Logout error:", error);

--- a/apps/web/app/[locale]/signup/page.tsx
+++ b/apps/web/app/[locale]/signup/page.tsx
@@ -11,7 +11,7 @@ import {
     User,
 } from "lucide-react";
 import { FcGoogle } from "react-icons/fc";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Link, useRouter } from "@/i18n/routing";
 import { createBrowserClient } from "@supabase/ssr";
@@ -37,7 +37,10 @@ export default function SignUpPage() {
     const supabaseUrl = getSupabaseUrl();
     const supabaseKey = getSupabaseAnonKey();
     const isMissingEnvVars = !supabaseUrl || !supabaseKey;
-    const supabase = createBrowserClient(supabaseUrl, supabaseKey);
+    const supabase = useMemo(
+        () => createBrowserClient(supabaseUrl, supabaseKey),
+        [supabaseUrl, supabaseKey]
+    );
     const [fullName, setFullName] = useState("");
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");

--- a/apps/web/components/reports/ReportWizard.tsx
+++ b/apps/web/components/reports/ReportWizard.tsx
@@ -7,7 +7,7 @@
  * Design: SahiDawa modern aesthetic — emerald accents, deep navy header, rounded corners
  */
 import { handleApiError } from "@/lib/apiErrorHandler";
-import React, { useState, useEffect, useId } from "react";
+import React, { useState, useEffect, useId, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { useForm, FormProvider, useFormContext } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -829,6 +829,17 @@ export default function ReportWizard() {
     const submitErrorId = useId();
     const searchParams = useSearchParams();
 
+    const supabase = useMemo(() => {
+        if (typeof window !== "undefined") {
+            try {
+                return createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey());
+            } catch {
+                return null;
+            }
+        }
+        return null;
+    }, []);
+
     const methods = useForm<FormValues>({
         resolver: zodResolver(schema),
         defaultValues: EMPTY,
@@ -913,9 +924,8 @@ export default function ReportWizard() {
         setSubmitErr(null);
 
         let token: string | undefined = undefined;
-        if (typeof window !== "undefined") {
+        if (supabase) {
             try {
-                const supabase = createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey());
                 const {
                     data: { session },
                 } = await supabase.auth.getSession();

--- a/apps/web/src/components/AuthProvider.tsx
+++ b/apps/web/src/components/AuthProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createBrowserClient } from "@supabase/ssr";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
-import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useState, useMemo, type ReactNode } from "react";
 import type { Session } from "@supabase/supabase-js";
 
 interface AuthContextValue {
@@ -25,9 +25,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const [session, setSession] = useState<Session | null>(null);
     const [isLoading, setIsLoading] = useState(true);
 
-    useEffect(() => {
-        const supabase = createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey());
+    const supabase = useMemo(() => createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey()), []);
 
+    useEffect(() => {
         supabase.auth.getSession().then(({ data }) => {
             const s = data.session ?? null;
             setSession(s);


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2363 **
- **Summary:**
- `createBrowserClient` is wrapped in `useMemo` in all client-side React components:

   - `Navbar.tsx`: Moved instantiation outside of the click handler and into a top-level `useMemo`.
    - `signup/page.tsx`: Wrapped the direct render-body instantiation in `useMemo` using the `supabaseUrl` and `supabaseKey` as dependencies.
   - `ReportWizard.tsx`: Lifted the instantiation out of the `onSubmit` block to the top of the component inside a `useMemo` block.
   - `AuthProvider.tsx`: Extracted the instantiation out of the `useEffect` body to a top-level `useMemo` definition.
   - `login/page.tsx`: Was already successfully wrapped in a `useMemo` hook.
- The Navbar and other impacted components render successfully without crashes.
- Instead of replacing or altering how the client handles tokens or API requests, the updates purely ensure that the same instance of the client is reused across re-renders. Component functions like `supabase.auth.signOut()` or `supabase.auth.getSession()` all point to the cached `useMemo` reference, keeping the internal `@supabase/ssr` persistence logic flawlessly intact.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
