### PR TITLE
fix(api): build update object dynamically in PATCH /phone to prevent NULL data corruption

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -383,13 +383,14 @@ router.patch("/phone", optionalAuth, async (req: AuthenticatedRequest, res) => {
 
         if (!dbFailed) {
             try {
-                let query = supabase.from("notification_subscribers").update({
-                    phone: formattedNewPhone,
-                    channels,
-                    language,
-                    district,
-                    is_active,
-                });
+                const updateData: Record<string, unknown> = {};
+                if (formattedNewPhone !== undefined) updateData.phone = formattedNewPhone;
+                if (channels !== undefined) updateData.channels = channels;
+                if (language !== undefined) updateData.language = language;
+                if (district !== undefined) updateData.district = district;
+                if (is_active !== undefined) updateData.is_active = is_active;
+
+                let query = supabase.from("notification_subscribers").update(updateData);
 
                 if (req.user) {
                     query = query.eq("user_id", req.user.id);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2492**
- **Summary:** The PATCH `/phone` endpoint at `notifications.ts:386-392` passed all destructured fields to Supabase `.update()` unconditionally. When a field was omitted from the request body (valid partial update), the value was `undefined`, which Supabase serialized as SQL NULL — overwriting existing subscriber values (phone, channels, language, district, is_active). Now builds the update object dynamically, only including explicitly provided fields.

## 📸 Proof of Work (Screenshots / Logs)

No UI change. Backend logic fix.

**Before:** `PATCH /phone { "phone": "+919876543210" }` would set `channels=NULL, language=NULL, district=NULL, is_active=NULL`  
**After:** Only `phone` is updated, all other fields retain their existing DB values

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2492`)
- [x] I have pulled the latest `main` and resolved any conflicts