### PR TITLE
[GSSoC'26] fix: use req.ip for rate limit key generation to prevent IP spoofing

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -19,11 +19,7 @@ export const batchLimiter = rateLimit({
     standardHeaders: true,
     legacyHeaders: false,
     keyGenerator: (req) => {
-        return (
-            req.headers["x-forwarded-for"]?.toString().split(",")[0]?.trim() ||
-            req.socket.remoteAddress ||
-            "unknown"
-        );
+        return req.ip || req.socket.remoteAddress || "unknown";
     },
     handler: (_req, res) => {
         res.status(429).json({
@@ -54,11 +50,7 @@ export const reportLimiter = rateLimit({
     standardHeaders: true,
     legacyHeaders: false,
     keyGenerator: (req) => {
-        return (
-            req.headers["x-forwarded-for"]?.toString().split(",")[0]?.trim() ||
-            req.socket.remoteAddress ||
-            "unknown"
-        );
+        return req.ip || req.socket.remoteAddress || "unknown";
     },
     handler: (_req, res) => {
         res.status(429).json({
@@ -104,11 +96,7 @@ export const interactionCheckLimiter = rateLimit({
     standardHeaders: true,
     legacyHeaders: false,
     keyGenerator: (req) => {
-        return (
-            req.headers["x-forwarded-for"]?.toString().split(",")[0]?.trim() ||
-            req.socket.remoteAddress ||
-            "unknown"
-        );
+        return req.ip || req.socket.remoteAddress || "unknown";
     },
     handler: (_req, res) => {
         res.status(429).json({


### PR DESCRIPTION
## Description

- Fixed rate-limit key generation in `batchLimiter`, `reportLimiter`, and `interactionCheckLimiter` to use `req.ip` instead of raw `X-Forwarded-For` header
- Previously, senders could spoof the `X-Forwarded-For` header to bypass rate limits — each request with a different forged IP would be treated as a separate client
- `req.ip` respects Express's `trust proxy` setting, correctly resolving the real client IP behind Nginx/reverse proxies

## Files Changed

- `apps/api/src/middleware/rateLimit.ts`: Changed `keyGenerator` in all three custom rate limiters to use `req.ip` instead of `req.headers["x-forwarded-for"]`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label so the contribution is scored correctly for GSSoC '26.

If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

No functional tests changed — the rate limiter key logic is exercised at runtime. Verified that `req.ip` is available when `trust proxy` is enabled (confirmed in `app.ts:78`).

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #2478
