### PR TITLE
fix(security): remove user_metadata fallback in role resolution to prevent self-escalation

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -18,11 +18,8 @@ export interface AuthenticatedRequest extends Request {
 
 type SupabaseAuthClient = Pick<SupabaseClient, "auth">;
 
-const getUserRole = (user: User): AuthRole => {
-    // Read role from app_metadata (server-controlled, cannot be set by user).
-    // app_metadata takes precedence; user_metadata is accepted as a fallback
-    // only for legacy compatibility during the transition period.
-    const metadataRole = user.app_metadata?.role || user.user_metadata?.role;
+export const getUserRole = (user: User): AuthRole => {
+    const metadataRole = user.app_metadata?.role;
     if (metadataRole === "admin") return "admin";
     if (metadataRole === "moderator") return "moderator";
     return "user";

--- a/apps/api/tests/auth.test.ts
+++ b/apps/api/tests/auth.test.ts
@@ -107,3 +107,60 @@ describe("auth middleware", () => {
         expect(next).not.toHaveBeenCalled();
     });
 });
+
+describe("getUserRole", () => {
+    const buildUser = (app_metadata, user_metadata): User =>
+        ({ id: "user-1", email: "user@example.com", app_metadata, user_metadata,
+           aud: "authenticated", created_at: new Date().toISOString() }) as User;
+
+    it("returns 'user' when only user_metadata.role is set to admin (self-escalation attempt)", () => {
+        expect(getUserRole(buildUser({}, { role: "admin" }))).toBe("user");
+    });
+    it("returns 'user' when only user_metadata.role is set to moderator (self-escalation attempt)", () => {
+        expect(getUserRole(buildUser({}, { role: "moderator" }))).toBe("user");
+    });
+    it("returns 'admin' when app_metadata.role is admin, regardless of user_metadata", () => {
+        expect(getUserRole(buildUser({ role: "admin" }, { role: "user" }))).toBe("admin");
+    });
+    it("returns 'moderator' when app_metadata.role is moderator", () => {
+        expect(getUserRole(buildUser({ role: "moderator" }, {}))).toBe("moderator");
+    });
+    it("returns 'user' when app_metadata.role is admin but user_metadata.role conflicts (app_metadata wins, no fallback merge)", () => {
+        expect(getUserRole(buildUser({ role: "user" }, { role: "admin" }))).toBe("user");
+    });
+    it("returns 'user' when neither app_metadata nor user_metadata has a role", () => {
+        expect(getUserRole(buildUser({}, {}))).toBe("user");
+    });
+    it("returns 'user' when app_metadata is missing entirely and user_metadata claims admin", () => {
+        const user = { id: "user-1", email: "user@example.com", user_metadata: { role: "admin" },
+            aud: "authenticated", created_at: new Date().toISOString() } as User;
+        expect(getUserRole(user)).toBe("user");
+    });
+});
+
+describe("auth middleware — privilege escalation regression (#2305)", () => {
+    it("does not grant admin role for a user who self-escalated via user_metadata", async () => {
+        const req = { headers: { authorization: "Bearer valid-token" } } as AuthenticatedRequest;
+        const res = createResponse();
+        const next = jest.fn();
+
+        await createAuthMiddleware(
+            createClient({
+                id: "attacker-1",
+                email: "attacker@example.com",
+                app_metadata: {},
+                user_metadata: { role: "admin" }, // supabase.auth.updateUser({ data: { role: "admin" } })
+            }) as never
+        )(req, res, next as NextFunction);
+
+        expect(next).toHaveBeenCalled();
+        expect(req.user?.role).toBe("user");
+
+        const adminRes = createResponse();
+        const adminNext = jest.fn();
+        requireRole("admin")(req, adminRes, adminNext as NextFunction);
+
+        expect(adminRes.statusCode).toBe(403);
+        expect(adminNext).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/lib/adminAuth.ts
+++ b/apps/web/lib/adminAuth.ts
@@ -13,7 +13,7 @@ function toAdminRole(value: unknown): AdminRole | null {
 export function getAdminRoleFromUser(
     user: Pick<User, "app_metadata" | "user_metadata"> | null | undefined
 ): AdminRole | null {
-    return toAdminRole(user?.app_metadata?.role) ?? toAdminRole(user?.user_metadata?.role);
+    return toAdminRole(user?.app_metadata?.role);
 }
 
 export function getAdminRoleFromSession(

--- a/apps/web/tests/adminAuth.test.ts
+++ b/apps/web/tests/adminAuth.test.ts
@@ -1,0 +1,94 @@
+import {
+    getAdminRoleFromUser,
+    getAdminRoleFromSession,
+    canMutateAdminData,
+} from "../lib/adminAuth";
+
+describe("getAdminRoleFromUser", () => {
+    it("returns null when only user_metadata.role is set to admin (self-escalation attempt)", () => {
+        const role = getAdminRoleFromUser({
+            app_metadata: {},
+            user_metadata: { role: "admin" },
+        });
+
+        expect(role).toBeNull();
+    });
+
+    it("returns null when only user_metadata.role is set to moderator (self-escalation attempt)", () => {
+        const role = getAdminRoleFromUser({
+            app_metadata: {},
+            user_metadata: { role: "moderator" },
+        });
+
+        expect(role).toBeNull();
+    });
+
+    it("returns 'admin' when app_metadata.role is admin, regardless of user_metadata", () => {
+        const role = getAdminRoleFromUser({
+            app_metadata: { role: "admin" },
+            user_metadata: { role: "user" },
+        });
+
+        expect(role).toBe("admin");
+    });
+
+    it("returns 'moderator' when app_metadata.role is moderator", () => {
+        const role = getAdminRoleFromUser({
+            app_metadata: { role: "moderator" },
+            user_metadata: {},
+        });
+
+        expect(role).toBe("moderator");
+    });
+
+    it("returns null when neither app_metadata nor user_metadata has a role", () => {
+        const role = getAdminRoleFromUser({ app_metadata: {}, user_metadata: {} });
+
+        expect(role).toBeNull();
+    });
+
+    it("returns null when user is null or undefined", () => {
+        expect(getAdminRoleFromUser(null)).toBeNull();
+        expect(getAdminRoleFromUser(undefined)).toBeNull();
+    });
+});
+
+describe("getAdminRoleFromSession", () => {
+    it("returns null for a self-escalated session (user_metadata only)", () => {
+        const role = getAdminRoleFromSession({
+            user: { app_metadata: {}, user_metadata: { role: "admin" } },
+        });
+
+        expect(role).toBeNull();
+    });
+
+    it("returns 'admin' for a legitimately admin session", () => {
+        const role = getAdminRoleFromSession({
+            user: { app_metadata: { role: "admin" }, user_metadata: {} },
+        });
+
+        expect(role).toBe("admin");
+    });
+
+    it("returns null when session is null", () => {
+        expect(getAdminRoleFromSession(null)).toBeNull();
+    });
+});
+
+describe("canMutateAdminData", () => {
+    it("returns false for a self-escalated role since it was never resolved past null", () => {
+        const selfEscalatedRole = getAdminRoleFromUser({
+            app_metadata: {},
+            user_metadata: { role: "admin" },
+        });
+
+        expect(canMutateAdminData(selfEscalatedRole)).toBe(false);
+    });
+
+    it("returns true only for admin", () => {
+        expect(canMutateAdminData("admin")).toBe(true);
+        expect(canMutateAdminData("moderator")).toBe(false);
+        expect(canMutateAdminData(null)).toBe(false);
+        expect(canMutateAdminData(undefined)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
Fixes #2305 — `getUserRole` in the API and its frontend counterpart `getAdminRoleFromUser` both trusted `user_metadata.role` as a fallback when `app_metadata.role` was unset. `user_metadata` is writable by any authenticated user via `supabase.auth.updateUser({ data: { role: "admin" } })` from the client SDK, while `app_metadata` can only be set server-side (service-role or admin API). This allowed trivial self-promotion to `admin`/`moderator`.

## Scope
The issue was filed against the backend (`apps/api/src/middleware/auth.ts`) but is labeled "Frontend — Next.js UI." Investigation found the identical vulnerable pattern in `apps/web/lib/adminAuth.ts`'s `getAdminRoleFromUser`, which gates whether the admin layout/dashboard renders client-side. Both were fixed:

- **`apps/api/src/middleware/auth.ts`** — `getUserRole` no longer reads `user_metadata.role`. This is the actual authorization boundary: `requireRole("admin")` on `PATCH /api/reports/:id/status`, `POST /api/notifications/broadcast`, drug alert ingestion, etc.
- **`apps/web/lib/adminAuth.ts`** — `getAdminRoleFromUser` no longer reads `user_metadata.role`. This is UI-only gating, but without this fix a self-escalated user would see the admin dashboard render (even though their actual API calls now correctly 403), which is a confusing/misleading UX and a defense-in-depth gap.

## Fix
Removed the `user_metadata` fallback in both places. Only `app_metadata.role` is read.

## Migration note
Per the issue's proposed approach: if any legacy accounts currently rely on `user_metadata.role` for legitimate admin/moderator access (rather than `app_metadata.role`), those accounts will lose access after this merges. Recommend running a one-time backfill script to copy `user_metadata.role` → `app_metadata.role` via the Supabase admin API for any affected accounts before/at deploy time.

## Testing
- `auth.test.ts`: added a `getUserRole` unit suite — explicit self-escalation attempts via `user_metadata` resolve to `"user"`; `app_metadata.role` is the sole source of truth even when `user_metadata` conflicts; plus an end-to-end test running a self-escalated user through `createAuthMiddleware` → `requireRole("admin")` and asserting a 403.
- `adminAuth.test.ts` (new): mirrors the same cases for the frontend helper (`getAdminRoleFromUser`, `getAdminRoleFromSession`, `canMutateAdminData`).
- Backend: 14/14 in `auth.test.ts` pass; full suite 227/233 (6 pre-existing/unrelated failures, verified identical against the unmodified baseline).
- Frontend: 11/11 in new `adminAuth.test.ts` pass; verified the 3 failures in `admin-dashboard-role-gating.test.tsx` are pre-existing and reproduce against the original unmodified file.
- `tsc --noEmit` clean on both modified files.

## Checklist
- [x] Reproduced the escalation path described in the issue
- [x] Fixed both the backend authorization check and the matching frontend UI-gating check
- [x] Added regression tests for both
- [x] Documented the legacy-account migration consideration