### PR TITLE
fix(api): include lat/lng coordinates in alternatives cache key to prevent geospatial collisions

### DIFF
--- a/apps/api/src/routes/alternatives.ts
+++ b/apps/api/src/routes/alternatives.ts
@@ -66,9 +66,12 @@ function extractCoordinates(p: StoreLocation): { lat: number; lng: number } {
 router.get("/:medicine_id", barcodeLimiter, async (req: Request, res: Response): Promise<void> => {
     try {
         const medicine_id = req.params.medicine_id as string;
-        const cacheKey = `alt_cache:${medicine_id.toLowerCase()}`;
         const lat = req.query.lat ? parseFloat(req.query.lat as string) : undefined;
         const lng = req.query.lng ? parseFloat(req.query.lng as string) : undefined;
+        const cacheKey =
+            lat !== undefined && lng !== undefined
+                ? `alt_cache:${medicine_id.toLowerCase()}:${lat.toFixed(3)}:${lng.toFixed(3)}`
+                : `alt_cache:${medicine_id.toLowerCase()}`;
 
         if (lat !== undefined && lng !== undefined) {
             if (isNaN(lat) || isNaN(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2888 **
- **Summary:**

1. Identified & Fixed the Bug: In apps/api/src/routes/alternatives.ts, I reordered the variable declarations to parse the lat/lng query parameters before constructing the Redis cache key, and updated the cacheKey to include these coordinates (rounded to 3 decimal places) when they are provided. This limits the cache scope and prevents geospatial collisions.
2. Created Branch: Created the new branch named fix-alternatives-geospatial-cache-key.
3. Validated Changes: Ran the test suite via npm run test --workspace=sahidawa-api which successfully passed all 380 tests.


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2888 `)
- [x] I have pulled the latest `main` and resolved any conflicts
