### PR TITLE
fix: use upsert with ignoreDuplicates to prevent 500 on duplicate bat…

### DIFF
--- a/apps/api/src/routes/batch.ts
+++ b/apps/api/src/routes/batch.ts
@@ -426,22 +426,28 @@ router.post("/report", batchLimiter, async (req: Request, res: Response) => {
             medicine_id = medicineMatch.id;
         }
 
-        const { error } = await supabase.from("counterfeit_reports").insert({
-            medicine_id,
-            scanned_barcode: barcodeId ?? batchNumber,
-            reported_brand_name: brandName ?? batchNumber,
-            description,
-            city: city ?? null,
-            state: state ?? null,
-            pincode: pincode ?? null,
-            pharmacy_name: pharmacyName ?? null,
-            status: "pending",
-            ip_address: hashedIp ?? null,
-            report_hash: computeReportHash(reportPayload),
-            risk_score: validation.riskScore,
-            is_escalated: validation.riskScore >= 0.6,
-            duplicate_group_id: validation.duplicateGroupId ?? null,
-        });
+        const { data: upserted, error } = await supabase
+            .from("counterfeit_reports")
+            .upsert(
+                {
+                    medicine_id,
+                    scanned_barcode: barcodeId ?? batchNumber,
+                    reported_brand_name: brandName ?? batchNumber,
+                    description,
+                    city: city ?? null,
+                    state: state ?? null,
+                    pincode: pincode ?? null,
+                    pharmacy_name: pharmacyName ?? null,
+                    status: "pending",
+                    ip_address: hashedIp ?? null,
+                    report_hash: computeReportHash(reportPayload),
+                    risk_score: validation.riskScore,
+                    is_escalated: validation.riskScore >= 0.6,
+                    duplicate_group_id: validation.duplicateGroupId ?? null,
+                },
+                { onConflict: "report_hash", ignoreDuplicates: true }
+            )
+            .select();
 
         if (error) {
             logger.error({
@@ -450,6 +456,14 @@ router.post("/report", batchLimiter, async (req: Request, res: Response) => {
                 route: "/api/verify/batch/report",
             });
             res.status(500).json({ error: "Failed to submit report" });
+            return;
+        }
+
+        if (!upserted || upserted.length === 0) {
+            res.status(200).json({
+                success: true,
+                message: "This batch report has already been logged. Thank you for helping keep India safe.",
+            });
             return;
         }
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #2839**
- **Summary:** The `POST /api/verify/batch/report` endpoint used `.insert()` into `counterfeit_reports`, which has a `UNIQUE (report_hash)` constraint. Duplicate submissions triggered a Postgres unique violation, handled generically and returned as a 500.

  Replaced `.insert()` with `.upsert(..., { onConflict: "report_hash", ignoreDuplicates: true })`. When a duplicate is submitted, no row is inserted and the returned data is empty — that case now returns a clean 200 with a "report already logged" message instead of a 500. Real database errors still return 500 as before.


## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #2839`)
- [x] I have pulled the latest `main` and resolved any conflicts