### PR TITLE
fix(web): add missing aria-labels to navbar buttons

### DIFF
--- a/apps/web/app/[locale]/components/Navbar/MobileMenu.tsx
+++ b/apps/web/app/[locale]/components/Navbar/MobileMenu.tsx
@@ -69,7 +69,7 @@ export default function MobileMenu({
             <button
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
                 className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-slate-50 text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300"
-                aria-label="Toggle system parameters"
+                aria-label={isMenuOpen ? "Close navigation menu" : "Open navigation menu"}
                 aria-expanded={isMenuOpen}
             >
                 {isMenuOpen ? <X size={16} /> : <Menu size={16} />}
@@ -177,6 +177,7 @@ export default function MobileMenu({
                                 <div className="my-1 border-t border-slate-100 dark:border-slate-800" />
                                 <button
                                     onClick={handleSignOut}
+                                    aria-label="Sign out"
                                     className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-semibold text-red-600 transition-colors hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30"
                                 >
                                     <LogOut size={14} /> Sign Out

--- a/apps/web/app/[locale]/components/Navbar/UserDropdown.tsx
+++ b/apps/web/app/[locale]/components/Navbar/UserDropdown.tsx
@@ -61,6 +61,8 @@ export default function UserDropdown({ session, authLoading, handleSignOut }: Us
         <div className="relative hidden sm:block" ref={profileRef}>
             <button
                 onClick={() => setIsProfileOpen(!isProfileOpen)}
+                aria-label="Open user menu"
+                aria-expanded={isProfileOpen}
                 className="flex h-9 items-center gap-2 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm transition-colors hover:bg-slate-50 sm:h-10 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
             >
                 <div className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-100 text-emerald-600 dark:bg-emerald-950/50 dark:text-emerald-400">
@@ -120,6 +122,7 @@ export default function UserDropdown({ session, authLoading, handleSignOut }: Us
                         <div className="my-1 border-t border-slate-100 dark:border-slate-900" />
                         <button
                             onClick={handleSignOut}
+                            aria-label="Sign out"
                             className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30"
                         >
                             <LogOut size={16} />


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [ ] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #2072**

* **Summary:**

  * Updated the mobile navigation toggle button with descriptive dynamic `aria-label`s ("Open navigation menu" / "Close navigation menu").
  * Added `aria-label` and `aria-expanded` to the desktop user menu button for improved screen reader support.
  * Added missing `aria-label` attributes to the desktop and mobile "Sign Out" buttons.

## 📸 Proof of Work (Screenshots / Logs)

Accessibility-only change (ARIA attributes). No visual UI changes.

## 🏷️ PR Type

* [x] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2072`)
* [x] I have pulled the latest `main` and resolved any conflicts
