### PR TITLE
fix(#2594): redact report anti-abuse fields

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -161,7 +161,9 @@ reportsRouter.post(
                     scanned_barcode: data.scannedBarcode ?? null,
                     medicine_id: data.medicineId ?? null,
                 })
-                .select()
+                .select(
+                    "id, reported_brand_name, status, district, created_at, scanned_barcode, medicine_id"
+                )
                 .single();
 
             if (error) {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #2594**
* **Summary:** Updated the `POST /api/reports` endpoint to return only a safe allowlist of public fields after inserting a counterfeit report, preventing internal anti-abuse metadata from being exposed in the API response.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

**Backend/API change (no UI changes).**

### Code Change

Changed the insert response from:

```ts
.select()
```

to:

```ts
.select("id, reported_brand_name, status, district, created_at, scanned_barcode, medicine_id")
```

This prevents internal fields such as:

* `ip_address`
* `report_hash`
* `risk_score`
* `is_escalated`
* `duplicate_group_id`

from being returned to the client while preserving them in the database.

### Testing

* Attempted `npm run lint` (existing unrelated workspace lint issues).
* Attempted `npm run test` (existing unrelated dependency/setup issues in the workspace).
* Verified by code inspection that only the explicitly selected public fields are returned in the API response.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [x] 🔒 `type: security`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2594`)
* [x] I have pulled the latest `main` and resolved any conflicts