### PR TITLE
fix(web): override default text selection color with brand emerald, W…

### DIFF
--- a/apps/web/app/[locale]/globals.css
+++ b/apps/web/app/[locale]/globals.css
@@ -424,3 +424,33 @@
 ::-webkit-scrollbar-thumb:hover {
     background: rgba(0, 0, 0, 0.4);
 }
+
+/*
+ * Text selection highlight — override the browser default bright blue with
+ * the brand emerald so highlighted text matches the rest of the UI.
+ * --color-text-primary works for the light-mode foreground (dark slate,
+ * 5.77:1 against the emerald background), but it flips to a near-white
+ * value in dark mode that would only hit 2.42:1 against the same
+ * background — short of WCAG AA's 4.5:1 minimum for normal text — so dark
+ * mode gets its own override using --color-dark-surface (near-black) as the
+ * foreground instead, which verifies at 7.04:1.
+ */
+::selection {
+    background-color: var(--color-brand-primary);
+    color: var(--color-text-primary);
+}
+
+::-moz-selection {
+    background-color: var(--color-brand-primary);
+    color: var(--color-text-primary);
+}
+
+.dark ::selection {
+    background-color: var(--color-brand-primary);
+    color: var(--color-dark-surface);
+}
+
+.dark ::-moz-selection {
+    background-color: var(--color-brand-primary);
+    color: var(--color-dark-surface);
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link
- **Closes:** issue about the browser's default bright blue text-selection highlight not matching brand colors (not auto-linked)
- **Summary:**
  Adds a `::selection`/`::-moz-selection` CSS rule in apps/web/app/[locale]/globals.css overriding the browser default highlight with the brand emerald (`--color-brand-primary`, #10b981).

  Contrast was checked rather than assumed, since the issue explicitly called for good contrast:
  - Light mode: emerald background + `--color-text-primary` (dark slate, #1e293b) foreground → 5.77:1, passes WCAG AA's 4.5:1 minimum for normal text.
  - Dark mode: `--color-text-primary` flips to a near-white value (#f8fafc) in `.dark`, which would only hit 2.42:1 against the same emerald background — short of AA. So dark mode gets an explicit `.dark ::selection` override using `--color-dark-surface` (near-black, #0f172a) as the foreground instead, which verifies at 7.04:1.

  No backend or component logic changes, as the issue noted — this is a pure CSS addition appended to the end of the existing stylesheet.

## 📸 Proof of Work (Screenshots / Logs)
> Attach light-mode and dark-mode screenshots here showing selected text using the new emerald highlight color (e.g. select a sentence on any page in both themes).

Contrast verified by calculation (WCAG relative luminance formula) rather than guessed:
- Light mode: 5.77:1
- Dark mode: 7.04:1
- WCAG AA minimum for normal text: 4.5:1

## 🏷️ PR Type
- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [x] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue
- [x] I have pulled the latest `main` and resolved any conflicts