### PR TITLE
fix(api): add Zod validation to Twilio webhook payload in notifications.ts

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -124,6 +124,15 @@ const updatePhoneSchema = z.object({
     is_active: z.boolean().optional(),
 });
 
+const twilioWebhookSchema = z.object({
+    From: z
+        .string()
+        .min(10, "From number too short")
+        .max(20, "From number too long")
+        .regex(/^\+?\d+$/, "From must contain only digits and an optional leading +"),
+    Body: z.string().optional(),
+});
+
 const deletePhoneSchema = z.object({
     phone: z.string().min(10).max(20).optional(),
 });
@@ -626,14 +635,13 @@ router.post(
     express.urlencoded({ extended: true }),
     verifyTwilioSignature,
     async (req, res) => {
-        const from = req.body.From;
-        const body = req.body.Body ? req.body.Body.trim().toUpperCase() : "";
-
-        if (!from) {
-            res.status(400).send("Missing From parameter");
+        const parsed = twilioWebhookSchema.safeParse(req.body);
+        if (!parsed.success) {
+            res.status(400).send("Invalid webhook payload");
             return;
         }
-
+        const from = parsed.data.From;
+        const body = parsed.data.Body ? parsed.data.Body.trim().toUpperCase() : "";
         const formattedFrom = formatPhoneNumber(from);
 
         try {


### PR DESCRIPTION
Closes #2469

### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #2469**
- **Summary:** Adds a Zod schema (`twilioWebhookSchema`) to validate the `/twilio-webhook` route's payload, consistent with every other route in this file (which all use `safeParse` against a schema). Previously, this route only checked that `From` was present (`if (!from)`), with no check on its shape — and no validation on `Body` at all. The new schema requires `From` to be 10-20 characters and match `^\+?\d+$` (digits with an optional leading `+`), and treats `Body` as an optional string.

## Scope Note
While investigating, I also found that `formatPhoneNumber()` (used by this route and 4 others — `/status`, `/register`, `/phone` PATCH, `/phone` DELETE) silently returns unrecognized input unchanged via a fallthrough `return cleaned;`, rather than rejecting it. I deliberately did **not** fix this in this PR, since changing the function's behavior would require updating all 5 call sites to handle a new "invalid" case, which is a larger, separate change.

For this specific route, the new schema's `.regex(/^\+?\d+$/, ...)` check already rejects non-digit input *before* it ever reaches `formatPhoneNumber`, so the immediate risk on `/twilio-webhook` is addressed even without touching the function itself. The broader fallthrough issue across the other 4 call sites remains and could be a good follow-up issue.

## 📸 Proof of Work (Screenshots / Logs)
Traced manually: a payload like `{ From: "abc123" }` now fails `twilioWebhookSchema.safeParse()` at the `.regex()` step (does not match `^\+?\d+$`) and returns a 400 with `"Invalid webhook payload"` before `formatPhoneNumber` is called. A valid payload like `{ From: "+919876543210", Body: "STOP" }` passes validation and proceeds through the existing logic unchanged.

## 🏷️ PR Type
- [x] 🐛 `type: bug`
- [x] 🔒 `type: security`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts