### PR TITLE
fix(web): cap nested chat-markdown list indentation so it doesn't ble…

### DIFF
--- a/apps/web/app/components/ChatMarkdown.tsx
+++ b/apps/web/app/components/ChatMarkdown.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import type { AnchorHTMLAttributes, ComponentPropsWithoutRef } from "react";
+import {
+    createContext,
+    useContext,
+    type AnchorHTMLAttributes,
+    type ComponentPropsWithoutRef,
+} from "react";
 import Markdown, { type MarkdownToJSX } from "markdown-to-jsx";
 import { normalizeChatMarkdown } from "@/lib/chatFormatting";
 
@@ -39,6 +44,42 @@ const MarkdownTable = ({ children }: ComponentPropsWithoutRef<"table">) => (
     </div>
 );
 
+/**
+ * Nested <ul>/<ol> compound their left padding with every ancestor list —
+ * each level adds its own indent on top of the parent's. In a narrow chat
+ * bubble (max-w-[78%]/[85%] of the message column), that compounding used to
+ * eat most of the available width by depth 3-4, squeezing wrapped text into
+ * a thin strip near the bubble's right edge (the "bleeds to the edge"
+ * symptom). ListDepthContext lets nested <ul>/<ol> know how deep they are so
+ * indentation can be capped past a maximum depth, rather than growing
+ * without bound for every additional level the model happens to produce.
+ */
+const ListDepthContext = createContext(0);
+
+const MAX_INDENTED_DEPTH = 3;
+const LIST_INDENT_CLASSES = ["pl-4", "pl-3", "pl-3", "pl-2"];
+
+const getListIndentClass = (depth: number) =>
+    LIST_INDENT_CLASSES[Math.min(depth, MAX_INDENTED_DEPTH)];
+
+const MarkdownList = (tag: "ul" | "ol") =>
+    function List({ children, ...props }: ComponentPropsWithoutRef<"ul" | "ol">) {
+        const depth = useContext(ListDepthContext);
+        const Tag = tag;
+        const listClass = tag === "ul" ? "list-disc" : "list-decimal";
+
+        return (
+            <ListDepthContext.Provider value={depth + 1}>
+                <Tag {...props} className={`${listClass} space-y-1.5 ${getListIndentClass(depth)}`}>
+                    {children}
+                </Tag>
+            </ListDepthContext.Provider>
+        );
+    };
+
+const MarkdownUl = MarkdownList("ul");
+const MarkdownOl = MarkdownList("ol");
+
 const markdownOptions: MarkdownToJSX.Options = {
     disableParsingRawHTML: true,
     overrides: {
@@ -62,14 +103,8 @@ const markdownOptions: MarkdownToJSX.Options = {
             component: "p",
             props: { className: "my-0" },
         },
-        ul: {
-            component: "ul",
-            props: { className: "list-disc space-y-1.5 pl-5" },
-        },
-        ol: {
-            component: "ol",
-            props: { className: "list-decimal space-y-1.5 pl-5" },
-        },
+        ul: MarkdownUl,
+        ol: MarkdownOl,
         li: {
             component: "li",
             props: { className: "pl-1" },

--- a/apps/web/tests/chatMarkdown-render.test.tsx
+++ b/apps/web/tests/chatMarkdown-render.test.tsx
@@ -51,4 +51,54 @@ describe("ChatMarkdown", () => {
         expect(html).not.toContain("javascript:");
         expect(html).toContain("&lt;script&gt;");
     });
+
+    it("indents a deeply nested unordered list without the indentation growing unbounded", () => {
+        const html = renderToStaticMarkup(
+            <ChatMarkdown
+                content={[
+                    "- Level 1 item",
+                    "  - Level 2 item",
+                    "    - Level 3 item",
+                    "      - Level 4 item",
+                ].join("\n")}
+            />
+        );
+
+        // Each nesting level should still produce a real <ul>, so depth is preserved.
+        expect(html.match(/<ul/g)?.length).toBe(4);
+
+        // Top-level list gets the largest indent; indentation should taper
+        // off rather than keep growing once a list nests past a few levels.
+        expect(html).toContain('class="list-disc space-y-1.5 pl-4"');
+        expect(html).toContain('class="list-disc space-y-1.5 pl-3"');
+        expect(html).toContain('class="list-disc space-y-1.5 pl-2"');
+        // The old uncapped behavior (pl-5 at every level) should not appear.
+        expect(html).not.toContain("pl-5");
+    });
+
+    it("caps indentation for an ordered list nested several levels deep", () => {
+        const html = renderToStaticMarkup(
+            <ChatMarkdown
+                content={[
+                    "1. Step one",
+                    "   1. Sub-step A",
+                    "      1. Sub-sub-step",
+                    "         1. Even deeper step",
+                ].join("\n")}
+            />
+        );
+
+        expect(html.match(/<ol/g)?.length).toBe(4);
+        expect(html).toContain('class="list-decimal space-y-1.5 pl-4"');
+        expect(html).toContain('class="list-decimal space-y-1.5 pl-2"');
+    });
+
+    it("keeps a shallow (single-level) list at the default top-level indent", () => {
+        const html = renderToStaticMarkup(
+            <ChatMarkdown content={["- Item one", "- Item two"].join("\n")} />
+        );
+
+        expect(html).toContain('class="list-disc space-y-1.5 pl-4"');
+        expect(html.match(/<ul/g)?.length).toBe(1);
+    });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link
- **Closes:** issue about ChatMarkdown failing to properly indent deeply nested lists (level 3+) from Gemini API output, causing text to bleed to the edge of the chat bubble (not auto-linked)
- **Summary:**
  Fixes nested markdown list indentation in apps/web/app/components/ChatMarkdown.tsx.

  Root cause turned out to differ from the issue's initial diagnosis: indentation wasn't missing — markdown-to-jsx already renders genuinely nested `<ul>`/`<ol>` elements, and each level's `pl-5` padding compounds correctly with its ancestors via normal CSS behavior. The actual bug is that this compounding had no ceiling. By depth 3-4, cumulative left padding (60-80px+) ate most of the available width inside a narrow chat bubble (`max-w-[78%]`/`[85%]` of the message column), squeezing wrapped text into a thin strip near the bubble's right edge — which is what produced the "bleeds to the edge" symptom.

  Fix: replaced the static `ul`/`ol` overrides with depth-aware components (`MarkdownUl`/`MarkdownOl`) that track nesting depth via React context and taper indentation after a max depth, instead of letting it grow unbounded:
  - Depth 0 (top level): `pl-4` (16px)
  - Depth 1: `pl-3` (+12px, 28px total)
  - Depth 2: `pl-3` (+12px, 40px total)
  - Depth 3+: `pl-2` (+8px per level, capped growth)

  Each level still renders a real `<ul>`/`<li>` with visible bullet/number markers, so depth and list semantics are fully preserved — only the indentation rate is capped.

## 📸 Proof of Work (Screenshots / Logs)
No screenshots attached — this is a Tailwind class/indentation change verified via rendered HTML output in tests rather than a visual screenshot capture.

Reproduced the original bug by rendering a 4-level nested list and inspecting the actual output HTML/classes (not guessed) before writing the fix. Added 3 new test cases in apps/web/tests/chatMarkdown-render.test.tsx asserting:
- A 4-level nested `<ul>` produces 4 real `<ul>` elements with tapering indent classes (`pl-4` → `pl-3` → `pl-3` → `pl-2`), and the old uncapped `pl-5` no longer appears anywhere.
- A 4-level nested `<ol>` caps the same way.
- A single-level list still gets the standard top-level indent (no regression for the common case).

All 3 pre-existing tests in that file pass unmodified; 6/6 total passing.

## 🏷️ PR Type
- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [x] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue
- [x] I have pulled the latest `main` and resolved any conflicts