### PR TITLE
fix: improve view history button visiblity in light mode

### DIFF
--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -567,7 +567,7 @@ export default function ScanPage() {
 
                 <Link
                     href="/history"
-                    className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-2 text-sm font-bold text-white shadow-sm transition-colors hover:bg-white/20 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-black focus:outline-none dark:border-white/20"
+                    className="inline-flex items-center justify-center gap-2 rounded-full border border-gray-300 bg-white/10 px-4 py-2 text-sm font-bold text-gray-700 shadow-sm transition-colors hover:border-gray-300 hover:bg-gray-100 focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 focus:ring-offset-black focus:outline-none dark:border-white/20 dark:text-white dark:hover:bg-white/20"
                 >
                     <History size={18} />
                     {tScan("viewHistory")}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2605**
- **Summary:**
This PR improves the visibility of the View History button on the Scan page in light mode.

### Changes Made
- Updated the View History button text color to ensure sufficient contrast in light mode.
- Refined the button styling to improve visibility while preserving the existing appearance in dark mode.

### Testing
- Verified the View History button is clearly visible in light mode.
- Confirmed the button styling remains unchanged and readable in dark mode.
- Verified the button continues to function as expected.

### File Changed
- `app/[locale]/scan/page.tsx`


## 🏷️ PR Type

- [x] 🐛 `type: bug`


## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2605`)
- [x] I have pulled the latest `main` and resolved any conflicts
