### PR TITLE
fix: remove deprecated notification options

### DIFF
--- a/apps/web/lib/expiry-notifications.ts
+++ b/apps/web/lib/expiry-notifications.ts
@@ -264,13 +264,11 @@ export async function cancelNotificationsForMedicine(id: string) {
         const registration = await navigator.serviceWorker.getRegistration();
         if (registration) {
             try {
-                const notifications = await (registration as any).getNotifications({
-                    includeTriggered: true,
-                });
+                const notifications = await registration.getNotifications();
                 const tagsToCancel = [`${id}-7days`, `${id}-1day`];
-                notifications.forEach((n: any) => {
-                    if (tagsToCancel.includes(n.tag)) {
-                        n.close();
+                notifications.forEach((notification) => {
+                    if (tagsToCancel.includes(notification.tag)) {
+                        notification.close();
                     }
                 });
             } catch (e) {

--- a/apps/web/tests/expiry-notifications.test.tsx
+++ b/apps/web/tests/expiry-notifications.test.tsx
@@ -136,10 +136,9 @@ describe("Expiry Tracker Notifications Library", () => {
                 notified1Day: true,
             });
 
-            mockGetNotifications.mockResolvedValue([
-                { tag: "med-1-7days", close: jest.fn() },
-                { tag: "med-2-7days", close: jest.fn() },
-            ]);
+            const matchingNotification = { tag: "med-1-7days", close: jest.fn() };
+            const unrelatedNotification = { tag: "med-2-7days", close: jest.fn() };
+            mockGetNotifications.mockResolvedValue([matchingNotification, unrelatedNotification]);
 
             await cancelNotificationsForMedicine("med-1");
 
@@ -149,10 +148,9 @@ describe("Expiry Tracker Notifications Library", () => {
             expect(item?.notified1Day).toBe(false);
 
             // Verify Sw notifications were fetched and closed
-            expect(mockGetNotifications).toHaveBeenCalledWith({ includeTriggered: true });
-            const notifications = await mockGetNotifications();
-            expect(notifications[0].close).toHaveBeenCalledTimes(1);
-            expect(notifications[1].close).not.toHaveBeenCalled();
+            expect(mockGetNotifications).toHaveBeenCalledWith();
+            expect(matchingNotification.close).toHaveBeenCalledTimes(1);
+            expect(unrelatedNotification.close).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
### ?? STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## ?? PR Summary & Link

- **Closes #2541**
- **Summary:**
  - Removes the deprecated `(registration as any)` cast from expiry notification cancellation.
  - Removes the non-standard `includeTriggered` option from `getNotifications()`.
  - Keeps the existing cancellation behavior by closing notifications with the existing medicine-specific tags.
  - Updates the matching unit test to assert the standard zero-argument `getNotifications()` call.

## ?? Proof of Work (Screenshots / Logs)

Validation run locally:

```bash
npx eslint "lib/expiry-notifications.ts" "tests/expiry-notifications.test.tsx"
npm test -w web -- --runTestsByPath tests/expiry-notifications.test.tsx --runInBand
git diff --check
```

Notes:
- This is a non-visual service worker notification cleanup, so no UI screenshot is needed.
- The repo-wide `quality-check` currently fails on a pre-existing lint error in `apps/web/tests/calculator-search.test.tsx` (`supabase` is imported but unused). This PR intentionally does not touch that unrelated file because the template asks contributors to keep PR file scope limited to the assigned issue.

## ??? PR Type

- [ ] ?? `type: bug`
- [ ] ? `type: feature`
- [ ] ?? `type: docs`
- [x] ?? `type: testing`
- [ ] ?? `type: security`
- [ ] ? `type: performance`
- [ ] ?? `type: design`
- [x] ?? `type: refactor`
- [ ] ??? `type: devops`
- [ ] ? `type: accessibility`

## ? Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
