### PR TITLE
fix(#2554): allow required browser permissions policy

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -24,7 +24,7 @@ const nextConfig = {
                     { key: "X-Content-Type-Options", value: "nosniff" },
                     { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
                     { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
-                    { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+                    { key: "Permissions-Policy", value: "camera=(self), microphone=(self), geolocation=(self)" },
                     { key: "Content-Security-Policy", value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;" },
                 ],
             },


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #2554**
* **Summary:**

  * Updated the global `Permissions-Policy` header to allow camera, microphone, and geolocation access for the application's own origin.
  * This enables browser permission requests for the barcode scanner, voice verification, and pharmacy map features while keeping the remaining security headers unchanged.
  * The change is limited to `apps/web/next.config.mjs`.

## 📸 Proof of Work (Screenshots / Logs)

### Code Change

```diff
- { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+ { key: "Permissions-Policy", value: "camera=(self), microphone=(self), geolocation=(self)" },
```

### Testing

**Lint**

```text
npm run lint
```

Result:

```text
Failed due to pre-existing unrelated lint errors:

apps/web/app/[locale]/calculator/page.tsx
  9:10  error  'escapePostgrest' is defined but never used

apps/web/app/api/chat/route.ts
  38:14  error  'e' is defined but never used
 225:32  error  'droppedMessages' is never reassigned. Use 'const' instead
```

**Build**

```text
npm run build
```

Result:

```text
Build could not complete because of pre-existing missing dependencies in unrelated parts of the project (including class-variance-authority, @opentelemetry/*, and tailwind-merge). No build errors were introduced by this change.
```

**Frontend Evidence**

> No visual UI changes. This PR only updates an HTTP response header in `next.config.mjs`.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [x] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2554`)
* [x] I have pulled the latest `main` and resolved any conflicts