### PR TITLE
fix: add rate limiting to POST /triage endpoints (#2558)

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -142,3 +142,23 @@ export const interactionCheckLimiter = rateLimit({
         });
     },
 });
+
+// ── Triage limiter ──────────────────────────────────────────────────────────
+// POST /triage/medicine-query and /triage/recommend perform expensive pgvector
+// semantic search + optional Gemini embedding calls + PostGIS RPC.
+// Throttle to prevent DoS via repeated semantic search queries.
+export const triageLimiter = rateLimit({
+    windowMs: 60 * 1000, // 1 minute
+    max: 15,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: buildStore("triage"),
+    keyGenerator: (req) => {
+        return req.ip || req.socket.remoteAddress || "unknown";
+    },
+    handler: (_req, res) => {
+        res.status(429).json({
+            error: "Too many triage requests. Please try again later.",
+        });
+    },
+});

--- a/apps/api/src/routes/triage.ts
+++ b/apps/api/src/routes/triage.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response, NextFunction } from "express";
 import { anonSupabase } from "../db/supabase";
 import logger from "../utils/logger";
+import { triageLimiter } from "../middleware/rateLimit";
 import {
     assessUrgency,
     medicineQuerySchema,
@@ -91,7 +92,7 @@ async function findNearestPharmacies(
  *       500:
  *         description: Server or database error
  */
-router.post("/medicine-query", async (req: Request, res: Response, next: NextFunction) => {
+router.post("/medicine-query", triageLimiter, async (req: Request, res: Response, next: NextFunction) => {
     const parsed = medicineQuerySchema.safeParse(req.body);
     if (!parsed.success) {
         res.status(400).json({
@@ -159,7 +160,7 @@ router.post("/medicine-query", async (req: Request, res: Response, next: NextFun
  *       500:
  *         description: Server or database error
  */
-router.post("/recommend", async (req: Request, res: Response, next: NextFunction) => {
+router.post("/recommend", triageLimiter, async (req: Request, res: Response, next: NextFunction) => {
     const parsed = recommendSchema.safeParse(req.body);
     if (!parsed.success) {
         res.status(400).json({


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #2558**
- **Summary:** Created new `triageLimiter` (15 req/min per IP) and applied to both `POST /triage/medicine-query` and `POST /triage/recommend`. These endpoints perform expensive pgvector semantic search + optional Gemini embedding calls + PostGIS RPC.

## 🏷️ PR Type

- [x] 🔒 `type: security`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2558`)
- [x] I have pulled the latest `main` and resolved any conflicts

## 📸 Proof of Work

- `triageLimiter` follows same pattern as `interactionCheckLimiter` (1 min window, IP-based key, Redis-backed)
- 15 req/min limit appropriate for expensive semantic search endpoints
- Prevents: Supabase connection pool exhaustion, Gemini API quota drain, pgvector CPU cost amplification

### Changed files:
- `apps/api/src/middleware/rateLimit.ts` — added `triageLimiter`
- `apps/api/src/routes/triage.ts` — imported and applied `triageLimiter` to both routes

---

cc @RatLoopz