### PR TITLE
[Bug] fix: remove duplicate GET /reports route registration (#2867)

### DIFF
--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -27,8 +27,6 @@ router.use(limiter);
 
 router.get("/reports", requireAuth, requireRole("admin", "moderator"), getPendingReports);
 const CACHE_INVALIDATION_CHUNK_SIZE = 100;
-
-router.get("/reports", requireAuth, requireRole("admin", "moderator"), getPendingReports);
 router.get("/medicines", requireAuth, requireRole("admin", "moderator"), getAllMedicines);
 router.get(
     "/pharmacies/pending",


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #2867**
- **Summary:** Removes duplicate `router.get("/reports", ...)` registration in admin.routes.ts. Both handlers executed on each request, causing "Cannot set headers after they are sent" errors.

## 📸 Proof of Work (Screenshots / Logs)

> N/A — Backend-only change. Verified by code diff.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2867`)
- [x] I have pulled the latest `main` and resolved any conflicts