### PR TITLE
fix: validate OCR-parsed DOB before setting state in handleScanCard

### DIFF
--- a/apps/web/components/vaccine/ChildVaccinationTracker.tsx
+++ b/apps/web/components/vaccine/ChildVaccinationTracker.tsx
@@ -333,7 +333,14 @@ export function ChildVaccinationTracker() {
             const dobMatch = text.match(/\b(\d{2})[\/\-](\d{2})[\/\-](\d{4})\b/);
             if (dobMatch) {
                 const isoDate = `${dobMatch[3]}-${dobMatch[2]}-${dobMatch[1]}`;
-                handleDateOfBirthChange(isoDate);
+                const validation = validateChildDateOfBirth(isoDate);
+                if (validation.isValid) {
+                    handleDateOfBirthChange(isoDate);
+                } else {
+                    setOcrError(
+                        "Could not read a valid date of birth from this card. Please enter it manually."
+                    );
+                }
             }
 
             // Match vaccine names against schedule


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link
- **Closes #2612**
- **Summary:** In `handleScanCard`, the OCR path was calling
  `handleDateOfBirthChange(isoDate)` directly without any validation —
  bypassing the existing `validateChildDateOfBirth()` function which is
  used correctly in the manual input path.

  If a blurry or malformed card caused OCR to produce a future date
  (e.g. `2045-01-01`) or an impossible date (e.g. `2020-32-15`), the
  bad date was silently set into state. `ocrError` stayed `null` so the
  user saw no feedback. At render time, `validateChildDateOfBirth()`
  returned `isValid: false`, causing the entire vaccination schedule to
  silently disappear — with no explanation shown to the user.

  **Fix:** Added a `validateChildDateOfBirth(isoDate)` call inside the
  `if (dobMatch)` block before setting state. If valid, `handleDateOfBirthChange`
  is called as before. If invalid, `setOcrError()` is called with a
  clear message telling the user to enter the DOB manually.

  `validateChildDateOfBirth` was already imported on line 10 and has
  `todayDateInput` as a default parameter — zero new dependencies needed.

**File changed:** `apps/web/components/vaccine/ChildVaccinationTracker.tsx` (only)


## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #2612`)
- [x] I have pulled the latest `main` and resolved any conflicts