### PR TITLE
Perf : Analytics heatmap endpoint has no row limit ,  can return 100k+ rows causing OOM on large scans#2540

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -162,3 +162,20 @@ export const triageLimiter = rateLimit({
         });
     },
 });
+
+// ── Analytics limiter ──────────────────────────────────────────────────────────
+export const analyticsLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: buildStore("analytics"),
+    keyGenerator: (req) => {
+        return req.ip || req.socket.remoteAddress || "unknown";
+    },
+    handler: (_req, res) => {
+        res.status(429).json({
+            error: "Too many analytics requests. Please try again later.",
+        });
+    },
+});

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -2,7 +2,8 @@ import { Router, Request, Response } from "express";
 import { z } from "zod";
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
-import { limiter } from "../middleware/rateLimit";
+import { analyticsLimiter } from "../middleware/rateLimit";
+import { requireAuth } from "../middleware/auth";
 
 const router = Router();
 const QuerySchema = z.object({
@@ -52,7 +53,7 @@ function summarizePushNotificationEvents(rows: PushNotificationEventRow[]) {
     };
 }
 
-router.get("/heatmap", limiter, async (req: Request, res: Response) => {
+router.get("/heatmap", requireAuth, analyticsLimiter, async (req: Request, res: Response) => {
     try {
         const { days } = QuerySchema.parse(req.query);
         const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
@@ -62,7 +63,8 @@ router.get("/heatmap", limiter, async (req: Request, res: Response) => {
             .select("latitude, longitude, created_at")
             .not("latitude", "is", null)
             .not("longitude", "is", null)
-            .gte("created_at", since);
+            .gte("created_at", since)
+            .limit(10000);
 
         if (error) {
             logger.error({ message: "Failed to fetch scan history for heatmap", error, days });


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2540 **
- **Summary:**
- The Supabase query chain in `analytics.ts` now explicitly ends with` .limit(10000)`, ensuring it will never fetch more than 10,000 rows in a single execution.
- created `analyticsLimiter` in `rateLimit.ts` with a strict limit of 10 requests per 15 minutes `(windowMs: 15 * 60 * 1000, max: 10)`. This limiter has successfully replaced the generic limiter on the /heatmap route.
- The combination of strict rate limiting (preventing request floods), a hard row limit (preventing memory exhaustion/timeout per request), and requiring authentication means the endpoint is heavily protected from both accidental heavy loads and intentional scraping.
-  I only modified the route's middleware and the query builder's `.limit()`. The actual data processing logic that iterates over the rows, groups them by coordinates, calculates intensity, and maps them into a GeoJSON FeatureCollection was completely untouched and will continue to process the data safely.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
