### PR TITLE
fix(api): include missing fields in Haversine fallback

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -663,7 +663,7 @@ router.get(
             const { data: allPharmacies, error: fetchError } = await supabase
                 .from("pharmacies")
                 .select(
-                    "name, address, location, phone_number, is_verified, district, state, status"
+                    "id, name, address, location, phone_number, is_verified, district, state, status, updated_at, is_active, deleted_at"
                 )
                 .eq("status", "approved")
                 .limit(3000);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2831**
- **Summary:**
  - Updated the Haversine fallback query in `apps/api/src/routes/pharmacies.ts` to include the missing `id`, `updated_at`, `is_active`, and `deleted_at` fields.
  - Ensured the fallback path returns the same payload structure as the PostGIS RPC path.
  - Prevented `undefined` values from being returned to clients for these fields.

## 📸 Proof of Work (Screenshots / Logs)

Backend-only change.

Validation performed:
- Verified the fallback query now fetches all fields required by `formatPharmacy`.
-