### PR TITLE
fix(api): apply rate limiting to ML endpoints

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -72,7 +72,6 @@ import eligibilityRouter from "./routes/eligibility";
 import { supabase } from "./db/client";
 import { createCorsOptions } from "./config/cors";
 import { errorHandler } from "./middleware/errorHandler";
-
 // ── Application Initialization ─────────────────────────────────────────────
 const app: Express = express();
 app.set("trust proxy", 1); // Trust first proxy (Nginx) — fixes req.ip for rate limiters

--- a/apps/api/src/routes/ml.ts
+++ b/apps/api/src/routes/ml.ts
@@ -4,7 +4,7 @@ import { promises as dns } from "node:dns";
 import { getMlServiceUrl, MISSING_ML_SERVICE_URL_MESSAGE } from "../config/mlService";
 import { requireAuth, AuthenticatedRequest } from "../middleware/auth";
 import logger from "../utils/logger";
-
+import { limiter } from "../middleware/rateLimit";
 const router = Router();
 
 const analyzeRequestSchema = z.object({
@@ -45,7 +45,7 @@ async function isPrivateHostname(urlStr: string): Promise<boolean> {
 
 const ML_ANALYSIS_TIMEOUT_MS = 8000;
 
-router.post("/analyze", requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+router.post("/analyze", limiter, requireAuth, async (req: AuthenticatedRequest, res: Response) => {
     const parsed = analyzeRequestSchema.safeParse(req.body);
 
     if (!parsed.success) {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #2621**

### Summary

* Applied the existing `limiter` middleware to the ML `/analyze` endpoint.
* Protected the image analysis endpoint from excessive requests to mitigate uncontrolled resource consumption (CWE-400).
* Kept the existing authentication flow intact by applying the rate limiter before `requireAuth`.
* Verified that the API builds successfully with `npm run build`.

## 📸 Proof of Work (Screenshots / Logs)

Backend-only change.

Validation performed:

```bash
cd apps/api
npm run build
```

Build completed successfully.

## 🏷️ PR Type

* [x] 🐛 type: bug
* [x] 🔒 type: security

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2621`)
* [x] I have pulled the latest `main` and resolved any conflicts
