### PR TITLE
fix: cache pharmacy geospatial responses

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
 import { requireAuth, AuthenticatedRequest } from "../middleware/auth";
+import { PharmacyRpcResult, FormattedPharmacy } from "../types/pharmacy.types";
 
 const router = Router();
 
@@ -10,6 +11,12 @@ const router = Router();
 
 /** Maximum number of pharmacies returned per request */
 const MAX_RESULTS = 200;
+
+const GEOSPATIAL_CACHE_CONTROL = "public, max-age=300, s-maxage=300, stale-while-revalidate=600";
+
+const setGeospatialCacheHeaders = (res: Response) => {
+    res.setHeader("Cache-Control", GEOSPATIAL_CACHE_CONTROL);
+};
 
 // ── TypeScript interfaces ────────────────────────────────────────────────────
 
@@ -401,6 +408,7 @@ router.get("/nearest", async (req: Request, res: Response, next: NextFunction) =
                 }))
                 .slice(0, MAX_RESULTS);
 
+            setGeospatialCacheHeaders(res);
             return res.json({ pharmacies });
         }
 
@@ -439,6 +447,7 @@ router.get("/nearest", async (req: Request, res: Response, next: NextFunction) =
             .slice(0, MAX_RESULTS)
             .map(({ rawDistance, ...rest }: PharmacyWithRawDistance): FormattedPharmacy => rest);
 
+        setGeospatialCacheHeaders(res);
         res.json({ pharmacies });
     } catch (err) {
         next(err);
@@ -608,6 +617,7 @@ router.get("/in-bounds", async (req: Request, res: Response, next: NextFunction)
                     state: p.state || null,
                 }))
                 .slice(0, MAX_RESULTS);
+            setGeospatialCacheHeaders(res);
             return res.json({ pharmacies });
         }
 
