### PR TITLE
Fix : Counterfeit reports reviewed and approved by admin are excluded from district alert tallies#2817

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -341,9 +341,14 @@ reportsRouter.patch(
                 return;
             }
 
+            const updatePayload: Record<string, unknown> = { status };
+            if (status === "verified_fake" || status === "false_alarm") {
+                updatePayload.is_escalated = false;
+            }
+
             const { data, error } = await supabase
                 .from("counterfeit_reports")
-                .update({ status })
+                .update(updatePayload)
                 .eq("id", req.params.id)
                 .select()
                 .single();

--- a/apps/api/tests/reports.test.ts
+++ b/apps/api/tests/reports.test.ts
@@ -822,5 +822,112 @@ describe("Reports API Routes", () => {
             expect(upsertPayload).not.toBeNull();
             expect(upsertPayload).toHaveProperty("broadcasted", false);
         });
+
+        it("escalated reports that are approved as verified_fake increment the district's verified counterfeit count", async () => {
+            const updatedReport = {
+                id: "report-id-123",
+                district: "Delhi",
+                reported_brand_name: "Fake Medicine",
+                status: "verified_fake",
+                is_escalated: false, // Updated state
+                created_at: "2026-06-01T00:00:00Z",
+            };
+
+            let updatePayload: Record<string, unknown> | null = null;
+            let countQueryExecuted = false;
+            const originalFrom = mockedSupabase.from;
+
+            (mockedSupabase.from as jest.Mock) = jest.fn().mockImplementation((table: string) => {
+                if (table === "counterfeit_reports") {
+                    return {
+                        select: jest.fn().mockImplementation((_cols?: string, opts?: any) => {
+                            if (opts && opts.head) {
+                                return {
+                                    eq: jest.fn().mockReturnValue({
+                                        eq: jest.fn().mockReturnValue({
+                                            eq: jest.fn().mockImplementation((col, val) => {
+                                                if (col === "is_escalated" && val === false) {
+                                                    countQueryExecuted = true;
+                                                    return Promise.resolve({
+                                                        count: 5,
+                                                        error: null,
+                                                    });
+                                                }
+                                                return Promise.resolve({ count: 5, error: null });
+                                            }),
+                                        }),
+                                    }),
+                                };
+                            }
+                            return {
+                                eq: jest.fn().mockReturnValue({
+                                    single: jest.fn().mockResolvedValue({
+                                        data: {
+                                            id: "report-id-123",
+                                            is_escalated: true,
+                                            district: "Delhi",
+                                            reported_brand_name: "Fake Medicine",
+                                        },
+                                        error: null,
+                                    }),
+                                }),
+                            };
+                        }),
+                        update: jest.fn().mockImplementation((payload) => {
+                            updatePayload = payload;
+                            return {
+                                eq: jest.fn().mockReturnValue({
+                                    select: jest.fn().mockReturnValue({
+                                        single: jest
+                                            .fn()
+                                            .mockResolvedValue({
+                                                data: updatedReport,
+                                                error: null,
+                                            }),
+                                    }),
+                                }),
+                            };
+                        }),
+                    };
+                }
+                if (table === "district_alerts") {
+                    return {
+                        select: jest.fn().mockReturnValue({
+                            eq: jest.fn().mockReturnValue({
+                                eq: jest.fn().mockReturnValue({
+                                    maybeSingle: jest.fn().mockResolvedValue({
+                                        data: { alert_level: "low" },
+                                        error: null,
+                                    }),
+                                }),
+                            }),
+                        }),
+                        upsert: jest.fn().mockImplementation((payload: Record<string, unknown>) => {
+                            return {
+                                select: jest.fn().mockReturnValue({
+                                    single: jest.fn().mockResolvedValue({
+                                        data: payload,
+                                        error: null,
+                                    }),
+                                }),
+                            };
+                        }),
+                    };
+                }
+                return {};
+            });
+
+            const response = await request(app)
+                .patch("/api/reports/report-id-123/status")
+                .set("Authorization", "Bearer admin-token")
+                .set("X-Admin", "true")
+                .send({ status: "verified_fake" });
+
+            mockedSupabase.from = originalFrom;
+
+            expect(response.status).toBe(200);
+            expect(updatePayload).toHaveProperty("is_escalated", false);
+            expect(countQueryExecuted).toBe(true);
+        });
     });
 });


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2817**
- **Summary:**
-  Updated the PATCH /:id/status route to inject `is_escalated = false` into the database update when an admin approves a report, we are effectively "resolving" the escalation. The threshold query specifically looks for `.eq("is_escalated", false)`, so stripping this flag means the previously escalated report is now successfully counted toward the district total.
- The logic that evaluates count >= 5 to upsert the district_alerts table and fire the push notification was already correctly structured. Now that the count accurately reflects all verified fake reports (because the approved escalations no longer bypass the is_escalated filter), the alerts will successfully trigger once that sum hits the threshold.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
