### PR TITLE
fix(api): validate medicine_id as UUID in tracking route

### DIFF
--- a/apps/api/src/routes/tracking.ts
+++ b/apps/api/src/routes/tracking.ts
@@ -8,7 +8,7 @@ const router = Router();
 
 // Validation schema
 const trackSchema = z.object({
-    medicine_id: z.string(),
+    medicine_id: z.string().uuid("Invalid medicine ID format"),
     medicine_name: z.string().min(1).max(200),
     batch_number: z.string().max(100).optional(),
     expiry_date: z.string().date(),


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2828**
- **Summary:**
  - Added UUID validation for `medicine_id` in the `/api/v1/medicines/track` endpoint using Zod.
  - Invalid UUIDs are now rejected during request validation with a **400 Bad Request**, preventing unnecessary database queries and PostgreSQL UUID parsing errors.

## 📸 Proof of Work (Screenshots / Logs)

### Before
Invalid `medicine_id` (`"hello"`) bypassed validation and reached the database, resulting in a **500 Internal Server Error**.

<img width="1143" height="666" alt="image" src="https://github.com/user-attachments/assets/a3280a2c-0d24-480b-860a-beb13268a6e0" />

### After
Invalid `medicine_id` is rejected during Zod validation with a **400 Bad Request** and the message:

<img width="1306" height="742" alt="image" src="https://github.com/user-attachments/assets/f6736a45-f9bc-4bdd-9ee7-1ffc16b9fb2e" />

```text
Invalid medicine ID format
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2828`)
- [x] I have pulled the latest `main` and resolved any conflicts.