### PR TITLE
security(web): validate uploaded image magic bytes

### DIFF
--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -60,6 +60,28 @@ export async function POST(req: NextRequest) {
                 { status: 413 }
             );
         }
+        const buffer = Buffer.from(await file.arrayBuffer());
+
+        const isJpeg = buffer.length >= 2 && buffer[0] === 0xff && buffer[1] === 0xd8;
+
+        const isPng =
+            buffer.length >= 4 &&
+            buffer[0] === 0x89 &&
+            buffer[1] === 0x50 &&
+            buffer[2] === 0x4e &&
+            buffer[3] === 0x47;
+
+        const isWebp = buffer.length >= 12 && buffer.toString("ascii", 8, 12) === "WEBP";
+
+        if (!isJpeg && !isPng && !isWebp) {
+            return NextResponse.json(
+                {
+                    error: "invalid_image_format",
+                    message: "File content is not a valid JPEG, PNG, or WebP image.",
+                },
+                { status: 415 }
+            );
+        }
         const cloudName = process.env.CLOUDINARY_CLOUD_NAME;
         const apiKey = process.env.CLOUDINARY_API_KEY;
         const apiSecret = process.env.CLOUDINARY_API_SECRET;
@@ -85,7 +107,9 @@ export async function POST(req: NextRequest) {
         const signature = crypto.createHash("sha256").update(paramsToSign).digest("hex");
 
         const cloudinaryFormData = new FormData();
-        cloudinaryFormData.append("file", file);
+        const validatedFile = new File([buffer], file.name, { type: file.type });
+
+        cloudinaryFormData.append("file", validatedFile);
         cloudinaryFormData.append("api_key", apiKey);
         cloudinaryFormData.append("timestamp", timestamp);
         cloudinaryFormData.append("signature_algorithm", "sha256");


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link

- Closes #2548

### Summary

This PR improves the security of the upload endpoint by validating the actual file contents instead of relying only on the client-provided MIME type.

### Changes made

- Added magic byte validation for JPEG, PNG and WebP uploads.
- Rejects spoofed image uploads with HTTP 415.
- Preserved the existing upload rate limiting.
- Preserved the existing 10 MB file size validation.
- Existing Cloudinary upload flow remains unchanged for valid images.

## 📸 Proof of Work

Build was executed.

Note: The current build fails because of an existing unrelated TypeScript error:

apps/web/lib/chatUtils.ts

Module "@/lib/constants" has no exported member "ChatMessage".

This issue is unrelated to the changes in this PR.

## 🏷️ PR Type

- [x] 🔒 type: security

## ✅ Checklist

- [x] My PR has a linked issue.
- [x] I have pulled the latest main and resolved conflicts.