### PR TITLE
fix(#2625): use API_BASE and auth for bulk inventory upload

### DIFF
--- a/apps/web/app/[locale]/(dashboard)/pharmacy/inventory/bulk-upload/page.tsx
+++ b/apps/web/app/[locale]/(dashboard)/pharmacy/inventory/bulk-upload/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useState } from "react";
+import { API_BASE } from "@/lib/api";
+import { useSession } from "@/src/components/AuthProvider";
 
 interface UploadResult {
     totalRows: number;
@@ -10,6 +12,7 @@ interface UploadResult {
 }
 
 export default function BulkUploadPage() {
+    const { token } = useSession();
     const [file, setFile] = useState<File | null>(null);
     const [isDragging, setIsDragging] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
@@ -62,10 +65,11 @@ export default function BulkUploadPage() {
             }
 
             try {
-                const response = await fetch("/api/pharmacies/bulk-upload", {
+                const response = await fetch(`${API_BASE}/api/pharmacies/bulk-upload`, {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",
+                        ...(token ? { Authorization: `Bearer ${token}` } : {}),
                     },
                     body: JSON.stringify({ fileContent: textContent }),
                 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #2625**
* **Summary:**

  * Updated the pharmacy bulk inventory upload page to use the shared `API_BASE` instead of a relative Next.js API path.
  * Added the authenticated user's bearer token to the request headers for the protected backend endpoint.
  * Kept the change limited to the affected bulk upload page.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> * **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.

No visual UI changes.

**Verification performed:**

* Confirmed the request now targets the Express API via `API_BASE`.
* Confirmed the authenticated bearer token is included in the request headers.
* Verified only the required frontend file was modified.
* Ran `tsc --noEmit`; existing unrelated type errors remain, with no new errors introduced by this change.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2625`)
* [x] I have pulled the latest `main` and resolved any conflicts
