### PR TITLE
[Bug/UX] fix: preserve first original name when multiple brands resolve to same generic (#2868)

### DIFF
--- a/apps/api/src/routes/interactions.ts
+++ b/apps/api/src/routes/interactions.ts
@@ -469,7 +469,9 @@ router.post("/check", interactionCheckLimiter, async (req: Request, res: Respons
 
         const genericToOriginalMap = new Map<string, string>();
         resolvedList.forEach((r) => {
-            genericToOriginalMap.set(r.generic.toLowerCase(), r.input);
+            if (!genericToOriginalMap.has(r.generic.toLowerCase())) {
+                genericToOriginalMap.set(r.generic.toLowerCase(), r.input);
+            }
         });
 
         const resolvedGenerics = Array.from(


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #2868**
- **Summary:** Changes `genericToOriginalMap` to preserve the first occurrence instead of overwriting with the last. When "Crocin" and "Calpol" both → "paracetamol", the response now shows "Crocin" as entered.

## 📸 Proof of Work (Screenshots / Logs)

> N/A — Backend-only change. Verified by code diff.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2868`)
- [x] I have pulled the latest `main` and resolved any conflicts