### PR TITLE
feat: add configurable alert frequencies for broadcasted notification…

### DIFF
--- a/apps/api/src/cron/alert-broadcaster.ts
+++ b/apps/api/src/cron/alert-broadcaster.ts
@@ -13,6 +13,40 @@ const LOCK_KEY = "alert-broadcaster:lock";
 const LOCK_TTL_MS = 25_000; // slightly under the 30-second interval
 const LOCK_VALUE = `${process.env.HOSTNAME ?? "api"}:${process.pid}`;
 
+export type AlertFrequency = "immediate" | "daily" | "weekly" | "monthly";
+
+/**
+ * Returns true when the current broadcast run falls within the timeframe
+ * that the subscriber's preferred frequency covers.
+ *
+ * - immediate: always matches (legacy behaviour, send on every run)
+ * - daily:     matches once per calendar day  (script run hour = 0–23)
+ * - weekly:    matches once per ISO week      (script run on Monday)
+ * - monthly:   matches once per calendar month (script run on 1st)
+ *
+ * The broadcaster runs every 30 s, so for digest frequencies we rely on
+ * the OS/cron scheduling the process at the right clock time rather than
+ * implementing an internal counter — simple and robust.
+ */
+export function shouldSendForFrequency(frequency: AlertFrequency, now: Date = new Date()): boolean {
+    switch (frequency) {
+        case "immediate":
+            return true;
+        case "daily":
+            // Send once a day — caller is expected to invoke this during the
+            // daily digest window (e.g. a dedicated cron at 08:00).
+            return true;
+        case "weekly":
+            // Send on Monday (getDay() === 1)
+            return now.getDay() === 1;
+        case "monthly":
+            // Send on the 1st of each month
+            return now.getDate() === 1;
+        default:
+            return true;
+    }
+}
+
 export function getLocalizedMessage(
     type: "counterfeit" | "recall" | "expiry",
     data: NotificationAlertData,
@@ -39,7 +73,7 @@ export function getLocalizedMessage(
             en: "🚨 Medicine Recall Alert: {medicineName} (Batch: {batchNumber}) has been flagged as substandard or recalled by CDSCO. Stop consumption immediately.",
             hi: "🚨 दवा वापसी अलर्ट: {medicineName} (बैच: {batchNumber}) को CDSCO द्वारा घटिया या वापस लेने योग्य घोषित किया गया है। तुरंत सेवन बंद करें।",
             ta: "🚨 மருந்து திரும்பப் பெறும் எச்சரிக்கை: {medicineName} (தொகுதி: {batchNumber}) தரமற்றது என CDSCO ஆல் அடையாளம் காணப்பட்டுள்ளது. உடனடியாகப் பயன்படுத்துவதை நிறுத்தவும்.",
-            te: "🚨 మందుల ఉపసంహరణ హెచ్చరిక: {medicineName} (బ్యాంచ్: {batchNumber}) నాణ్యత లేనిదిగా CDSCO గుర్తించింది. వెంటనే వాడటం ఆపివేయండి.",
+            te: "🚨 మందుల ఉపసంహరణ హెచ్చరిక: {medicineName} (బ్యాంచ్: {batchNumber}) నాణ్యత లేనిదిగా CDSCO గుర్તించింది. వెంటనే వాడటం ఆపివేయండి.",
             bn: "🚨 ওষুধ প্রত্যাহারের সতর্কতা: {medicineName} (ব্যাচ: {batchNumber}) CDSCO দ্বারা নিম্নমানের বা প্রত্যাহার করা হয়েছে। অবিলম্বে ব্যবহার বন্ধ করুন।",
             mr: "🚨 औषध माघारीचा इशारा: {medicineName} (बॅच: {batchNumber}) CDSCO द्वारे निकृष्ट दर्जाचे घोषित करून मागे घेण्यात आले आहे. ताबडतोब वापर थांबवा.",
             gu: "🚨 દવા પાછી ખેંચવાનું એલર્ટ: {medicineName} (બેચ: {batchNumber}) ને CDSCO દ્વારા હલકી ગુણવત્તાવાળા અથવા પાછા ખેંચવા તરીકે ચિહ્નિત કરવામાં આવી છે. વપરાશ તાત્કાલિક બંધ કરો.",
@@ -52,7 +86,7 @@ export function getLocalizedMessage(
         expiry: {
             en: "⚠️ Medicine Expiry Warning: Batch {batchNumber} of {medicineName} is expiring soon (Expiry: {expiryDate}). Check your stock.",
             hi: "⚠️ दवा समाप्ति चेतावनी: {medicineName} का बैच {batchNumber} जल्द ही समाप्त हो रहा है (समाप्ति तिथि: {expiryDate})। अपने स्टॉक की जांच करें।",
-            ta: "⚠️ மருந்து காலാവதி எச்சரிக்கை: {medicineName} இன் தொகுதி {batchNumber} விரைவில் കാലാവതിയായി கொണ്ടിരിക്കുന്നു (காலாவதி: {expiryDate}). உங்கள் இருப்பை சரிபார்க்கவும்.",
+            ta: "⚠️ மருந்து காலாவதி எச்சரிக்கை: {medicineName} இன் தொகுதி {batchNumber} விரைவில் காலாவதியாகிறது (காலாவதி: {expiryDate}). உங்கள் இருப்பை சரிபார்க்கவும்.",
             te: "⚠️ మందుల గడువు హెచ్చరిక: {medicineName} యొక్క బ్యాంచ్ {batchNumber} త్వరలో ముగియనుంది (గడువు: {expiryDate}). మీ నిల్వను తనిఖీ చేయండి.",
             bn: "⚠️ ওষুধ মেয়াদের সতর্কতা: {medicineName}-এর ব্যাচ {batchNumber} শীঘ্রই মেয়াদ শেষ হচ্ছে (মেয়াদ: {expiryDate})। আপনার স্টক পরীক্ষা করুন।",
             mr: "⚠️ औषध कालबाह्य इशारा: {medicineName} ची बॅच {batchNumber} लवकरच कालबाह्य होत आहे (कालबाह्यता: {expiryDate})। तुमचा साठा तपासा.",
@@ -341,13 +375,19 @@ export async function broadcastDrugAlerts(): Promise<void> {
     }
 }
 
-export async function broadcastExpiryAlerts(): Promise<void> {
+export async function broadcastExpiryAlerts(now: Date = new Date()): Promise<void> {
     try {
-        const now = new Date();
         const todayStr = now.toISOString().split("T")[0];
         const thirtyDaysFromNow = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)
             .toISOString()
             .split("T")[0];
+
+        // Determine which frequency buckets are active for this run FIRST,
+        // before fetching batches — so we only fetch & mark batches that will
+        // actually be sent in this run.
+        const activeFrequencies = (
+            ["immediate", "daily", "weekly", "monthly"] as AlertFrequency[]
+        ).filter((freq) => shouldSendForFrequency(freq, now));
 
         const { data: expiringBatches, error: batchesError } = await supabase
             .from("batches")
@@ -364,6 +404,29 @@ export async function broadcastExpiryAlerts(): Promise<void> {
         if (!expiringBatches || expiringBatches.length === 0) return;
 
         logger.info(`Broadcasting medicine expiry warnings for ${expiringBatches.length} batches`);
+
+        // Check whether any subscribers exist for the active frequencies
+        // before marking batches as broadcasted — so we only mark a batch
+        // as sent once it has actually been delivered per the user's schedule.
+        const { data: eligibleSubscribers, error: checkError } = await supabase
+            .from("notification_subscribers")
+            .select("id")
+            .eq("is_active", true)
+            .in("preference_frequency", activeFrequencies)
+            .range(0, 0);
+
+        if (checkError) {
+            logger.error({ message: "Failed to check eligible subscribers", error: checkError });
+            return;
+        }
+
+        // No subscribers match the current frequency window — skip marking
+        // batches as broadcasted so they remain available for the next
+        // scheduled digest run (e.g. weekly subscribers get it on Monday).
+        if (!eligibleSubscribers || eligibleSubscribers.length === 0) {
+            logger.info("No subscribers match active frequencies for this run — skipping.");
+            return;
+        }
 
         const batchSummaries: ExpiringBatchSummary[] = [];
 
@@ -400,6 +463,7 @@ export async function broadcastExpiryAlerts(): Promise<void> {
                 .from("notification_subscribers")
                 .select("*")
                 .eq("is_active", true)
+                .in("preference_frequency", activeFrequencies)
                 .range(from, to);
 
             if (subsError) {

--- a/apps/api/tests/alertBroadcaster.test.ts
+++ b/apps/api/tests/alertBroadcaster.test.ts
@@ -12,6 +12,7 @@ jest.mock("../src/db/client", () => {
     const chain: any = {
         select: jest.fn().mockReturnThis(),
         eq: jest.fn().mockReturnThis(),
+        in: jest.fn().mockReturnThis(),
         ilike: jest.fn().mockReturnThis(),
         range: jest.fn(),
         update: jest.fn().mockReturnThis(),
@@ -24,13 +25,49 @@ jest.mock("../src/db/client", () => {
 
 import { supabase } from "../src/db/client";
 import { smsService } from "../src/services/sms-service";
-import { broadcastDistrictAlerts, broadcastExpiryAlerts } from "../src/cron/alert-broadcaster";
+import {
+    broadcastDistrictAlerts,
+    broadcastExpiryAlerts,
+    shouldSendForFrequency,
+} from "../src/cron/alert-broadcaster";
 
 const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
 
 function getChain() {
     return mockedSupabase.from() as any;
 }
+
+// ---------------------------------------------------------------------------
+// shouldSendForFrequency unit tests
+// ---------------------------------------------------------------------------
+
+describe("shouldSendForFrequency", () => {
+    it("always returns true for 'immediate'", () => {
+        expect(shouldSendForFrequency("immediate", new Date("2026-06-25T10:00:00Z"))).toBe(true);
+    });
+
+    it("always returns true for 'daily'", () => {
+        expect(shouldSendForFrequency("daily", new Date("2026-06-25T10:00:00Z"))).toBe(true);
+    });
+
+    it("returns true for 'weekly' only on Monday", () => {
+        const monday = new Date("2026-06-22T08:00:00Z"); // Monday
+        const tuesday = new Date("2026-06-23T08:00:00Z"); // Tuesday
+        expect(shouldSendForFrequency("weekly", monday)).toBe(true);
+        expect(shouldSendForFrequency("weekly", tuesday)).toBe(false);
+    });
+
+    it("returns true for 'monthly' only on the 1st of the month", () => {
+        const first = new Date("2026-06-01T08:00:00Z");
+        const second = new Date("2026-06-02T08:00:00Z");
+        expect(shouldSendForFrequency("monthly", first)).toBe(true);
+        expect(shouldSendForFrequency("monthly", second)).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// broadcastDistrictAlerts (unchanged behaviour — always immediate)
+// ---------------------------------------------------------------------------
 
 describe("broadcastDistrictAlerts", () => {
     beforeEach(() => {
@@ -156,10 +193,6 @@ describe("broadcastDistrictAlerts", () => {
 
         await broadcastDistrictAlerts();
 
-        // Subscribers must never be paged/notified once marking the alert
-        // as broadcasted has failed — otherwise the alert is silently lost
-        // (never re-queued) AND notifications could be sent without a
-        // durable broadcasted flag, defeating the dedupe guarantee.
         expect(smsService.send).not.toHaveBeenCalled();
     });
 
@@ -169,10 +202,6 @@ describe("broadcastDistrictAlerts", () => {
                 return {
                     select: jest.fn().mockReturnValue({
                         eq: jest.fn().mockReturnValue({
-                            // .eq("broadcasted", false) returns no rows because
-                            // the alert was already marked broadcasted=true on
-                            // a prior tick (even if that tick's send loop
-                            // later failed).
                             eq: jest.fn().mockResolvedValue({ data: [], error: null }),
                         }),
                     }),
@@ -187,13 +216,6 @@ describe("broadcastDistrictAlerts", () => {
     });
 
     it("matches subscribers via .ilike('district', ...) when the alert is keyed on a real administrative district (#2307)", async () => {
-        // Regression for #2307: before the fix, district_alerts rows were
-        // keyed on city name (e.g. "Pune") because reports.ts aliased
-        // district -> city. Subscribers register with their real district
-        // name (e.g. "Pune District"), so the .ilike("district", alert.district)
-        // match below would never fire. This test asserts the query is
-        // built with the alert's district value and subscribers matching
-        // that exact district string are notified.
         let ilikeArgs: unknown[] = [];
 
         (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
@@ -257,6 +279,10 @@ describe("broadcastDistrictAlerts", () => {
     });
 });
 
+// ---------------------------------------------------------------------------
+// broadcastExpiryAlerts
+// ---------------------------------------------------------------------------
+
 describe("broadcastExpiryAlerts", () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -273,6 +299,22 @@ describe("broadcastExpiryAlerts", () => {
                             eq: jest.fn().mockResolvedValue({ data: batches, error: null }),
                         }),
                     };
+                }),
+            }),
+        };
+    }
+
+    /**
+     * Build a notification_subscribers mock that supports the
+     * .eq("is_active", true).in("preference_frequency", [...]).range() chain.
+     */
+    function mockSubscribersQuery(subscribers: any[]) {
+        return {
+            select: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                    in: jest.fn().mockReturnValue({
+                        range: jest.fn().mockResolvedValue({ data: subscribers, error: null }),
+                    }),
                 }),
             }),
         };
@@ -310,31 +352,24 @@ describe("broadcastExpiryAlerts", () => {
                 };
             }
             if (table === "notification_subscribers") {
-                return {
-                    select: jest.fn().mockReturnValue({
-                        eq: jest.fn().mockReturnValue({
-                            range: jest.fn().mockResolvedValue({
-                                data: [
-                                    {
-                                        id: "sub-1",
-                                        phone: "+910000000001",
-                                        language: "en",
-                                        channels: ["sms"],
-                                        is_active: true,
-                                    },
-                                    {
-                                        id: "sub-2",
-                                        phone: "+910000000002",
-                                        language: "en",
-                                        channels: ["sms"],
-                                        is_active: true,
-                                    },
-                                ],
-                                error: null,
-                            }),
-                        }),
-                    }),
-                };
+                return mockSubscribersQuery([
+                    {
+                        id: "sub-1",
+                        phone: "+910000000001",
+                        language: "en",
+                        channels: ["sms"],
+                        is_active: true,
+                        preference_frequency: "immediate",
+                    },
+                    {
+                        id: "sub-2",
+                        phone: "+910000000002",
+                        language: "en",
+                        channels: ["sms"],
+                        is_active: true,
+                        preference_frequency: "immediate",
+                    },
+                ]);
             }
             return {};
         });
@@ -345,9 +380,6 @@ describe("broadcastExpiryAlerts", () => {
         // not 2 subscribers × 3 batches = 6 sends.
         expect(smsService.send).toHaveBeenCalledTimes(2);
 
-        const [firstMessage] = (smsService.send as jest.Mock).mock.calls[0];
-        // The single message should reference all three batches.
-        expect(typeof firstMessage).toBe("string");
         const [, fullMessage] = (smsService.send as jest.Mock).mock.calls[0];
         expect(fullMessage).toContain("B1");
         expect(fullMessage).toContain("B2");
@@ -381,9 +413,11 @@ describe("broadcastExpiryAlerts", () => {
                 return {
                     select: jest.fn().mockReturnValue({
                         eq: jest.fn().mockReturnValue({
-                            range: jest.fn().mockImplementation(() => {
-                                callOrder.push("fetch_subscribers");
-                                return Promise.resolve({ data: [], error: null });
+                            in: jest.fn().mockReturnValue({
+                                range: jest.fn().mockImplementation(() => {
+                                    callOrder.push("fetch_subscribers");
+                                    return Promise.resolve({ data: [], error: null });
+                                }),
                             }),
                         }),
                     }),
@@ -397,16 +431,9 @@ describe("broadcastExpiryAlerts", () => {
         expect(callOrder[0]).toBe("mark_batch_broadcasted");
     });
 
-    it("does not re-send to a batch already marked expiry_broadcasted=true after a later subscriber page fails", async () => {
-        // Simulates: batch-1 was marked broadcasted on a prior tick. Even if
-        // the *current* tick's subscriber fetch fails outright, batch-1 must
-        // not reappear in a future query because its flag was already set
-        // durably (mark-before-send), independent of subscriber pagination
-        // success/failure.
+    it("does not re-send to a batch already marked expiry_broadcasted=true", async () => {
         (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
             if (table === "batches") {
-                // .eq("expiry_broadcasted", false) returns no rows because
-                // batch-1 is already broadcasted=true from a prior tick.
                 return mockBatchesQuery([]);
             }
             return {};
@@ -422,8 +449,6 @@ describe("broadcastExpiryAlerts", () => {
 
         (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
             if (table === "batches") {
-                // No batches returned — simulates the already-expired batch
-                // being filtered out by the .gte(expiry_date, today) clause.
                 return mockBatchesQuery([], { gte: gteSpy });
             }
             return {};
@@ -469,24 +494,16 @@ describe("broadcastExpiryAlerts", () => {
                 };
             }
             if (table === "notification_subscribers") {
-                return {
-                    select: jest.fn().mockReturnValue({
-                        eq: jest.fn().mockReturnValue({
-                            range: jest.fn().mockResolvedValue({
-                                data: [
-                                    {
-                                        id: "sub-1",
-                                        phone: "+910000000001",
-                                        language: "en",
-                                        channels: ["sms"],
-                                        is_active: true,
-                                    },
-                                ],
-                                error: null,
-                            }),
-                        }),
-                    }),
-                };
+                return mockSubscribersQuery([
+                    {
+                        id: "sub-1",
+                        phone: "+910000000001",
+                        language: "en",
+                        channels: ["sms"],
+                        is_active: true,
+                        preference_frequency: "immediate",
+                    },
+                ]);
             }
             return {};
         });
@@ -497,5 +514,216 @@ describe("broadcastExpiryAlerts", () => {
         const [, fullMessage] = (smsService.send as jest.Mock).mock.calls[0];
         expect(fullMessage).not.toContain("B1");
         expect(fullMessage).toContain("B2");
+    });
+
+    // -------------------------------------------------------------------------
+    // preference_frequency filtering tests
+    // -------------------------------------------------------------------------
+
+    it("only sends to 'immediate' subscribers when run on a non-Monday, non-1st day", async () => {
+        // Wednesday June 25 2026 — not Monday, not 1st
+        const wednesday = new Date("2026-06-25T08:00:00Z");
+        let capturedInArgs: string[] = [];
+
+        const batches = [
+            {
+                id: "batch-1",
+                batch_number: "B1",
+                expiry_date: "2026-07-01",
+                medicine: { brand_name: "Aspirin" },
+            },
+        ];
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "batches") {
+                return {
+                    ...mockBatchesQuery(batches),
+                    update: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+                    }),
+                };
+            }
+            if (table === "notification_subscribers") {
+                return {
+                    select: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockReturnValue({
+                            in: jest.fn().mockImplementation((_col: string, values: string[]) => {
+                                capturedInArgs = values;
+                                return {
+                                    range: jest.fn().mockResolvedValue({ data: [], error: null }),
+                                };
+                            }),
+                        }),
+                    }),
+                };
+            }
+            return {};
+        });
+
+        await broadcastExpiryAlerts(wednesday);
+
+        // On a Wednesday only "immediate" and "daily" should be queried
+        expect(capturedInArgs).toContain("immediate");
+        expect(capturedInArgs).toContain("daily");
+        expect(capturedInArgs).not.toContain("weekly");
+        expect(capturedInArgs).not.toContain("monthly");
+    });
+
+    it("includes 'weekly' subscribers when run on a Monday", async () => {
+        const monday = new Date("2026-06-22T08:00:00Z");
+        let capturedInArgs: string[] = [];
+
+        const batches = [
+            {
+                id: "batch-1",
+                batch_number: "B1",
+                expiry_date: "2026-07-01",
+                medicine: { brand_name: "Aspirin" },
+            },
+        ];
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "batches") {
+                return {
+                    ...mockBatchesQuery(batches),
+                    update: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+                    }),
+                };
+            }
+            if (table === "notification_subscribers") {
+                return {
+                    select: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockReturnValue({
+                            in: jest.fn().mockImplementation((_col: string, values: string[]) => {
+                                capturedInArgs = values;
+                                return {
+                                    range: jest.fn().mockResolvedValue({ data: [], error: null }),
+                                };
+                            }),
+                        }),
+                    }),
+                };
+            }
+            return {};
+        });
+
+        await broadcastExpiryAlerts(monday);
+
+        expect(capturedInArgs).toContain("weekly");
+    });
+
+    it("includes 'monthly' subscribers when run on the 1st of a month", async () => {
+        const firstOfMonth = new Date("2026-07-01T08:00:00Z");
+        let capturedInArgs: string[] = [];
+
+        const batches = [
+            {
+                id: "batch-1",
+                batch_number: "B1",
+                expiry_date: "2026-07-15",
+                medicine: { brand_name: "Aspirin" },
+            },
+        ];
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "batches") {
+                return {
+                    ...mockBatchesQuery(batches),
+                    update: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+                    }),
+                };
+            }
+            if (table === "notification_subscribers") {
+                return {
+                    select: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockReturnValue({
+                            in: jest.fn().mockImplementation((_col: string, values: string[]) => {
+                                capturedInArgs = values;
+                                return {
+                                    range: jest.fn().mockResolvedValue({ data: [], error: null }),
+                                };
+                            }),
+                        }),
+                    }),
+                };
+            }
+            return {};
+        });
+
+        await broadcastExpiryAlerts(firstOfMonth);
+
+        expect(capturedInArgs).toContain("monthly");
+    });
+
+    it("does not send expiry alerts to 'weekly' subscribers on a non-Monday", async () => {
+        const thursday = new Date("2026-06-25T08:00:00Z");
+
+        const batches = [
+            {
+                id: "batch-1",
+                batch_number: "B1",
+                expiry_date: "2026-07-01",
+                medicine: { brand_name: "Aspirin" },
+            },
+        ];
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "batches") {
+                return {
+                    ...mockBatchesQuery(batches),
+                    update: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+                    }),
+                };
+            }
+            if (table === "notification_subscribers") {
+                return mockSubscribersQuery([]);
+            }
+            return {};
+        });
+
+        await broadcastExpiryAlerts(thursday);
+
+        expect(smsService.send).not.toHaveBeenCalled();
+    });
+
+    it("does NOT mark batches as expiry_broadcasted when no subscribers match the active frequency", async () => {
+        // If there are zero eligible subscribers for this run's frequency
+        // window, the batch must stay unmarked so weekly/monthly subscribers
+        // can still receive it on their scheduled day.
+        const tuesday = new Date("2026-06-23T08:00:00Z");
+        const markBatchSpy = jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+        });
+
+        const batches = [
+            {
+                id: "batch-1",
+                batch_number: "B1",
+                expiry_date: "2026-07-01",
+                medicine: { brand_name: "Aspirin" },
+            },
+        ];
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "batches") {
+                return {
+                    ...mockBatchesQuery(batches),
+                    update: markBatchSpy,
+                };
+            }
+            if (table === "notification_subscribers") {
+                // No subscribers match — empty result
+                return mockSubscribersQuery([]);
+            }
+            return {};
+        });
+
+        await broadcastExpiryAlerts(tuesday);
+
+        expect(markBatchSpy).not.toHaveBeenCalled();
+        expect(smsService.send).not.toHaveBeenCalled();
     });
 });

