### PR TITLE
fix: use constant-time comparison for webhook secret verification

### DIFF
--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -1,9 +1,15 @@
 import { Router, Request, Response } from "express";
+import crypto from "crypto";
 import { redisClient } from "../utils/redis";
 import logger from "../utils/logger";
 import { webhookLimiter } from "../middleware/rateLimit";
 
 const router = Router();
+function safeCompare(a: string, b: string): boolean {
+    const hashA = crypto.createHash("sha256").update(a).digest();
+    const hashB = crypto.createHash("sha256").update(b).digest();
+    return crypto.timingSafeEqual(hashA, hashB);
+}
 
 /**
  * POST /api/webhooks/supabase/health-schemes
@@ -17,11 +23,16 @@ router.post(
     "/supabase/health-schemes",
     webhookLimiter,
     async (req: Request, res: Response): Promise<void> => {
-        // Verify secret token
+        // Verify secret token using a timing-safe comparison
         const secret = process.env.SUPABASE_WEBHOOK_SECRET;
         const authHeader = req.headers["authorization"];
 
-        if (!secret || authHeader !== `Bearer ${secret}`) {
+        const isValid =
+            typeof secret === "string" &&
+            typeof authHeader === "string" &&
+            safeCompare(authHeader, `Bearer ${secret}`);
+
+        if (!isValid) {
             logger.warn("Unauthorized webhook attempt on /api/webhooks/supabase/health-schemes", {
                 ip: req.ip,
                 headers: req.headers,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [X] I am assigned to this issue.
- [X] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2827**
- **Summary:**
- Replaced the standard string comparison (`!==`) used to verify the `SUPABASE_WEBHOOK_SECRET` with a constant-time comparison to prevent a timing side-channel attack. Both the incoming auth header and expected secret are hashed with SHA-256 before comparison via `crypto.timingSafeEqual`, since `timingSafeEqual` requires equal-length buffers and the raw header length is attacker-controlled. Also added a type check on `authHeader` since Express headers can be `string | string[] | undefined`.

## 📸 Proof of Work (Screenshots / Logs)
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/504a19e3-195b-4401-a021-99d921dc0e3f" />


> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [X] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [X] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [X] My PR has a linked issue (`Closes #2827`)
- [X] I have pulled the latest `main` and resolved any conflicts