@@ -651,6 +661,7 @@ router.get("/in-bounds", async (req: Request, res: Response, next: NextFunction)
             .slice(0, MAX_RESULTS)
             .map(({ coords, ...rest }) => rest);
 
+        setGeospatialCacheHeaders(res);
         res.json({ pharmacies });
     } catch (err) {
         next(err);
@@ -719,7 +730,7 @@ router.post(
 
                 const validationResult = inventoryRowSchema.safeParse(rowData);
                 if (!validationResult.success) {
-                    const errorMessage = validationResult.error.errors
+                    const errorMessage = validationResult.error.issues
                         .map((e) => e.message)
                         .join(", ");
                     failedRows.push({ row: i + 1, reason: errorMessage });

--- a/apps/api/tests/pharmacies.test.ts
+++ b/apps/api/tests/pharmacies.test.ts
@@ -28,6 +28,7 @@ import app from "../src/app";
 import { supabase } from "../src/db/client";
 
 const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
+const GEOSPATIAL_CACHE_CONTROL = "public, max-age=300, s-maxage=300, stale-while-revalidate=600";
 
 describe("GET /api/pharmacies/nearest", () => {
     beforeEach(() => {
@@ -43,10 +44,12 @@ describe("GET /api/pharmacies/nearest", () => {
         expect(missingLatitude.status).toBe(400);
         expect(missingLatitude.body.error).toBe("Invalid coordinates");
         expect(missingLatitude.body.details).toHaveProperty("lat");
+        expect(missingLatitude.headers["cache-control"]).toBeUndefined();
 
         expect(missingLongitude.status).toBe(400);
         expect(missingLongitude.body.error).toBe("Invalid coordinates");
         expect(missingLongitude.body.details).toHaveProperty("lng");
+        expect(missingLongitude.headers["cache-control"]).toBeUndefined();
     });
 
     it("returns 400 for out-of-bounds coordinates", async () => {
@@ -105,6 +108,7 @@ describe("GET /api/pharmacies/nearest", () => {
         );
 
         expect(response.status).toBe(200);
+        expect(response.headers["cache-control"]).toBe(GEOSPATIAL_CACHE_CONTROL);
         expect(response.body.pharmacies).toHaveLength(2);
         expect(response.body.pharmacies[0].name).toBe("PMBJAK - AIIMS");
         expect(response.body.pharmacies[0].distance).toBe("2.3 km");
@@ -244,6 +248,7 @@ describe("GET /api/pharmacies/nearest", () => {
         );
 
         expect(response.status).toBe(200);
+        expect(response.headers["cache-control"]).toBe(GEOSPATIAL_CACHE_CONTROL);
 
         expect(mockedSupabase.rpc).toHaveBeenCalledWith("get_nearest_pharmacies", {
             query_lat: 12.9716,
@@ -280,6 +285,7 @@ describe("GET /api/pharmacies/in-bounds", () => {
 
         expect(response.status).toBe(400);
         expect(response.body.error).toBe("Invalid bounds");
+        expect(response.headers["cache-control"]).toBeUndefined();
     });
 
     it("returns 400 for out-of-range bounds", async () => {
@@ -327,6 +333,7 @@ describe("GET /api/pharmacies/in-bounds", () => {
         );
 
         expect(response.status).toBe(200);
+        expect(response.headers["cache-control"]).toBe(GEOSPATIAL_CACHE_CONTROL);
         expect(response.body.pharmacies).toHaveLength(1);
         expect(response.body.pharmacies[0].name).toBe("PMBJAK - AIIMS");
         expect(response.body.pharmacies[0].distance).toBe("3.5 km");
@@ -382,6 +389,7 @@ describe("GET /api/pharmacies/in-bounds", () => {
         );
 
         expect(response.status).toBe(200);
+        expect(response.headers["cache-control"]).toBe(GEOSPATIAL_CACHE_CONTROL);
         expect(response.body.pharmacies).toHaveLength(1);
         expect(response.body.pharmacies[0].name).toBe("Inside Bounds Pharmacy");
         expect(eq).toHaveBeenCalledWith("status", "approved");

--- a/apps/web/app/[locale]/expiry-tracker/page.tsx
+++ b/apps/web/app/[locale]/expiry-tracker/page.tsx
@@ -40,6 +40,7 @@ export default function ExpiryTrackerPage() {
 
     const [isScannerOpen, setIsScannerOpen] = useState(false);
     const [isVerifying, setIsVerifying] = useState(false);
+    const [, setIsSubmitting] = useState(false);
     const [apiError, setApiError] = useState<string | null>(null);
     const [notificationPermission, setNotificationPermission] = useState<string>("default");
     useEffect(() => {

--- a/apps/web/app/[locale]/history/page.tsx
+++ b/apps/web/app/[locale]/history/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
+import dynamic from "next/dynamic";
 
 import {
     getScanHistory,
@@ -13,6 +14,8 @@ import { CopyButton } from "@/components/ui/CopyButton";
 import { ClipboardList, Download, RefreshCw, Trash2 } from "lucide-react";
 import { syncScanHistoryWithCloud } from "@/lib/scanHistoryCloudSync";
 import { EmptyState } from "@/components/ui/EmptyState";
+
+const ExportModal = dynamic(() => import("./ExportModal"));
 
 export default function HistoryPage() {
     const [history, setHistory] = useState<ScanHistoryEntry[]>([]);

--- a/apps/web/lib/expiry-notifications.ts
+++ b/apps/web/lib/expiry-notifications.ts
@@ -112,13 +112,13 @@ export function isPushSupported(): boolean {
  * Request notification permissions from the user.
  */
 export async function requestNotificationPermission(): Promise<string> {
-    if (!isPushSupported()) {
+    if (typeof window === "undefined" || !("Notification" in window)) {
         return "unsupported";
     }
 
     try {
         const permission = await Notification.requestPermission();
-        if (permission === "granted") {
+        if (permission === "granted" && "serviceWorker" in navigator) {
             await registerPeriodicExpiryCheck();
         }
         return permission;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
         "@opentelemetry/auto-instrumentations-web": "^0.64.0",
         "@opentelemetry/context-zone": "^2.8.0",
         "@opentelemetry/sdk-trace-web": "^2.8.0",
+        "@radix-ui/react-tooltip": "^1.2.10",
         "@supabase/auth-helpers-nextjs": "^0.15.0",
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.106.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,9 @@
     "dependencies": {
         "@google/genai": "^2.5.0",
         "@hookform/resolvers": "^5.4.0",
+        "@opentelemetry/auto-instrumentations-web": "^0.64.0",
+        "@opentelemetry/context-zone": "^2.8.0",
+        "@opentelemetry/sdk-trace-web": "^2.8.0",
         "@supabase/auth-helpers-nextjs": "^0.15.0",
         "@supabase/ssr": "^0.10.3",
         "@supabase/supabase-js": "^2.106.2",
@@ -24,6 +27,7 @@
         "@zxing/browser": "^0.2.0",
         "@zxing/library": "^0.23.0",
         "browser-image-compression": "^2.0.2",
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.39.0",
         "google-auth-library": "^10.6.2",
@@ -42,6 +46,7 @@
         "react-leaflet": "^5.0.0",
         "recharts": "^2.15.3",
         "sonner": "^2.0.7",
+        "tailwind-merge": "^3.6.0",
         "tailwindcss-rtl": "^0.9.0",
         "tesseract.js": "^7.0.0",
         "zod": "^4.4.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,7 @@
                 "@opentelemetry/auto-instrumentations-web": "^0.64.0",
                 "@opentelemetry/context-zone": "^2.8.0",
                 "@opentelemetry/sdk-trace-web": "^2.8.0",
+                "@radix-ui/react-tooltip": "^1.2.10",
                 "@supabase/auth-helpers-nextjs": "^0.15.0",
                 "@supabase/ssr": "^0.10.3",
                 "@supabase/supabase-js": "^2.106.2",
@@ -1217,6 +1218,44 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/@floating-ui/core": {
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+            "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/utils": "^0.2.11"
+            }
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+            "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/core": "^1.7.5",
+                "@floating-ui/utils": "^0.2.11"
+            }
+        },
+        "node_modules/@floating-ui/react-dom": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+            "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/dom": "^1.7.6"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+            "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+            "license": "MIT"
         },
         "node_modules/@formatjs/fast-memoize": {
             "version": "3.1.6",
@@ -4055,6 +4094,414 @@
             "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
             "license": "BSD-3-Clause"
         },
+        "node_modules/@radix-ui/primitive": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+            "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+            "license": "MIT"
+        },
+        "node_modules/@radix-ui/react-arrow": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz",
+            "integrity": "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.6"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-compose-refs": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+            "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-context": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+            "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-dismissable-layer": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
+            "integrity": "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.4",
+                "@radix-ui/react-compose-refs": "1.1.3",
+                "@radix-ui/react-primitive": "2.1.6",
+                "@radix-ui/react-use-callback-ref": "1.1.2",
+                "@radix-ui/react-use-escape-keydown": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-id": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+            "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-popper": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.1.tgz",
+            "integrity": "sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/react-dom": "^2.0.0",
+                "@radix-ui/react-arrow": "1.1.10",
+                "@radix-ui/react-compose-refs": "1.1.3",
+                "@radix-ui/react-context": "1.1.4",
+                "@radix-ui/react-primitive": "2.1.6",
+                "@radix-ui/react-use-callback-ref": "1.1.2",
+                "@radix-ui/react-use-layout-effect": "1.1.2",
+                "@radix-ui/react-use-rect": "1.1.2",
+                "@radix-ui/react-use-size": "1.1.2",
+                "@radix-ui/rect": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-portal": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
+            "integrity": "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.6",
+                "@radix-ui/react-use-layout-effect": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-presence": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+            "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+            "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.3.0"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-slot": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+            "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tooltip": {
+            "version": "1.2.10",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.10.tgz",
+            "integrity": "sha512-NlNe8D0dWEpVfXFli90IO6X07Josx/b1iu98tDnx9Xv0HT4wLIL+m2VOheMHhK7qbp2HoTBqALEFzGyZs/levw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.4",
+                "@radix-ui/react-compose-refs": "1.1.3",
+                "@radix-ui/react-context": "1.1.4",
+                "@radix-ui/react-dismissable-layer": "1.1.13",
+                "@radix-ui/react-id": "1.1.2",
+                "@radix-ui/react-popper": "1.3.1",
+                "@radix-ui/react-portal": "1.1.12",
+                "@radix-ui/react-presence": "1.1.6",
+                "@radix-ui/react-primitive": "2.1.6",
+                "@radix-ui/react-slot": "1.3.0",
+                "@radix-ui/react-use-controllable-state": "1.2.3",
+                "@radix-ui/react-visually-hidden": "1.2.6"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-callback-ref": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+            "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-controllable-state": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+            "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-effect-event": "0.0.3",
+                "@radix-ui/react-use-layout-effect": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-effect-event": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+            "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-escape-keydown": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+            "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-callback-ref": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-layout-effect": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+            "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-rect": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+            "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/rect": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-size": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+            "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-visually-hidden": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.6.tgz",
+            "integrity": "sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.6"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/rect": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+            "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
+            "license": "MIT"
+        },
         "node_modules/@react-leaflet/core": {
             "version": "3.0.0",
             "license": "Hippocratic-2.1",
@@ -5190,7 +5637,7 @@
         },
         "node_modules/@types/react": {
             "version": "19.2.16",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.2.2"
@@ -5198,7 +5645,7 @@
         },
         "node_modules/@types/react-dom": {
             "version": "19.2.3",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,9 @@
             "dependencies": {
                 "@google/genai": "^2.5.0",
                 "@hookform/resolvers": "^5.4.0",
+                "@opentelemetry/auto-instrumentations-web": "^0.64.0",
+                "@opentelemetry/context-zone": "^2.8.0",
+                "@opentelemetry/sdk-trace-web": "^2.8.0",
                 "@supabase/auth-helpers-nextjs": "^0.15.0",
                 "@supabase/ssr": "^0.10.3",
                 "@supabase/supabase-js": "^2.106.2",
@@ -165,6 +168,7 @@
                 "@zxing/browser": "^0.2.0",
                 "@zxing/library": "^0.23.0",
                 "browser-image-compression": "^2.0.2",
+                "class-variance-authority": "^0.7.1",
                 "clsx": "^2.1.1",
                 "framer-motion": "^12.39.0",
                 "google-auth-library": "^10.6.2",
@@ -183,6 +187,7 @@
                 "react-leaflet": "^5.0.0",
                 "recharts": "^2.15.3",
                 "sonner": "^2.0.7",
+                "tailwind-merge": "^3.6.0",
                 "tailwindcss-rtl": "^0.9.0",
                 "tesseract.js": "^7.0.0",
                 "zod": "^4.4.3"
@@ -2188,6 +2193,26 @@
                 "@opentelemetry/core": "^2.0.0"
             }
         },
+        "node_modules/@opentelemetry/auto-instrumentations-web": {
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/auto-instrumentations-web/-/auto-instrumentations-web-0.64.0.tgz",
+            "integrity": "sha512-buJP7HIjBPltoGo/rXotGWsEMuJGv4ANXNd+mdh4A32ZKrquLjnqUfJkMsZklROp02+QG0ISJCU33QDBXAg9mg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/instrumentation": "^0.219.0",
+                "@opentelemetry/instrumentation-document-load": "^0.64.0",
+                "@opentelemetry/instrumentation-fetch": "^0.219.0",
+                "@opentelemetry/instrumentation-user-interaction": "^0.63.0",
+                "@opentelemetry/instrumentation-xml-http-request": "^0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.9.0",
+                "zone.js": "^0.11.4 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
+            }
+        },
         "node_modules/@opentelemetry/configuration": {
             "version": "0.219.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.219.0.tgz",
@@ -2214,6 +2239,32 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/context-zone": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-2.8.0.tgz",
+            "integrity": "sha512-ddfwDmm6zVVf3J7+ik1SQRRv6Xrn/YpWxuoXvk4vhJK8LKUt8oqFMuofiDY5RbEleOahWfQnsI69uBEWmm00Nw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/context-zone-peer-dep": "2.8.0",
+                "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            }
+        },
+        "node_modules/@opentelemetry/context-zone-peer-dep": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-2.8.0.tgz",
+            "integrity": "sha512-SnaZDuBMYJlsDsgVeZ2IgFseAEXHBkYEn3nCon9YR3L2zdP/UpxZVWwbCWu2HOELmV1jy3RWmk2FusFpSrfh5Q==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0",
+                "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
             }
         },
         "node_modules/@opentelemetry/core": {
@@ -2613,6 +2664,24 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-document-load": {
+            "version": "0.64.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.64.0.tgz",
+            "integrity": "sha512-I0fTRpfgY7Qr8qaTJBPgDi+Eo4YjOqHSm3OB9U5JaJmCfm0ryDGFMKef8OBS+DeDqYZvaHWyq/zg7YJqnCWaoA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.219.0",
+                "@opentelemetry/sdk-trace-web": "^2.0.0",
+                "@opentelemetry/semantic-conventions": "^1.23.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-express": {
             "version": "0.67.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.67.0.tgz",
@@ -2622,6 +2691,24 @@
                 "@opentelemetry/core": "^2.0.0",
                 "@opentelemetry/instrumentation": "^0.219.0",
                 "@opentelemetry/semantic-conventions": "^1.27.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-fetch": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.219.0.tgz",
+            "integrity": "sha512-nhjrhJ/tlE+1I1950dJkcl0xCGf7IrZGwWHS0X5J4gZtqP4YD+qp/gVfXkzZZBjFDx+39IaDQLS296E+Pcw5Tw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/instrumentation": "0.219.0",
+                "@opentelemetry/sdk-trace-web": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
@@ -3127,6 +3214,24 @@
                 "@opentelemetry/api": "^1.7.0"
             }
         },
+        "node_modules/@opentelemetry/instrumentation-user-interaction": {
+            "version": "0.63.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-user-interaction/-/instrumentation-user-interaction-0.63.0.tgz",
+            "integrity": "sha512-lSFNi+SHG0DwUYnbzKFxocvd+p8PZXyUAXj7tZDxi5/iu9j5KATKD096GbZt2DCKpq5S3tjl3ApKmj3Z+h4rhg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.219.0",
+                "@opentelemetry/sdk-trace-web": "^2.0.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0",
+                "zone.js": "^0.11.4 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
+            }
+        },
         "node_modules/@opentelemetry/instrumentation-winston": {
             "version": "0.63.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.63.0.tgz",
@@ -3135,6 +3240,24 @@
             "dependencies": {
                 "@opentelemetry/api-logs": "^0.219.0",
                 "@opentelemetry/instrumentation": "^0.219.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation-xml-http-request": {
+            "version": "0.219.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.219.0.tgz",
+            "integrity": "sha512-R1qn0xVh4OPFta1A2hMgYiOpxUWdZlYuol4ZqQLYonklgo+gQTCtQyAVco/5FqM34h2mYd6KRQfo3kjiQdUe4A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/instrumentation": "0.219.0",
+                "@opentelemetry/sdk-trace-web": "2.8.0",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
@@ -3507,6 +3630,22 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/context-async-hooks": "2.8.0",
+                "@opentelemetry/core": "2.8.0",
+                "@opentelemetry/sdk-trace-base": "2.8.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-web": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.8.0.tgz",
+            "integrity": "sha512-P3ZM8BGJ5mwjtyfAxRyxsCyWHvaj+xahdhLoS3YiPsEyTHcWTVzx2691C8SrGkpvro3tNFCsWuNNrvM+spKODg==",
+            "license": "Apache-2.0",
+            "dependencies": {
                 "@opentelemetry/core": "2.8.0",
                 "@opentelemetry/sdk-trace-base": "2.8.0"
             },
@@ -6393,6 +6532,18 @@
         "node_modules/cjs-module-lexer": {
             "version": "2.2.0",
             "license": "MIT"
+        },
+        "node_modules/class-variance-authority": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+            "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "clsx": "^2.1.1"
+            },
+            "funding": {
+                "url": "https://polar.sh/cva"
+            }
         },
         "node_modules/cli-cursor": {
             "version": "5.0.0",
@@ -14413,6 +14564,16 @@
                 "url": "https://www.buymeacoffee.com/systeminfo"
             }
         },
+        "node_modules/tailwind-merge": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+            "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/dcastil"
+            }
+        },
         "node_modules/tailwindcss": {
             "version": "4.3.0",
             "dev": true,
@@ -15839,6 +16000,12 @@
             "peerDependencies": {
                 "zod": "^3.25.0 || ^4.0.0"
             }
+        },
+        "node_modules/zone.js": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
+            "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
+            "license": "MIT"
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a shared Cache-Control policy for pharmacy geospatial endpoints
- apply caching only to successful `/nearest` and `/in-bounds` responses
- cover both RPC and fallback paths while validation/error responses remain uncached
- declare existing web imports that were missing from `apps/web/package.json` so the repo-wide CI build can resolve them
- add narrow web build/test unblockers for existing `setIsSubmitting`, lazy `ExportModal`, tooltip dependency, and notification permission behavior

## Why
The pharmacy geospatial endpoints are read-heavy and currently return fresh responses every time. Adding short-lived public caching reduces repeated geospatial query work while keeping results reasonably fresh.

The follow-up web changes are scoped to CI blockers surfaced by the repo-wide build/test pipeline: missing dependency declarations and existing components/state/helpers that were referenced but not wired in the current upstream base.

## Validation
- `git diff --check`
- `npm.cmd test -w sahidawa-api -- pharmacies.test.ts --runInBand --forceExit`
- `npm.cmd run build -w sahidawa-api`
- `npm.cmd test -w web -- tests/expiry-tracker-notifications.test.tsx --runInBand`
- `npm.cmd run build -w web` progressed through the fixed TypeScript/module blockers locally, then timed out once without a new diagnostic
- `npm.cmd test -w web -- --runInBand` still has unrelated failures in vaccine-hub tests, admin-dashboard role-gating tests, and `tests/mapMedicineRow.test.tsx` importing `vitest` under Jest

Closes #2369