### PR TITLE
Fix : Schedules summary cache invalidation only clears the current date#2829

### DIFF
--- a/apps/api/src/routes/medicineSchedules.ts
+++ b/apps/api/src/routes/medicineSchedules.ts
@@ -7,17 +7,19 @@ import logger from "../utils/logger";
 import { redisClient } from "../utils/redis";
 
 const router = Router();
-const invalidateTodaySummaryCache = async (userId: string) => {
+const invalidateUserSummaryCaches = async (userId: string) => {
     if (!redisClient.isOpen) return;
 
-    const { today } = getIstDateTime();
-    const cacheKey = `schedules:summary:${userId}:${today}`;
+    const matchPattern = `schedules:summary:${userId}:*`;
 
     try {
-        await redisClient.del(cacheKey);
+        for await (const key of redisClient.scanIterator({ MATCH: matchPattern, COUNT: 100 })) {
+            await redisClient.del(key);
+        }
     } catch (redisErr) {
-        logger.error("Failed to invalidate summary cache", {
+        logger.error("Failed to invalidate user summary caches", {
             error: redisErr,
+            userId,
         });
     }
 };
@@ -128,7 +130,7 @@ router.get("/:id", requireAuth, async (req: AuthenticatedRequest, res: Response)
             res.status(404).json({ error: "Schedule not found" });
             return;
         }
-        await invalidateTodaySummaryCache(req.user!.id);
+        await invalidateUserSummaryCaches(req.user!.id);
         res.json({ schedule: data });
     } catch (err) {
         logger.error("Error fetching schedule", { error: err, scheduleId: req.params.id });
@@ -161,7 +163,7 @@ router.post("/", requireAuth, async (req: AuthenticatedRequest, res: Response) =
             res.status(500).json({ error: "Failed to create schedule" });
             return;
         }
-        await invalidateTodaySummaryCache(req.user!.id);
+        await invalidateUserSummaryCaches(req.user!.id);
         res.status(201).json({ schedule: data });
     } catch (err) {
         logger.error("Error creating schedule", { error: err });
@@ -198,7 +200,7 @@ router.put("/:id", requireAuth, async (req: AuthenticatedRequest, res: Response)
             res.status(404).json({ error: "Schedule not found" });
             return;
         }
-        await invalidateTodaySummaryCache(req.user!.id);
+        await invalidateUserSummaryCaches(req.user!.id);
         res.json({ schedule: data });
     } catch (err) {
         logger.error("Error updating schedule", { error: err, scheduleId: req.params.id });
@@ -219,7 +221,7 @@ router.delete("/:id", requireAuth, async (req: AuthenticatedRequest, res: Respon
             res.status(500).json({ error: "Failed to delete schedule" });
             return;
         }
-        await invalidateTodaySummaryCache(req.user!.id);
+        await invalidateUserSummaryCaches(req.user!.id);
         res.json({ success: true });
     } catch (err) {
         logger.error("Error deleting schedule", { error: err, scheduleId: req.params.id });


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2829 **
- **Summary:**
- I replaced `invalidateTodaySummaryCache` with a new helper, `invalidateUserSummaryCaches`.
- The new helper uses Redis's scanIterator to search for schedules:summary:${userId}:* and efficiently deletes all cached summary keys across all dates that belong to the user.
- I updated the usages of the helper in the GET, POST, PUT, and DELETE endpoints for medicine schedules.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
