### PR TITLE
feat(api): add West Bengal, Punjab, and Rajasthan state health schemes to eligibility checker

### DIFF
--- a/apps/api/src/routes/eligibility.ts
+++ b/apps/api/src/routes/eligibility.ts
@@ -155,6 +155,39 @@ router.post("/", async (req: Request, res: Response): Promise<void> => {
                     link: "https://sha.kerala.gov.in/",
                 });
             }
+        } else if (normalizedState.includes("west bengal")) {
+            eligibleSchemes.push({
+                name: "Swasthya Sathi",
+                description:
+                    "Universal healthcare scheme of West Bengal offering cashless healthcare to state residents.",
+                coverage:
+                    "Comprehensive coverage of up to ₹5 Lakh per family per year, covering secondary and tertiary care with no family size cap.",
+                how_to_apply:
+                    "Register at any Common Service Center (CSC), Sewa Kendra, or directly through the official scheme portal. Bring your Aadhaar Card and family details to receive your Swasthya Sathi Smart Card.",
+                link: "https://swasthyasathi.gov.in/",
+            });
+        } else if (normalizedState.includes("punjab")) {
+            eligibleSchemes.push({
+                name: "Mukh Mantri Sehat Yojana",
+                description:
+                    "Universal cashless health insurance scheme of Punjab covering all residents regardless of income.",
+                coverage:
+                    "Cashless treatment of up to ₹10 Lakh per family per year at government and empaneled private hospitals.",
+                how_to_apply:
+                    "Visit your nearest Sewa Kendra or Common Service Center with Aadhaar Card and Voter ID, or register via the Ayushman App. You will receive a Mukh Mantri Sehat Card for cashless treatment.",
+                link: "https://sha.punjab.gov.in/",
+            });
+        } else if (normalizedState.includes("rajasthan")) {
+            eligibleSchemes.push({
+                name: "Mukhyamantri Ayushman Arogya Yojana (MAAY)",
+                description:
+                    "Rajasthan government's flagship health insurance scheme (formerly Chiranjeevi Yojana) providing cashless treatment for all residents.",
+                coverage:
+                    "Cashless treatment of up to ₹25 Lakh per family per year, including pre and post-hospitalization expenses.",
+                how_to_apply:
+                    "Register via the Rajasthan SSO portal or visit your nearest e-Mitra center with your Jan Aadhaar or Aadhaar card. Most BPL, NFSA, and SECC families are enrolled automatically.",
+                link: "https://maayojana.rajasthan.gov.in/",
+            });
         } else if (
             normalizedState.includes("andhra pradesh") ||
             normalizedState.includes("telangana")


### PR DESCRIPTION
Closes #2458

### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #2458**
- **Summary:** Adds three new state-specific branches to the `if/else if` chain in `apps/api/src/routes/eligibility.ts`, following the exact existing pattern (name, description, coverage, how_to_apply, link): West Bengal (Swasthya Sathi), Punjab (Mukh Mantri Sehat Yojana), and Rajasthan (Mukhyamantri Ayushman Arogya Yojana). Previously, only 6 states/state-groups had explicit branches; all others fell into a generic, non-specific fallback.

## Verification Sources
Each scheme's name, coverage amount, and link were verified against multiple sources before implementation, since several state schemes have recently changed names/coverage:
- **West Bengal — Swasthya Sathi**: ₹5 Lakh/family/year, no income cap, no family size cap. Consistently confirmed across the scheme's own domain (swasthyasathi.gov.in) and multiple official district government sites.
- **Punjab — Mukh Mantri Sehat Yojana**: ₹10 Lakh/family/year (upgraded from the older "Mukh Mantri Sehat Bima Yojana" at ₹5 Lakh; the upgraded version rolled out statewide from January 2026). Verified against sha.punjab.gov.in and multiple recent (2026) sources.
- **Rajasthan — Mukhyamantri Ayushman Arogya Yojana (MAAY)**: ₹25 Lakh/family/year (renamed from "Chiranjeevi Swasthya Bima Yojana" in Feb 2024). I initially found conflicting older figures (₹5 Lakh) from outdated sources, but multiple 2026-dated sources consistently confirm ₹25 Lakh as the current figure.

I did not add any state where I couldn't find consistent, current confirmation of the scheme details.

## 📸 Proof of Work (Screenshots / Logs)
This is a pure backend logic addition (no new request/response shape), verified by tracing the `if/else if` chain manually — confirmed each new state's normalized string match (`"west bengal"`, `"punjab"`, `"rajasthan"`) sits correctly in the chain before the generic fallback `else`, and that existing states/fallback behavior is untouched.

## 🏷️ PR Type
- [x] ✨ `type: feature`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts