### PR TITLE
fix: add AbortController timeout to voice-triage ML fetch

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -11,6 +11,8 @@ import { trimHistoryByTokens } from "@/lib/chatUtils";
 
 const summaryCache = new Map<string, string>();
 
+const ML_TRIAGE_TIMEOUT_MS = 30_000;
+
 const DEFAULT_DISCLAIMER =
     "This guidance is for informational use only and is not a diagnosis. Consult a doctor or pharmacist, especially for severe or persistent symptoms.";
 
@@ -243,6 +245,9 @@ export async function POST(req: Request) {
                     formattedMessages.push({ role: ChatRoles.USER, content: latestMessageText });
                 }
 
+                const mlAbortController = new AbortController();
+                const mlTimeoutId = setTimeout(() => mlAbortController.abort(), ML_TRIAGE_TIMEOUT_MS);
+
                 const mlResponse = await fetch(`${mlServiceUrl}/triage/chat`, {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
@@ -250,7 +255,10 @@ export async function POST(req: Request) {
                         messages: formattedMessages,
                         locale: locale || "en",
                     }),
+                    signal: mlAbortController.signal,
                 });
+
+                clearTimeout(mlTimeoutId);
 
                 if (!mlResponse.ok) {
                     throw new Error(`ML service returned status ${mlResponse.status}`);
@@ -277,13 +285,23 @@ export async function POST(req: Request) {
                     },
                 });
             } catch (mlError: any) {
+                const isTimeout = mlError instanceof Error && mlError.name === "AbortError";
                 structuredLog({
-                    log_level: "warn",
+                    log_level: isTimeout ? "error" : "warn",
                     route: ROUTE,
+                    latency_ms: Date.now() - startTime,
+                    error: isTimeout
+                        ? {
+                              message: "ML triage service timed out",
+                              code: 504,
+                              stack: mlError.stack,
+                          }
+                        : undefined,
                     meta: {
-                        reason: "ml_service_triage_failed",
+                        reason: isTimeout ? "ml_service_triage_timeout" : "ml_service_triage_failed",
                         error: mlError.message,
                         fallback: "direct_gemini",
+                        ...(isTimeout ? { timeoutMs: ML_TRIAGE_TIMEOUT_MS } : {}),
                     },
                 });
 


### PR DESCRIPTION
## Summary

Adds a 30-second `AbortController` timeout to the voice-triage ML service `fetch()` call, preventing indefinite hangs when the ML service is slow or unresponsive.

## Problem

In `apps/web/app/api/chat/route.ts` (line 246), the voice-triage mode called the ML service without an `AbortController` timeout:

```typescript
const mlResponse = await fetch(`${mlServiceUrl}/triage/chat`, {
    method: "POST",
    headers: { "Content-Type": "application/json" },
    body: JSON.stringify({...}),
    // No signal, no timeout
});
```

If the ML service accepted the connection but hung (model overloaded, worker deadlocked), this `fetch()` blocked the Node.js event loop thread indefinitely.

The other two ML-calling routes both implement proper timeouts:
- `/api/voice/tts`: 15s timeout (`ML_TTS_TIMEOUT_MS`)
- `/api/voice/transcribe`: 45s timeout (`ML_TRANSCRIBE_TIMEOUT_MS`)

## Changes

- Added `ML_TRIAGE_TIMEOUT_MS = 30_000` constant (appropriate for LLM triage response)
- Created `AbortController` with timeout before the `fetch()` call
- Passed `signal` to `fetch()` to enable abort on timeout
- Cleared timeout on successful response
- Enhanced catch block to detect `AbortError` and log it as a timeout (HTTP 504) with `timeoutMs` metadata
- On timeout, falls through to existing Gemini direct-call fallback (no behavior change for users)

Closes #2629