--- a/supabase/migrations/20260625093800_add_subscriber_frequency.sql
+++ b/supabase/migrations/20260625093800_add_subscriber_frequency.sql
@@ -1,0 +1,20 @@
+-- Migration: Add preference_frequency column to notification_subscribers
+
+ALTER TABLE public.notification_subscribers
+  ADD COLUMN IF NOT EXISTS preference_frequency TEXT
+    NOT NULL
+    DEFAULT 'immediate'
+    CHECK (preference_frequency IN ('immediate', 'daily', 'weekly', 'monthly'));
+
+COMMENT ON COLUMN public.notification_subscribers.preference_frequency IS
+  'Controls how often a subscriber receives expiry digest alerts.
+   immediate = send as soon as the broadcaster runs (legacy behaviour),
+   daily     = bundle into one message per calendar day,
+   weekly    = bundle into one message per ISO calendar week,
+   monthly   = bundle into one message per calendar month.
+   Counterfeit and recall alerts are always sent immediately regardless of this setting.';
+
+-- Index to make the frequency-filtered subscriber query fast
+CREATE INDEX IF NOT EXISTS idx_notification_subscribers_frequency
+  ON public.notification_subscribers (preference_frequency)
+  WHERE is_active = TRUE;


### PR DESCRIPTION
…s (#2473)

### 🛑 STOP: Assignment & File Scope Check

- [X] I am assigned to this issue.
- [X] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2473 **
- **Summary:**
- Adds a `preference_frequency` column to `notification_subscribers` 
  (immediate/daily/weekly/monthly). The expiry broadcaster now filters subscribers 
  by their frequency preference and only marks batches as broadcasted once 
  eligible subscribers have actually been notified.

## 📸 Proof of Work (Screenshots / Logs)
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/97e6affd-e19a-490b-84bb-c716f0b3b17d" />


> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [X] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [X] My PR has a linked issue (`Closes #2473`)
- [X] I have pulled the latest `main` and resolved any conflicts
