### PR TITLE
perf: load PDF export dependencies in parallel

### DIFF
--- a/apps/web/app/[locale]/expiry-tracker/page.tsx
+++ b/apps/web/app/[locale]/expiry-tracker/page.tsx
@@ -449,7 +449,12 @@ export default function ExpiryTrackerPage() {
 
     const handleExportPDF = async () => {
         if (processedMedicines.length === 0) return;
-        const { jsPDF } = await import("jspdf");
+
+        const [{ jsPDF }, { default: autoTable }] = await Promise.all([
+            import("jspdf"),
+            import("jspdf-autotable"),
+        ]);
+
         const doc = new jsPDF();
 
         doc.setFontSize(16);
@@ -466,7 +471,6 @@ export default function ExpiryTrackerPage() {
         ]);
 
         try {
-            const autoTable = (await import("jspdf-autotable")).default;
             autoTable(doc, {
                 head: [headers],
                 body: rows,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

---

## 📋 PR Summary & Link

- **Closes #2122 **
- **Summary:**
  - Optimized PDF export by loading `jspdf` and `jspdf-autotable` in parallel using `Promise.all()`.
  - Preserved lazy-loading behavior so the libraries are only downloaded when the user exports a PDF.
  - Reduced the wait time before PDF generation without affecting existing functionality.

---

## 📸 Proof of Work (Screenshots / Logs)

**Build/Test Notes:**
- Verified that the code compiles logically and maintains the existing export functionality.
- Local production build is currently blocked by missing project dependencies unrelated to this PR (`jspdf`, `jspdf-autotable`, `@tanstack/react-virtual`, etc.).

_Attach any screenshots or terminal output here._

---

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

---

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2122 `)
- [x] I have pulled the latest `main` and resolved any conflicts