### PR TITLE
feat(api): add pagination support to pharmacies in-bounds endpoint

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -170,6 +170,10 @@ const boundsQuerySchema = z
         west: z.coerce.number().min(-180).max(180),
         north: z.coerce.number().min(-90).max(90),
         east: z.coerce.number().min(-180).max(180),
+
+        limit: z.coerce.number().int().min(1).max(1000).default(200),
+
+        offset: z.coerce.number().int().min(0).default(0),
     })
     .refine((data) => data.south < data.north, {
         message: "South boundary must be less than North boundary",
@@ -626,7 +630,7 @@ router.get("/in-bounds", async (req: Request, res: Response, next: NextFunction)
             return;
         }
 
-        const { south, west, north, east } = result.data;
+        const { south, west, north, east, limit, offset } = result.data;
 
         const centerLat = (south + north) / 2;
         const centerLng = (west + east) / 2;
@@ -639,6 +643,8 @@ router.get("/in-bounds", async (req: Request, res: Response, next: NextFunction)
                 bound_west: west,
                 bound_north: north,
                 bound_east: east,
+                query_limit: limit,
+                query_offset: offset,
             }
         );
 

--- a/apps/api/tests/pharmacies.test.ts
+++ b/apps/api/tests/pharmacies.test.ts
@@ -343,6 +343,8 @@ describe("GET /api/pharmacies/in-bounds", () => {
             bound_west: 77.0,
             bound_north: 28.8,
             bound_east: 77.4,
+            query_limit: 500,
+            query_offset: 100,
         });
 
         expect(mockedSupabase.from).not.toHaveBeenCalled();

--- a/supabase/migrations/20260623000000_add_pagination_to_pharmacy_bounds_rpc.sql
+++ b/supabase/migrations/20260623000000_add_pagination_to_pharmacy_bounds_rpc.sql
@@ -1,0 +1,54 @@
+CREATE OR REPLACE FUNCTION get_pharmacies_in_bounds(
+  bound_south DOUBLE PRECISION,
+  bound_west DOUBLE PRECISION,
+  bound_north DOUBLE PRECISION,
+  bound_east DOUBLE PRECISION,
+  query_limit INTEGER DEFAULT 200,
+  query_offset INTEGER DEFAULT 0
+)
+RETURNS TABLE (
+  id          UUID,
+  name        VARCHAR(255),
+  address     TEXT,
+  district    VARCHAR(100),
+  state       VARCHAR(100),
+  phone_number VARCHAR(20),
+  is_verified BOOLEAN,
+  lat         DOUBLE PRECISION,
+  lng         DOUBLE PRECISION,
+  distance    DOUBLE PRECISION
+) AS $$
+DECLARE
+  center_lat DOUBLE PRECISION := (bound_south + bound_north) / 2.0;
+  center_lng DOUBLE PRECISION := (bound_west + bound_east) / 2.0;
+BEGIN
+  RETURN QUERY
+  SELECT
+    p.id,
+    p.name,
+    p.address,
+    p.district,
+    p.state,
+    p.phone_number,
+    p.is_verified,
+    ST_Y(p.location::geometry) AS lat,
+    ST_X(p.location::geometry) AS lng,
+    ROUND(
+      (ST_Distance(
+        p.location,
+        ST_SetSRID(ST_MakePoint(center_lng, center_lat), 4326)::geography
+      ) / 1000.0)::numeric,
+      2
+    )::double precision AS distance
+  FROM public.pharmacies p
+  WHERE p.location IS NOT NULL
+    AND p.status = 'approved'
+    AND ST_Intersects(
+          p.location,
+          ST_MakeEnvelope(bound_west, bound_south, bound_east, bound_north, 4326)::geography
+        )
+  ORDER BY distance ASC
+  LIMIT query_limit
+  OFFSET query_offset;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2235 **
- **Summary:**
1. Added limit and offset query parameters to /api/pharmacies/in-bounds.
2. Added validation with defaults (limit=200, offset=0) and maximum limit of 1000.
3. Updated the get_pharmacies_in_bounds RPC to support pagination via LIMIT and OFFSET.
4. Added a migration for the updated RPC function.
5. Updated tests to verify pagination parameters are passed correctly.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2235 `)
- [x] I have pulled the latest `main` and resolved any conflicts
