### PR TITLE
fix(api): strip UTF-8 BOM from CSV content in bulk-upload routes

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -990,11 +990,12 @@ router.post(
                 return;
             }
 
-            const { fileContent } = req.body;
-            if (!fileContent || typeof fileContent !== "string") {
+            const { fileContent: rawFileContent } = req.body;
+            if (!rawFileContent || typeof rawFileContent !== "string") {
                 res.status(400).json({ error: "No valid file data content provided." });
                 return;
             }
+            const fileContent = rawFileContent.replace(/^\uFEFF/, "");
 
             const { data: pharmacy, error: pharmError } = await supabase
                 .from("pharmacies")
@@ -1234,7 +1235,7 @@ router.post(
                 return;
             }
 
-            const fileContent = req.file.buffer.toString("utf-8");
+            const fileContent = req.file.buffer.toString("utf-8").replace(/^\uFEFF/, "");
 
             const lines = fileContent
                 .split(/\r?\n/)

--- a/apps/api/tests/pharmacies.test.ts
+++ b/apps/api/tests/pharmacies.test.ts
@@ -507,3 +507,82 @@ describe("POST /api/pharmacies", () => {
         expect(response.body.error).toBe("Invalid pharmacy payload");
     });
 });
+
+describe("POST /api/pharmacies/bulk-upload — BOM stripping", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("parses CSV with UTF-8 BOM marker correctly", async () => {
+        const csvWithBOM =
+            "\uFEFFmedicine_name,batch_number,expiry_date,quantity,mrp\n" +
+            "Paracetamol 500mg,BATCH001,2027-01-01,100,50\n";
+
+        const fromMock = jest.fn();
+        const selectMock = jest.fn().mockReturnThis();
+        const eqMock = jest.fn().mockReturnThis();
+        const maybeSingleMock = jest.fn().mockResolvedValue({
+            data: { id: "pharmacy-uuid-123" },
+            error: null,
+        });
+        const insertMock = jest.fn().mockResolvedValue({ error: null });
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "pharmacies") {
+                return {
+                    select: selectMock,
+                    eq: eqMock,
+                    maybeSingle: maybeSingleMock,
+                };
+            }
+            if (table === "pharmacy_inventory") {
+                return { insert: insertMock };
+            }
+            return {};
+        });
+
+        const response = await request(app)
+            .post("/api/pharmacies/bulk-upload")
+            .send({ fileContent: csvWithBOM });
+
+        expect(response.status).toBe(200);
+        expect(response.body.successCount).toBe(1);
+        expect(response.body.failedCount).toBe(0);
+    });
+
+    it("parses CSV without BOM marker correctly", async () => {
+        const csvWithoutBOM =
+            "medicine_name,batch_number,expiry_date,quantity,mrp\n" +
+            "Ibuprofen 400mg,BATCH002,2027-06-01,50,30\n";
+
+        const selectMock = jest.fn().mockReturnThis();
+        const eqMock = jest.fn().mockReturnThis();
+        const maybeSingleMock = jest.fn().mockResolvedValue({
+            data: { id: "pharmacy-uuid-123" },
+            error: null,
+        });
+        const insertMock = jest.fn().mockResolvedValue({ error: null });
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "pharmacies") {
+                return {
+                    select: selectMock,
+                    eq: eqMock,
+                    maybeSingle: maybeSingleMock,
+                };
+            }
+            if (table === "pharmacy_inventory") {
+                return { insert: insertMock };
+            }
+            return {};
+        });
+
+        const response = await request(app)
+            .post("/api/pharmacies/bulk-upload")
+            .send({ fileContent: csvWithoutBOM });
+
+        expect(response.status).toBe(200);
+        expect(response.body.successCount).toBe(1);
+        expect(response.body.failedCount).toBe(0);
+    });
+});


### PR DESCRIPTION
## 📋 PR Summary & Link
- **Closes #2830**
- **Summary:** Strips the UTF-8 BOM marker (`\uFEFF`) from CSV file 
  content in both pharmacy inventory bulk-upload routes before parsing. 
  Excel and Windows CSV exporters prepend this marker, causing the first 
  header to be parsed as `\uFEFFmedicine_name` instead of `medicine_name`, 
  silently rejecting every row. Two one-line `.replace(/^\uFEFF/, "")` 
  fixes resolve this. Two test cases added to `pharmacies.test.ts` 
  covering BOM and non-BOM CSV inputs.

## 📸 Proof of Work (Screenshots / Logs)
<img width="1438" height="111" alt="image" src="https://github.com/user-attachments/assets/492a7fef-5bd0-4864-9fce-c44dd32205e0" />


**Files changed:**
- `apps/api/src/routes/pharmacies.ts` — 2 BOM strip fixes
- `apps/api/tests/pharmacies.test.ts` — 2 new test cases

## 🏷️ PR Type
- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #2830`)
- [x] I have pulled the latest `main` and resolved any conflicts