### PR TITLE
[GSSoC'26] fix(api): allow CORS requests from non-browser clients

### DIFF
--- a/apps/api/src/config/cors.ts
+++ b/apps/api/src/config/cors.ts
@@ -37,7 +37,7 @@ export function createCorsOptions(env: NodeJS.ProcessEnv = process.env): CorsOpt
 
     return {
         origin(origin, callback) {
-            if (origin && allowedOrigins.includes(origin)) {
+            if (!origin || allowedOrigins.includes(origin)) {
                 callback(null, true);
                 return;
             }


### PR DESCRIPTION
## Description

- Fixed CORS middleware to allow requests without an `Origin` header (non-browser clients)
- Changed `if (origin && allowedOrigins.includes(origin))` to `if (!origin || allowedOrigins.includes(origin))`
- Non-browser clients (curl, Postman, server-to-server, mobile apps) now pass through CORS without being blocked

## Files Changed

- `apps/api/src/config/cors.ts`: Changed origin check to allow undefined origins

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

- Code review: verified logic change allows undefined origin while still rejecting unknown origins

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2452
