### PR TITLE
refactor(i18n): localize remaining accessibility labels

### DIFF
--- a/apps/web/app/[locale]/components/Chatbot.tsx
+++ b/apps/web/app/[locale]/components/Chatbot.tsx
@@ -42,6 +42,7 @@ export default function Chatbot() {
     const pathname = usePathname();
     const t = useTranslations("chatbot");
     const tHome = useTranslations("Home");
+    const tA11y = useTranslations("A11y");
     const [isOpen, setIsOpen] = useState(false);
     const [isLoadingWelcome, setIsLoadingWelcome] = useState(true);
     const [messages, setMessages] = useState<Message[]>([
@@ -188,16 +189,16 @@ export default function Chatbot() {
                                 <button
                                     onClick={handleClear}
                                     className="rounded-full p-1.5 text-green-300 transition-colors hover:bg-white/20 hover:text-green-200"
-                                    aria-label="Confirm clear conversation"
-                                    title={t("confirmClear")}
+                                    aria-label={tA11y("confirmClearConversation")}
+                                    title={tA11y("confirmClearConversation")}
                                 >
                                     <Check size={16} />
                                 </button>
                                 <button
                                     onClick={() => setIsConfirmingClear(false)}
                                     className="rounded-full p-1.5 text-red-300 transition-colors hover:bg-white/20 hover:text-red-200"
-                                    aria-label="Cancel clear conversation"
-                                    title={t("cancelClear")}
+                                    aria-label={tA11y("cancelClearConversation")}
+                                    title={tA11y("cancelClearConversation")}
                                 >
                                     <X size={16} />
                                 </button>
@@ -215,14 +216,14 @@ export default function Chatbot() {
                         <Link
                             href="/"
                             className="rounded-full p-2 text-white/80 transition-colors hover:bg-white/20 hover:text-white"
-                            aria-label="Go to homepage"
+                            aria-label={tA11y("goToHomepage")}
                         >
                             <Home size={18} />
                         </Link>
                         <button
                             onClick={() => setIsOpen(false)}
                             className="rounded-full p-2 text-white transition-colors hover:bg-white/20"
-                            aria-label="Close chat"
+                            aria-label={tA11y("closeChat")}
                         >
                             <X size={20} />
                         </button>
@@ -264,7 +265,7 @@ export default function Chatbot() {
                         onClick={handleSend}
                         disabled={!input.trim()}
                         className="flex h-11 w-11 items-center justify-center rounded-full bg-green-600 p-3 text-white shadow-md transition-colors hover:bg-green-700 disabled:opacity-50 dark:bg-green-700 dark:hover:bg-green-800"
-                        aria-label="Send message"
+                        aria-label={tA11y("sendMessage")}
                     >
                         <Send size={18} className="relative right-[1px] bottom-[1px]" />
                     </button>
@@ -281,7 +282,7 @@ export default function Chatbot() {
                 <button
                     onClick={() => setIsOpen(!isOpen)}
                     className="relative z-10 flex h-14 w-14 items-center justify-center rounded-full bg-green-600 text-white shadow-[0_8px_20px_rgba(22,163,74,0.3)] transition-all hover:scale-105 hover:shadow-[0_8px_25px_rgba(22,163,74,0.4)] active:scale-95 dark:bg-green-700 dark:hover:bg-green-800"
-                    aria-label={isOpen ? "Close AI chat" : "Open AI chat"}
+                    aria-label={isOpen ? tA11y("closeAiChat") : tA11y("openAiChat")}
                 >
                     {isOpen ? <X size={28} /> : <MessageSquare size={28} />}
                 </button>

--- a/apps/web/app/[locale]/components/Navbar/DesktopNavLinks.tsx
+++ b/apps/web/app/[locale]/components/Navbar/DesktopNavLinks.tsx
@@ -13,6 +13,7 @@ const activeDesktopNavLinkClassName =
 export default function DesktopNavLinks() {
     const pathname = usePathname();
     const tNav = useTranslations("Navigation");
+    const tA11y = useTranslations("A11y");
     const [isFeaturesOpen, setIsFeaturesOpen] = useState(false);
     const featuresRef = useRef<HTMLDivElement>(null);
 
@@ -51,7 +52,7 @@ export default function DesktopNavLinks() {
     return (
         <nav
             className="hidden items-center justify-center gap-4 text-sm font-semibold text-(--color-text-secondary) lg:flex xl:gap-6"
-            aria-label="Main navigation"
+            aria-label={tA11y("mainNavigation")}
         >
             <Link
                 href="/how-it-works"

--- a/apps/web/app/[locale]/components/Navbar/MobileBottomNav.tsx
+++ b/apps/web/app/[locale]/components/Navbar/MobileBottomNav.tsx
@@ -61,6 +61,7 @@ interface MobileBottomNavProps {
 export default function MobileBottomNav({ isNavVisible }: MobileBottomNavProps) {
     const pathname = usePathname();
     const tNav = useTranslations("Navigation");
+    const tA11y = useTranslations("A11y");
 
     const isActive = (href: string) => {
         if (href === "/") return pathname === "/";
@@ -70,7 +71,7 @@ export default function MobileBottomNav({ isNavVisible }: MobileBottomNavProps) 
     return (
         <nav
             className={`fixed right-0 bottom-0 left-0 z-50 flex items-center justify-around border-t border-(--color-border-muted)/60 bg-(--color-surface-page)/90 px-1 py-2 pb-[env(safe-area-inset-bottom)] backdrop-blur-md transition-transform duration-300 ease-out md:hidden ${isNavVisible ? "translate-y-0" : "translate-y-full"}`}
-            aria-label="Mobile navigation"
+            aria-label={tA11y("mobileNavigation")}
         >
             {MOBILE_NAV_ITEMS.map(
                 ({

--- a/apps/web/app/[locale]/components/Navbar/MobileMenu.tsx
+++ b/apps/web/app/[locale]/components/Navbar/MobileMenu.tsx
@@ -37,6 +37,7 @@ export default function MobileMenu({
     const pathname = usePathname();
     const tHome = useTranslations("Home");
     const tNav = useTranslations("Navigation");
+    const tA11y = useTranslations("A11y");
     const menuRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
@@ -69,7 +70,7 @@ export default function MobileMenu({
             <button
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
                 className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-slate-50 text-slate-700 transition-colors hover:bg-slate-100 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300"
-                aria-label="Toggle system parameters"
+                aria-label={tA11y("toggleSystemParameters")}
                 aria-expanded={isMenuOpen}
             >
                 {isMenuOpen ? <X size={16} /> : <Menu size={16} />}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -50,6 +50,18 @@
         "voices_title": "Voices from the SahiDawa community",
         "voices_description": "Families, pharmacists, doctors, and contributors using SahiDawa to make medicine safety easier to act on."
     },
+    "A11y": {
+        "confirmClearConversation": "Confirm clear conversation",
+        "cancelClearConversation": "Cancel clear conversation",
+        "goToHomepage": "Go to homepage",
+        "closeChat": "Close chat",
+        "sendMessage": "Send message",
+        "openAiChat": "Open AI chat",
+        "closeAiChat": "Close AI chat",
+        "mainNavigation": "Main navigation",
+        "mobileNavigation": "Mobile navigation",
+        "toggleSystemParameters": "Toggle system parameters"
+    },
     "Navigation": {
         "how_it_works": "How it Works",
         "alerts": "Alerts",


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

---

## 📋 PR Summary

**Closes #2607**

### Changes Made

* Added a shared **`A11y`** translation namespace in `apps/web/messages/en.json`.
* Replaced the remaining hardcoded English `aria-label` values with `next-intl` translations.
* Introduced `useTranslations("A11y")` in the affected components.
* Updated accessibility labels in:

  * `Chatbot.tsx`
  * `Navbar/DesktopNavLinks.tsx`
  * `Navbar/MobileBottomNav.tsx`
  * `Navbar/MobileMenu.tsx`
* Preserved all existing UI behavior while improving localization and accessibility.

---

## 📸 Proof of Work

* ✅ Verified that only the required files are modified.
* ✅ Accessibility labels are now resolved through `next-intl`.
* ✅ No unrelated backend or API files are included in this PR.

---

## 🏷️ PR Type

* [x] ♻️ `type: refactor`
* [x] ♿ `type: accessibility`

---

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2607`)
* [x] I have pulled the latest `main` and resolved any conflicts.
* [x] Only the required files were modified.
* [x] Replaced remaining hardcoded accessibility labels with localized translations.
