### PR TITLE
[Bug/Caching] fix: remove cache invalidation from GET /:id read handler (#2866)

### DIFF
--- a/apps/api/src/routes/medicineSchedules.ts
+++ b/apps/api/src/routes/medicineSchedules.ts
@@ -128,7 +128,6 @@ router.get("/:id", requireAuth, async (req: AuthenticatedRequest, res: Response)
             res.status(404).json({ error: "Schedule not found" });
             return;
         }
-        await invalidateTodaySummaryCache(req.user!.id);
         res.json({ schedule: data });
     } catch (err) {
         logger.error("Error fetching schedule", { error: err, scheduleId: req.params.id });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #2866**
- **Summary:** Removes `invalidateTodaySummaryCache()` call from `GET /:id` handler. Cache invalidation on reads evicts the Redis cache on every schedule view, defeating the summary cache purpose.

## 📸 Proof of Work (Screenshots / Logs)

> N/A — Backend-only change. Verified by code diff.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2866`)
- [x] I have pulled the latest `main` and resolved any conflicts