### PR TITLE
feat(interaction-checker): show offline badge when verified flag is false

### DIFF
--- a/apps/web/app/[locale]/interaction-checker/page.tsx
+++ b/apps/web/app/[locale]/interaction-checker/page.tsx
@@ -12,9 +12,10 @@ import {
     BookOpen,
     RefreshCw,
     CheckCircle2,
+    WifiOff,
 } from "lucide-react";
 import { fuzzyMatchBrand } from "@/lib/api";
-import { checkInteractions, type InteractionResult } from "@/lib/api/interactions";
+import { checkInteractions, type InteractionResult, type InteractionResponse } from "@/lib/api/interactions";
 import { PageHeader } from "../components/PageHeader";
 
 const STORAGE_KEY = "sahidawa-my-medicines";
@@ -86,6 +87,7 @@ export default function InteractionCheckerPage() {
     const [interactions, setInteractions] = useState<InteractionResult[]>([]);
     const [error, setError] = useState<string | null>(null);
     const [hasChecked, setHasChecked] = useState(false);
+    const [isOfflineResult, setIsOfflineResult] = useState(false);
 
     const inputRef = useRef<HTMLInputElement>(null);
     const dropdownRef = useRef<HTMLDivElement>(null);
@@ -193,6 +195,7 @@ export default function InteractionCheckerPage() {
             });
 
             setInteractions(sorted);
+            setIsOfflineResult(response.verified === false);
             setHasChecked(true);
         } catch (err: any) {
             setError(err.message || t("errorMessage"));
@@ -373,6 +376,22 @@ export default function InteractionCheckerPage() {
                         <h2 className="border-b border-(--color-border-muted) pb-2 text-xl font-black text-(--color-text-primary)">
                             {t("resultsHeading")}
                         </h2>
+
+                        {isOfflineResult && (
+                            <div
+                                role="alert"
+                                aria-live="polite"
+                                className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 p-4 dark:border-amber-900/30 dark:bg-amber-950/20"
+                            >
+                                <WifiOff
+                                    size={18}
+                                    className="mt-0.5 shrink-0 text-amber-600 dark:text-amber-400"
+                                />
+                                <p className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                                    {t("offlineBadge")}
+                                </p>
+                            </div>
+                        )}
 
                         {interactions.length === 0 ? (
                             <div className="flex flex-col items-center gap-4 rounded-3xl border border-emerald-200 bg-emerald-50/30 px-6 py-12 text-center shadow-sm dark:border-emerald-900/30 dark:bg-emerald-950/10">

--- a/apps/web/lib/api/interactions.ts
+++ b/apps/web/lib/api/interactions.ts
@@ -13,10 +13,15 @@ export type InteractionResult = {
     source: string;
 };
 
+export type InteractionResponse = {
+    interactions: InteractionResult[];
+    verified?: boolean;
+};
+
 export async function checkInteractions(
     medicines: string[],
     signal?: AbortSignal
-): Promise<{ interactions: InteractionResult[] }> {
+): Promise<InteractionResponse> {
     const csrfToken = await getCsrfToken();
     const res = await fetchWithRetry(`${API_BASE}/api/v1/interactions/check`, {
         method: "POST",
@@ -38,5 +43,5 @@ export async function checkInteractions(
         throw new Error(errMsg ?? "Failed to check drug interactions");
     }
 
-    return res.json() as Promise<{ interactions: InteractionResult[] }>;
+    return res.json() as Promise<InteractionResponse>;
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -981,7 +981,8 @@
         "clinicalRecommendation": "Clinical Recommendation:",
         "mechanism": "Mechanism:",
         "source": "Source:",
-        "errorMessage": "Failed to complete interaction check. Please try again."
+        "errorMessage": "Failed to complete interaction check. Please try again.",
+        "offlineBadge": "Offline Result — Connect to internet for latest data"
     },
     "ScanHistory": {
         "export_modal_title": "Export Scan History",


### PR DESCRIPTION
## 📋 PR Summary & Link
- **Closes #2336**
- **Summary:** Adds an amber "Offline Result" warning badge to the 
  Medicine Interaction Checker page. PR #2301 added a `verified: false` 
  flag to interaction results generated from offline fallbacks. This PR 
  exposes that flag in the UI — when `verified === false`, a yellow 
  warning badge with a WifiOff icon appears above the results list, 
  telling the user their result may not be fully up to date. No existing 
  behaviour is changed when the API returns a live result.

## 📸 Proof of Work (Screenshots / Logs)
<img width="1920" height="968" alt="image" src="https://github.com/user-attachments/assets/3174c574-c7ce-4551-859c-35ea7ee875a4" />

**Files changed:**
- `apps/web/lib/api/interactions.ts` — added `InteractionResponse` type 
  with optional `verified` boolean
- `apps/web/app/[locale]/interaction-checker/page.tsx` — added 
  `isOfflineResult` state + amber badge rendered when 
  `response.verified === false`
- `apps/web/messages/en.json` — added `offlineBadge` translation key

**Badge renders when `verified === false`:**

> The backend API is not running locally (frontend-only setup), 
> so a live interaction check cannot be demonstrated. The badge 
> logic is: `setIsOfflineResult(response.verified === false)` — 
> it only shows when the API explicitly returns `verified: false`, 
> which is the offline fallback flag added by PR #2301. 
> No UI change occurs for normal live results.

## 🏷️ PR Type
- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [x] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [x] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #2336`)
- [x] I have pulled the latest `main` and resolved any conflicts