### PR TITLE
fix: add rate limiting to /api/voice/transcribe endpoint

### DIFF
--- a/apps/web/app/api/voice/transcribe/route.ts
+++ b/apps/web/app/api/voice/transcribe/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { structuredLog } from "@/lib/structuredLogger";
+import { rateLimit } from "@/lib/rateLimit";
 
 const ROUTE = "/api/voice/transcribe";
 const ML_TRANSCRIBE_TIMEOUT_MS = 45_000;
@@ -19,6 +20,18 @@ async function readJsonSafely(response: Response) {
 
 export async function POST(req: Request) {
     const startTime = Date.now();
+
+    const forwardedFor = req.headers.get("x-forwarded-for");
+    const realIp = req.headers.get("x-real-ip");
+    const ip = forwardedFor?.split(",")[0]?.trim() || realIp || "127.0.0.1";
+    const { success } = await rateLimit.limit(ip);
+    if (!success) {
+        return NextResponse.json(
+            { error: "Too many requests. Please try again in a few moments." },
+            { status: 429 }
+        );
+    }
+
     const formData = await req.formData();
     const file = formData.get("file");
     const language = formData.get("language");


### PR DESCRIPTION
## Summary

Adds IP-based rate limiting to the `/api/voice/transcribe` endpoint using the project's shared rate limiter from `@/lib/rateLimit`.

## Problem

The `/api/voice/transcribe` endpoint forwarded all requests directly to the ML ASR service without any rate limiting. Other expensive endpoints (`/api/chat`, `/api/upload`) already use the shared rate limiter, but this endpoint was unprotected.

An attacker could spam this endpoint to exhaust ML service resources and drive up infrastructure costs.

## Changes

- Imported `rateLimit` from `@/lib/rateLimit`
- Added IP extraction from `x-forwarded-for` / `x-real-ip` headers (same pattern as `/api/chat`)
- Added rate limit check before processing the request
- Returns HTTP 429 with retry message when limit is exceeded

## Testing

- Verified the rate limiter import matches the one used by `/api/chat`
- The `MockRateLimit` fallback (used in dev/test) always returns `success: true`, so this change is safe for local development

Closes #2627