### PR TITLE
Fix : Validated Uploaded Image Integrity in OCR to Prevent DoS#2850

### DIFF
--- a/apps/ml/routers/ocr.py
+++ b/apps/ml/routers/ocr.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, UploadFile, File, HTTPException
 from starlette.concurrency import run_in_threadpool
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 import pytesseract
 import io
 import logging
@@ -35,6 +35,13 @@ async def extract_text(file: UploadFile = File(...)):
     try:
         # Read image content
         contents = await file.read()
+        
+        try:
+            image_to_verify = Image.open(io.BytesIO(contents))
+            image_to_verify.verify()
+        except (UnidentifiedImageError, SyntaxError):
+            raise HTTPException(status_code=400, detail="Invalid or corrupted image file.")
+            
         image = Image.open(io.BytesIO(contents))
 
         # Perform OCR to extract text


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2850 **
- **Summary:**
- Added `UnidentifiedImageError` to the PIL import.
- Added `image.verify()` inside a try...except: Wrapped the verification logic in a try-except block directly after reading the bytes.
- Re-loaded image = `Image.open(io.BytesIO(contents))`  because `.verify()` closes the file and makes the original Image object unusable for `pytesseract`. 

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
