### PR TITLE
ui/ux fix: Add confirmation dialogs for deleting tracked medicines

### DIFF
--- a/apps/web/app/[locale]/expiry-tracker/page.tsx
+++ b/apps/web/app/[locale]/expiry-tracker/page.tsx
@@ -9,6 +9,7 @@ import { ExpiryForm } from "./components/ExpiryForm";
 import { ExpiryModal } from "./components/ExpiryModal";
 import { ExpirySummary } from "./components/ExpirySummary";
 import { ExpiryTable } from "./components/ExpiryTable";
+import { ConfirmationDialog } from "@/components/ConfirmationDialog";
 import { formatDateInputValue, isValidDateString, parseLocalDate } from "./components/dateUtils";
 import type { FilterStatus, SortOption } from "./components/types";
 import {
@@ -44,6 +45,19 @@ export default function ExpiryTrackerPage() {
     const [sortBy, setSortBy] = useState<SortOption>("expirySoonest");
     const [filterStatus, setFilterStatus] = useState<FilterStatus>("all");
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+    // Confirmation dialog state
+    const [confirmDialog, setConfirmDialog] = useState<{
+        isOpen: boolean;
+        type: "single" | "bulk";
+        medicineId?: string;
+        medicineName?: string;
+        count?: number;
+    }>({
+        isOpen: false,
+        type: "single",
+    });
+    const [isDeleting, setIsDeleting] = useState(false);
 
     // IO / System state
     const [importError, setImportError] = useState<string | null>(null);
@@ -190,15 +204,62 @@ export default function ExpiryTrackerPage() {
         }
     };
 
-    const handleDelete = async (id: string) => {
-        await deleteMedicine(id);
-        if (editingId === id) cancelEdit();
-        setSelectedIds((prev) => {
-            if (!prev.has(id)) return prev;
-            const next = new Set(prev);
-            next.delete(id);
-            return next;
+    const handleDelete = (id: string) => {
+        const medicine = medicines.find((m) => m.id === id);
+        setConfirmDialog({
+            isOpen: true,
+            type: "single",
+            medicineId: id,
+            medicineName: medicine?.name || "this medicine",
         });
+    };
+
+    const confirmDeleteMedicine = async () => {
+        if (confirmDialog.medicineId) {
+            setIsDeleting(true);
+            try {
+                await deleteMedicine(confirmDialog.medicineId);
+                if (editingId === confirmDialog.medicineId) cancelEdit();
+                setSelectedIds((prev) => {
+                    if (!prev.has(confirmDialog.medicineId!)) return prev;
+                    const next = new Set(prev);
+                    next.delete(confirmDialog.medicineId!);
+                    return next;
+                });
+                toast.success("Medicine deleted successfully");
+            } catch (error) {
+                console.error("Failed to delete medicine:", error);
+                toast.error("Failed to delete medicine. Please try again.");
+            } finally {
+                setIsDeleting(false);
+                setConfirmDialog({ isOpen: false, type: "single" });
+            }
+        }
+    };
+
+    const handleBulkDelete = () => {
+        if (selectedIds.size === 0) return;
+        setConfirmDialog({
+            isOpen: true,
+            type: "bulk",
+            count: selectedIds.size,
+        });
+    };
+
+    const confirmBulkDelete = async () => {
+        if (selectedIds.size === 0) return;
+        setIsDeleting(true);
+        try {
+            await bulkDeleteMedicines(Array.from(selectedIds));
+            setSelectedIds(new Set());
+            toast.success(`${selectedIds.size} medicines deleted successfully`);
+        } catch (error) {
+            console.error("Failed to delete medicines:", error);
+            toast.error("Failed to delete medicines. Please try again.");
+        } finally {
+            setIsDeleting(false);
+            setConfirmDialog({ isOpen: false, type: "single" });
+        }
     };
 
     const startEdit = (med: Medicine) => {
@@ -228,12 +289,6 @@ export default function ExpiryTrackerPage() {
             else next.add(id);
             return next;
         });
-    };
-
-    const handleBulkDelete = async () => {
-        if (selectedIds.size === 0) return;
-        await bulkDeleteMedicines(Array.from(selectedIds));
-        setSelectedIds(new Set());
     };
 
     const getDiffDays = (dateStr: string) => {
@@ -471,6 +526,38 @@ export default function ExpiryTrackerPage() {
                 onRetry={() => {
                     setApiError(null);
                 }}
+            />
+
+            {/* Single delete confirmation */}
+            <ConfirmationDialog
+                isOpen={confirmDialog.isOpen && confirmDialog.type === "single"}
+                title={t("deleteConfirmTitle") || "Delete Medicine?"}
+                description={
+                    t("deleteConfirmMessage") ||
+                    `This will permanently remove "${confirmDialog.medicineName}" from your tracked medicines. This action cannot be undone.`
+                }
+                confirmText={t("deleteMedicine") || "Delete"}
+                cancelText={t("cancelButton") || "Cancel"}
+                variant="danger"
+                isLoading={isDeleting}
+                onConfirm={confirmDeleteMedicine}
+                onCancel={() => setConfirmDialog({ isOpen: false, type: "single" })}
+            />
+
+            {/* Bulk delete confirmation */}
+            <ConfirmationDialog
+                isOpen={confirmDialog.isOpen && confirmDialog.type === "bulk"}
+                title={t("bulkDeleteConfirmTitle") || "Delete Multiple Medicines?"}
+                description={
+                    t("bulkDeleteConfirmMessage") ||
+                    `This will permanently remove ${confirmDialog.count} medicine(s) from your tracked list. This action cannot be undone.`
+                }
+                confirmText={t("deleteMedicine") || "Delete All"}
+                cancelText={t("cancelButton") || "Cancel"}
+                variant="danger"
+                isLoading={isDeleting}
+                onConfirm={confirmBulkDelete}
+                onCancel={() => setConfirmDialog({ isOpen: false, type: "single" })}
             />
         </div>
     );

--- a/apps/web/app/[locale]/my-medicines/page.tsx
+++ b/apps/web/app/[locale]/my-medicines/page.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Pill, Plus, Bookmark, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/Badge";
+import { ConfirmationDialog } from "@/components/ConfirmationDialog";
 
 interface TrackedMedicine {
     id: string;
@@ -54,6 +55,13 @@ export default function MyMedicinesPage() {
     const [medicines, setMedicines] = useState<TrackedMedicine[]>([]);
     const [savedMedicines, setSavedMedicines] = useState<BookmarkedMedicine[]>([]);
     const [, setError] = useState<string | null>(null);
+    const [confirmDialog, setConfirmDialog] = useState<{
+        isOpen: boolean;
+        bookmarkName?: string;
+    }>({
+        isOpen: false,
+    });
+    const [isDeleting, setIsDeleting] = useState(false);
 
     useEffect(() => {
         // Fetch tracked medicines from API
@@ -68,9 +76,25 @@ export default function MyMedicinesPage() {
     }, []);
 
     const removeBookmark = (name: string) => {
-        const updated = savedMedicines.filter((item) => item.alternative_name !== name);
-        localStorage.setItem("medicine-bookmarks", JSON.stringify(updated));
-        setSavedMedicines(updated);
+        setConfirmDialog({
+            isOpen: true,
+            bookmarkName: name,
+        });
+    };
+
+    const confirmRemoveBookmark = async () => {
+        if (!confirmDialog.bookmarkName) return;
+        setIsDeleting(true);
+        try {
+            const updated = savedMedicines.filter((item) => item.alternative_name !== confirmDialog.bookmarkName);
+            localStorage.setItem("medicine-bookmarks", JSON.stringify(updated));
+            setSavedMedicines(updated);
+        } catch (error) {
+            console.error("Failed to remove bookmark:", error);
+        } finally {
+            setIsDeleting(false);
+            setConfirmDialog({ isOpen: false });
+        }
     };
 
     const medicinesWithDays = useMemo(
@@ -189,6 +213,19 @@ export default function MyMedicinesPage() {
                     </div>
                 )}
             </section>
+
+            {/* Bookmark deletion confirmation */}
+            <ConfirmationDialog
+                isOpen={confirmDialog.isOpen}
+                title="Remove Bookmark?"
+                description={`This will remove "${confirmDialog.bookmarkName}" from your saved alternatives. You can add it back later if needed.`}
+                confirmText="Remove"
+                cancelText="Cancel"
+                variant="warning"
+                isLoading={isDeleting}
+                onConfirm={confirmRemoveBookmark}
+                onCancel={() => setConfirmDialog({ isOpen: false })}
+            />
         </div>
     );
 }

--- a/apps/web/components/ConfirmationDialog.tsx
+++ b/apps/web/components/ConfirmationDialog.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { AlertTriangle, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
+
+interface ConfirmationDialogProps {
+    isOpen: boolean;
+    title: string;
+    description: string;
+    confirmText?: string;
+    cancelText?: string;
+    variant?: "danger" | "warning";
+    onConfirm: () => void | Promise<void>;
+    onCancel: () => void;
+    isLoading?: boolean;
+}
+
+export function ConfirmationDialog({
+    isOpen,
+    title,
+    description,
+    confirmText = "Delete",
+    cancelText = "Cancel",
+    variant = "danger",
+    onConfirm,
+    onCancel,
+    isLoading = false,
+}: ConfirmationDialogProps) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [isButtonEnabled, setIsButtonEnabled] = useState(false);
+    useFocusTrap(containerRef, isOpen);
+
+    // Enable confirm button after 500ms delay to prevent accidental clicks
+    useEffect(() => {
+        if (!isOpen) {
+            setIsButtonEnabled(false);
+            return;
+        }
+
+        const timer = setTimeout(() => {
+            setIsButtonEnabled(true);
+        }, 500);
+
+        return () => clearTimeout(timer);
+    }, [isOpen]);
+
+    if (!isOpen) return null;
+
+    const handleConfirm = async () => {
+        if (isButtonEnabled && !isLoading) {
+            await onConfirm();
+        }
+    };
+
+    const handleEscape = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === "Escape" && !isLoading) {
+            onCancel();
+        }
+    };
+
+    const accentColor = variant === "danger" ? "red" : "orange";
+    const accentBg =
+        variant === "danger"
+            ? "bg-red-50 dark:bg-red-950/20"
+            : "bg-orange-50 dark:bg-orange-950/20";
+    const accentBorder =
+        variant === "danger"
+            ? "border-red-200 dark:border-red-900"
+            : "border-orange-200 dark:border-orange-900";
+    const accentText =
+        variant === "danger"
+            ? "text-red-700 dark:text-red-300"
+            : "text-orange-700 dark:text-orange-300";
+    const accentIcon =
+        variant === "danger"
+            ? "text-red-600 dark:text-red-400"
+            : "text-orange-600 dark:text-orange-400";
+    const confirmButtonBg =
+        variant === "danger"
+            ? "bg-red-600 hover:bg-red-700 disabled:bg-red-400"
+            : "bg-orange-600 hover:bg-orange-700 disabled:bg-orange-400";
+
+    return (
+        <div
+            ref={containerRef}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="confirmation-title"
+            aria-describedby="confirmation-description"
+            onKeyDown={handleEscape}
+        >
+            <div
+                className={`relative w-full max-w-sm rounded-2xl border ${accentBorder} ${accentBg} p-6 shadow-2xl`}
+            >
+                {/* Close button */}
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    disabled={isLoading}
+                    className="absolute top-4 right-4 rounded-full p-1 text-slate-400 transition-colors hover:bg-slate-200/50 disabled:cursor-not-allowed dark:hover:bg-slate-700/50"
+                    aria-label="Close dialog"
+                >
+                    <X size={20} />
+                </button>
+
+                {/* Header with icon */}
+                <div className="mb-4 flex items-start gap-3">
+                    <div className={`mt-0.5 flex-shrink-0 ${accentIcon}`}>
+                        <AlertTriangle size={24} />
+                    </div>
+                    <div className="flex-1 pr-8">
+                        <h2
+                            id="confirmation-title"
+                            className={`text-lg font-bold ${accentText}`}
+                        >
+                            {title}
+                        </h2>
+                    </div>
+                </div>
+
+                {/* Description */}
+                <p
+                    id="confirmation-description"
+                    className="mb-6 text-sm text-slate-600 dark:text-slate-300"
+                >
+                    {description}
+                </p>
+
+                {/* Action buttons */}
+                <div className="flex gap-3">
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        disabled={isLoading}
+                        className="flex-1 rounded-lg border border-slate-300 bg-white px-4 py-2.5 font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+                    >
+                        {cancelText}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleConfirm}
+                        disabled={!isButtonEnabled || isLoading}
+                        className={`flex-1 rounded-lg px-4 py-2.5 font-medium text-white transition-all ${confirmButtonBg} disabled:cursor-not-allowed disabled:opacity-50`}
+                    >
+                        {isLoading ? "Deleting..." : confirmText}
+                    </button>
+                </div>
+
+                {/* Accessibility hint */}
+                {!isButtonEnabled && (
+                    <p className="sr-only" role="status" aria-live="polite">
+                        Delete button will be available in a moment
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/web/components/ConfirmationDialog.tsx
+++ b/apps/web/components/ConfirmationDialog.tsx
@@ -59,7 +59,6 @@ export function ConfirmationDialog({
         }
     };
 
-    const accentColor = variant === "danger" ? "red" : "orange";
     const accentBg =
         variant === "danger"
             ? "bg-red-50 dark:bg-red-950/20"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -634,7 +634,12 @@
         "pdfExportSuccess": "PDF exported successfully",
         "noMedicinesToDisplay": "No medicines to display",
         "generatedOn": "Generated On",
-        "deleteMedicine": "Delete medicine"
+        "deleteMedicine": "Delete medicine",
+        "cancelButton": "Cancel",
+        "deleteConfirmTitle": "Delete Medicine?",
+        "deleteConfirmMessage": "This will permanently remove \"{medicine}\" from your tracked medicines. This action cannot be undone.",
+        "bulkDeleteConfirmTitle": "Delete Multiple Medicines?",
+        "bulkDeleteConfirmMessage": "This will permanently remove {count} medicine(s) from your tracked list. This action cannot be undone."
     },
     "Login": {
         "brandSubtitle": "Medicine safety platform",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -79,7 +79,12 @@
         "pdfExportSuccess": "PDF सफलतापूर्वक निर्यात हुई",
         "noMedicinesToDisplay": "दिखाने के लिए कोई दवा नहीं",
         "generatedOn": "तैयार तिथि",
-        "deleteMedicine": "दवा हटाएं"
+        "deleteMedicine": "दवा हटाएं",
+        "cancelButton": "रद्द करें",
+        "deleteConfirmTitle": "दवा हटाएं?",
+        "deleteConfirmMessage": "यह \"{medicine}\" को आपकी ट्रैक की गई दवाओं से स्थायी रूप से हटा देगा। यह कार्रवाई पूर्ववत नहीं की जा सकती।",
+        "bulkDeleteConfirmTitle": "कई दवाएं हटाएं?",
+        "bulkDeleteConfirmMessage": "यह आपकी ट्रैक की गई सूची से {count} दवा(ओं) को स्थायी रूप से हटा देगा। यह कार्रवाई पूर्ववत नहीं की जा सकती।"
     },
     "Navigation": {
         "how_it_works": "यह कैसे काम करता है",


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [X] I am assigned to this issue.
- [X] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2918 **
- **Summary:** 
  - Implemented reusable `ConfirmationDialog` component with visual warning indicators and safety features
  - Added confirmation dialogs before deleting tracked medicines (single and bulk operations)
  - Added confirmation dialog before removing bookmarked medicines
  - Includes 500ms delay on confirm button to prevent accidental clicks
  - Added multilingual support (English & Hindi translations)
  - Proper accessibility: focus trap, ARIA labels, keyboard navigation (Escape key)
  - Toast notifications for success/error feedback
  
## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_
<img width="1462" height="770" alt="image" src="https://github.com/user-attachments/assets/748c963e-bda4-473e-ac70-96ec228fa4ed" />
<img width="686" height="320" alt="image" src="https://github.com/user-attachments/assets/e71a282e-c2e0-49d1-802e-a471f8035fdf" />
canceled the above one
now deleting only one medicine
<img width="930" height="398" alt="image" src="https://github.com/user-attachments/assets/f99c2637-24c1-4596-b10f-a99c6b53783d" />
<img width="2448" height="1208" alt="image" src="https://github.com/user-attachments/assets/9cbc82b5-7c90-467c-be7f-d74953c06e60" />



## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [X] 🎨 `type: design`
- [X] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [X] My PR has a linked issue (`Closes #2918 `)
- [X] I have pulled the latest `main` and resolved any conflicts