### PR TITLE
fix(security): replace in-memory rate limiter store with distributed …

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
         "multer": "^2.2.0",
         "natural": "^8.1.1",
         "node-cron": "^3.0.3",
+        "rate-limit-redis": "^5.0.0",
         "redis": "^6.0.0",
         "swagger-jsdoc": "^6.3.0",
         "swagger-ui-express": "^5.0.1",

--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -1,10 +1,39 @@
-import rateLimit from "express-rate-limit";
+import rateLimit, { Store } from "express-rate-limit";
+import { RedisStore } from "rate-limit-redis";
+import { redisClient } from "../utils/redis";
+import logger from "../utils/logger";
 
+// ── Store factory ──────────────────────────────────────────────────────────────
+//
+// Uses a Redis-backed store when the client is connected so that counters are
+// shared across every API replica (critical for horizontal scaling and Cloud Run).
+// Falls back to the in-process MemoryStore when Redis is unavailable, so the
+// service continues to function in local development without a Redis instance.
+
+function buildStore(prefix: string): Store | undefined {
+    if (redisClient.isOpen) {
+        return new RedisStore({
+            // Adapts the node-redis v4 client to the interface expected by rate-limit-redis
+            sendCommand: (...args: string[]) => redisClient.sendCommand(args),
+            prefix: `rl:${prefix}:`,
+        });
+    }
+    logger.warn(
+        `[rateLimit] Redis not connected — ${prefix} limiter falling back to MemoryStore. ` +
+            "Rate limiting will NOT be shared across replicas."
+    );
+    return undefined; // undefined → express-rate-limit uses its default MemoryStore
+}
+
+// ── Limiters ───────────────────────────────────────────────────────────────────
+
+/** Medicine verification endpoint — unauthenticated, moderately expensive. */
 export const verifyLimiter = rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 mins
+    windowMs: 15 * 60 * 1000, // 15 minutes
     max: process.env.NODE_ENV === "development" ? 500 : 20,
     standardHeaders: true,
     legacyHeaders: false,
+    store: buildStore("verify"),
     handler: (_req, res) => {
         res.status(429).json({
             error: "Too many requests. Please try again later.",
@@ -12,12 +41,13 @@ export const verifyLimiter = rateLimit({
     },
 });
 
-// ── Batch traceability limiter ─────────────────────────────────────────────
+/** Batch traceability lookup — throttle to prevent database scraping. */
 export const batchLimiter = rateLimit({
     windowMs: 60 * 60 * 1000, // 1 hour
     max: 100,
     standardHeaders: true,
     legacyHeaders: false,
+    store: buildStore("batch"),
     keyGenerator: (req) => {
         return req.ip || req.socket.remoteAddress || "unknown";
     },
@@ -28,11 +58,13 @@ export const batchLimiter = rateLimit({
     },
 });
 
+/** General-purpose API limiter. */
 export const limiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 100,
     standardHeaders: true,
     legacyHeaders: false,
+    store: buildStore("general"),
     handler: (_req, res) => {
         res.status(429).json({
             error: "Too many requests. Please try again later.",
@@ -49,6 +81,7 @@ export const reportLimiter = rateLimit({
     max: 3,
     standardHeaders: true,
     legacyHeaders: false,
+    store: buildStore("report"),
     keyGenerator: (req) => {
         return req.ip || req.socket.remoteAddress || "unknown";
     },
@@ -58,11 +91,14 @@ export const reportLimiter = rateLimit({
         });
     },
 });
+
+/** LASA (Look-Alike Sound-Alike) drug check limiter. */
 export const lasaLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 30,
     standardHeaders: true,
     legacyHeaders: false,
+    store: buildStore("lasa"),
     handler: (_req, res) => {
         res.status(429).json({
             error: "Too many LASA check requests. Please try again later.",
@@ -70,7 +106,7 @@ export const lasaLimiter = rateLimit({
     },
 });
 
-// ── Scan query limiter ───────────────────────────────────────────────────────
+// ── Scan query limiter ────────────────────────────────────────────────────────
 // /scan/match calls search_medicines_text RPC (trigram full-text search).
 // /scan/verify-brand does ILIKE over the medicines table.
 // Both are unauthenticated and moderately expensive — throttle to prevent
@@ -80,6 +116,7 @@ export const scanQueryLimiter = rateLimit({
     max: 30,
     standardHeaders: true,
     legacyHeaders: false,
+    store: buildStore("scan"),
     handler: (_req, res) => {
         res.status(429).json({
             error: "Too many scan queries. Please try again later.",
@@ -87,7 +124,7 @@ export const scanQueryLimiter = rateLimit({
     },
 });
 
-// ── Interaction check limiter ──────────────────────────────────────────────
+// ── Interaction check limiter ─────────────────────────────────────────────────
 // POST /interactions/check accepts up to 20 medicines, generating up to 190
 // DB queries per request. Throttle to prevent DoS via batch interaction checks.
 export const interactionCheckLimiter = rateLimit({
@@ -95,6 +132,7 @@ export const interactionCheckLimiter = rateLimit({
     max: 10,
     standardHeaders: true,
     legacyHeaders: false,
+    store: buildStore("interactions"),
     keyGenerator: (req) => {
         return req.ip || req.socket.remoteAddress || "unknown";
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
                 "multer": "^2.2.0",
                 "natural": "^8.1.1",
                 "node-cron": "^3.0.3",
+                "rate-limit-redis": "^5.0.0",
                 "redis": "^6.0.0",
                 "swagger-jsdoc": "^6.3.0",
                 "swagger-ui-express": "^5.0.1",
@@ -13593,6 +13594,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/rate-limit-redis": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-5.0.0.tgz",
+            "integrity": "sha512-+M9el8KZjZ2HXM6/E38jFGmozBbN4C200iLE8+80TgS+8PzSfAAvD1zkx2oWu6YEgSrdiJJNrd4LCFm5vjVJkg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "peerDependencies": {
+                "express-rate-limit": ">= 8.5.0"
             }
         },
         "node_modules/raw-body": {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2485**
- **Summary:** All rate limiters in `apps/api/src/middleware/rateLimit.ts` previously used `express-rate-limit`'s default `MemoryStore`, which stores counters in the Node.js process heap. In a horizontally scaled deployment (multiple Docker containers or Cloud Run instances), each replica maintains its own independent counter — an attacker can bypass all limits by spreading requests across replicas.

  This PR installs `rate-limit-redis` and replaces the `MemoryStore` with a distributed **Redis-backed store** on every limiter, using the existing `redisClient` connection already present in the codebase. A `buildStore()` factory gracefully falls back to `MemoryStore` with a warning when Redis is unavailable (e.g. local dev without Redis), so no functionality is broken in development.

  Limiters fixed: `verifyLimiter`, `batchLimiter`, `limiter`, `reportLimiter`, `lasaLimiter`, `scanQueryLimiter`, `interactionCheckLimiter`.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

This is a backend security/infrastructure change with no UI. Verified via:

- `npm run build -w apps/api` — TypeScript compilation passes with zero errors ✅
- Confirmed `rate-limit-redis` correctly adapts to the existing `node-redis` v4 client via `sendCommand`
- Each limiter uses a unique Redis key namespace (e.g. `rl:verify:`, `rl:report:`) to prevent key collisions

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #XXXX`)
- [x] I have pulled the latest `main` and resolved any conflicts