### PR TITLE
fix: clear search input on Escape key press in MedicineSearchSelect

### DIFF
--- a/apps/web/src/components/MedicineSearchSelect.tsx
+++ b/apps/web/src/components/MedicineSearchSelect.tsx
@@ -204,6 +204,20 @@ export default function MedicineSearchSelect({
                             }}
                             onFocus={() => setOpen(true)}
                             onKeyDown={(e) => {
+                                if (e.key === "Escape") {
+                                    // Stop the key from bubbling up and
+                                    // accidentally closing a parent modal.
+                                    e.preventDefault();
+                                    e.stopPropagation();
+
+                                    setQuery("");
+                                    setResults([]);
+                                    setActiveIndex(-1);
+                                    setOpen(false);
+                                    e.currentTarget.blur();
+                                    return;
+                                }
+
                                 if (!results.length) return;
 
                                 switch (e.key) {
@@ -232,11 +246,6 @@ export default function MedicineSearchSelect({
                                             setOpen(false);
                                             setActiveIndex(-1);
                                         }
-                                        break;
-
-                                    case "Escape":
-                                        setOpen(false);
-                                        setActiveIndex(-1);
                                         break;
                                 }
                             }}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #2337
- **Summary:** Added an `Escape` key keyboard shortcut to the search input in `MedicineSearchSelect`. Pressing `Escape` while the input is focused now clears the search text, resets the dropdown/results, and removes focus — improving accessibility and the power-user experience as requested in the issue. The previous `Escape` handling (inside the `switch` statement) was incomplete: it closed the dropdown but did not clear the text, and didn't fire at all when there were no search results yet (e.g. after typing a single character). This has been fixed by moving the `Escape` check to the top of the `onKeyDown` handler, before the results-length guard. Also added `preventDefault()` and `stopPropagation()` to prevent the key from bubbling up and accidentally closing a parent modal.

## 📸 Proof of Work (Screenshots / Logs)
<img width="900" height="408" alt="escape_key_demo" src="https://github.com/user-attachments/assets/35f0fe3c-46a1-4bd8-943b-8d500398d988" />

**Manual testing performed on the Compare Medicines page (`/en/compare`):**
- Typed text in the search input, pressed `Escape` → text cleared, "X" button disappeared, dropdown closed
- Typed a single character (below the 2-character search threshold), pressed `Escape` → input cleared correctly (previously broken in this case)
- Verified `ArrowUp` / `ArrowDown` navigation and `Enter` selection still work as before (no regression)
- Verified no console errors when pressing `Escape`

## 🏷️ PR Type
- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [x] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts