### PR TITLE
fix(api): stop leaking stack traces in POST /api/reports error responses

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,4 +1,4 @@
-import { Router, Response } from "express";
+import { Router, Response, NextFunction } from "express";
 import { z } from "zod";
 import { supabase } from "../db/client";
 import { AuthenticatedRequest, optionalAuth, requireAuth, requireRole } from "../middleware/auth";
@@ -78,7 +78,7 @@ reportsRouter.post(
     "/",
     reportLimiter,
     optionalAuth,
-    async (req: AuthenticatedRequest, res: Response) => {
+    async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
         const parsed = createReportSchema.safeParse(req.body);
 
         if (!parsed.success) {
@@ -160,12 +160,7 @@ reportsRouter.post(
 
             res.status(201).json(response);
         } catch (err) {
-            console.error("Unexpected error in POST /api/reports:", err);
-            res.status(500).json({
-                error: "An unexpected error occurred",
-                details: err instanceof Error ? err.message : String(err),
-                stack: err instanceof Error ? err.stack : undefined,
-            });
+            next(err);
         }
     }
 );

--- a/apps/api/tests/reports.test.ts
+++ b/apps/api/tests/reports.test.ts
@@ -305,6 +305,69 @@ describe("Reports API Routes", () => {
             expect(insertedPayload.risk_score).toBe(0.9);
             expect(insertedPayload.duplicate_group_id).toBe("original-report-id");
         });
+
+        it("does not leak stack trace or internal error details when validateReport throws", async () => {
+            const originalEnv = process.env.NODE_ENV;
+            process.env.NODE_ENV = "production";
+
+            const { validateReport } = require("../src/services/reportValidation.service");
+            validateReport.mockRejectedValueOnce(new Error("DB connection failed: ECONNREFUSED"));
+
+            const payload = {
+                medicineName: "Aspirin 500mg",
+                manufacturer: "TestCo",
+                description: "This is a detailed description of the issue",
+                images: ["https://example.com/image1.jpg"],
+                pharmacyName: "Test Pharmacy",
+                address: "123 Main St",
+                city: "Delhi",
+                state: "Delhi",
+                pincode: "110001",
+            };
+
+            const response = await request(app)
+                .post("/api/reports")
+                .set("X-Forwarded-For", "9.9.9.9")
+                .send(payload);
+
+            process.env.NODE_ENV = originalEnv;
+
+            expect(response.status).toBe(500);
+            expect(response.body).not.toHaveProperty("stack");
+            expect(response.body).not.toHaveProperty("details");
+            expect(response.body.error).not.toHaveProperty("stack");
+            expect(JSON.stringify(response.body)).not.toContain("ECONNREFUSED");
+            expect(JSON.stringify(response.body)).not.toContain(".ts");
+        });
+
+        it("delegates errors to the global error handler instead of the inline catch block", async () => {
+            const { validateReport } = require("../src/services/reportValidation.service");
+            validateReport.mockRejectedValueOnce(new Error("Simulated internal failure"));
+
+            const payload = {
+                medicineName: "Aspirin 500mg",
+                manufacturer: "TestCo",
+                description: "This is a detailed description of the issue",
+                images: ["https://example.com/image1.jpg"],
+                pharmacyName: "Test Pharmacy",
+                address: "123 Main St",
+                city: "Delhi",
+                state: "Delhi",
+                pincode: "110001",
+            };
+
+            const response = await request(app)
+                .post("/api/reports")
+                .set("X-Forwarded-For", "9.9.9.8")
+                .send(payload);
+
+            // Shape matches errorHandler's { success, error: { message, ... } }
+            // contract, not the old inline { error, details, stack } shape.
+            expect(response.status).toBe(500);
+            expect(response.body).toHaveProperty("success", false);
+            expect(response.body.error).toHaveProperty("message");
+            expect(response.body).not.toHaveProperty("details");
+        });
     });
 
     describe("GET /api/reports/mine", () => {


### PR DESCRIPTION
## Summary
Fixes #2304 — POST /api/reports leaked full Node.js stack traces and internal error messages to anonymous callers on any unhandled exception (e.g. DB outage, validation crash).

## Root cause
The route's inline `catch` block returned `err.message` and `err.stack` directly with no environment check, bypassing the global `errorHandler` middleware which already gates stack exposure behind `NODE_ENV !== 'production'`. Since the route uses `optionalAuth` (not `requireAuth`), this was reachable by unauthenticated users.

## Fix
- Added `next: NextFunction` to the route handler signature.
- Replaced the inline `catch` block's manual response with `next(err)`, delegating to the existing global `errorHandler`, which already handles production-safe serialization and logging.

## Testing
- Added test: confirms a 500 response in `NODE_ENV=production` contains no `stack`, no `details`, and none of the underlying error message/file paths.
- Added test: confirms the response shape matches the global `errorHandler`'s contract (`{ success, error: { message } }`), proving requests are now routed through `next(err)` rather than the old inline shape.
- All existing tests in `reports.test.ts` (17/17) pass.
- `tsc --noEmit` shows no new type errors.

## Checklist
- [x] Reproduced the issue locally
- [x] Fix verified against both prod and non-prod `NODE_ENV`
- [x] Added regression tests
- [x] No changes to happy-path/400 behavior