### PR TITLE
fix(#2623): fail closed when Upstash rate limit config is missing

### DIFF
--- a/apps/web/lib/rateLimit.ts
+++ b/apps/web/lib/rateLimit.ts
@@ -3,8 +3,15 @@ import { Redis } from "@upstash/redis";
 
 const hasCredentials =
     typeof process !== "undefined" &&
-    process.env.UPSTASH_REDIS_REST_URL &&
-    process.env.UPSTASH_REDIS_REST_TOKEN;
+    Boolean(process.env.UPSTASH_REDIS_REST_URL) &&
+    Boolean(process.env.UPSTASH_REDIS_REST_TOKEN);
+
+if (!hasCredentials && process.env.NODE_ENV === "production") {
+    throw new Error(
+        "Missing Upstash Redis rate limit configuration in production. " +
+            "Please set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN."
+    );
+}
 
 class MockRateLimit {
     async limit() {
@@ -12,11 +19,10 @@ class MockRateLimit {
     }
 }
 
-export const rateLimit =
-    process.env.NODE_ENV === "test" || !hasCredentials
-        ? (new MockRateLimit() as unknown as Ratelimit)
-        : new Ratelimit({
-              redis: Redis.fromEnv(),
-              limiter: Ratelimit.slidingWindow(10, "60 s"),
-              analytics: true,
-          });
+export const rateLimit = hasCredentials
+    ? new Ratelimit({
+          redis: Redis.fromEnv(),
+          limiter: Ratelimit.slidingWindow(10, "60 s"),
+          analytics: true,
+      })
+    : (new MockRateLimit() as unknown as Ratelimit);

--- a/apps/web/tests/rateLimit.test.ts
+++ b/apps/web/tests/rateLimit.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+describe("rateLimit", () => {
+    const ORIGINAL_ENV = process.env;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env = { ...ORIGINAL_ENV };
+        delete process.env.UPSTASH_REDIS_REST_URL;
+        delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    });
+
+    afterAll(() => {
+        process.env = ORIGINAL_ENV;
+    });
+
+    it("throws in production when Upstash credentials are missing", () => {
+        process.env.NODE_ENV = "production";
+
+        expect(() => {
+            require("@/lib/rateLimit");
+        }).toThrow("Missing Upstash Redis rate limit configuration in production");
+    });
+
+    it("does not throw in development when Upstash credentials are missing", () => {
+        process.env.NODE_ENV = "development";
+
+        expect(() => {
+            require("@/lib/rateLimit");
+        }).not.toThrow();
+    });
+
+    it("does not throw in test when Upstash credentials are missing", () => {
+        process.env.NODE_ENV = "test";
+
+        expect(() => {
+            require("@/lib/rateLimit");
+        }).not.toThrow();
+    });
+
+    it("returns a mock rate limiter in non-production without credentials", async () => {
+        process.env.NODE_ENV = "development";
+
+        const { rateLimit } = require("@/lib/rateLimit");
+        const result = await rateLimit.limit("test-key");
+
+        expect(result.success).toBe(true);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #2623**
* **Summary:**

  * Added a production safeguard in `apps/web/lib/rateLimit.ts` that throws a clear configuration error when `UPSTASH_REDIS_REST_URL` or `UPSTASH_REDIS_REST_TOKEN` is missing.
  * Restricted the `MockRateLimit` fallback to non-production environments, preventing rate limiting from being silently disabled in production deployments.
  * Added Jest tests covering production, development, and test environment behavior to verify the new logic.

## 📸 Proof of Work (Screenshots / Logs)

### Test Results

```text
PASS tests/rateLimit.test.ts

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
```

### Lint

```text
npm run lint -- lib/rateLimit.ts tests/rateLimit.test.ts
✓ Passed with no errors
```

> No UI changes were made. This is a backend/configuration fix, so screenshots are not applicable.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [x] 🧪 `type: testing`
* [x] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2623`)
* [x] I have pulled the latest `main` and resolved any conflicts
