### PR TITLE
perf(api): migrate reports endpoint to cursor pagination

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -197,37 +197,39 @@ reportsRouter.get("/mine", requireAuth, async (req: AuthenticatedRequest, res: R
         return;
     }
 
-    const rawPage = parseInt(req.query.page as string, 10);
+    const cursor = req.query.cursor as string | undefined;
+
     const rawLimit = parseInt(req.query.limit as string, 10);
-    const page = isNaN(rawPage) || rawPage < 1 ? 1 : rawPage;
     const limit = isNaN(rawLimit) || rawLimit < 1 ? 20 : Math.min(rawLimit, 100);
-    const offset = (page - 1) * limit;
 
     try {
-        const { data, error, count } = await supabase
+        let query = supabase
             .from("counterfeit_reports")
             .select(
-                "id, reported_brand_name, scanned_barcode, photo_url, district, status, created_at",
-                { count: "exact" }
+                "id, reported_brand_name, scanned_barcode, photo_url, district, status, created_at"
             )
             .eq("reporter_id", userId)
             .order("created_at", { ascending: false })
-            .range(offset, offset + limit - 1);
+            .limit(limit);
+
+        if (cursor) {
+            query = query.lt("created_at", cursor);
+        }
+
+        const { data, error } = await query;
 
         if (error) {
             res.status(500).json({ error: "Failed to fetch your reports" });
             return;
         }
 
-        const totalCount = count ?? 0;
-        const totalPageCount = Math.ceil(totalCount / limit);
+        const reports = data ?? [];
+
+        const nextCursor = reports.length === limit ? reports[reports.length - 1].created_at : null;
 
         res.json({
-            reports: data ?? [],
-            pageIndex: page,
-            pageSize: (data ?? []).length,
-            totalCount,
-            totalPageCount,
+            reports,
+            nextCursor,
         });
     } catch (err) {
         console.error("Unexpected error in GET /api/reports/mine:", err);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #2591**
* **Summary:**

  * Replaced OFFSET-based pagination in `GET /api/v1/reports/mine` with cursor-based pagination.
  * Introduced an optional `cursor` query parameter using the `created_at` timestamp.
  * Updated the Supabase query to use `.lt("created_at", cursor)` instead of `.range(...)`.
  * Preserved configurable `limit` support while removing OFFSET scanning.
  * Updated the response payload to return `nextCursor` instead of `pageIndex` and `totalPageCount`, enabling efficient pagination for large datasets.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Build / Validation

```bash
cd apps/api
npm run build
```

**Result:**

```text
> sahidawa-api@1.0.0 build
> tsc
```

TypeScript build completed successfully for the API package.

## 🏷️ PR Type

* [ ] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [x] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2591`)
* [x] I have pulled the latest `main` and resolved any conflicts.
