### PR TITLE
feat(api): implement dynamic dependency checks in health endpoint

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,7 +5,8 @@ import path from "path";
 import logger from "./utils/logger";
 import swaggerUi from "swagger-ui-express";
 import { swaggerSpec } from "./utils/swagger";
-import { validateMlServiceConfig } from "./config/mlService";
+import { validateMlServiceConfig, getMlServiceUrl } from "./config/mlService";
+import { redisClient } from "./utils/redis";
 import cookieParser from "cookie-parser";
 import { doubleCsrf } from "csrf-csrf";
 import mapRouter from "./routes/map";
@@ -187,8 +188,37 @@ app.get("/health", async (_req: Request, res: Response) => {
     try {
         const { error } = await supabase.from("medicines").select("id").limit(1);
         const uptime = process.uptime();
+
+        // Redis
+        const redisStatus = redisClient.isOpen ? "connected" : "disconnected";
+
+        // ML service — check config first, then do a lightweight reachability ping
+        let mlStatus: string;
+        const mlUrl = getMlServiceUrl();
+        if (!mlUrl) {
+            mlStatus = "not-configured";
+        } else {
+            try {
+                const controller = new AbortController();
+                const timeout = setTimeout(() => controller.abort(), 3000);
+                const res = await fetch(mlUrl, { method: "HEAD", signal: controller.signal });
+                clearTimeout(timeout);
+                mlStatus = res.ok ? "healthy" : "unreachable";
+            } catch {
+                mlStatus = "unreachable";
+            }
+        }
+
+        // Overall status
+        const overallStatus =
+            redisStatus === "connected" &&
+            mlStatus !== "not-configured" &&
+            mlStatus !== "unreachable"
+                ? "healthy"
+                : "degraded";
+
         const healthData = {
-            status: error ? "degraded" : "ok",
+            status: error ? "degraded" : overallStatus,
             service: "sahidawa-api",
             version: process.env.npm_package_version || "unknown",
             environment: process.env.NODE_ENV || "development",
@@ -196,8 +226,8 @@ app.get("/health", async (_req: Request, res: Response) => {
             database: { status: error ? "unreachable" : "connected" },
             services: {
                 api: "healthy",
-                redis: "not-configured-yet",
-                mlService: "not-configured-yet",
+                redis: redisStatus,
+                mlService: mlStatus,
             },
             system: {
                 nodeVersion: process.version,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2529 ** 
- **Summary:**
  - Updated the `/health` endpoint in `apps/api/src/app.ts` to perform real-time, dynamic reachability checks for dependencies.
  - Implemented dynamic Redis status evaluation using `redisClient.isOpen`.
  - Implemented a lightweight, non-blocking reachability ping (via `HEAD` request) for the ML service, falling back gracefully if unconfigured or unreachable.
  - Refactored the top-level API `status` property to dynamically calculate `"healthy"` or `"degraded"` based on the collective states of Redis and the ML service, while preserving the existing database failure fallback logic.

## 📸 Proof of Work (Screenshots / Logs)

Ran the API server locally and hit the GET /health endpoint. The screenshot above shows:

services.redis correctly evaluates to "connected" (or "disconnected") instead of "not-configured-yet".
services.mlService gracefully returns "not-configured", "healthy", or "unreachable".
The top-level status dynamically updates to "healthy" or "degraded" based on those dependencies.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
