### PR TITLE
perf(api): add Redis cache for alternatives endpoint

### DIFF
--- a/apps/api/src/routes/alternatives.ts
+++ b/apps/api/src/routes/alternatives.ts
@@ -3,6 +3,7 @@ import { supabase } from "../db/client";
 import logger from "../utils/logger";
 import { escapePostgrest } from "../utils/db";
 import { barcodeLimiter } from "../middleware/rateLimit";
+import { redisClient } from "../utils/redis";
 
 const router = Router();
 
@@ -65,6 +66,7 @@ function extractCoordinates(p: StoreLocation): { lat: number; lng: number } {
 router.get("/:medicine_id", barcodeLimiter, async (req: Request, res: Response): Promise<void> => {
     try {
         const medicine_id = req.params.medicine_id as string;
+        const cacheKey = `alt_cache:${medicine_id.toLowerCase()}`;
         const lat = req.query.lat ? parseFloat(req.query.lat as string) : undefined;
         const lng = req.query.lng ? parseFloat(req.query.lng as string) : undefined;
 
@@ -80,6 +82,17 @@ router.get("/:medicine_id", barcodeLimiter, async (req: Request, res: Response):
         if (!medicine_id) {
             res.status(400).json({ error: "medicine_id is required" });
             return;
+        }
+        try {
+            const cached = await redisClient.get(cacheKey);
+
+            if (cached) {
+                logger.info(`Alternatives cache HIT: ${cacheKey}`);
+                res.status(200).json(JSON.parse(cached));
+                return;
+            }
+        } catch (err) {
+            logger.warn("Redis cache read failed", { err });
         }
 
         interface MedicineRecord {
@@ -238,7 +251,7 @@ router.get("/:medicine_id", barcodeLimiter, async (req: Request, res: Response):
             alternative.savings_percentage ??
             Math.round(((brandPrice - jaPrice) / brandPrice) * 100);
 
-        res.status(200).json({
+        const responseData = {
             brand_name: alternative.brand_name || medicine?.brand_name || medicine_id,
             generic_name: alternative.generic_name || medicine?.generic_name,
             brand_price: brandPrice,
@@ -251,7 +264,19 @@ router.get("/:medicine_id", barcodeLimiter, async (req: Request, res: Response):
                     ? `${medicine.generic_name} (Generic)`
                     : "Atorvastatin 10mg (Generic)"),
             nearest_store: nearestStore,
-        });
+        };
+
+        try {
+            await redisClient.set(cacheKey, JSON.stringify(responseData), {
+                EX: 86400,
+            });
+
+            logger.info(`Alternatives cache SET: ${cacheKey}`);
+        } catch (err) {
+            logger.warn("Redis cache write failed", { err });
+        }
+
+        res.status(200).json(responseData);
     } catch (error) {
         logger.error("Error in alternatives lookup", { error });
         res.status(500).json({ error: "Failed to fetch medicine alternatives" });


### PR DESCRIPTION
## 🛑 STOP: Assignment & File Scope Check

* ✅ I am assigned to this issue.
* ✅ This PR only modifies the required file.

## 📋 PR Summary

Closes #2532

### Changes Made

* Added Redis cache lookup before database queries.
* Added cache key using `alt_cache:<medicine_id_lowercase>`.
* Cached successful responses with a TTL of **86400 seconds (24 hours)**.
* Wrapped Redis read/write operations in `try/catch` so Redis failures gracefully fall back to the existing database flow.
* Preserved the existing API response format and database lookup logic.

### Benefits

* Reduces repeated Supabase queries for the same medicine.
* Improves response time for cache hits.
* Reduces database load.
* Redis failures do not impact API availability.

## 🏷️ PR Type

* ⚡ Performance

## ✅ Checklist

* [x] Linked to the assigned issue
* [x] Only required file modified
* [x] Cache TTL set to 86400 seconds
* [x] Redis failures gracefully fall back to the database
