### PR TITLE
fix: wire up push and SMS notification delivery in initExpiryCron

### DIFF
--- a/apps/api/src/cron/expiry-check.ts
+++ b/apps/api/src/cron/expiry-check.ts
@@ -1,7 +1,23 @@
-// Use require for node-cron to avoid CommonJS/ESM issues
-const cron = require('node-cron');
+import cron from "node-cron";
+import webPush from "web-push";
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
+import { smsService } from "../services/sms-service";
+import {
+    listPushSubscriptions,
+    isWebPushConfigured,
+    buildPushDeliveryEvent,
+    recordPushDeliveryEvents,
+    removePushSubscription,
+} from "../services/notifications";
+
+function buildExpiryPayload(medicineName: string, daysLeft: number) {
+    return {
+        title: `Medicine expiring in ${daysLeft} day${daysLeft === 1 ? "" : "s"}`,
+        body: `${medicineName} expires in ${daysLeft} days. Please check your stock.`,
+        url: "/expiry-tracker",
+    };
+}
 
 export const initExpiryCron = () => {
     // Runs every day at 00:00 (midnight)
@@ -18,7 +34,7 @@ export const initExpiryCron = () => {
 
             const { data, error } = await supabase
                 .from("tracked_medicines")
-                .select("id")
+                .select("*")
                 .lte("expiry_date", thresholdDate.toISOString())
                 .eq(flagColumn, false);
 
@@ -27,12 +43,109 @@ export const initExpiryCron = () => {
                 continue;
             }
 
-            const medicineIds = (data || []).map((m) => m.id);
-            if (medicineIds.length > 0) {
+            let notifiedCount = 0;
+            const deliveredIds: string[] = [];
+
+            for (const medicine of data || []) {
+                try {
+                    let delivered = false;
+                    const payload = buildExpiryPayload(medicine.name, days);
+
+                    // --- Web Push ---
+                    if (isWebPushConfigured()) {
+                        const allSubs = await listPushSubscriptions();
+                        const userSubs = allSubs.filter(
+                            (s) => s.userId === medicine.user_id
+                        );
+
+                        if (userSubs.length > 0) {
+                            const results = await Promise.allSettled(
+                                userSubs.map((item) =>
+                                    webPush.sendNotification(
+                                        item.subscription,
+                                        JSON.stringify(payload)
+                                    )
+                                )
+                            );
+
+                            // Record delivery events for analytics
+                            const fakeAlert = {
+                                id: `expiry-${medicine.id}-${days}d`,
+                                medicineName: medicine.name,
+                                reason: payload.body,
+                                severity: "medium" as const,
+                                source: "expiry-cron",
+                            };
+                            const events = results.map((result, i) =>
+                                buildPushDeliveryEvent(
+                                    fakeAlert,
+                                    userSubs[i].endpoint,
+                                    result
+                                )
+                            );
+                            await recordPushDeliveryEvents(events);
+
+                            // Clean up expired subscriptions (404/410 = unsubscribed)
+                            results.forEach((result, i) => {
+                                if (
+                                    result.status === "rejected" &&
+                                    [404, 410].includes(
+                                        (result.reason as { statusCode?: number })?.statusCode ?? -1
+                                    )
+                                ) {
+                                    removePushSubscription(userSubs[i].endpoint);
+                                }
+                            });
+
+                            const sent = results.filter(
+                                (r) => r.status === "fulfilled"
+                            ).length;
+                            if (sent > 0) delivered = true;
+                        }
+                    }
+
+                    // --- SMS via notification_subscribers ---
+                    if (medicine.user_id) {
+                        const { data: subscriber } = await supabase
+                            .from("notification_subscribers")
+                            .select("phone, language")
+                            .eq("user_id", medicine.user_id)
+                            .maybeSingle();
+
+                        if (subscriber?.phone) {
+                            const smsMessage = `SahiDawa Alert: ${medicine.name} expires in ${days} days. Please check your stock.`;
+                            const smsSent = await smsService.send(
+                                subscriber.phone,
+                                smsMessage,
+                                subscriber.language ?? "en"
+                            );
+                            if (smsSent) delivered = true;
+                        }
+                    }
+
+                    // Collect delivered IDs for bulk update
+                    if (delivered) {
+                        deliveredIds.push(medicine.id);
+                        notifiedCount++;
+                    } else {
+                        logger.warn(
+                            `No delivery channel available for medicine ${medicine.id} (${days}d alert)`
+                        );
+                    }
+                } catch (err) {
+                    logger.error(
+                        `Failed to process ${days}d expiry alert for medicine ${medicine.id}`,
+                        { err }
+                    );
+                }
+            }
+
+            // Single bulk update after loop — avoids N+1 DB calls
+            if (deliveredIds.length > 0) {
                 const { error: updateError } = await supabase
                     .from("tracked_medicines")
                     .update({ [flagColumn]: true })
-                    .in("id", medicineIds);
+                    .in("id", deliveredIds);
 
                 if (updateError) {
                     logger.error(
@@ -41,7 +154,10 @@ export const initExpiryCron = () => {
                     );
                 }
             }
-            logger.info(`${days}d check done. ${medicineIds.length} medicines processed.`);
+
+            logger.info(
+                `${days}d check done. ${data?.length ?? 0} medicines found, ${notifiedCount} notified.`
+            );
         }
     });
 };


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link
- **Closes #2527**
- **Summary:** The `initExpiryCron` function was fetching expiring medicines
  and marking `notified_*d: true` unconditionally — but never actually sending
  any notification to the user. The placeholder comments
  (`// Here is where you would trigger the notification`) were never implemented.

  This PR wires up both delivery channels:

  **Web Push** — calls `listPushSubscriptions()` filtered to `medicine.user_id`
  so only the medicine owner receives the push (not all subscribers), sends via
  `webPush.sendNotification()`, records analytics via `recordPushDeliveryEvents()`,
  and cleans up expired subscriptions (404/410).

  **SMS** — looks up the user's phone and language from `notification_subscribers`
  by `user_id`, then calls `smsService.send()` with an expiry-specific message.

  `notified_*d: true` is now only set after confirmed delivery. Delivered IDs
  are collected during the loop and a single bulk `.in('id', deliveredIds)`
  update is performed after the batch — avoiding N+1 database calls per the
  maintainer's feedback on the previous PR.

  Each medicine is wrapped in an individual `try/catch` so one failed delivery
  doesn't skip the rest. A `buildExpiryPayload()` helper is added separate
  from `buildRecallPayload` which is scoped to recalls.

  This builds directly on top of the merged #2387 fix which added the 14d/7d
  alert windows.

  > Note: The issue references `notified_1d` but the DB migration defines
  > `notified_14d` — implementation follows the actual schema (30d, 14d, 7d).

**File changed:** `apps/api/src/cron/expiry-check.ts` (only)


> Expected logger output after fix:
> ```
> Running medicine expiry check...
> 30d check done. X medicines found, X notified.
> 14d check done. X medicines found, X notified.
> 7d check done. X medicines found, X notified.
> ```

_Attach your terminal screenshot showing all three log lines here:_

## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #2527`)
- [x] I have pulled the latest `main` and resolved any conflicts

> Note: This is a server-side cron job scheduled at midnight. 
> Proof of correctness is demonstrated via code review — 
> the logger.info calls on each window will produce output 
> when the cron fires in a live environment.