### PR TITLE
fix(compare): support dynamic comparison grid for multiple medicines

### DIFF
--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -327,11 +327,7 @@ export default function ComparePage() {
                         </button>
                     </div>
                 )}
-                <ComparisonGrid
-                    medicine1={medicine1}
-                    medicine2={medicine2}
-                    labels={comparisonLabels}
-                />
+                <ComparisonGrid medicines={selectedMedicines} labels={comparisonLabels} />
                 {selectedIds.length >= 2 && (
                     <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm print:hidden">
                         <div className="mb-4 flex items-start justify-between gap-3">

--- a/apps/web/src/components/ComparisonGrid.tsx
+++ b/apps/web/src/components/ComparisonGrid.tsx
@@ -208,15 +208,15 @@ function shareComparison(medicine1: Medicine | null, medicine2: Medicine | null)
 }
 
 export default function ComparisonGrid({
-    medicine1,
-    medicine2,
+    medicines,
     labels = defaultLabels,
 }: {
-    medicine1: Medicine | null;
-    medicine2: Medicine | null;
+    medicines: (Medicine | null)[];
     labels?: ComparisonGridLabels;
 }) {
-    if (!medicine1 && !medicine2) {
+    const validMedicines = medicines.filter((m): m is Medicine => m !== null);
+
+    if (validMedicines.length === 0) {
         return (
             <div className="rounded-xl border border-dashed border-slate-200 bg-white py-14 text-center text-slate-500">
                 {labels.emptyComparison}
@@ -224,11 +224,17 @@ export default function ComparisonGrid({
         );
     }
 
-    const directComparison = getDirectComparison(medicine1, medicine2);
+    const directComparison =
+        validMedicines.length >= 2
+            ? getDirectComparison(
+                  validMedicines.reduce((a, b) =>
+                      (a.mrp ?? Infinity) < (b.mrp ?? Infinity) ? a : b
+                  ),
+                  validMedicines.reduce((a, b) => ((a.mrp ?? 0) > (b.mrp ?? 0) ? a : b))
+              )
+            : null;
 
-    const flaggedMedicines = [medicine1, medicine2].filter(
-        (m): m is Medicine => m != null && isFlaggedStatus(m.cdsco_approval_status)
-    );
+    const flaggedMedicines = validMedicines.filter((m) => isFlaggedStatus(m.cdsco_approval_status));
 
     const rows: { label: string; getValue: (m: Medicine) => string }[] = [
         { label: labels.rows.brandName, getValue: (m) => m.brand_name?.trim() || "—" },
@@ -286,12 +292,14 @@ export default function ComparisonGrid({
                             <th className="w-1/4 px-5 py-3 text-left text-xs font-semibold tracking-wide text-slate-500 uppercase">
                                 {labels.fieldHeader}
                             </th>
-                            <th className="px-5 py-3 text-center text-sm font-semibold text-slate-800">
-                                {medicine1 ? displayName(medicine1) : labels.medicineA}
-                            </th>
-                            <th className="px-5 py-3 text-center text-sm font-semibold text-slate-800">
-                                {medicine2 ? displayName(medicine2) : labels.medicineB}
-                            </th>
+                            {validMedicines.map((medicine) => (
+                                <th
+                                    key={medicine.id}
+                                    className="px-5 py-3 text-center text-sm font-semibold text-slate-800"
+                                >
+                                    {displayName(medicine)}
+                                </th>
+                            ))}
                         </tr>
                     </thead>
                     <tbody>
@@ -302,42 +310,30 @@ export default function ComparisonGrid({
                                     <td className="px-5 py-3 font-medium text-slate-600">
                                         {label}
                                     </td>
-                                    <td className="px-5 py-3 text-center text-slate-800">
-                                        {medicine1 ? (
-                                            isCdsco ? (
+                                    {validMedicines.map((medicine) => (
+                                        <td
+                                            key={medicine.id}
+                                            className="px-5 py-3 text-center text-slate-800"
+                                        >
+                                            {isCdsco ? (
                                                 <CdscoStatusBadge
-                                                    status={medicine1.cdsco_approval_status}
+                                                    status={medicine.cdsco_approval_status}
                                                 />
                                             ) : (
-                                                getValue(medicine1)
-                                            )
-                                        ) : (
-                                            "—"
-                                        )}
-                                    </td>
-                                    <td className="px-5 py-3 text-center text-slate-800">
-                                        {medicine2 ? (
-                                            isCdsco ? (
-                                                <CdscoStatusBadge
-                                                    status={medicine2.cdsco_approval_status}
-                                                />
-                                            ) : (
-                                                getValue(medicine2)
-                                            )
-                                        ) : (
-                                            "—"
-                                        )}
-                                    </td>
+                                                getValue(medicine)
+                                            )}
+                                        </td>
+                                    ))}
                                 </tr>
                             );
                         })}
                     </tbody>
                 </table>
-                {medicine1 && medicine2 && (
+                {validMedicines.length >= 2 && (
                     <div className="flex justify-end border-t border-slate-200 p-4">
                         <button
                             type="button"
-                            onClick={() => shareComparison(medicine1, medicine2)}
+                            onClick={() => shareComparison(validMedicines[0], validMedicines[1])}
                             className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
                         >
                             Share Comparison

--- a/apps/web/tests/ComparisonGrid.test.tsx
+++ b/apps/web/tests/ComparisonGrid.test.tsx
@@ -30,15 +30,13 @@ describe("ComparisonGrid", () => {
     };
 
     it("renders empty state when no medicines are selected", () => {
-        const markup = renderToStaticMarkup(<ComparisonGrid medicine1={null} medicine2={null} />);
+        const markup = renderToStaticMarkup(<ComparisonGrid medicines={[null, null]} />);
 
         expect(markup).toContain("Select two medicines above to see the comparison.");
     });
 
     it("renders medicine names in table headers", () => {
-        const markup = renderToStaticMarkup(
-            <ComparisonGrid medicine1={medicineA} medicine2={medicineB} />
-        );
+        const markup = renderToStaticMarkup(<ComparisonGrid medicines={[medicineA, medicineB]} />);
 
         expect(markup).toContain("Crocin");
         expect(markup).toContain("Dolo");
@@ -50,26 +48,20 @@ describe("ComparisonGrid", () => {
             brand_name: null,
         };
 
-        const markup = renderToStaticMarkup(
-            <ComparisonGrid medicine1={genericMedicine} medicine2={null} />
-        );
+        const markup = renderToStaticMarkup(<ComparisonGrid medicines={[genericMedicine, null]} />);
 
         expect(markup).toContain("Paracetamol");
     });
 
     it("formats prices correctly", () => {
-        const markup = renderToStaticMarkup(
-            <ComparisonGrid medicine1={medicineA} medicine2={medicineB} />
-        );
+        const markup = renderToStaticMarkup(<ComparisonGrid medicines={[medicineA, medicineB]} />);
 
         expect(markup).toContain("₹100.00");
         expect(markup).toContain("₹25.00");
     });
 
     it("shows savings amount and percentage", () => {
-        const markup = renderToStaticMarkup(
-            <ComparisonGrid medicine1={medicineA} medicine2={medicineB} />
-        );
+        const markup = renderToStaticMarkup(<ComparisonGrid medicines={[medicineA, medicineB]} />);
 
         expect(markup).toContain("Save ₹75.00 (75.0%)");
     });
@@ -81,26 +73,20 @@ describe("ComparisonGrid", () => {
             jan_aushadhi_price: 50,
         };
 
-        const markup = renderToStaticMarkup(
-            <ComparisonGrid medicine1={medicine} medicine2={null} />
-        );
+        const markup = renderToStaticMarkup(<ComparisonGrid medicines={[medicine, null]} />);
 
         expect(markup).toContain("No savings");
     });
 
     it("formats CDSCO status labels", () => {
-        const markup = renderToStaticMarkup(
-            <ComparisonGrid medicine1={medicineA} medicine2={medicineB} />
-        );
+        const markup = renderToStaticMarkup(<ComparisonGrid medicines={[medicineA, medicineB]} />);
 
         expect(markup).toContain("Approved");
         expect(markup).toContain("Recalled");
     });
 
     it("shows a safety alert banner when a medicine is recalled", () => {
-        const markup = renderToStaticMarkup(
-            <ComparisonGrid medicine1={medicineA} medicine2={medicineB} />
-        );
+        const markup = renderToStaticMarkup(<ComparisonGrid medicines={[medicineA, medicineB]} />);
 
         expect(markup).toContain('role="alert"');
         expect(markup).toContain("Safety alert");
@@ -113,9 +99,7 @@ describe("ComparisonGrid", () => {
             cdsco_approval_status: "banned",
         };
 
-        const markup = renderToStaticMarkup(
-            <ComparisonGrid medicine1={bannedMedicine} medicine2={null} />
-        );
+        const markup = renderToStaticMarkup(<ComparisonGrid medicines={[bannedMedicine, null]} />);
 
         expect(markup).toContain('role="alert"');
         expect(markup).toContain("Crocin has been flagged as");
@@ -128,7 +112,7 @@ describe("ComparisonGrid", () => {
         };
 
         const markup = renderToStaticMarkup(
-            <ComparisonGrid medicine1={medicineA} medicine2={approvedMedicine} />
+            <ComparisonGrid medicines={[medicineA, approvedMedicine]} />
         );
 
         expect(markup).not.toContain("Safety alert");
@@ -141,10 +125,24 @@ describe("ComparisonGrid", () => {
             jan_aushadhi_price: null,
         };
 
-        const markup = renderToStaticMarkup(
-            <ComparisonGrid medicine1={medicine} medicine2={null} />
-        );
+        const markup = renderToStaticMarkup(<ComparisonGrid medicines={[medicine, null]} />);
 
         expect(markup).toContain("Price unavailable");
+    });
+
+    it("renders more than two medicines", () => {
+        const medicineC = {
+            ...medicineA,
+            id: "3",
+            brand_name: "Calpol",
+        };
+
+        const markup = renderToStaticMarkup(
+            <ComparisonGrid medicines={[medicineA, medicineB, medicineC]} />
+        );
+
+        expect(markup).toContain("Crocin");
+        expect(markup).toContain("Dolo");
+        expect(markup).toContain("Calpol");
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2824**

### Summary

This PR refactors the comparison grid to support rendering multiple medicines dynamically instead of being limited to two medicines.

### Changes Made

- Refactored `ComparisonGrid` to accept a `medicines: (Medicine | null)[]` prop instead of separate `medicine1` and `medicine2` props.
- Updated the comparison table to dynamically render headers and rows for all selected medicines (up to 6).
- Updated the comparison page to pass the complete `selectedMedicines` array to `ComparisonGrid`.
- Updated the direct comparison summary to work with multiple selected medicines by comparing the lowest and highest priced medicines.
- Updated the existing tests to use the new component API.
- Added test coverage to verify rendering of more than two medicines.

## 📸 Proof of Work (Screenshots / Logs)

- Verified that the comparison grid renders all selected medicines dynamically.
- Verified that adding additional medicine slots displays new comparison columns.
- Verified that existing comparison functionality and safety alerts continue to work correctly.
- Updated tests for the new array-based API.

> _(Attach screenshots/GIFs here before submitting the PR.)_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2824`)
- [x] I have pulled the latest `main` and resolved any conflicts.