### PR TITLE
refactor(api): extract reusable PostgREST query builder

### DIFF
--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -11,7 +11,7 @@ import { uploadRateLimiter } from "../middleware/uploadRateLimit";
 import { scanQueryLimiter } from "../middleware/rateLimit";
 import { redisClient } from "../utils/redis";
 
-import { escapeIlike, escapePostgrest } from "../utils/db";
+import { escapePostgrest, buildOrConditions } from "../utils/db";
 
 const router = Router();
 
@@ -371,12 +371,7 @@ router.post("/extract", uploadRateLimiter, validateUploadSize, (req: Request, re
 
                 if (searchWords.length > 0) {
                     // Build OR filter: brand_name ILIKE any word OR generic_name ILIKE any word
-                    const orFilter = searchWords
-                        .map((w) => {
-                            const safe = escapeIlike(w);
-                            return `brand_name.ilike."%${safe}%",generic_name.ilike."%${safe}%"`;
-                        })
-                        .join(",");
+                    const orFilter = buildOrConditions(["brand_name", "generic_name"], searchWords);
 
                     const { data: dbMedicines, error: dbError } = await supabase
                         .from("medicines")
@@ -673,12 +668,7 @@ router.post("/match", scanQueryLimiter, async (req: Request, res: Response) => {
                 .split(/\s+/)
                 .filter((w: string) => w.length > 2);
             if (words.length > 1) {
-                const orConditions = words
-                    .map(
-                        (w: string) =>
-                            `brand_name.ilike."%${escapePostgrest(w)}%",generic_name.ilike."%${escapePostgrest(w)}%"`
-                    )
-                    .join(",");
+                const orConditions = buildOrConditions(["brand_name", "generic_name"], words);
 
                 const { data: fallback } = await supabase
                     .from("medicines")

--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -11,7 +11,7 @@ import { uploadRateLimiter } from "../middleware/uploadRateLimit";
 import { scanQueryLimiter } from "../middleware/rateLimit";
 import { redisClient } from "../utils/redis";
 
-import { escapePostgrest, buildOrConditions } from "../utils/db";
+import { escapeIlike, escapePostgrest, buildOrConditions } from "../utils/db";
 
 const router = Router();
 

--- a/apps/api/src/utils/db.ts
+++ b/apps/api/src/utils/db.ts
@@ -14,3 +14,13 @@ export function escapeIlike(word: string): string {
 export function escapePostgrest(val: string): string {
     return val.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_").replace(/"/g, '""');
 }
+
+export function buildOrConditions(fields: string[], words: string[]): string {
+    return words
+        .map((word) => {
+            const safeWord = escapePostgrest(word);
+
+            return fields.map((field) => `${field}.ilike."%${safeWord}%"`).join(",");
+        })
+        .join(",");
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link

- Closes #2401

### Summary

This PR extracts the repeated PostgREST OR query construction logic into a reusable helper function.

### Changes made

- Added `buildOrConditions(fields, words)` in `apps/api/src/utils/db.ts`
- Reused the existing `escapePostgrest()` sanitization logic
- Replaced duplicated `map().join()` query construction in `apps/api/src/routes/scan.ts`
- Preserved the existing query behavior while improving code reuse and maintainability

## 📸 Proof of Work

- Refactor only (no UI changes)
- Project compiles successfully
- Existing query behavior remains unchanged

## 🏷️ PR Type

- [x] ♻️ type: refactor

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2401`)
- [x] I have pulled the latest main and resolved any conflicts