### PR TITLE
Fix : overlapping z-index issues in PharmacyPanels#2087

### DIFF
--- a/apps/web/app/[locale]/map/PharmacyPanels.tsx
+++ b/apps/web/app/[locale]/map/PharmacyPanels.tsx
@@ -610,7 +610,7 @@ export default function PharmacyPanels({
 
     return (
         <section
-            className={`flex h-full flex-col overflow-hidden rounded-[28px] border border-(--color-border-muted) bg-(--color-surface-page)/96 shadow-xl backdrop-blur-xl ${
+            className={`relative z-10 flex h-full flex-col overflow-hidden rounded-[28px] border border-(--color-border-muted) bg-(--color-surface-page)/96 shadow-xl backdrop-blur-xl ${
                 className || ""
             }`}
         >


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2087 **
- **Summary:**
 The main `<section>` element of the panel had no explicit z-index, allowing it to establish a new context with a potentially higher inferred stacking order when the backdrop-blur-xl or other positioned elements inside were applied.

I've fixed this by assigning the container an explicit class of `relative z-10`. This properly groups the map panels at z-10 layer, allowing any dropdowns, tooltips, or modals `(which typically use z-40 or z-50)` to overlay them correctly across all screen sizes.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
