### PR TITLE
fix: improve empty states on map and alerts pages

### DIFF
--- a/apps/web/app/[locale]/alerts/page.tsx
+++ b/apps/web/app/[locale]/alerts/page.tsx
@@ -12,13 +12,13 @@ import {
     ChevronDown,
     ShieldAlert,
     BellOff,
-    RefreshCw,
     Download,
     Building2,
 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import RecallPushSubscriber from "@/components/alerts/RecallPushSubscriber";
 import { CopyButton } from "@/components/ui/CopyButton";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { LiveMessage } from "@/components/ui/LiveMessage";
 import { API_BASE } from "@/lib/api";
 import BackToTopButton from "@/app/[locale]/components/BackToTopButton";
@@ -404,31 +404,26 @@ export default function FullAlertsLogPage() {
                         {t("loading")}
                     </div>
                 ) : allAlerts.length === 0 ? (
-                    <div className="group my-6 flex flex-col items-center justify-center rounded-3xl border border-(--color-border-muted) bg-(--color-surface-page) px-6 py-16 text-center shadow-xs transition-all duration-300 hover:bg-slate-50/50 dark:hover:bg-slate-900/10">
-                        <div className="rounded-full bg-amber-50 p-4 text-amber-600 shadow-inner transition-transform duration-300 group-hover:scale-105 dark:bg-amber-950/30 dark:text-amber-400">
-                            <BellOff className="h-8 w-8" />
-                        </div>
-                        <div className="mt-4 max-w-sm space-y-2">
-                            <h3 className="text-xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
-                                No Active Health Alerts
-                            </h3>
-                            <p className="text-sm leading-relaxed font-medium text-slate-500 dark:text-slate-400">
-                                {error
-                                    ? "Database synchronization error encountered while fetching active logs. Please try checking for sync updates."
-                                    : "The safety registry is clear. No active drug recalls, counterfeit warnings, or banned formulations match your filters."}
-                            </p>
-                        </div>
-                        <div className="pt-6">
-                            <button
-                                type="button"
-                                onClick={() => setRefreshTrigger((prev) => prev + 1)}
-                                className="group/btn inline-flex cursor-pointer items-center gap-2 rounded-xl bg-slate-900 px-5 py-2.5 text-sm font-bold text-white shadow-sm transition-all duration-200 hover:bg-slate-800 hover:shadow-md active:scale-95 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-200"
-                            >
-                                <RefreshCw className="h-4 w-4 transition-transform duration-500 group-hover/btn:rotate-180" />
-                                Check For Sync Updates
-                            </button>
-                        </div>
-                    </div>
+                    <EmptyState
+                        icon={<BellOff className="h-8 w-8" />}
+                        title={
+                            error
+                                ? "We couldn't load alerts right now"
+                                : brandSearch.trim() || regionSearch.trim()
+                                  ? "No alerts match your filters"
+                                  : "No active health alerts"
+                        }
+                        description={
+                            error
+                                ? "The safety registry is temporarily unavailable. Try refreshing to sync the latest reports."
+                                : brandSearch.trim() || regionSearch.trim()
+                                  ? "Try clearing one of your filters or refreshing the feed to see the latest safety updates."
+                                  : "The safety registry is clear right now. No active drug recalls, counterfeit warnings, or banned formulations match your search."
+                        }
+                        actionLabel="Refresh alerts"
+                        onAction={() => setRefreshTrigger((prev) => prev + 1)}
+                        className="my-6 border border-(--color-border-muted) bg-(--color-surface-page) px-6 py-16 shadow-xs"
+                    />
                 ) : (
                     /* --- Alerts List View --- */
                     <div role="feed" className="space-y-4">

--- a/apps/web/app/[locale]/map/PharmacyPanels.tsx
+++ b/apps/web/app/[locale]/map/PharmacyPanels.tsx
@@ -601,6 +601,10 @@ export default function PharmacyPanels({
     onSelectPharmacy,
     onHeatmapModeChange,
     className,
+    emptyStateTitle,
+    emptyStateDescription,
+    emptyStateActionLabel,
+    onEmptyStateAction,
 }: PharmacyPanelsProps) {
     const verifiedCount = pharmacies.filter((pharmacy) => pharmacy.isVerified).length;
     const govtCount = pharmacies.filter((pharmacy) => pharmacy.type === "govt").length;

--- a/apps/web/app/[locale]/map/PharmacyPanels.tsx
+++ b/apps/web/app/[locale]/map/PharmacyPanels.tsx
@@ -38,6 +38,10 @@ export interface PharmacyPanelsProps {
     onSelectPharmacy: (pharmacyId: number) => void;
     onHeatmapModeChange: (mode: HeatmapMode) => void;
     className?: string;
+    emptyStateTitle?: string;
+    emptyStateDescription?: string;
+    emptyStateActionLabel?: string;
+    onEmptyStateAction?: () => void;
 }
 
 export interface TrustBreakdown {
@@ -715,8 +719,13 @@ export default function PharmacyPanels({
                 ) : pharmacies.length === 0 ? (
                     <EmptyState
                         icon={<MapPin size={26} className="text-slate-400" />}
-                        title="No pharmacies found"
-                        description="Try panning the map and pressing “Search this area”"
+                        title={emptyStateTitle ?? "No pharmacies found nearby"}
+                        description={
+                            emptyStateDescription ??
+                            "Try widening the search area or using your current location to find nearby verified stores."
+                        }
+                        actionLabel={emptyStateActionLabel}
+                        onAction={onEmptyStateAction}
                         className="border-none !bg-transparent p-6 shadow-none"
                     />
                 ) : (

--- a/apps/web/app/[locale]/map/page.tsx
+++ b/apps/web/app/[locale]/map/page.tsx
@@ -739,6 +739,10 @@ export default function PharmacyMapPage() {
         setSelectedPharmacyId(pharmacyId);
     }, []);
 
+    const hasActiveMapFilters = Boolean(
+        searchQuery.trim() || activeFilter !== "all" || activeAdvancedFilterCount > 0
+    );
+
     const pharmacyPanelProps = {
         pharmacies: filteredPharmacies,
         isLoading,
@@ -748,6 +752,12 @@ export default function PharmacyMapPage() {
         riskSummaryText,
         onSelectPharmacy: handleSelectPharmacy,
         onHeatmapModeChange: setHeatmapMode,
+        emptyStateTitle: "No pharmacies found nearby",
+        emptyStateDescription: hasActiveMapFilters
+            ? "Try clearing your search or filters, or widen the area to discover more nearby pharmacies."
+            : "Try widening the search area or using your current location to find nearby verified stores.",
+        emptyStateActionLabel: "Use my location",
+        onEmptyStateAction: handleLocateUser,
     };
 
     return (

--- a/apps/web/tests/pharmacy-panels.test.tsx
+++ b/apps/web/tests/pharmacy-panels.test.tsx
@@ -72,11 +72,16 @@ describe("PharmacyPanels", () => {
             pharmacies: [],
             isLoading: false,
             selectedPharmacyId: null,
+            emptyStateTitle: "No pharmacies found nearby",
+            emptyStateDescription:
+                "Try widening the search area or using your current location to find nearby verified stores.",
+            emptyStateActionLabel: "Use my location",
         });
 
         expect(markup).toContain("Nearby Pharmacies");
-        expect(markup).toContain("No pharmacies found");
-        expect(markup).toContain("Search this area");
+        expect(markup).toContain("No pharmacies found nearby");
+        expect(markup).toContain("Try widening the search area or using your current location to find nearby verified stores.");
+        expect(markup).toContain("Use my location");
     });
 
     it("renders the loading state when pharmacies are still being fetched", () => {

--- a/apps/web/tests/pharmacy-panels.test.tsx
+++ b/apps/web/tests/pharmacy-panels.test.tsx
@@ -76,6 +76,7 @@ describe("PharmacyPanels", () => {
             emptyStateDescription:
                 "Try widening the search area or using your current location to find nearby verified stores.",
             emptyStateActionLabel: "Use my location",
+            onEmptyStateAction: () => undefined,
         });
 
         expect(markup).toContain("Nearby Pharmacies");


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2919 **
- **Summary:** Improved the empty-state experience on the map and alerts pages so users get clearer guidance when no pharmacies or alerts are available. The update adds more contextual messages, actionable recovery steps, and a refresh/locate action to help users recover quickly from empty results.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** Please attach screenshots or screen recordings showing the updated empty states on the map and alerts pages.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [x] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [X] My PR has a linked issue (`Closes #2919 `)
- [X] I have pulled the latest `main` and resolved any conflicts