### PR TITLE
feat: implement nonce-based strict CSP via Next.js middleware

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import type { Metadata, Viewport } from "next";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations } from "next-intl/server";
@@ -73,6 +74,8 @@ export default async function LocaleLayout({
     params: Promise<{ locale: string }>;
 }) {
     const { locale } = await params;
+    const headersList = await headers();
+    const nonce = headersList.get("x-nonce") ?? "";
 
     if (!routing.locales.includes(locale as any)) {
         notFound();

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(request: NextRequest) {
+    // Generate a cryptographically secure nonce per request
+    const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+    const mlUrl = process.env.NEXT_PUBLIC_ML_SERVICE_URL;
+
+    const getOrigin = (url: string | undefined) => {
+        try { return url ? new URL(url).origin : ""; } catch { return ""; }
+    };
+    const getWsOrigin = (url: string | undefined) => {
+        try {
+            if (!url) return "";
+            const parsed = new URL(url);
+            parsed.protocol = parsed.protocol === "https:" ? "wss:" : "ws:";
+            return parsed.origin;
+        } catch { return ""; }
+    };
+
+    const connectSrc = [...new Set([
+        "'self'",
+        getOrigin(supabaseUrl),
+        getOrigin(apiUrl),
+        getOrigin(mlUrl),
+        getWsOrigin(mlUrl),
+    ].filter(Boolean))].join(" ");
+
+    // Nonce-based strict CSP — replaces 'unsafe-inline' with nonce
+    const csp = [
+        "default-src 'self'",
+        `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+        `style-src 'self' 'nonce-${nonce}'`,
+        `connect-src ${connectSrc}`,
+        "img-src 'self' blob: data:",
+        "font-src 'self'",
+        "object-src 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+        "frame-ancestors 'none'",
+        "upgrade-insecure-requests",
+    ].join("; ");
+
+    const requestHeaders = new Headers(request.headers);
+    // Forward nonce to App Router via request header
+    requestHeaders.set("x-nonce", nonce);
+    requestHeaders.set("x-csp", csp);
+
+    const response = NextResponse.next({
+        request: { headers: requestHeaders },
+    });
+
+    // Set CSP on the response
+    response.headers.set("Content-Security-Policy", csp);
+
+    return response;
+}
+
+export const config = {
+    matcher: [
+        // Skip static assets, images, and Next.js internals
+        "/((?!_next/static|_next/image|favicon.ico|icons|manifest.json|sw.js).*)",
+    ],
+};

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -15,36 +15,6 @@ const nextConfig = {
     reactStrictMode: true,
     poweredByHeader: false,
     async headers() {
-        const getOrigin = (url) => {
-            try { return url ? new URL(url).origin : ""; } catch { return ""; }
-        };
-
-        const getWebSocketOrigin = (url) => {
-            try {
-                if (!url) return "";
-                const parsedUrl = new URL(url);
-                parsedUrl.protocol = parsedUrl.protocol === "https:" ? "wss:" : "ws:";
-                return parsedUrl.origin;
-            } catch {
-                return "";
-            }
-        };
-
-        const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-        const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-        const mlUrl = process.env.NEXT_PUBLIC_ML_SERVICE_URL;
-
-        const connectSrcUrls = [
-            "'self'",
-            getOrigin(supabaseUrl),
-            getOrigin(apiUrl),
-            getOrigin(mlUrl),
-            getWebSocketOrigin(mlUrl),
-        ].filter(Boolean);
-
-        const uniqueConnectSrc = [...new Set(connectSrcUrls)].join(" ");
-        const csp = `default-src 'self'; connect-src ${uniqueConnectSrc}; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;`;
-
         return [
             {
                 source: "/(.*)",
@@ -54,7 +24,7 @@ const nextConfig = {
                     { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
                     { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
                     { key: "Permissions-Policy", value: "camera=(self), microphone=(self), geolocation=(self)" },
-                    { key: "Content-Security-Policy", value: csp },
+                    // CSP removed — now handled dynamically per-request in middleware.ts
                 ],
             },
             {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link
- **Closes #2610**
- **Summary:** The previous CSP in `next.config.mjs` used a static
  `'unsafe-inline'` and `'unsafe-eval'` for both `script-src` and
  `style-src`, leaving the app vulnerable to XSS attacks. This PR
  migrates to a nonce-based strict CSP.

  **What changed:**

  `apps/web/middleware.ts` (new file) — generates a cryptographically
  secure nonce per request using `crypto.randomUUID()` encoded as Base64,
  builds a dynamic CSP string with `'nonce-${nonce}'` for `script-src`
  and `style-src` (with `'strict-dynamic'` for modern browser support),
  sets the `Content-Security-Policy` response header, and forwards the
  nonce to the App Router via the `x-nonce` request header. A `matcher`
  config skips static assets (`_next/static`, `_next/image`, `icons`,
  `manifest.json`, `sw.js`).

  `apps/web/app/[locale]/layout.tsx` — reads the `x-nonce` header via
  Next.js `headers()` utility, making it available to pass to any
  `<Script>` or inline tags added in future.

  `apps/web/next.config.mjs` — removed the static `Content-Security-Policy`
  header and all associated `connectSrcUrls`/`csp` variable logic. All
  other security headers (`X-Frame-Options`, `HSTS`, etc.) are preserved.
  The dynamic `connect-src` allowlist (Supabase, API, ML service origins)
  is now built in middleware instead.

**Files changed:**
- `apps/web/middleware.ts` — CREATE
- `apps/web/app/[locale]/layout.tsx` — UPDATE
- `apps/web/next.config.mjs` — UPDATE


> Run the app locally and open DevTools → Network → any request →
> Response Headers. You should see:
> ```
> content-security-policy: default-src 'self'; script-src 'self' 'nonce-<hash>' 'strict-dynamic'; style-src 'self' 'nonce-<hash>'; ...
> ```
> The nonce value should be different on every page refresh.

_Attach your DevTools screenshot showing the CSP header with nonce here:_

## 🏷️ PR Type
- [x] ✨ `type: feature`
- [x] 🔒 `type: security`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #2610`)
- [x] I have pulled the latest `main` and resolved any conflicts