### PR TITLE
perf : Implemented Redis Caching for Medicine Schedules Daily Summary #2509

### DIFF
--- a/apps/api/src/routes/medicineSchedules.ts
+++ b/apps/api/src/routes/medicineSchedules.ts
@@ -4,6 +4,7 @@ import { supabase } from "../db/client";
 import { requireAuth } from "../middleware/auth";
 import type { AuthenticatedRequest } from "../middleware/auth";
 import logger from "../utils/logger";
+import { redisClient } from "../utils/redis";
 
 const router = Router();
 
@@ -261,6 +262,15 @@ router.post("/:id/doses", requireAuth, async (req: AuthenticatedRequest, res: Re
             return;
         }
 
+        if (redisClient.isOpen) {
+            const cacheKey = `schedules:summary:${req.user!.id}:${parsed.data.log_date}`;
+            try {
+                await redisClient.del(cacheKey);
+            } catch (redisErr) {
+                logger.error("Failed to invalidate cache", { error: redisErr, cacheKey });
+            }
+        }
+
         res.json({ dose: data });
     } catch (err) {
         logger.error("Error logging dose", { error: err, scheduleId: req.params.id });
@@ -374,6 +384,19 @@ router.get("/today/summary", requireAuth, async (req: AuthenticatedRequest, res:
         const today = queryResult.data.date || istToday;
         const nowTime = queryResult.data.time || istNowTime;
 
+        const cacheKey = `schedules:summary:${req.user!.id}:${today}`;
+        if (redisClient.isOpen) {
+            try {
+                const cached = await redisClient.get(cacheKey);
+                if (cached) {
+                    res.json(JSON.parse(cached));
+                    return;
+                }
+            } catch (redisErr) {
+                logger.error("Redis get error for today/summary", { error: redisErr, cacheKey });
+            }
+        }
+
         const { data: schedules, error: schedError } = await supabase
             .from("medicine_schedules")
             .select("*")
@@ -438,10 +461,20 @@ router.get("/today/summary", requireAuth, async (req: AuthenticatedRequest, res:
             };
         });
 
-        res.json({
+        const responseData = {
             date: today,
             schedules: todaySchedules,
-        });
+        };
+
+        if (redisClient.isOpen) {
+            try {
+                await redisClient.set(cacheKey, JSON.stringify(responseData), { EX: 86400 });
+            } catch (redisErr) {
+                logger.error("Redis set error for today/summary", { error: redisErr, cacheKey });
+            }
+        }
+
+        res.json(responseData);
     } catch (err) {
         logger.error("Error fetching today's summary", { error: err });
         res.status(500).json({ error: "An unexpected error occurred" });


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2509 **
- **Summary:**
- I modified the `GET /today/summary route in apps/api/src/routes/medicineSchedules.ts` to generate a dynamic cache key using the format: `schedules:summary:${req.user.id}:${today}`.
- If there is a cache miss, it runs the standard Supabase queries, computes the schedule combinations, and then saves the result into Redis using an 86400-second (24-hour) TTL (EX: 86400) before returning the response.
- The dose logging logic is actually located within the same file (medicineSchedules.ts) under the POST /:id/doses route. I updated this route so that whenever a user successfully logs a dose, it constructs the exact same cache key `(schedules:summary:${req.user.id}:${parsed.data.log_date})` and actively deletes it using `redisClient.del(cacheKey)`.
This guarantees that the next time the dashboard fetches /today/summary, it forces a fresh read from the database, preventing stale dose data from showing up in the UI

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
