### PR TITLE
fix(db): recreate pharmacy delta function after return type change

### DIFF
--- a/supabase/migrations/20260621000001_add_pharmacy_delta_sync_rpc.sql
+++ b/supabase/migrations/20260621000001_add_pharmacy_delta_sync_rpc.sql
@@ -13,8 +13,15 @@
 -- the rug. A follow-up issue should add a tombstone table or soft-delete
 -- flag if deletions need to propagate to clients holding stale data.
 -- =============================================================================
+DROP FUNCTION IF EXISTS public.get_pharmacies_in_bounds_delta(
+    DOUBLE PRECISION,
+    DOUBLE PRECISION,
+    DOUBLE PRECISION,
+    DOUBLE PRECISION,
+    TIMESTAMP WITH TIME ZONE
+);
 
-CREATE OR REPLACE FUNCTION get_pharmacies_in_bounds_delta(
+CREATE FUNCTION public.get_pharmacies_in_bounds_delta(
   bound_south DOUBLE PRECISION,
   bound_west  DOUBLE PRECISION,
   bound_north DOUBLE PRECISION,

--- a/supabase/migrations/20260622000000_soft_delete_pharmacies.sql
+++ b/supabase/migrations/20260622000000_soft_delete_pharmacies.sql
@@ -114,7 +114,15 @@ $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;
 
 -- Update get_pharmacies_in_bounds_delta to return is_active and deleted_at,
 -- and return soft-deleted pharmacies if since is specified.
-CREATE OR REPLACE FUNCTION get_pharmacies_in_bounds_delta(
+DROP FUNCTION IF EXISTS public.get_pharmacies_in_bounds_delta(
+    DOUBLE PRECISION,
+    DOUBLE PRECISION,
+    DOUBLE PRECISION,
+    DOUBLE PRECISION,
+    TIMESTAMP WITH TIME ZONE
+);
+
+CREATE FUNCTION public.get_pharmacies_in_bounds_delta(
   bound_south DOUBLE PRECISION,
   bound_west  DOUBLE PRECISION,
   bound_north DOUBLE PRECISION,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR *ONLY* touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- *Closes #2872*
- *Summary:*
  - Fixed the migration failure caused by CREATE OR REPLACE FUNCTION get_pharmacies_in_bounds_delta(...) attempting to change the function's RETURNS TABLE definition.
  - Updated the migration to drop the existing function before recreating it with the new return type, allowing the migration chain to proceed successfully.

## 📸 Proof of Work (Screenshots / Logs)

### Before
- Migration failed while applying 20260622000000_soft_delete_pharmacies.sql.
- PostgreSQL error:
  text
  ERROR: cannot change return type of existing function (SQLSTATE 42P13)
  Row type defined by OUT parameters is different.
  
<img width="1285" height="826" alt="image" src="https://github.com/user-attachments/assets/5eced443-4151-4cb2-9877-579f61517a3a" />

### After
- Migration successfully recreates get_pharmacies_in_bounds_delta and continues through the remaining migrations.
- Verified that the migration chain progresses through the remaining migrations up to database seeding.

<img width="625" height="220" alt="image" src="https://github.com/user-attachments/assets/a3f72749-0a0e-4295-ba06-cd0065cd7acf" />


## 🏷️ PR Type

- [x] 🐛 type: bug
- [ ] ✨ type: feature
- [ ] ♻️ type: refactor
- [ ] 🛠️ type: devops
- [ ] ♿ type: accessibility

## ✅ Checklist

- [x] My PR has a linked issue (Closes #2872)
- [x] I have pulled the latest main and resolved any conflicts.