### PR TITLE
fix: detect preferred recording MIME type for Safari/iOS compatibility

### DIFF
--- a/apps/web/src/hooks/useVoiceVerification.ts
+++ b/apps/web/src/hooks/useVoiceVerification.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
+import { getPreferredRecordingMimeType } from "@/app/[locale]/voice/lib/recording";
 
 type VerificationResult = {
     medicine_name_original: string;
@@ -55,7 +56,8 @@ export function useVoiceVerification(): UseVoiceVerificationReturn {
         setError(null);
         try {
             const form = new FormData();
-            form.append("audio", blob, "recording.webm");
+            const ext = blob.type.includes("mp4") ? "mp4" : "webm";
+            form.append("audio", blob, `recording.${ext}`);
 
             const res = await fetch("/api/medicine/verify-voice", {
                 method: "POST",
@@ -102,7 +104,8 @@ export function useVoiceVerification(): UseVoiceVerificationReturn {
             draw();
 
             // Start MediaRecorder
-            const recorder = new MediaRecorder(stream, { mimeType: "audio/webm" });
+            const mimeType = getPreferredRecordingMimeType(MediaRecorder);
+            const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : {});
             chunksRef.current = [];
 
             recorder.ondataavailable = (e) => {
@@ -114,7 +117,7 @@ export function useVoiceVerification(): UseVoiceVerificationReturn {
                 if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
                 setAudioLevel(0);
 
-                const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+                const blob = new Blob(chunksRef.current, { type: mimeType || "audio/webm" });
                 await sendAudioToApi(blob);
             };
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #2795**
- **Summary:** Fixes two related bugs in `useVoiceVerification.ts` that silently broke voice recording on Safari and iOS. The hook hardcoded `audio/webm` as the `MediaRecorder` MIME type, which Safari/iOS don't support — `MediaRecorder` throws `NotSupportedError`, which was then caught and misreported as "Microphone access denied" even though the mic was never blocked. It also always sent the recorded file to the backend as `recording.webm`, regardless of the actual
recorded format, causing a MIME/extension mismatch on Safari where `audio/mp4` was actually recorded.

  Fix uses the existing `getPreferredRecordingMimeType()` helper from `apps/web/app/[locale]/voice/lib/recording.ts` to detect a supported MIME type at runtime, passes it to `MediaRecorder`, builds the resulting `Blob` with that type, and derives the filename extension (`webm` or `mp4`) from the actual blob type before sending it to the backend.


## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #2795`)
- [x] I have pulled the latest `main` and resolved any conflicts