### PR TITLE
perf(cron): replace N+1 update loop with bulk .in() query in expiry-c…

### DIFF
--- a/apps/api/src/cron/expiry-check.ts
+++ b/apps/api/src/cron/expiry-check.ts
@@ -17,7 +17,7 @@ export const initExpiryCron = () => {
 
             const { data, error } = await supabase
                 .from("tracked_medicines")
-                .select("*")
+                .select("id")
                 .lte("expiry_date", thresholdDate.toISOString())
                 .eq(flagColumn, false);
 
@@ -26,13 +26,21 @@ export const initExpiryCron = () => {
                 continue;
             }
 
-            for (const medicine of data || []) {
-                await supabase
+            const medicineIds = (data || []).map((m) => m.id);
+            if (medicineIds.length > 0) {
+                const { error: updateError } = await supabase
                     .from("tracked_medicines")
                     .update({ [flagColumn]: true })
-                    .eq("id", medicine.id);
+                    .in("id", medicineIds);
+
+                if (updateError) {
+                    logger.error(
+                        `Error updating notification flags for ${days}d expiring medicines`,
+                        { error: updateError }
+                    );
+                }
             }
-            logger.info(`${days}d check done. ${data?.length || 0} medicines processed.`);
+            logger.info(`${days}d check done. ${medicineIds.length} medicines processed.`);
         }
     });
 };


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## PR Summary & Link

Closes #2640 

**Summary:**
In `apps/api/src/cron/expiry-check.ts`, the medicine expiry cron job was firing N individual `UPDATE` queries — one per expiring medicine — inside a `for` loop. This N+1 pattern causes database socket exhaustion and request timeouts when hundreds of medicines are expiring. Fixed by collecting all IDs first and issuing a single bulk `UPDATE` using `.in("id", medicineIds)`. Also narrowed the `SELECT` from `"*"` to `"id"` to reduce unnecessary data transfer.

## Proof of Work

**Before fix** — N individual UPDATE queries for N medicines:
```typescript
const { data } = await supabase
    .from("tracked_medicines")
    .select("*")          // fetches all columns unnecessarily
    .lte("expiry_date", thresholdDate.toISOString())
    .eq(flagColumn, false);

for (const medicine of data || []) {
    await supabase
        .from("tracked_medicines")
        .update({ [flagColumn]: true })
        .eq("id", medicine.id);  // 🔴 1 DB call per medicine
}
```

**After fix** — 1 single bulk UPDATE for all medicines:
```typescript
const { data } = await supabase
    .from("tracked_medicines")
    .select("id")         // ✅ only fetch what's needed
    .lte("expiry_date", thresholdDate.toISOString())
    .eq(flagColumn, false);

const medicineIds = (data || []).map((m) => m.id);
if (medicineIds.length > 0) {
    await supabase
        .from("tracked_medicines")
        .update({ [flagColumn]: true })
        .in("id", medicineIds);   // ✅ 1 DB call for all medicines
}
```

## 🏷️ PR Type
- 🐛 type: bug
- ⚡ type: performance

## ✅ Checklist
- [x] My PR has a linked issue (Closes #2640 )
- [x] I have pulled the latest main and resolved any conflicts
```
