### PR TITLE
fix: add pagination and rate limiters to API endpoints (#2560, #2559, #2558)

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -142,3 +142,23 @@ export const interactionCheckLimiter = rateLimit({
         });
     },
 });
+
+// ── Triage limiter ──────────────────────────────────────────────────────────
+// POST /triage/medicine-query and /triage/recommend perform expensive pgvector
+// semantic search + optional Gemini embedding calls + PostGIS RPC.
+// Throttle to prevent DoS via repeated semantic search queries.
+export const triageLimiter = rateLimit({
+    windowMs: 60 * 1000, // 1 minute
+    max: 15,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: buildStore("triage"),
+    keyGenerator: (req) => {
+        return req.ip || req.socket.remoteAddress || "unknown";
+    },
+    handler: (_req, res) => {
+        res.status(429).json({
+            error: "Too many triage requests. Please try again later.",
+        });
+    },
+});

--- a/apps/api/src/routes/interactions.ts
+++ b/apps/api/src/routes/interactions.ts
@@ -251,7 +251,7 @@ async function loadInteractionsForGenerics(genericNames: string[]): Promise<Inte
  *           type: string
  *         example: med-a,med-b,med-c
  */
-router.get("/", async (req: Request, res: Response) => {
+router.get("/", interactionCheckLimiter, async (req: Request, res: Response) => {
     const ids = parseIdsParam(req.query.ids);
 
     if (ids.length < 2) {

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -195,21 +195,38 @@ reportsRouter.get("/mine", requireAuth, async (req: AuthenticatedRequest, res: R
         return;
     }
 
+    const rawPage = parseInt(req.query.page as string, 10);
+    const rawLimit = parseInt(req.query.limit as string, 10);
+    const page = isNaN(rawPage) || rawPage < 1 ? 1 : rawPage;
+    const limit = isNaN(rawLimit) || rawLimit < 1 ? 20 : Math.min(rawLimit, 100);
+    const offset = (page - 1) * limit;
+
     try {
-        const { data, error } = await supabase
+        const { data, error, count } = await supabase
             .from("counterfeit_reports")
             .select(
-                "id, reported_brand_name, scanned_barcode, photo_url, district, status, created_at"
+                "id, reported_brand_name, scanned_barcode, photo_url, district, status, created_at",
+                { count: "exact" }
             )
             .eq("reporter_id", userId)
-            .order("created_at", { ascending: false });
+            .order("created_at", { ascending: false })
+            .range(offset, offset + limit - 1);
 
         if (error) {
             res.status(500).json({ error: "Failed to fetch your reports" });
             return;
         }
 
-        res.json({ reports: data ?? [] });
+        const totalCount = count ?? 0;
+        const totalPageCount = Math.ceil(totalCount / limit);
+
+        res.json({
+            reports: data ?? [],
+            pageIndex: page,
+            pageSize: (data ?? []).length,
+            totalCount,
+            totalPageCount,
+        });
     } catch (err) {
         console.error("Unexpected error in GET /api/reports/mine:", err);
         res.status(500).json({ error: "An unexpected error occurred" });

--- a/apps/api/src/routes/triage.ts
+++ b/apps/api/src/routes/triage.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response, NextFunction } from "express";
 import { anonSupabase } from "../db/supabase";
 import logger from "../utils/logger";
+import { triageLimiter } from "../middleware/rateLimit";
 import {
     assessUrgency,
     medicineQuerySchema,
@@ -91,7 +92,7 @@ async function findNearestPharmacies(
  *       500:
  *         description: Server or database error
  */
-router.post("/medicine-query", async (req: Request, res: Response, next: NextFunction) => {
+router.post("/medicine-query", triageLimiter, async (req: Request, res: Response, next: NextFunction) => {
     const parsed = medicineQuerySchema.safeParse(req.body);
     if (!parsed.success) {
         res.status(400).json({
@@ -159,7 +160,7 @@ router.post("/medicine-query", async (req: Request, res: Response, next: NextFun
  *       500:
  *         description: Server or database error
  */
-router.post("/recommend", async (req: Request, res: Response, next: NextFunction) => {
+router.post("/recommend", triageLimiter, async (req: Request, res: Response, next: NextFunction) => {
     const parsed = recommendSchema.safeParse(req.body);
     if (!parsed.success) {
         res.status(400).json({


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #2560, #2559, #2558**
- **Summary:**
  - **#2560** — Added `page`/`limit` query parameters with Supabase `.range()` to `GET /api/v1/reports/mine`. Returns paginated results with `pageIndex`, `pageSize`, `totalCount`, `totalPageCount` metadata (consistent with `/alerts` endpoint).
  - **#2559** — Added `interactionCheckLimiter` to `GET /api/v1/interactions` route. The POST endpoint was previously fixed but the GET sibling was unprotected.
  - **#2558** — Created new `triageLimiter` (15 req/min per IP) and applied to both `POST /triage/medicine-query` and `POST /triage/recommend`. These endpoints perform expensive pgvector semantic search + optional Gemini embedding calls + PostGIS RPC.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] 🔒 `type: security`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2560, #2559, #2558`)
- [x] I have pulled the latest `main` and resolved any conflicts

## 📸 Proof of Work

All changes follow existing patterns in the codebase:
- Pagination matches `GET /api/v1/alerts` response schema
- Rate limiters use Redis-backed store with MemoryStore fallback (same as other limiters)
- `triageLimiter` configuration consistent with `interactionCheckLimiter` (1 min window, IP-based key)

### Changed files:
- `apps/api/src/middleware/rateLimit.ts` — added `triageLimiter`
- `apps/api/src/routes/reports.ts` — added pagination to `/mine` route
- `apps/api/src/routes/interactions.ts` — added limiter to `GET /` route
- `apps/api/src/routes/triage.ts` — imported and applied `triageLimiter` to both routes

---

cc @RatLoopz/maintainers