### PR TITLE
fix(login): associate labels with form inputs

### DIFF
--- a/apps/web/app/[locale]/login/page.tsx
+++ b/apps/web/app/[locale]/login/page.tsx
@@ -226,7 +226,10 @@ export default function LoginPage() {
                     <form onSubmit={handleLogin} className="space-y-5">
                         {/* Email */}
                         <div>
-                            <label className="text-sm font-medium text-(--color-text-primary)">
+                            <label
+                                htmlFor="login-email"
+                                className="text-sm font-medium text-(--color-text-primary)"
+                            >
                                 {t("emailLabel")}
                             </label>
 
@@ -234,6 +237,7 @@ export default function LoginPage() {
                                 <Mail className="h-5 w-5 text-(--color-text-muted)" />
 
                                 <input
+                                    id="login-email"
                                     type="email"
                                     placeholder={t("emailPlaceholder")}
                                     value={email}
@@ -247,7 +251,10 @@ export default function LoginPage() {
 
                         {/* Password */}
                         <div>
-                            <label className="text-sm font-medium text-(--color-text-primary)">
+                            <label
+                                htmlFor="login-password"
+                                className="text-sm font-medium text-(--color-text-primary)"
+                            >
                                 {t("passwordLabel")}
                             </label>
 
@@ -255,6 +262,7 @@ export default function LoginPage() {
                                 <Lock className="h-5 w-5 text-(--color-text-muted)" />
 
                                 <input
+                                    id="login-password"
                                     type={showPassword ? "text" : "password"}
                                     placeholder={t("passwordPlaceholder")}
                                     value={password}


### PR DESCRIPTION
## Related Issue
Closes #2922 

## Description

Fixed an accessibility issue on the login page by properly associating form labels with their corresponding input fields.

Previously, the email and password labels were not linked to their respective inputs using `htmlFor` and matching `id` attributes. This prevented users from focusing the input by clicking the label and reduced compatibility with screen readers.

## Changes Made

- Added `id="login-email"` to the email input
- Added `htmlFor="login-email"` to the email label
- Added `id="login-password"` to the password input
- Added `htmlFor="login-password"` to the password label
- Improved accessibility and keyboard usability without changing the UI

## Steps to Test

1. Open the login page
2. Click the **Email** label
3. Verify the email input receives focus
4. Click the **Password** label
5. Verify the password input receives focus
6. Inspect the HTML and confirm each label's `htmlFor` matches the corresponding input `id`
7. Verify screen readers correctly announce the associated labels

## Expected Result

- Clicking a label focuses its corresponding input.
- Labels are correctly associated with their inputs.
- Accessibility is improved for screen reader and keyboard users.

## Files Changed

- `apps/web/app/[locale]/login/page.tsx`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update