### PR TITLE
fix: replace hardcoded localhost:8000 fallback with null guard in voice-triage

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -226,10 +226,28 @@ export async function POST(req: Request) {
             let emergencyFromML = false;
 
             try {
-                const mlServiceUrl =
-                    process.env.ML_SERVICE_URL?.trim() ||
-                    process.env.NEXT_PUBLIC_ML_SERVICE_URL?.trim() ||
-                    "http://localhost:8000";
+                const mlServiceUrl = process.env.ML_SERVICE_URL?.trim()?.replace(/\/+$/, "");
+
+                if (!mlServiceUrl) {
+                    structuredLog({
+                        log_level: "error",
+                        route: ROUTE,
+                        error: {
+                            message: "ML_SERVICE_URL is not configured",
+                            code: 500,
+                            stack: undefined,
+                        },
+                        meta: { missingVars: ["ML_SERVICE_URL"] },
+                    });
+                    return NextResponse.json(
+                        {
+                            error: "Server configuration error: ML service URL is missing.",
+                            code: "ML_SERVICE_URL_MISSING",
+                        },
+                        { status: 500 }
+                    );
+                }
+
                 const formattedMessages = trimmedMessages.map((m: any) => ({
                     role:
                         m.role === ChatRoles.ASSISTANT || m.role === ChatRoles.MODEL


### PR DESCRIPTION
## Summary

Replaces the dangerous `localhost:8000` fallback in the chat voice-triage mode with a proper null guard that returns HTTP 500 when `ML_SERVICE_URL` is not configured.

## Problem

In `apps/web/app/api/chat/route.ts` (lines 229-232), the voice-triage mode resolved the ML service URL with:

```typescript
const mlServiceUrl =
    process.env.ML_SERVICE_URL?.trim() ||
    process.env.NEXT_PUBLIC_ML_SERVICE_URL?.trim() ||
    "http://localhost:8000";
```

When neither env var was set, the route silently fell back to `localhost:8000`. In production, this caused requests to hang for 75-121 seconds on TCP timeout before failing.

The other ML-calling routes handled this correctly:
- `/api/voice/tts`: Returns HTTP 500 with `ML_SERVICE_URL_MISSING`
- `/api/voice/transcribe`: Returns HTTP 500 with `ML_SERVICE_URL_MISSING`

Additionally, using `NEXT_PUBLIC_ML_SERVICE_URL` exposed the ML service URL to the client bundle.

## Changes

- Removed `NEXT_PUBLIC_ML_SERVICE_URL` fallback
- Removed hardcoded `http://localhost:8000` fallback
- Added null guard returning HTTP 500 with structured logging
- Error response matches the pattern used by TTS and transcribe routes

Closes #2628