### PR TITLE
FEAT :  Implemented Chat Context Summarization to Preserve Long-Term Memory  #2508

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -6,11 +6,16 @@ import { BASE_PROMPT } from "@/lib/chatPrompts";
 import { structuredLog } from "@/lib/structuredLogger";
 import { ChatRoles, ChatRole } from "@/lib/constants";
 import { get_encoding } from "tiktoken";
+import crypto from "crypto";
 
-export function trimHistoryByTokens(messages: ChatMessage[], maxTokens: number): ChatMessage[] {
+export function trimHistoryByTokens(
+    messages: ChatMessage[],
+    maxTokens: number
+): { trimmedMessages: ChatMessage[]; droppedMessages: ChatMessage[] } {
     try {
         const enc = get_encoding("cl100k_base");
         const trimmed: ChatMessage[] = [];
+        const dropped: ChatMessage[] = [];
         let currentTokens = 0;
 
         for (let i = messages.length - 1; i >= 0; i--) {
@@ -20,7 +25,8 @@ export function trimHistoryByTokens(messages: ChatMessage[], maxTokens: number):
             const msgTokens = tokens + 4; // overhead buffer
 
             if (currentTokens + msgTokens > maxTokens && trimmed.length > 0) {
-                break;
+                dropped.unshift(msg);
+                continue;
             }
 
             currentTokens += msgTokens;
@@ -28,11 +34,13 @@ export function trimHistoryByTokens(messages: ChatMessage[], maxTokens: number):
         }
 
         enc.free();
-        return trimmed;
+        return { trimmedMessages: trimmed, droppedMessages: dropped };
     } catch (e) {
-        return messages.slice(-50);
+        return { trimmedMessages: messages.slice(-50), droppedMessages: [] };
     }
 }
+
+const summaryCache = new Map<string, string>();
 
 const DEFAULT_DISCLAIMER =
     "This guidance is for informational use only and is not a diagnosis. Consult a doctor or pharmacist, especially for severe or persistent symptoms.";
@@ -214,7 +222,7 @@ export async function POST(req: Request) {
         const MAX_MESSAGE_CHARS = 2000;
         const MAX_TOKENS = 3000; // Safe limit for standard context + response
         const recentMessages = messages.slice(-MAX_MESSAGES);
-        const trimmedMessages = trimHistoryByTokens(recentMessages, MAX_TOKENS);
+        let { trimmedMessages, droppedMessages } = trimHistoryByTokens(recentMessages, MAX_TOKENS);
 
         for (const msg of trimmedMessages) {
             const text = msg.text || msg.content || "";
@@ -333,6 +341,50 @@ export async function POST(req: Request) {
                 ...parsedResponse,
                 emergency: emergencyFromML || deterministicEmergency.isEmergency,
             });
+        }
+
+        if (droppedMessages.length > 0) {
+            try {
+                const droppedText = droppedMessages
+                    .map((m) => `${m.role}: ${m.text || m.content}`)
+                    .join("\n");
+                const cacheKey = crypto.createHash("sha256").update(droppedText).digest("hex");
+
+                let summary = summaryCache.get(cacheKey);
+
+                if (!summary) {
+                    const summaryPrompt = `Summarize the following conversation history briefly to retain key context for the ongoing chat. Keep it concise.\n\n${droppedText}`;
+                    const summaryResponse = await ai.models.generateContent({
+                        model: "gemini-2.5-flash",
+                        contents: summaryPrompt,
+                    });
+
+                    summary = summaryResponse.text || "";
+                    if (summary) {
+                        summaryCache.set(cacheKey, summary);
+                        if (summaryCache.size > 1000) {
+                            const firstKey = summaryCache.keys().next().value;
+                            if (firstKey) summaryCache.delete(firstKey);
+                        }
+                    }
+                }
+
+                if (summary) {
+                    trimmedMessages = [
+                        {
+                            role: ChatRoles.ASSISTANT,
+                            content: `[Previous Context Summary]: ${summary}`,
+                        },
+                        ...trimmedMessages,
+                    ];
+                }
+            } catch (error) {
+                structuredLog({
+                    log_level: "warn",
+                    route: ROUTE,
+                    meta: { reason: "summarization_failed", error: String(error) },
+                });
+            }
         }
 
         const formattedContents = mapMessagesToGeminiContents(trimmedMessages);

--- a/apps/web/tests/chat-route.test.ts
+++ b/apps/web/tests/chat-route.test.ts
@@ -206,7 +206,8 @@ describe("trimHistoryByTokens", () => {
             { role: "assistant", content: "Hi there" },
         ];
         const trimmed = trimHistoryByTokens(messages, 100);
-        expect(trimmed).toHaveLength(2);
+        expect(trimmed.trimmedMessages).toHaveLength(2);
+        expect(trimmed.droppedMessages).toHaveLength(0);
     });
 
     it("truncates older messages when total tokens exceed the limit", () => {
@@ -222,8 +223,12 @@ describe("trimHistoryByTokens", () => {
         // "Recent message X" is roughly 3 tokens each + 4 overhead = 7 tokens per msg -> 14 total.
         // If maxTokens is 20, it should only keep the last two.
         const trimmed = trimHistoryByTokens(messages, 20);
-        expect(trimmed).toHaveLength(2);
-        expect(trimmed[0].content).toBe("Recent message 1");
+        expect(trimmed.trimmedMessages).toHaveLength(2);
+        expect(trimmed.trimmedMessages[0].content).toBe("Recent message 1");
+        expect(trimmed.droppedMessages).toHaveLength(1);
+        expect(trimmed.droppedMessages[0].content).toBe(
+            "This is a very old message that should be truncated because it pushes the limit."
+        );
     });
 
     it("always keeps at least the last message even if it exceeds the limit", () => {
@@ -235,9 +240,11 @@ describe("trimHistoryByTokens", () => {
             },
         ];
         const trimmed = trimHistoryByTokens(messages, 5); // extremely small limit
-        expect(trimmed).toHaveLength(1);
-        expect(trimmed[0].content).toBe(
+        expect(trimmed.trimmedMessages).toHaveLength(1);
+        expect(trimmed.trimmedMessages[0].content).toBe(
             "Very long recent message that exceeds the limit on its own"
         );
+        expect(trimmed.droppedMessages).toHaveLength(1);
+        expect(trimmed.droppedMessages[0].content).toBe("Short old message");
     });
 });


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2508 **
- **Summary:**
- Whenever `trimHistoryByTokens` detects that the message history exceeds the 3000 token limit, it separates the overflowing older messages into the `droppedMessages` array. We then format those messages into a single text block and pass it to the Gemini API (gemini-2.5-flash) using a concise prompt: "Summarize the following conversation history briefly to retain key context for the ongoing chat...".
- Once the summary is generated, it is prepended directly to the `trimmedMessages` array as an assistant message ([Previous Context Summary]: <summary>). Because we trimmed the main context down to ~3,000 tokens (leaving massive headroom for Gemini's 1-Million+ token context window), injecting a short 1-2 paragraph summary safely retains the memory without any risk of overflowing or crashing the LLM.
-  If the user sends a new message without adding enough text to push another message out of the context window, the exact same `droppedMessages` would normally be re-summarized. To prevent this, I added an in-memory `summaryCache` using a fast SHA-256 hash of the dropped text. On subsequent chat turns where the dropped history is identical, the backend skips the Gemini call entirely and fetches the summary instantly from RAM—meaning 0ms added latency for the vast majority of ongoing interactions.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
