### PR TITLE
fix(etl): return non-zero exit code on pipeline failure

### DIFF
--- a/apps/etl/run_all.py
+++ b/apps/etl/run_all.py
@@ -59,7 +59,7 @@ async def run(
     refresh_cdsco: bool = False,
     limit: int = None,
     backfill_ja_price: bool = False,
-) -> dict | None:
+) -> dict | bool:
     _banner("SahiDawa Unified ETL Pipeline")
 
     # ── RETRY MODE ─────────────────────────────────────────────────────────────
@@ -86,7 +86,7 @@ async def run(
         ja_files = sorted(RAW_DIR.glob("janaushadhi_raw_*.csv"))
         if not ja_files:
             logger.error("No existing raw Jan Aushadhi file found. Remove --skip-scrape and try again.")
-            return None
+            return False
         raw_ja_path = ja_files[-1]
         logger.info(f"Using existing Jan Aushadhi raw file: {raw_ja_path.name}")
 
@@ -95,13 +95,13 @@ async def run(
         comm_files = sorted(comm_dir.glob("indian_medicine_data.csv"))
         if not comm_files:
             logger.error("No existing raw Commercial file found. Remove --skip-scrape and try again.")
-            return None
+            return False
         raw_comm_path = comm_files[-1]
         logger.info(f"Using existing Commercial raw file: {raw_comm_path.name}")
 
     if scrape_only:
         logger.info(f"Scrape complete. Jan Aushadhi: {raw_ja_path}, Commercial: {raw_comm_path}")
-        return None
+        return True
 
     # ── STEP 2: NORMALIZE ──────────────────────────────────────────────────────
     logger.info("STEP 2/3 — Normalizing raw data...")
@@ -288,11 +288,21 @@ if __name__ == "__main__":
                         ))
     args = parser.parse_args()
 
-    asyncio.run(run(
-        skip_scrape=args.skip_scrape,
-        scrape_only=args.scrape_only,
-        retry_failed=args.retry_failed,
-        refresh_cdsco=args.refresh_cdsco,
-        limit=args.limit,
-        backfill_ja_price=args.backfill_ja_price,
-    ))
+    try:
+        result = asyncio.run(
+            run(
+                skip_scrape=args.skip_scrape,
+                scrape_only=args.scrape_only,
+                retry_failed=args.retry_failed,
+                refresh_cdsco=args.refresh_cdsco,
+                limit=args.limit,
+                backfill_ja_price=args.backfill_ja_price,
+            )
+        )
+
+        if result is False:
+            sys.exit(1)
+
+    except Exception:
+        logger.exception("ETL pipeline failed")
+        sys.exit(1)


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2823**
- **Summary:**
  - Return explicit execution status from `run()` (`True` for successful early exit, `False` for pipeline failure).
  - Exit with a non-zero status code when the ETL pipeline fails.
  - Log unexpected exceptions before exiting.

## 📸 Proof of Work (Screenshots / Logs)

### Code Changes

- Replaced ambiguous `None` return values with explicit execution status (`True`/`False`) in `run()`.
- Updated the ETL entry point to exit with status code `1` only on actual pipeline failures.
- Added exception logging before exiting on unexpected errors.

### Testing

- **Screenshot 1 (Before - `main`):** `--skip-scrape` with missing raw files logs an error but exits with status code **0**, demonstrating the original bug.

<img width="628" height="119" alt="image" src="https://github.com/user-attachments/assets/ebe75dad-3a00-4496-a12e-86766c041467" />


- **Screenshot 2:** `--skip-scrape` with missing raw files logs an error and exits with status code **1**.

<img width="1294" height="262" alt="image" src="https://github.com/user-attachments/assets/f44b8647-0601-42ed-9fb4-c68004ca7edf" />

- **Screenshot 3:** `--scrape-only` completes successfully and exits with status code **0**.

<img width="1312" height="381" alt="image" src="https://github.com/user-attachments/assets/95d36934-459b-46d8-af61-85e153056e6b" />


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] 🛠️ `type: devops`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2823`)
- [x] I have pulled the latest `main` and resolved any conflicts