### PR TITLE
fix(compare): preserve selected medicines on back navigation

### DIFF
--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -95,6 +95,34 @@ export default function ComparePage() {
         loadMedicines();
     }, []);
 
+    // Keep URL in sync with the currently selected medicines so
+    // browser back/navigation preserves the comparison workflow.
+    useEffect(() => {
+        const params = new URLSearchParams(window.location.search);
+
+        const nextM1 = medicine1?.id ?? "";
+        const nextM2 = medicine2?.id ?? "";
+
+        const currentM1 = params.get("m1") ?? "";
+        const currentM2 = params.get("m2") ?? "";
+
+        // Only update when something actually changes to avoid extra history churn.
+        if (currentM1 === nextM1 && currentM2 === nextM2) return;
+
+        if (!nextM1 || !nextM2) {
+            params.delete("m1");
+            params.delete("m2");
+        } else {
+            params.set("m1", nextM1);
+            params.set("m2", nextM2);
+        }
+
+        const qs = params.toString();
+        const newUrl = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+        window.history.replaceState({}, "", newUrl);
+    }, [medicine1?.id, medicine2?.id]);
+
+
     useEffect(() => {
         if (selectedIds.length < 2) {
             setInteractions([]);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2642 **
- **Summary:**
Problem: Compare Medicine page loses selected medicines after browser back/navigation because selections are only held in React state and the URL query params (m1, m2) aren’t kept in sync.
Fix: In apps/web/app/[locale]/compare/page.tsx, added a useEffect that updates the browser URL query params (m1, m2) using window.history.replaceState whenever the selected medicines change.
Result: On back navigation, the page’s existing mount logic reads m1/m2/m3 from the URL and restores selections reliably.


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2642 `)
- [x] I have pulled the latest `main` and resolved any conflicts
