### PR TITLE
feat(api): add Supabase webhook to invalidate health-schemes Redis cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,6 @@ SARVAM_API_KEY=your_sarvam_api_key
 OPENAI_API_KEY=your_openai_api_key
 GEMINI_API_KEY=your_gemini_api_key
 CSRF_SECRET=generate-a-strong-random-secret-here
+
+# Supabase Database Webhook secret for cache invalidation endpoints
+SUPABASE_WEBHOOK_SECRET=your_webhook_secret_here

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -69,6 +69,7 @@ import triageRouter from "./routes/triage";
 import interactionsRouter from "./routes/interactions";
 import alternativesRouter from "./routes/alternatives";
 import eligibilityRouter from "./routes/eligibility";
+import webhooksRouter from "./routes/webhooks";
 import { supabase } from "./db/client";
 import { createCorsOptions } from "./config/cors";
 import { errorHandler } from "./middleware/errorHandler";
@@ -255,6 +256,7 @@ app.use("/api/v1/interactions", interactionsRouter);
 app.use("/api/schedules", medicineSchedulesRouter);
 app.use("/api/v1/abha", abhaRoutes);
 app.use("/api/v1/scheme-eligibility", eligibilityRouter);
+app.use("/api/webhooks", webhooksRouter);
 app.use("/api/v1/medicines", trackingRouter);
 
 // ── Swagger UI Documentation (/api/docs) ──────────────────────────────────

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1,0 +1,73 @@
+import { Router, Request, Response } from "express";
+import { redisClient } from "../utils/redis";
+import logger from "../utils/logger";
+
+const router = Router();
+
+/**
+ * POST /api/webhooks/supabase/health-schemes
+ *
+ * Supabase Database Webhook endpoint — triggered on INSERT, UPDATE, or DELETE
+ * on the health_schemes table. Invalidates all matching Redis cache keys.
+ *
+ * Secured via SUPABASE_WEBHOOK_SECRET environment variable.
+ */
+router.post(
+    "/supabase/health-schemes",
+    async (req: Request, res: Response): Promise<void> => {
+        // Verify secret token
+        const secret = process.env.SUPABASE_WEBHOOK_SECRET;
+        const authHeader = req.headers["authorization"];
+
+        if (!secret || authHeader !== `Bearer ${secret}`) {
+            logger.warn("Unauthorized webhook attempt on /api/webhooks/supabase/health-schemes", {
+                ip: req.ip,
+                headers: req.headers,
+            });
+            res.status(401).json({ error: "Unauthorized" });
+            return;
+        }
+
+        // Invalidate all schemes:state:* cache keys using SCAN
+        try {
+            if (!redisClient.isOpen) {
+                logger.warn("Redis not connected — skipping cache invalidation");
+                res.status(200).json({ invalidated: 0, message: "Redis unavailable" });
+                return;
+            }
+
+            const keysToDelete: string[] = [];
+            let cursor = 0;
+
+            do {
+                const result = await redisClient.scan(cursor, {
+                    MATCH: "schemes:state:*",
+                    COUNT: 100,
+                });
+                cursor = result.cursor;
+                keysToDelete.push(...result.keys);
+            } while (cursor !== 0);
+
+            if (keysToDelete.length > 0) {
+                await redisClient.del(keysToDelete);
+                logger.info(
+                    `Health schemes cache invalidated — deleted ${keysToDelete.length} key(s)`,
+                    { keys: keysToDelete }
+                );
+            } else {
+                logger.info("Health schemes webhook fired — no cache keys found to invalidate");
+            }
+
+            res.status(200).json({
+                invalidated: keysToDelete.length,
+                keys: keysToDelete,
+            });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            logger.error("Failed to invalidate health schemes cache", { error: message });
+            res.status(500).json({ error: "Cache invalidation failed" });
+        }
+    }
+);
+
+export default router;


### PR DESCRIPTION
## 📋 PR Summary & Link
- **Closes #2609**
- **Summary:** Adds a Supabase Database Webhook endpoint that 
  invalidates all `schemes:state:*` Redis cache keys whenever the 
  `health_schemes` table is updated. Creates a new 
  `apps/api/src/routes/webhooks.ts` with a secure 
  `POST /api/webhooks/supabase/health-schemes` endpoint, registered 
  in `app.ts`. Uses Redis `SCAN` with pattern matching instead of 
  blocking `KEYS *` to safely find and delete cache entries in 
  production. Secured via `SUPABASE_WEBHOOK_SECRET` environment 
  variable checked against the `Authorization` header.

## 📸 Proof of Work (Screenshots / Logs)
**TypeScript compilation — zero new errors:**
<img width="1157" height="88" alt="image" src="https://github.com/user-attachments/assets/7d08bc36-ed22-44d9-adba-779b331ac078" />

**Files changed:**
- `apps/api/src/routes/webhooks.ts` (new) — webhook handler with 
  SCAN-based cache invalidation
- `apps/api/src/app.ts` — import + route registration at 
  `/api/webhooks`
- `.env.example` — added `SUPABASE_WEBHOOK_SECRET` placeholder

**Key implementation details:**
- Uses `redisClient.scan()` with `MATCH: "schemes:state:*"` and 
  `COUNT: 100` — non-blocking, safe for production Redis
- Gracefully handles Redis unavailable state (returns 200 with 
  `message: "Redis unavailable"` instead of 500)
- Returns `{ invalidated: N, keys: [...] }` for observability
- 401 returned immediately if `Authorization` header doesn't match 
  `SUPABASE_WEBHOOK_SECRET`

**Supabase Dashboard Setup (for maintainers):**
1. Go to Supabase Dashboard → Database → Webhooks
2. Create webhook on `health_schemes` table
3. Events: INSERT, UPDATE, DELETE
4. URL: `https://your-api.com/api/webhooks/supabase/health-schemes`
5. HTTP Header: `Authorization: Bearer <SUPABASE_WEBHOOK_SECRET>`

## 🏷️ PR Type
- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #2609`)
- [x] I have pulled the latest `main` and resolved any conflicts