### PR TITLE
fix(api): capture request metadata before setImmediate

### DIFF
--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -319,6 +319,9 @@ router.post(
                     "This batch has unusually high scan volume in the last week, increasing the risk of counterfeit reuse."
                 );
             }
+            const clientIp = maskClientIp(req.ip);
+            const userAgent = req.headers["user-agent"] ?? null;
+            const origin = req.headers.origin ?? null;
 
             setImmediate(async () => {
                 const { error: insertError } = await supabase.from("scan_history").insert([
@@ -326,9 +329,9 @@ router.post(
                         batch_number: data.batch_number,
                         medicine_id: data.id,
                         barcode_id: data.barcode_id,
-                        client_ip: maskClientIp(req.ip),
-                        origin: req.headers.origin ?? null,
-                        user_agent: req.headers["user-agent"] ?? null,
+                        client_ip: clientIp,
+                        origin,
+                        user_agent: userAgent,
                         latitude: latitude ?? null,
                         longitude: longitude ?? null,
                     },


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2838**

### Summary

This PR fixes the asynchronous scan logging in the verify route by capturing request metadata before scheduling the `setImmediate` callback.

### Changes Made

- Captured the masked client IP before scheduling the background task.
- Captured the request origin before scheduling the background task.
- Captured the user-agent before scheduling the background task.
- Updated the asynchronous `scan_history` insert to use the captured local variables instead of accessing `req` inside `setImmediate`.

This prevents asynchronous code from referencing the Express request object after the response lifecycle has completed.

## 📸 Proof of Work (Screenshots / Logs)

- Verified that only `apps/api/src/routes/verify.ts` was modified.
- Verified the request metadata is captured synchronously before `setImmediate`.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2838`)
- [x] I have pulled the latest `main` and resolved any conflicts
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [ ] My PR has a linked issue (`Closes #123`)
- [ ] I have pulled the latest `main` and resolved any conflicts
