### PR TITLE
refactor(pharmacies): use redisCache middleware for nearest endpoint

### DIFF
--- a/apps/api/src/middleware/redisCache.ts
+++ b/apps/api/src/middleware/redisCache.ts
@@ -1,0 +1,77 @@
+import { Request, Response, NextFunction } from "express";
+import { redisClient } from "../utils/redis";
+import logger from "../utils/logger";
+
+/**
+ * Function used to generate a unique cache key for a request.
+ */
+type CacheKeyGenerator = (req: Request) => string;
+
+/**
+ * Reusable Redis cache middleware.
+ *
+ * - Checks Redis before route execution.
+ * - Returns cached response on cache hit.
+ * - Transparently caches successful responses.
+ * - Falls back gracefully if Redis is unavailable.
+ *
+ * @param ttl Cache expiration time in seconds
+ * @param keyGenerator Function that generates a cache key from the request
+ */
+export const redisCache =
+    (ttl: number, keyGenerator: CacheKeyGenerator) =>
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+        const cacheKey = keyGenerator(req);
+
+        // Skip caching entirely when Redis is unavailable.
+        if (!redisClient.isOpen) {
+            next();
+            return;
+        }
+
+        try {
+            // Check Redis before executing route logic.
+            const cached = await redisClient.get(cacheKey);
+
+            if (cached) {
+                res.json(JSON.parse(cached));
+                return;
+            }
+        } catch (error) {
+            logger.warn("Redis cache read failed", { error });
+            next();
+            return;
+        }
+
+        // Preserve original response methods.
+        const originalJson = res.json.bind(res);
+        const originalSend = res.send.bind(res);
+
+        /**
+         * Cache JSON responses before sending them to the client.
+         */
+        res.json = function (body: unknown): Response {
+            if (res.statusCode >= 200 && res.statusCode < 300) {
+                redisClient.set(cacheKey, JSON.stringify(body), { EX: ttl }).catch((error) => {
+                    logger.warn("Redis cache write failed", { error });
+                });
+            }
+
+            return originalJson(body);
+        };
+
+        /**
+         * Cache non-JSON responses before sending them to the client.
+         */
+        res.send = function (body: unknown): Response {
+            if (res.statusCode >= 200 && res.statusCode < 300) {
+                redisClient.set(cacheKey, JSON.stringify(body), { EX: ttl }).catch((error) => {
+                    logger.warn("Redis cache write failed", { error });
+                });
+            }
+
+            return originalSend(body);
+        };
+
+        next();
+    };

--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -6,6 +6,7 @@ import { redisClient } from "../utils/redis";
 import { limiter } from "../middleware/rateLimit";
 import { requireAuth, AuthenticatedRequest } from "../middleware/auth";
 import { FormattedPharmacy, PharmacyRpcResult } from "../types/pharmacy.types";
+import { redisCache } from "../middleware/redisCache";
 
 const router = Router();
 
