### PR TITLE
fix(performance): resolve O(N^2) Supabase query explosion in POST /in…

### DIFF
--- a/apps/api/src/routes/interactions.ts
+++ b/apps/api/src/routes/interactions.ts
@@ -476,68 +476,20 @@ router.post("/check", interactionCheckLimiter, async (req: Request, res: Respons
             new Set(resolvedList.map((r) => r.generic.toLowerCase()))
         );
 
-        // 2. Generate all unique pairs
-        const pairs: [string, string][] = [];
-        for (let i = 0; i < resolvedGenerics.length; i++) {
-            for (let j = i + 1; j < resolvedGenerics.length; j++) {
-                pairs.push([resolvedGenerics[i], resolvedGenerics[j]]);
-            }
-        }
+        // 2. Fetch all potential interactions in one batched query
+        const allInteractions = await loadInteractionsForGenerics(resolvedGenerics);
+        const interactionByPair = indexInteractions(allInteractions);
+        const isFallback = dbConfig?.isSupabaseOffline ?? true;
 
         const matchedInteractions: MatchedInteraction[] = [];
-        let dbFailed = dbConfig?.isSupabaseOffline;
 
-        // 3. Query interactions for each pair
-        await Promise.all(
-            pairs.map(async ([a, b]) => {
-                let match = null;
-                let isFallback = false;
+        // 3. Generate all unique pairs and check against the batched results in-memory
+        for (let i = 0; i < resolvedGenerics.length; i++) {
+            for (let j = i + 1; j < resolvedGenerics.length; j++) {
+                const a = resolvedGenerics[i];
+                const b = resolvedGenerics[j];
 
-                if (!dbFailed) {
-                    try {
-                        const { data, error } = await supabase
-                            .from("drug_interactions")
-                            .select("*")
-                            .or(buildInteractionPairFilter(a, b))
-                            .maybeSingle();
-
-                        if (error) {
-                            dbFailed = true;
-                            if (
-                                error.message?.includes("fetch failed") ||
-                                error.message?.includes("refused") ||
-                                error.message?.includes("timeout")
-                            ) {
-                                if (dbConfig) dbConfig.isSupabaseOffline = true;
-                            }
-                        } else if (data) {
-                            match = data;
-                        }
-                    } catch (dbErr: unknown) {
-                        dbFailed = true;
-                        const msg = dbErr instanceof Error ? dbErr.message : String(dbErr);
-                        if (
-                            msg.includes("fetch failed") ||
-                            msg.includes("refused") ||
-                            msg.includes("timeout")
-                        ) {
-                            if (dbConfig) dbConfig.isSupabaseOffline = true;
-                        }
-                    }
-                }
-
-                if (dbFailed || !match) {
-                    // Fallback to local static check
-                    const found = localInteractions.find(
-                        (li) =>
-                            (li.drug_a_id === a && li.drug_b_id === b) ||
-                            (li.drug_a_id === b && li.drug_b_id === a)
-                    );
-                    if (found) {
-                        match = found;
-                        isFallback = true;
-                    }
-                }
+                const match = interactionByPair.get(getInteractionPairKey(a, b));
 
                 if (match) {
                     // Map back generic names to the original user input strings for display
@@ -559,8 +511,8 @@ router.post("/check", interactionCheckLimiter, async (req: Request, res: Respons
                         verified: !isFallback,
                     });
                 }
-            })
-        );
+            }
+        }
 
         res.status(200).json({ interactions: matchedInteractions });
     } catch (err) {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2490**
- **Summary:** The `POST /interactions/check` endpoint had a major \(O(N^2)\) N+1 query vulnerability where it executed a separate database query for every unique combination of medicines being checked. Checking 20 medicines resulted in 190 parallel database queries, causing major latency and functioning as an unintentional DoS vector on the Supabase connection pool. 

  This PR refactors the endpoint to fetch all possible interactions in a single, batched `.in()` query using the existing `loadInteractionsForGenerics` helper. It then indexes the interactions in memory and iterates the pairs locally, reducing the number of database queries from 190 down to 1.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

This is a backend performance fix with no UI. Verified via:
- `npm run build -w apps/api` — TypeScript compilation passes perfectly with 0 errors ✅
- Tested the code logic manually; it mirrors the exact flow successfully used in the `GET /interactions` endpoint for the same exact operation.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2490`)
- [x] I have pulled the latest `main` and resolved any conflicts