### PR TITLE
 Perf : added  short-lived Redis JWT cache to reduce latency#2547

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { SupabaseClient, User } from "@supabase/supabase-js";
 import { supabase, dbConfig } from "../db/client";
 import logger from "../utils/logger";
+import { redisClient } from "../utils/redis";
 
 export type AuthRole = "user" | "admin" | "moderator";
 
@@ -79,6 +80,23 @@ export const createAuthMiddleware =
             return;
         }
 
+        const cacheKey = `auth:user:${token.slice(-16)}`;
+        try {
+            if (redisClient.isOpen) {
+                const cached = await redisClient.get(cacheKey);
+                if (cached) {
+                    req.user = JSON.parse(cached);
+                    next();
+                    return;
+                }
+            }
+        } catch (err) {
+            logger.warn({
+                message: "Redis cache get error in auth middleware",
+                error: String(err),
+            });
+        }
+
         try {
             const { data, error } = await client.auth.getUser(token);
 
@@ -120,6 +138,17 @@ export const createAuthMiddleware =
                 role: getUserRole(data.user),
                 raw: data.user,
             };
+
+            try {
+                if (redisClient.isOpen) {
+                    await redisClient.setEx(cacheKey, 300, JSON.stringify(req.user));
+                }
+            } catch (err) {
+                logger.warn({
+                    message: "Redis cache set error in auth middleware",
+                    error: String(err),
+                });
+            }
 
             next();
         } catch (err) {
@@ -172,6 +201,23 @@ export const createOptionalAuthMiddleware =
             return next();
         }
 
+        const cacheKey = `auth:user:${token.slice(-16)}`;
+        try {
+            if (redisClient.isOpen) {
+                const cached = await redisClient.get(cacheKey);
+                if (cached) {
+                    req.user = JSON.parse(cached);
+                    next();
+                    return;
+                }
+            }
+        } catch (err) {
+            logger.warn({
+                message: "Redis cache get error in optional auth middleware",
+                error: String(err),
+            });
+        }
+
         try {
             const { data, error } = await client.auth.getUser(token);
 
@@ -217,6 +263,17 @@ export const createOptionalAuthMiddleware =
                 role: getUserRole(data.user),
                 raw: data.user,
             };
+
+            try {
+                if (redisClient.isOpen) {
+                    await redisClient.setEx(cacheKey, 300, JSON.stringify(req.user));
+                }
+            } catch (err) {
+                logger.warn({
+                    message: "Redis cache set error in optional auth middleware",
+                    error: String(err),
+                });
+            }
 
             next();
         } catch (err) {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2547 **
- **Summary:**
- The cache is set using await redisClient.setEx(cacheKey, 300, JSON.stringify(req.user));. The setEx command sets the cache and an expiration time of 300 seconds.
- The key is derived using the last 16 characters of the token string via const `cacheKey = \auth:user:${token.slice(-16)}``;`. This ensures the raw JWT isn't fully stored in Redis keys, preventing security issues.
- The middleware first attempts to find a cached user. If cached is null or undefined (a cache miss), the code execution bypasses the early return and proceeds down to the const { data, error } = await client.auth.getUser(token); block as it normally would.
- Because of the 300 second TTL , the cached token entry will expire and disappear from Redis after exactly 5 minutes. On the next request after that expiration, the cache will miss, forcing a network check to Supabase which will recognize the token has been revoked.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
