### PR TITLE
feat(web): add TTL and max queue size for offline request queue

### DIFF
--- a/apps/web/lib/apiWithRetry.ts
+++ b/apps/web/lib/apiWithRetry.ts
@@ -164,6 +164,8 @@ function sleep(ms: number): Promise<void> {
 }
 
 const OFFLINE_QUEUE_STORAGE_KEY = "offline-request-queue";
+const MAX_QUEUE_SIZE = 50;
+const QUEUE_TTL = 24 * 60 * 60 * 1000; // 24 hours
 
 class OfflineRequestQueue {
     private queue: Array<{
@@ -174,6 +176,11 @@ class OfflineRequestQueue {
         retryCount: number;
     }> = [];
 
+    private removeExpiredRequests(): void {
+        const now = Date.now();
+        this.queue = this.queue.filter((request) => now - request.timestamp <= QUEUE_TTL);
+    }
+
     private listeners: Set<() => void> = new Set();
 
     constructor() {
@@ -183,6 +190,8 @@ class OfflineRequestQueue {
             const stored = localStorage.getItem(OFFLINE_QUEUE_STORAGE_KEY);
             if (stored) {
                 this.queue = JSON.parse(stored);
+                this.removeExpiredRequests();
+                this.persist();
             }
         } catch {
             this.queue = [];
@@ -192,6 +201,12 @@ class OfflineRequestQueue {
 
     add(url: string, options: FetchOptions): string {
         const id = `${Date.now()}-${Math.random()}`;
+        this.removeExpiredRequests();
+
+        while (this.queue.length >= MAX_QUEUE_SIZE) {
+            this.queue.shift();
+        }
+
         this.queue.push({
             id,
             url,
@@ -211,6 +226,11 @@ class OfflineRequestQueue {
     }
 
     getAll() {
+        const oldLength = this.queue.length;
+        this.removeExpiredRequests();
+        if (this.queue.length !== oldLength) {
+            this.persist();
+        }
         return [...this.queue];
     }
 
@@ -228,10 +248,22 @@ class OfflineRequestQueue {
     private persist(): void {
         if (typeof window === "undefined") return;
 
+        this.removeExpiredRequests();
+
         try {
             localStorage.setItem(OFFLINE_QUEUE_STORAGE_KEY, JSON.stringify(this.queue));
-        } catch {
-            // Ignore storage failures
+        } catch (error) {
+            if (error instanceof DOMException && error.name === "QuotaExceededError") {
+                // Remove oldest half of the queue
+                this.queue.splice(0, Math.ceil(this.queue.length / 2));
+
+                try {
+                    localStorage.setItem(OFFLINE_QUEUE_STORAGE_KEY, JSON.stringify(this.queue));
+                    this.notify();
+                } catch {
+                    // Ignore storage failures
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #2606**
* **Summary:**

  * Added a configurable `MAX_QUEUE_SIZE` (50) to prevent unbounded growth of the offline request queue.
  * Added a `QUEUE_TTL` (24 hours) to automatically discard stale queued requests.
  * Purge expired requests when loading from localStorage, before persisting, and before accessing queued requests.
  * Implemented FIFO eviction so the oldest requests are removed when the queue reaches the maximum size.
  * Improved resilience against `QuotaExceededError` by removing the oldest half of the queue and retrying persistence.

## 📸 Proof of Work (Screenshots / Logs)

**Build / Validation**

* Updated only `apps/web/lib/apiWithRetry.ts`.
* Verified the offline queue logic for:

  * Maximum queue size enforcement (50 items)
  * Automatic TTL cleanup (24 hours)
  * FIFO eviction of oldest requests
  * Graceful recovery from `QuotaExceededError`

> Note: `next build` currently fails due to an existing upstream TypeScript error unrelated to this PR (`lib/chatUtils.ts` importing `ChatMessage` from `@/lib/constants`). My changes compile independently and do not introduce this issue.

## 🏷️ PR Type

* [ ] 🐛 `type: bug`
* [x] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2606`)
* [x] I have pulled the latest `main` and resolved any conflicts
