### PR TITLE
fix: upgrade postcss to patch XSS vulnerability in style tag output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -515,6 +515,7 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -637,6 +638,7 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -969,6 +971,7 @@
         "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
             "version": "8.20.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -1064,6 +1067,7 @@
             "version": "7.29.7",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
                 "@babel/generator": "^7.29.7",
@@ -1590,6 +1594,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -1634,6 +1639,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -2155,9 +2161,6 @@
             "cpu": [
                 "arm"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2173,9 +2176,6 @@
             "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2193,9 +2193,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2212,9 +2209,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2230,9 +2224,6 @@
             "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
@@ -2264,9 +2255,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2283,9 +2271,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -2301,9 +2286,6 @@
             "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
             "cpu": [
                 "arm"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2327,9 +2309,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2351,9 +2330,6 @@
             "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
             "cpu": [
                 "ppc64"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2377,9 +2353,6 @@
             "cpu": [
                 "riscv64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2401,9 +2374,6 @@
             "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -2447,9 +2417,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -2471,9 +2438,6 @@
             "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "Apache-2.0",
             "optional": true,
@@ -3303,6 +3267,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
             "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -3462,6 +3427,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
             "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
@@ -5695,6 +5661,7 @@
             "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.0.1.tgz",
             "integrity": "sha512-SwYl64hKHE/NeO2VSSG1y/4zIm0cNepyOZtQrOpLiNRHmH2FdWBOecNzsLiXCQdFCF9MCyoPXwAbaG2iMO0A7Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2"
             },
@@ -5933,6 +5900,7 @@
             "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.2.tgz",
             "integrity": "sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@supabase/auth-js": "2.108.2",
                 "@supabase/functions-js": "2.108.2",
@@ -6125,6 +6093,7 @@
         "node_modules/@swc/helpers": {
             "version": "0.5.15",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.8.0"
             }
@@ -6300,27 +6269,6 @@
             },
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
             }
         },
         "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -6736,6 +6684,7 @@
             "version": "5.0.6",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^5.0.0",
@@ -6889,6 +6838,7 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
             "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~8.3.0"
             }
@@ -6967,6 +6917,7 @@
             "version": "19.2.16",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -6975,6 +6926,7 @@
             "version": "19.2.3",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -7161,6 +7113,7 @@
             "version": "8.60.1",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.60.1",
                 "@typescript-eslint/types": "8.60.1",
@@ -7381,6 +7334,7 @@
         "node_modules/@upstash/redis": {
             "version": "1.38.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "uncrypto": "^0.1.3"
             }
@@ -7388,6 +7342,7 @@
         "node_modules/@zxing/library": {
             "version": "0.23.0",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "ts-custom-error": "^3.3.1"
             },
@@ -7417,6 +7372,7 @@
         "node_modules/acorn": {
             "version": "8.16.0",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8043,6 +7999,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -8864,6 +8821,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -8885,6 +8843,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -9532,6 +9491,7 @@
             "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "workspaces": [
                 "packages/*"
             ],
@@ -9805,6 +9765,7 @@
         "node_modules/express": {
             "version": "5.2.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -9846,6 +9807,7 @@
         "node_modules/express-rate-limit": {
             "version": "8.5.2",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ip-address": "^10.2.0"
             },
@@ -11523,6 +11485,7 @@
             "version": "30.4.2",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "30.4.2",
                 "@jest/types": "30.4.1",
@@ -12497,6 +12460,7 @@
             "version": "29.1.1",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@asamuzakjp/css-color": "^5.1.11",
                 "@asamuzakjp/dom-selector": "^7.1.1",
@@ -12618,6 +12582,7 @@
             "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
             "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.6",
                 "fast-png": "^6.2.0",
@@ -12707,7 +12672,8 @@
         },
         "node_modules/leaflet": {
             "version": "1.9.4",
-            "license": "BSD-2-Clause"
+            "license": "BSD-2-Clause",
+            "peer": true
         },
         "node_modules/leven": {
             "version": "3.1.0",
@@ -13472,6 +13438,7 @@
             "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
             "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2"
             },
@@ -13560,6 +13527,7 @@
             "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
             "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@next/env": "16.2.9",
                 "@swc/helpers": "0.5.15",
@@ -14192,6 +14160,7 @@
         "node_modules/pg": {
             "version": "8.21.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.13.0",
                 "pg-pool": "^3.14.0",
@@ -14269,6 +14238,7 @@
         "node_modules/picomatch": {
             "version": "4.0.4",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -14458,6 +14428,7 @@
             "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -14693,6 +14664,7 @@
         "node_modules/react": {
             "version": "19.2.7",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -14700,6 +14672,7 @@
         "node_modules/react-dom": {
             "version": "19.2.7",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -14712,6 +14685,7 @@
             "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.80.0.tgz",
             "integrity": "sha512-4P+fk6oXsxY+6xSj7Euhc2sumQD8zQqCuVHoJwoyp9EchP+IUW9OESB7uHFJOKsIBQ4MQqYE84INJFqUCYNoOg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             },
@@ -14749,7 +14723,8 @@
             "version": "19.2.7",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
             "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/react-is-18": {
             "name": "react-is",
@@ -14780,6 +14755,7 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
             "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
                 "use-sync-external-store": "^1.4.0"
@@ -14864,7 +14840,8 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/redux-thunk": {
             "version": "3.1.0",
@@ -16774,6 +16751,7 @@
             "version": "6.0.3",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -17222,6 +17200,7 @@
         "node_modules/winston": {
             "version": "3.19.0",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@colors/colors": "^1.6.0",
                 "@dabh/diagnostics": "^2.0.8",
@@ -17558,6 +17537,7 @@
         "node_modules/zod": {
             "version": "4.4.3",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -17577,7 +17557,8 @@
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
             "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     },
     "overrides": {
         "@zxing/library": "0.23.0",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.15",
         "form-data": "^4.0.6",
         "protobufjs": "^7.6.3",
         "js-yaml": "^4.1.2",


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2622 **
- **Summary:**
  - Fixed a Moderate severity PostCSS XSS vulnerability (unescaped `</style>` in CSS stringify output) flagged by Dependabot. 
  - Unified the `postcss` override version in the root `package.json` to `^8.5.15` to match `apps/web`.
  - Cleanly regenerated `package-lock.json` to ensure the safe version is locked for all transitive consumers.

## 📸 Proof of Work (Screenshots / Logs)


<img width="368" height="72" alt="Screenshot 2026-06-28 023354" src="https://github.com/user-attachments/assets/30fec30b-a188-4d7e-90ac-8026e1cf2dd5" />


## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