@@ -378,124 +379,112 @@ function handleFetchError(
  *       500:
  *         description: Server or database error
  */
-router.get("/nearest", limiter, async (req: Request, res: Response, next: NextFunction) => {
-    try {
-        const result = nearestQuerySchema.safeParse(req.query);
+router.get(
+    "/nearest",
+    limiter,
+    redisCache(3600, (req: Request) => {
+        const lat = Number(req.query.lat);
+        const lng = Number(req.query.lng);
+        const radius = Number(req.query.radius ?? 50);
 
-        if (!result.success) {
-            res.status(400).json({
-                error: "Invalid coordinates",
-                details: result.error.flatten().fieldErrors,
-            });
-            return;
-        }
-
-        const { lat, lng, radius } = result.data;
-
-        const roundedLat = lat.toFixed(3);
-        const roundedLng = lng.toFixed(3);
-
-        const cacheKey = `pharmacies:nearest:${roundedLat}:${roundedLng}:${radius}`;
-
+        return `pharmacies:nearest:${lat.toFixed(3)}:${lng.toFixed(3)}:${radius}`;
+    }),
+     async (req: Request, res: Response, next: NextFunction) => {
         try {
-            if (redisClient.isOpen) {
-                const cached = await redisClient.get(cacheKey);
+            const result = nearestQuerySchema.safeParse(req.query);
 
-                if (cached) {
-                    return res.json(JSON.parse(cached));
-                }
+            if (!result.success) {
+                res.status(400).json({
+                    error: "Invalid coordinates",
+                    details: result.error.flatten().fieldErrors,
+                });
+                return;
             }
-        } catch (error) {
-            logger.warn("Redis cache read failed", { error });
-        }
 
-        // Primary path: PostGIS RPC with server-side radius filtering
-        const { data: rpcData, error: rpcError } = await supabase.rpc("get_nearest_pharmacies", {
-            query_lat: lat,
-            query_lng: lng,
-            search_radius_km: radius,
-        });
+            const { lat, lng, radius } = result.data;
 
-        if (!rpcError && rpcData) {
-            const pharmacies: FormattedPharmacy[] = (rpcData as PharmacyRpcResult[])
-                .map((p: PharmacyRpcResult) => ({
-                    name: p.name || "Unknown Pharmacy",
-                    address: p.address || "Unknown Address",
-                    lat: p.lat,
-                    lng: p.lng,
-                    distance: `${Number(p.distance).toFixed(1)} km`,
-                    phone_number: p.phone_number || null,
-                    is_verified: p.is_verified ?? false,
-                    district: p.district || null,
-                    state: p.state || null,
-                }))
-                .slice(0, MAX_RESULTS);
+            // Primary path: PostGIS RPC with server-side radius filtering
+            const { data: rpcData, error: rpcError } = await supabase.rpc(
+                "get_nearest_pharmacies",
+                {
+                    query_lat: lat,
+                    query_lng: lng,
+                    search_radius_km: radius,
+                }
+            );
+
+            if (!rpcError && rpcData) {
+                const pharmacies: FormattedPharmacy[] = (rpcData as PharmacyRpcResult[])
+                    .map((p: PharmacyRpcResult) => ({
+                        name: p.name || "Unknown Pharmacy",
+                        address: p.address || "Unknown Address",
+                        lat: p.lat,
+                        lng: p.lng,
+                        distance: `${Number(p.distance).toFixed(1)} km`,
+                        phone_number: p.phone_number || null,
+                        is_verified: p.is_verified ?? false,
+                        district: p.district || null,
+                        state: p.state || null,
+                    }))
+                    .slice(0, MAX_RESULTS);
+
+                const responseData = { pharmacies };
+
+                setGeospatialCacheHeaders(res);
+                return res.json(responseData);
+            }
+
+            // Fallback path: Haversine calculation in JavaScript
+            logger.warn(
+                "PostGIS RPC failed or unavailable, falling back to Haversine calculation",
+                {
+                    error: rpcError?.message,
+                    code: rpcError?.code,
+                }
+            );
+
+            const { data: allPharmacies, error: fetchError } = await supabase
+                .from("pharmacies")
+                .select(
+                    "name, address, location, phone_number, is_verified, district, state, status"
+                )
+                .eq("status", "approved")
+                .limit(3000);
+
+            if (fetchError) {
+                handleFetchError(fetchError, res);
+                return;
+            }
+
+            const pharmacies: FormattedPharmacy[] = ((allPharmacies || []) as PharmacyRow[])
+                .filter((p: PharmacyRow) => p.status === "approved")
+                .map((p: PharmacyRow): PharmacyWithRawDistance => {
+                    const coords = extractCoordinates(p);
+                    const distanceKm = calculateDistanceKM(lat, lng, coords.lat, coords.lng);
+                    return { ...formatPharmacy(p, distanceKm), rawDistance: distanceKm };
+                })
+                .filter(
+                    (p: PharmacyWithRawDistance) =>
+                        p.lat !== 0 && p.lng !== 0 && p.rawDistance <= radius
+                )
+                .sort(
+                    (a: PharmacyWithRawDistance, b: PharmacyWithRawDistance) =>
+                        a.rawDistance - b.rawDistance
+                )
+                .slice(0, MAX_RESULTS)
+                .map(
+                    ({ rawDistance, ...rest }: PharmacyWithRawDistance): FormattedPharmacy => rest
+                );
 
             const responseData = { pharmacies };
 
-            try {
-                if (redisClient.isOpen) {
-                    await redisClient.set(cacheKey, JSON.stringify(responseData), { EX: 3600 });
-                }
-            } catch (error) {
-                logger.warn("Redis cache write failed", { error });
-            }
-
             setGeospatialCacheHeaders(res);
-            return res.json(responseData);
+            res.json(responseData);
+        } catch (err) {
+            next(err);
         }
-
-        // Fallback path: Haversine calculation in JavaScript
-        logger.warn("PostGIS RPC failed or unavailable, falling back to Haversine calculation", {
-            error: rpcError?.message,
-            code: rpcError?.code,
-        });
-
-        const { data: allPharmacies, error: fetchError } = await supabase
-            .from("pharmacies")
-            .select("name, address, location, phone_number, is_verified, district, state, status")
-            .eq("status", "approved")
-            .limit(3000);
-
-        if (fetchError) {
-            handleFetchError(fetchError, res);
-            return;
-        }
-
-        const pharmacies: FormattedPharmacy[] = ((allPharmacies || []) as PharmacyRow[])
-            .filter((p: PharmacyRow) => p.status === "approved")
-            .map((p: PharmacyRow): PharmacyWithRawDistance => {
-                const coords = extractCoordinates(p);
-                const distanceKm = calculateDistanceKM(lat, lng, coords.lat, coords.lng);
-                return { ...formatPharmacy(p, distanceKm), rawDistance: distanceKm };
-            })
-            .filter(
-                (p: PharmacyWithRawDistance) =>
-                    p.lat !== 0 && p.lng !== 0 && p.rawDistance <= radius
-            )
-            .sort(
-                (a: PharmacyWithRawDistance, b: PharmacyWithRawDistance) =>
-                    a.rawDistance - b.rawDistance
-            )
-            .slice(0, MAX_RESULTS)
-            .map(({ rawDistance, ...rest }: PharmacyWithRawDistance): FormattedPharmacy => rest);
-
-        const responseData = { pharmacies };
-
-        try {
-            if (redisClient.isOpen) {
-                await redisClient.set(cacheKey, JSON.stringify(responseData), { EX: 3600 });
-            }
-        } catch (error) {
-            logger.warn("Redis cache write failed", { error });
-        }
-
-        setGeospatialCacheHeaders(res);
-        res.json(responseData);
-    } catch (err) {
-        next(err);
     }
-});
+);
 
 /**
  * @openapi


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2462 **
- **Summary:**

1. Refactored the `/api/pharmacies/nearest`  endpoint to use the reusable `redisCache` middleware instead of implementing Redis caching logic directly in the route.
2. Removed duplicate cache read/write logic from `pharmacies.ts` , making the route cleaner and easier to maintain.
3. Added a reusable `redisCache` middleware for handling Redis-based response caching with configurable cache keys and TTL.
4. Preserved the existing endpoint behavior, cache headers, and response format while improving code reusability.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
**Backend changes only.**
 **Testing performed:**
- Added redisCache middleware to the /api/pharmacies/nearest endpoint.
- Verified that the endpoint behaviour remains  unchanged.
-  Confirmed existing pharmacies route tests pass successfully 
`Test Suites: 1 passed, 1 total 
Tests:       17 passed, 17 total 
Snapshots:   0 total 
Time:        1.923 s, estimated 4 s
Ran all test suites matching tests/pharmacies.test.ts. `
- Commit passed the projects pre-commit checks(Husky+Prettier).
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
> No frontend chnages made.
> _Please drag & drop your screenshots/GIFs here:_
<img width="896" height="230" alt="image" src="https://github.com/user-attachments/assets/99d9b866-edf9-4ca1-b5cd-59bbb5b670d5" />
npx jest tests/pharmacies.test.ts

<img width="698" height="159" alt="image" src="https://github.com/user-attachments/assets/d7e0425f-def7-478c-81cf-98694eca39b9" />

**Note:**
During testing, a few existing test cases related to rate limiting may fail due to the current project setup/environment. These are pre-existing and are unrelated to this PR. This contribution only refactors the Redis caching middleware for the "/api/pharmacies/nearest" endpoint and does not modify the rate-limiting logic. The relevant pharmacy route tests for this change pass successfully.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2462 `)
- [x] I have pulled the latest `main` and resolved any conflicts
