### PR TITLE
fix: add rate limiter to GET /api/v1/interactions (#2559)

### DIFF
--- a/apps/api/src/routes/interactions.ts
+++ b/apps/api/src/routes/interactions.ts
@@ -251,7 +251,7 @@ async function loadInteractionsForGenerics(genericNames: string[]): Promise<Inte
  *           type: string
  *         example: med-a,med-b,med-c
  */
-router.get("/", async (req: Request, res: Response) => {
+router.get("/", interactionCheckLimiter, async (req: Request, res: Response) => {
     const ids = parseIdsParam(req.query.ids);
 
     if (ids.length < 2) {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #2559**
- **Summary:** Added `interactionCheckLimiter` to `GET /api/v1/interactions` route. The POST endpoint was previously fixed (#2375) but the GET sibling was unprotected.

## 🏷️ PR Type

- [x] 🔒 `type: security`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2559`)
- [x] I have pulled the latest `main` and resolved any conflicts

## 📸 Proof of Work

- Reuses existing `interactionCheckLimiter` (10 req/min per IP, Redis-backed)
- Consistent protection for both GET and POST interaction endpoints
- Prevents DoS bypass by switching from POST to GET

### Changed file:
- `apps/api/src/routes/interactions.ts` — added `interactionCheckLimiter` to `GET /` route

---

cc @RatLoopz