### PR TITLE
fix(api): import randomUUID from node:crypto directly instead of relying on globalThis

### DIFF
--- a/apps/api/src/services/abha.service.ts
+++ b/apps/api/src/services/abha.service.ts
@@ -1,4 +1,4 @@
-import { constants, publicEncrypt } from "node:crypto";
+import { constants, publicEncrypt, randomUUID } from "node:crypto";
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
 
@@ -157,7 +157,7 @@ const requestAbdm = async <T>(
             method: options.method,
             headers: {
                 "Content-Type": "application/json",
-                "REQUEST-ID": crypto.randomUUID(),
+                "REQUEST-ID": randomUUID(),
                 TIMESTAMP: new Date().toISOString(),
                 ...(options.accessToken ? { Authorization: `Bearer ${options.accessToken}` } : {}),
             },


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2493**
- **Summary:** `abha.service.ts:160` called `crypto.randomUUID()` but line 1 only imported `{ constants, publicEncrypt }` from `"node:crypto"` — the `crypto` identifier was not in scope. On Node.js 18 (minimum supported version per CONTRIBUTING.md), `globalThis.crypto.randomUUID()` does not exist (added in Node.js 19), causing a `TypeError` runtime crash on every ABDM API request. Now imports `randomUUID` from `node:crypto` and calls it directly.

## 📸 Proof of Work (Screenshots / Logs)

No UI change. Backend fix.

**Before:** Line 1 `import { constants, publicEncrypt } from "node:crypto"` — line 160 `crypto.randomUUID()` crashes on Node.js 18  
**After:** Line 1 `import { constants, publicEncrypt, randomUUID } from "node:crypto"` — line 160 `randomUUID()` works on all supported versions

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2493`)
- [x] I have pulled the latest `main` and resolved any conflicts