### PR TITLE
fix: remove deprecated scan clipboard fallback

### DIFF
--- a/apps/web/app/[locale]/scan/page.tsx
+++ b/apps/web/app/[locale]/scan/page.tsx
@@ -40,23 +40,15 @@ function formatMedicineDetails(medicine: VerifiedMedicine) {
 }
 
 async function copyTextToClipboard(text: string) {
+    if (!navigator.clipboard?.writeText) {
+        return false;
+    }
+
     try {
-        if (!navigator.clipboard?.writeText) {
-            throw new Error("Clipboard API unavailable");
-        }
         await navigator.clipboard.writeText(text);
         return true;
     } catch {
-        const textArea = document.createElement("textarea");
-        textArea.value = text;
-        textArea.setAttribute("readonly", "");
-        textArea.style.position = "fixed";
-        textArea.style.opacity = "0";
-        document.body.appendChild(textArea);
-        textArea.select();
-        const copied = document.execCommand("copy");
-        document.body.removeChild(textArea);
-        return copied;
+        return false;
     }
 }
 


### PR DESCRIPTION
### ?? STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## ?? PR Summary & Link

- **Closes #2542**
- **Summary:**
  - Removes the deprecated `document.execCommand("copy")` fallback from the Scan page clipboard helper.
  - Uses `navigator.clipboard.writeText` when available.
  - Returns `false` when clipboard access is unavailable or denied so the existing failure toast path remains unchanged.

## ?? Proof of Work (Screenshots / Logs)

Validation run locally:

```bash
npm ci
npx eslint "app/[locale]/scan/page.tsx"
git diff --check
```

Notes:
- This is a non-visual clipboard helper cleanup, so no UI screenshot is needed.
- The repo-wide `quality-check` currently fails on a pre-existing lint error in `apps/web/tests/calculator-search.test.tsx` (`supabase` is imported but unused). This PR intentionally does not touch that unrelated file because the template asks contributors to keep PR file scope limited to the assigned issue.

## ??? PR Type

- [ ] ?? `type: bug`
- [ ] ? `type: feature`
- [ ] ?? `type: docs`
- [ ] ?? `type: testing`
- [ ] ?? `type: security`
- [ ] ? `type: performance`
- [ ] ?? `type: design`
- [x] ?? `type: refactor`
- [ ] ??? `type: devops`
- [ ] ? `type: accessibility`

## ? Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
