### PR TITLE
fix(api): prevent duplicate expiry notifications

### DIFF
--- a/apps/api/src/cron/expiry-check.ts
+++ b/apps/api/src/cron/expiry-check.ts
@@ -14,7 +14,7 @@ import {
 function buildExpiryPayload(medicineName: string, daysLeft: number) {
     return {
         title: `Medicine expiring in ${daysLeft} day${daysLeft === 1 ? "" : "s"}`,
-        body: `${medicineName} expires in ${daysLeft} days. Please check your stock.`,
+        body: `${medicineName} expires in ${daysLeft} day${daysLeft === 1 ? "" : "s"}. Please check your stock.`,
         url: "/expiry-tracker",
     };
 }
@@ -23,19 +23,30 @@ export const initExpiryCron = () => {
     // Runs every day at 00:00 (midnight)
     cron.schedule("0 0 * * *", async () => {
         logger.info("Running medicine expiry check...");
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const alertWindows = [
+            { days: 30, min: 15, max: 30 },
+            { days: 14, min: 8, max: 14 },
+            { days: 7, min: 0, max: 7 },
+        ];
+        for (const window of alertWindows) {
+            const days = window.days;
 
-        const alertWindows = [30, 14, 7];
+            const minDate = new Date(today);
+            minDate.setDate(today.getDate() + window.min);
+            minDate.setHours(0, 0, 0, 0);
 
-        for (const days of alertWindows) {
-            const thresholdDate = new Date();
-            thresholdDate.setDate(thresholdDate.getDate() + days);
-
+            const maxDate = new Date(today);
+            maxDate.setDate(today.getDate() + window.max);
+            maxDate.setHours(23, 59, 59, 999);
             const flagColumn = `notified_${days}d`;
 
             const { data, error } = await supabase
                 .from("tracked_medicines")
                 .select("*")
-                .lte("expiry_date", thresholdDate.toISOString())
+                .gte("expiry_date", minDate.toISOString())
+                .lte("expiry_date", maxDate.toISOString())
                 .eq(flagColumn, false);
 
             if (error) {
@@ -49,7 +60,13 @@ export const initExpiryCron = () => {
             for (const medicine of data || []) {
                 try {
                     let delivered = false;
-                    const payload = buildExpiryPayload(medicine.name, days);
+                    const expiry = new Date(medicine.expiry_date);
+
+                    const daysLeft = Math.max(
+                        0,
+                        Math.ceil((expiry.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+                    );
+                    const payload = buildExpiryPayload(medicine.name, daysLeft);
 
                     // --- Web Push ---
                     if (isWebPushConfigured()) {
@@ -105,7 +122,7 @@ export const initExpiryCron = () => {
                             .maybeSingle();
 
                         if (subscriber?.phone) {
-                            const smsMessage = `SahiDawa Alert: ${medicine.name} expires in ${days} days. Please check your stock.`;
+                            const smsMessage = `SahiDawa Alert: ${medicine.name} expires in ${daysLeft} day${daysLeft === 1 ? "" : "s"}. Please check your stock.`;
                             const smsSent = await smsService.send(
                                 subscriber.phone,
                                 smsMessage,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2815**

**Summary:**

This PR fixes duplicate expiry notifications in the medicine expiry cron job.

### Changes Made
- Refactored the expiry alert logic to use non-overlapping notification windows (30-day, 14-day, and 7-day ranges) instead of overlapping `<=` queries.
- Ensured each medicine is notified only once during a single cron execution.
- Calculated the actual remaining days until expiry instead of using the alert threshold value.
- Updated both Push Notification and SMS messages to display the real remaining days (e.g. "expires in 5 days") instead of the threshold label.

## 📸 Proof of Work (Screenshots / Logs)

Backend-only change (no UI screenshots applicable).

### Verification
- Updated `apps/api/src/cron/expiry-check.ts`.
- Verified that medicines close to expiry match only one alert window.
- Verified that notification messages now display the actual remaining days.
- Verified that duplicate notifications are prevented during the same cron execution.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2815`)
- [x] I have pulled the latest `main` and resolved any conflicts.applicable).