### PR TITLE
Fix/start alert broadcaster after redis

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -20,10 +20,11 @@ if (process.env.NODE_ENV !== "test") {
         // Initialize Redis Connection and warm cache
         await connectRedis();
         await warmCache();
-    });
 
-    startAlertBroadcaster();
-    startTempCleanupJob();
+        // Start cron jobs only after Redis is ready
+        startAlertBroadcaster();
+        startTempCleanupJob();
+    });
 
     const gracefulShutdown = createGracefulShutdown(server);
 


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files. *(Note: Aside from the functional bug fix in `apps/api/src/index.ts`, a few web files are in the diff solely due to automatic Prettier formatting adjustments applied during conflict resolution).*

## PR Summary & Link

Closes #2635

**Summary:**
`startAlertBroadcaster()` was being called outside the `app.listen()` callback in `apps/api/src/index.ts`, causing it to fire before `connectRedis()` and `warmCache()` had finished. This caused the alert broadcaster to run against an unready Redis connection, leading to potential startup crashes or silent failures. Fixed by moving `startAlertBroadcaster()` inside the `listen` callback, after Redis is fully connected and warmed.

## Proof of Work

**Before fix** — `startAlertBroadcaster()` fires before Redis is ready:
```typescript
startAlertBroadcaster(); // outside listen callback
```

**After fix** — `startAlertBroadcaster()` fires only after Redis is connected and ready:
```typescript
await connectRedis();
await warmCache();
startAlertBroadcaster(); // inside listen callback ✅
```

## 🏷️ PR Type
- 🐛 type: bug

## ✅ Checklist
- [x] My PR has a linked issue (Closes #2635)
- [x] I have pulled the latest main and resolved any conflicts
```