### PR TITLE
fix: wire up push and SMS notification delivery in initExpiryCron

### DIFF
--- a/apps/api/src/cron/expiry-check.ts
+++ b/apps/api/src/cron/expiry-check.ts
@@ -1,6 +1,23 @@
 import cron from "node-cron";
+import webPush from "web-push";
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
+import { smsService } from "../services/sms-service";
+import {
+    listPushSubscriptions,
+    isWebPushConfigured,
+    buildPushDeliveryEvent,
+    recordPushDeliveryEvents,
+    removePushSubscription,
+} from "../services/notifications";
+
+function buildExpiryPayload(medicineName: string, daysLeft: number) {
+    return {
+        title: `Medicine expiring in ${daysLeft} day${daysLeft === 1 ? "" : "s"}`,
+        body: `${medicineName} expires in ${daysLeft} days. Please check your stock.`,
+        url: "/expiry-tracker",
+    };
+}
 
 export const initExpiryCron = () => {
     // Runs every day at 00:00 (midnight)
@@ -26,13 +43,108 @@ export const initExpiryCron = () => {
                 continue;
             }
 
+            let notifiedCount = 0;
+
             for (const medicine of data || []) {
-                await supabase
-                    .from("tracked_medicines")
-                    .update({ [flagColumn]: true })
-                    .eq("id", medicine.id);
+                try {
+                    let delivered = false;
+                    const payload = buildExpiryPayload(medicine.name, days);
+
+                    // --- Web Push ---
+                    if (isWebPushConfigured()) {
+                        const allSubs = await listPushSubscriptions();
+                        const userSubs = allSubs.filter(
+                            (s) => s.userId === medicine.user_id
+                        );
+
+                        if (userSubs.length > 0) {
+                            const results = await Promise.allSettled(
+                                userSubs.map((item) =>
+                                    webPush.sendNotification(
+                                        item.subscription,
+                                        JSON.stringify(payload)
+                                    )
+                                )
+                            );
+
+                            // Record delivery events for analytics
+                            const fakeAlert = {
+                                id: `expiry-${medicine.id}-${days}d`,
+                                medicineName: medicine.name,
+                                reason: payload.body,
+                                severity: "medium" as const,
+                                source: "expiry-cron",
+                            };
+                            const events = results.map((result, i) =>
+                                buildPushDeliveryEvent(
+                                    fakeAlert,
+                                    userSubs[i].endpoint,
+                                    result
+                                )
+                            );
+                            await recordPushDeliveryEvents(events);
+
+                            // Clean up expired subscriptions (404/410 = unsubscribed)
+                            results.forEach((result, i) => {
+                                if (
+                                    result.status === "rejected" &&
+                                    [404, 410].includes(
+                                        (result.reason as { statusCode?: number })?.statusCode ?? -1
+                                    )
+                                ) {
+                                    removePushSubscription(userSubs[i].endpoint);
+                                }
+                            });
+
+                            const sent = results.filter(
+                                (r) => r.status === "fulfilled"
+                            ).length;
+                            if (sent > 0) delivered = true;
+                        }
+                    }
+
+                    // --- SMS via notification_subscribers ---
+                    if (medicine.user_id) {
+                        const { data: subscriber } = await supabase
+                            .from("notification_subscribers")
+                            .select("phone, language")
+                            .eq("user_id", medicine.user_id)
+                            .maybeSingle();
+
+                        if (subscriber?.phone) {
+                            const smsMessage = `SahiDawa Alert: ${medicine.name} expires in ${days} days. Please check your stock.`;
+                            const smsSent = await smsService.send(
+                                subscriber.phone,
+                                smsMessage,
+                                subscriber.language ?? "en"
+                            );
+                            if (smsSent) delivered = true;
+                        }
+                    }
+
+                    // --- Only mark flag after confirmed delivery ---
+                    if (delivered) {
+                        await supabase
+                            .from("tracked_medicines")
+                            .update({ [flagColumn]: true })
+                            .eq("id", medicine.id);
+                        notifiedCount++;
+                    } else {
+                        logger.warn(
+                            `No delivery channel available for medicine ${medicine.id} (${days}d alert)`
+                        );
+                    }
+                } catch (err) {
+                    logger.error(
+                        `Failed to process ${days}d expiry alert for medicine ${medicine.id}`,
+                        { err }
+                    );
+                }
             }
-            logger.info(`${days}d check done. ${data?.length || 0} medicines processed.`);
+
+            logger.info(
+                `${days}d check done. ${data?.length ?? 0} medicines found, ${notifiedCount} notified.`
+            );
         }
     });
 };


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link
- **Closes #2527**
- **Summary:** The `initExpiryCron` function was fetching expiring medicines
  and marking `notified_*d: true` unconditionally — but never actually sending
  any notification to the user. The placeholder comments
  (`// Here is where you would trigger the notification`) were never implemented.

  This PR wires up both delivery channels:

  **Web Push** — calls `listPushSubscriptions()` filtered to `medicine.user_id`
  so only the medicine owner receives the push (not all subscribers), sends via
  `webPush.sendNotification()`, records analytics via `recordPushDeliveryEvents()`,
  and cleans up expired subscriptions (404/410).

  **SMS** — looks up the user's phone and language from `notification_subscribers`
  by `user_id`, then calls `smsService.send()` with an expiry-specific message.

  `notified_*d: true` is now only set **after confirmed delivery** from at least
  one channel. Each medicine is wrapped in an individual `try/catch` so one
  failed delivery doesn't skip the rest. A `buildExpiryPayload()` helper is
  added (separate from `buildRecallPayload` which is scoped to recalls).

  This builds directly on top of the merged #2387 fix which added the 14d/7d
  alert windows.

**Files changed:** `apps/api/src/cron/expiry-check.ts` (only)

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> Temporarily change the cron schedule to `* * * * *` to test locally,
> then revert before pushing.

> Expected logger output after fix:
> ```
> Running medicine expiry check...
> 30d check done. X medicines found, X notified.
> 14d check done. X medicines found, X notified.
> 7d check done. X medicines found, X notified.
> ```

_Attach your terminal screenshot showing all three log lines here:_

## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #2527`)
- [x] I have pulled the latest `main` and resolved any conflicts

Note: The issue references `notified_1d` but the DB migration defines
`notified_14d` — our implementation follows the actual schema (30d, 14d, 7d).