### PR TITLE
[GSSoC'26] fix(api): remove duplicate alternativesRouter mount

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -254,7 +254,6 @@ app.use("/api/map", mapRouter);
 app.use("/api/v1/interactions", interactionsRouter);
 app.use("/api/schedules", medicineSchedulesRouter);
 app.use("/api/v1/abha", abhaRoutes);
-app.use("/api/v1/alternatives", alternativesRouter);
 app.use("/api/v1/scheme-eligibility", eligibilityRouter);
 app.use("/api/v1/medicines", trackingRouter);
 


### PR DESCRIPTION
## Description

- Removed duplicate `app.use("/api/v1/alternatives", alternativesRouter)` at line 257 of `app.ts`
- The router was registered twice on the same path, causing all route handlers to execute twice, leading to duplicate DB queries and potential duplicate side effects

## Files Changed

- `apps/api/src/app.ts`: Removed duplicate alternativesRouter mount at line 257

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

- Code review: removed 1 duplicate line, verified alternativesRouter still mounted at line 250

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2453
