### PR TITLE
fix: prevent silent data loss on failed medicine edit

### DIFF
--- a/apps/web/app/[locale]/expiry-tracker/page.tsx
+++ b/apps/web/app/[locale]/expiry-tracker/page.tsx
@@ -171,8 +171,13 @@ export default function ExpiryTrackerPage() {
             setDateError("");
 
             if (editingId) {
-                await editMedicine(editingId, { name, expiryDate, batchNumber, notes });
-                cancelEdit();
+                try {
+                    await editMedicine(editingId, { name, expiryDate, batchNumber, notes });
+                    cancelEdit();
+                } catch (error) {
+                    console.error("Failed to update medicine:", error);
+                    toast.error("Failed to save changes. Please try again.");
+                }
             } else {
                 await addMedicine({ name, expiryDate, batchNumber, notes });
                 setName("");

--- a/apps/web/hooks/useMedicineTracker.ts
+++ b/apps/web/hooks/useMedicineTracker.ts
@@ -189,11 +189,13 @@ export function useMedicineTracker(): UseMedicineTrackerReturn {
                     })
                     .eq("id", id);
 
-                if (!error) {
-                    setMedicines((prev) => prev.map((m) => (m.id === id ? updatedMed : m)));
-                    await cancelNotificationsForMedicine(id);
-                    scheduleNotificationsForMedicine(updatedMed);
+                if (error) {
+                    throw new Error("Failed to update medicine in Supabase");
                 }
+
+                setMedicines((prev) => prev.map((m) => (m.id === id ? updatedMed : m)));
+                await cancelNotificationsForMedicine(id);
+                scheduleNotificationsForMedicine(updatedMed);
             } else {
                 setMedicines((prev) => {
                     const updated = prev.map((m) => (m.id === id ? updatedMed : m));


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #2880 **
- **Summary:** `editMedicine()` in `useMedicineTracker.ts` silently swallowed Supabase update errors — it only updated local state inside an `if (!error)` check, with no else branch. The caller in `expiry-tracker/page.tsx` always called `cancelEdit()` right after awaiting it, so the edit form closed and reset even when the save failed, silently discarding the user's changes with no feedback.

  Fixed by having `editMedicine()` throw on a Supabase error, matching the existing convention already used by `importMedicines()` in the same hook. The caller now wraps the edit call in try/catch: on success it behaves exactly as before, on failure it shows `toast.error(...)` and skips `cancelEdit()`, keeping the form open with the user's unsaved input intact.


## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #ISSUE_NUMBER`)
- [x] I have pulled the latest `main` and resolved any conflicts