### PR TITLE
fix(api): prevent mock verification bypass in production environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,8 @@ SARVAM_API_KEY=your_sarvam_api_key
 OPENAI_API_KEY=your_openai_api_key
 GEMINI_API_KEY=your_gemini_api_key
 CSRF_SECRET=generate-a-strong-random-secret-here
+
+# ⚠️ DANGER:
+# Never set VERIFY_ENABLE_MOCKS=true in production.
+# It bypasses the database and returns fake verified responses.
+VERIFY_ENABLE_MOCKS=false

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,10 @@ import { warmCache } from "./services/cache.service";
 
 const port = process.env.PORT || 4000;
 
+if (process.env.NODE_ENV === "production" && process.env.VERIFY_ENABLE_MOCKS === "true") {
+    throw new Error("FATAL: VERIFY_ENABLE_MOCKS must not be enabled in production.");
+}
+
 if (process.env.NODE_ENV !== "test") {
     const server = app.listen(port, async () => {
         logger.info(`SahiDawa API is running at http://localhost:${port}`);

--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -193,7 +193,11 @@ router.post(
             "AUG625D",
         ]);
 
-        if (process.env.VERIFY_ENABLE_MOCKS === "true" && ALLOWED_MOCK_BATCHES.has(upperBatch)) {
+        if (
+            process.env.NODE_ENV !== "production" &&
+            process.env.VERIFY_ENABLE_MOCKS === "true" &&
+            ALLOWED_MOCK_BATCHES.has(upperBatch)
+        ) {
             const brandName = upperBatch.includes("DOLO")
                 ? "Dolo 650"
                 : upperBatch === "AUG625D"


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #2572**

**Summary:**

* Prevent the mock verification bypass from running in production by requiring `NODE_ENV !== "production"` in addition to `VERIFY_ENABLE_MOCKS === "true"`.
* Add a startup guard that throws a fatal error if `VERIFY_ENABLE_MOCKS=true` is detected in a production environment.
* Add a clear warning to `.env.example` and set `VERIFY_ENABLE_MOCKS=false` as the safe default.

## 📸 Proof of Work (Screenshots / Logs)

### Validation

* Verified the mock bypass is disabled when `NODE_ENV=production`.
* Verified the application fails to start if `VERIFY_ENABLE_MOCKS=true` in production.
* Confirmed development and test environments remain unaffected since the mock feature continues to work outside production.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [x] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2572`)
* [x] I have pulled the latest `main` and resolved any conflicts.
