### PR TITLE
fix(api):  add periodic Supabase health checks for offline recovery

### DIFF
--- a/apps/api/src/db/client.ts
+++ b/apps/api/src/db/client.ts
@@ -158,24 +158,42 @@ if (process.env.NODE_ENV !== "test") {
     }, 5_000);
 }
 
-// Quick check on startup to see if Supabase is offline
-if (process.env.NODE_ENV !== "test") {
+// Periodic Supabase health probe.
+// The offline flag can be set by transient network failures during runtime.
+// Re-check connectivity periodically so the application can automatically
+// recover from fallback mode without requiring a server restart.
+
+async function probeSupabase(): Promise<void> {
     const checkTimeout = AbortSignal.timeout ? AbortSignal.timeout(1500) : undefined;
-    fetch(`${supabaseUrl}/auth/v1/health`, { signal: checkTimeout })
-        .then((res) => {
-            if (!res.ok) {
-                dbConfig.isSupabaseOffline = true;
-                logger.warn(
-                    "Supabase database health check failed. Setting database state to offline fallback mode."
-                );
-            } else {
-                logger.info("Supabase database health check passed. Supabase is online.");
-            }
-        })
-        .catch(() => {
+
+    try {
+        const res = await fetch(`${supabaseUrl}/auth/v1/health`, { signal: checkTimeout });
+
+        if (!res.ok) {
             dbConfig.isSupabaseOffline = true;
+
             logger.warn(
-                "Supabase database is offline. Setting database state to offline fallback mode."
+                "Supabase database health check failed. Setting database state to offline fallback mode."
             );
-        });
+        } else {
+            if (dbConfig.isSupabaseOffline) {
+                logger.info("Supabase database health check passed. Restoring online mode.");
+            }
+            dbConfig.isSupabaseOffline = false;
+        }
+    } catch {
+        dbConfig.isSupabaseOffline = true;
+
+        logger.warn(
+            "Supabase database health check failed. Setting database state to offline fallback mode."
+        );
+    }
+}
+
+if (process.env.NODE_ENV !== "test") {
+    void probeSupabase();
+
+    setInterval(() => {
+        void probeSupabase();
+    }, 30_000);
 }


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #2415 **
* **Summary:**

  * Refactored the one-time Supabase startup health check into a reusable `probeSupabase()` function.
  * Added a periodic health probe that runs every 30 seconds.
  * Automatically restores `dbConfig.isSupabaseOffline` when Supabase becomes available again.
  * Prevents the application from remaining in fallback mode indefinitely after transient Supabase outages.
  * Preserves existing test behavior by keeping the `NODE_ENV !== "test"` guard.

## 📸 Proof of Work (Screenshots / Logs)

### Test Results

```bash
npm test -- interactions.test.ts

PASS tests/interactions.test.ts

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
```

### Code Change

* Added `probeSupabase()` helper.
* Added periodic health checks using `setInterval`.
* Restored online mode automatically when health checks succeed.

(Attach your test screenshot and the diff screenshot here.)

## 🏷️ PR Type

* [x] 🐛 `type: bug`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2415 `)
* [x] I have pulled the latest `main` and resolved any conflicts
