### PR TITLE
fix(performance): resolve N+1 queries in medicine schedules summary

### DIFF
--- a/apps/api/src/routes/medicineSchedules.ts
+++ b/apps/api/src/routes/medicineSchedules.ts
@@ -387,41 +387,56 @@ router.get("/today/summary", requireAuth, async (req: AuthenticatedRequest, res:
             return;
         }
 
-        const todaySchedules = await Promise.all(
-            (schedules ?? []).map(async (schedule) => {
-                const times = (schedule.times as string[]) ?? [];
-                const { data: loggedDoses } = await supabase
-                    .from("dose_logs")
-                    .select("*")
-                    .eq("schedule_id", schedule.id)
-                    .eq("user_id", req.user!.id)
-                    .eq("log_date", today);
+        const scheduleIds = (schedules ?? []).map((s) => s.id);
+        let allDoseLogs: any[] = [];
 
-                const loggedMap = new Map(
-                    (loggedDoses ?? []).map((d) => [d.log_time.slice(0, 5), d.status])
-                );
+        if (scheduleIds.length > 0) {
+            const { data: doseLogsData, error: doseLogsError } = await supabase
+                .from("dose_logs")
+                .select("*")
+                .in("schedule_id", scheduleIds)
+                .eq("user_id", req.user!.id)
+                .eq("log_date", today);
 
-                const doses = times.map((time: string) => {
-                    const status = loggedMap.get(time);
-                    const isPast = time < nowTime;
-                    return {
-                        time,
-                        status: status ?? (isPast ? "pending" : "upcoming"),
-                    };
-                });
+            if (!doseLogsError && doseLogsData) {
+                allDoseLogs = doseLogsData;
+            }
+        }
 
-                const allTaken = doses.every((d: { status: string }) => d.status === "taken");
+        const doseLogsBySchedule = new Map<string, any[]>();
+        for (const log of allDoseLogs) {
+            if (!doseLogsBySchedule.has(log.schedule_id)) {
+                doseLogsBySchedule.set(log.schedule_id, []);
+            }
+            doseLogsBySchedule.get(log.schedule_id)!.push(log);
+        }
 
+        const todaySchedules = (schedules ?? []).map((schedule) => {
+            const times = (schedule.times as string[]) ?? [];
+            const loggedDoses = doseLogsBySchedule.get(schedule.id) ?? [];
+
+            const loggedMap = new Map(loggedDoses.map((d) => [d.log_time.slice(0, 5), d.status]));
+
+            const doses = times.map((time: string) => {
+                const status = loggedMap.get(time);
+                const isPast = time < nowTime;
                 return {
-                    id: schedule.id,
-                    medicine_name: schedule.medicine_name,
-                    dosage: schedule.dosage,
-                    times: schedule.times,
-                    doses,
-                    completed: allTaken,
+                    time,
+                    status: status ?? (isPast ? "pending" : "upcoming"),
                 };
-            })
-        );
+            });
+
+            const allTaken = doses.every((d: { status: string }) => d.status === "taken");
+
+            return {
+                id: schedule.id,
+                medicine_name: schedule.medicine_name,
+                dosage: schedule.dosage,
+                times: schedule.times,
+                doses,
+                completed: allTaken,
+            };
+        });
 
         res.json({
             date: today,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2505**
- **Summary:** The `GET /today/summary` endpoint previously contained an N+1 query vulnerability. It used a `Promise.all` loop to execute a separate Supabase query for the `dose_logs` of **each** active schedule. If a user had 15 schedules, it fired 15 independent queries. This PR refactors the endpoint to execute a single, batched `.in("schedule_id", scheduleIds)` query and group the results in-memory, ensuring the payload loads in exactly 2 DB queries total regardless of how many schedules the user has.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

This is a backend performance fix with no UI. Verified via:
- `npm run build -w apps/api` — TypeScript compilation passes perfectly with 0 errors ✅
- Tested the code logic manually; the API groups the single query response into an in-memory Map exactly matching the original object format structure.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2505`)
- [x] I have pulled the latest `main` and resolved any conflicts