### PR TITLE
[Resilience] Add Exponential Backoff Retry for Twilio SMS Service Rate Limits

### DIFF
--- a/apps/api/src/services/sms-service.ts
+++ b/apps/api/src/services/sms-service.ts
@@ -28,28 +28,6 @@ export class TwilioSMSService implements SMSProvider {
             params.append("From", this.fromNumber);
             params.append("Body", message);
 
-        //     const response = await fetch(endpoint, {
-        //         method: "POST",
-        //         headers: {
-        //             Authorization: `Basic ${credentials}`,
-        //             "Content-Type": "application/x-www-form-urlencoded",
-        //         },
-        //         body: params.toString(),
-        //     });
-
-        //     if (!response.ok) {
-        //         const errText = await response.text();
-        //         logger.error(`Twilio SMS API error: ${response.status} ${errText}`);
-        //         return false;
-        //     }
-
-        //     logger.info(`Twilio SMS sent successfully to ${phone}`);
-        //     return true;
-        // } catch (error) {
-        //     logger.error(`Failed to send SMS to ${phone} via Twilio`, { error });
-        //     return false;
-        // }
-
             const maxRetries = 4;
             let retryDelay = 1000; // Start with 1 second
 

--- a/apps/api/src/services/sms-service.ts
+++ b/apps/api/src/services/sms-service.ts
@@ -28,24 +28,84 @@ export class TwilioSMSService implements SMSProvider {
             params.append("From", this.fromNumber);
             params.append("Body", message);
 
-            const response = await fetch(endpoint, {
-                method: "POST",
-                headers: {
-                    Authorization: `Basic ${credentials}`,
-                    "Content-Type": "application/x-www-form-urlencoded",
-                },
-                body: params.toString(),
-            });
+        //     const response = await fetch(endpoint, {
+        //         method: "POST",
+        //         headers: {
+        //             Authorization: `Basic ${credentials}`,
+        //             "Content-Type": "application/x-www-form-urlencoded",
+        //         },
+        //         body: params.toString(),
+        //     });
 
-            if (!response.ok) {
+        //     if (!response.ok) {
+        //         const errText = await response.text();
+        //         logger.error(`Twilio SMS API error: ${response.status} ${errText}`);
+        //         return false;
+        //     }
+
+        //     logger.info(`Twilio SMS sent successfully to ${phone}`);
+        //     return true;
+        // } catch (error) {
+        //     logger.error(`Failed to send SMS to ${phone} via Twilio`, { error });
+        //     return false;
+        // }
+
+            const maxRetries = 4;
+            let retryDelay = 1000; // Start with 1 second
+
+            for (let attempt = 0; attempt <= maxRetries; attempt++) {
+                const response = await fetch(endpoint, {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Basic ${credentials}`,
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    },
+                    body: params.toString(),
+                });
+
+                // Success case
+                if (response.ok) {
+                    logger.info(`Twilio SMS sent successfully to ${phone}`);
+                    return true;
+                }
+
+                // Retry only for rate-limit errors (HTTP 429)
+                if (response.status === 429) {
+                    // If we've exhausted all retries, log and fail gracefully
+                    if (attempt === maxRetries) {
+                        const errText = await response.text();
+
+                        logger.error(
+                            `Twilio SMS failed after ${maxRetries} retries due to rate limiting: ${errText}`
+                        );
+
+                        return false;
+                    }
+
+                    logger.warn(
+                        `Twilio rate limit hit for ${phone}. Retrying in ${retryDelay}ms (attempt ${
+                            attempt + 1
+                        }/${maxRetries})`
+                    );
+
+                    // Non-blocking async delay
+                    await new Promise((resolve) => setTimeout(resolve, retryDelay));
+
+                    // Exponential backoff: 1s -> 2s -> 4s -> 8s
+                    retryDelay *= 2;
+
+                    continue;
+                
+                }
+
+                // Existing behavior for all non-429 errors
                 const errText = await response.text();
                 logger.error(`Twilio SMS API error: ${response.status} ${errText}`);
                 return false;
             }
 
-            logger.info(`Twilio SMS sent successfully to ${phone}`);
-            return true;
-        } catch (error) {
+            return false;
+       } catch (error) {
             logger.error(`Failed to send SMS to ${phone} via Twilio`, { error });
             return false;
         }


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #2334 **
- **Summary:** Added exponential backoff retry handling for Twilio SMS rate-limit (HTTP 429) responses. The service now retries failed requests up to 4 times with increasing delays (1s, 2s, 4s, 8s), includes retry logging for better observability, and gracefully logs failures after all retry attempts are exhausted while preserving existing behavior for non-429 errors.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

N/A – Backend-only change. No UI changes were made.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2334 `)
- [x] I have pulled the latest `main` and resolved any conflicts
