### PR TITLE
[BUG/SECURITY] Fix SSRF bypass: medicine.ts now uses centralized getMlServiceUrl() validator

### DIFF
--- a/apps/api/src/routes/medicine.ts
+++ b/apps/api/src/routes/medicine.ts
@@ -4,6 +4,7 @@ import { supabase } from "../db/client";
 import { redisClient } from "../utils/redis";
 import { scanQueryLimiter } from "../middleware/rateLimit";
 import { escapePostgrest } from "../utils/db";
+import { getMlServiceUrl } from "../config/mlService";
 
 const router = Router();
 
@@ -17,7 +18,7 @@ const upload = multer({
     },
 });
 
-const ML_SERVICE_URL = process.env.ML_SERVICE_URL || "http://localhost:8000";
+const ML_SERVICE_URL = getMlServiceUrl();
 
 export function buildMedicineVoiceSearchFilter(transcribedText: string): string {
     const safeTranscribedText = escapePostgrest(transcribedText);
@@ -35,6 +36,10 @@ router.post(
     upload.single("audio"),
     async (req: Request, res: Response) => {
         try {
+            if (!ML_SERVICE_URL) {
+                return res.status(503).json({ success: false, error: "ML service not configured" });
+            }
+
             if (!req.file) {
                 return res.status(400).json({ success: false, error: "No audio file provided." });
             }
@@ -108,7 +113,6 @@ router.post(
 
             // Cache result in Redis (key: transcribed medicine name, TTL: 1 hour)
             try {
-                // Use the shared redisClient
                 if (transcribedText) {
                     const cacheKey = `medicine:voice:${transcribedText.toLowerCase().replace(/\s+/g, "_")}`;
                     await redisClient.setEx(cacheKey, 3600, JSON.stringify(result));
@@ -133,6 +137,10 @@ router.post(
  */
 router.get("/languages", async (_req: Request, res: Response) => {
     try {
+        if (!ML_SERVICE_URL) {
+            return res.status(503).json({ error: "ML service not configured" });
+        }
+
         const mlResponse = await fetch(`${ML_SERVICE_URL}/voice/languages`);
         const data = await mlResponse.json();
         res.json(data);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #2751**
- **Summary:** `medicine.ts` read `ML_SERVICE_URL` directly from `process.env` with a hardcoded loopback fallback (`http://localhost:8000`), bypassing the SSRF-safe `getMlServiceUrl()` validator used by every other ML-dependent route. Fix uses the centralized validator which blocks private IPs, loopback addresses, and validates URL format. Added null checks on both routes returning 503 when unconfigured.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] 🔒 `type: security`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2751`)
- [x] I have pulled the latest `main` and resolved any conflicts
