### PR TITLE
[GSSoC'26] fix(api): use req.ip instead of raw X-Forwarded-For header in reports route

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -92,10 +92,7 @@ reportsRouter.post(
         const data = parsed.data;
 
         try {
-            const rawIp =
-                req.headers["x-forwarded-for"]?.toString().split(",")[0]?.trim() ||
-                req.socket.remoteAddress;
-            const ipAddress = anonymizeIp(rawIp);
+            const ipAddress = anonymizeIp(req.ip);
             const validationPayload = {
                 medicineName: data.medicineName,
                 manufacturer: data.manufacturer,


### PR DESCRIPTION
## Description

- Replaced raw `X-Forwarded-For` header parsing with Express's trusted `req.ip` in reports route
- The app already has `app.set("trust proxy", 1)` configured, making `req.ip` the correct way to resolve client IP behind a proxy
- Previously, clients could spoof their IP by sending a custom `X-Forwarded-For` header, bypassing IP-based abuse detection
- Consistent with how `batch.ts` and `verify.ts` already handle client IP

## Files Changed

- `apps/api/src/routes/reports.ts`: Replaced raw header parsing with `req.ip`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

- Code review: verified req.ip is the correct Express property when trust proxy is enabled
- Verified consistency with batch.ts:380 and verify.ts:303 which already use req.ip

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2454
