### PR TITLE
fix(my-medicines): show API errors instead of empty state

### DIFF
--- a/apps/web/app/[locale]/my-medicines/page.tsx
+++ b/apps/web/app/[locale]/my-medicines/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import { Pill, Plus, Bookmark, Trash2 } from "lucide-react";
+import { Pill, Plus, Bookmark, Trash2, AlertTriangle, RefreshCw } from "lucide-react";
 import { Badge } from "@/components/ui/Badge";
+import { getApiBaseUrl } from "@/lib/env";
 
 interface TrackedMedicine {
     id: string;
@@ -50,22 +51,61 @@ function getStatusColor(daysLeft: number): string {
     return "bg-green-500";
 }
 
+type FetchStatus = "loading" | "success" | "error";
+
 export default function MyMedicinesPage() {
     const [medicines, setMedicines] = useState<TrackedMedicine[]>([]);
     const [savedMedicines, setSavedMedicines] = useState<BookmarkedMedicine[]>([]);
-    const [, setError] = useState<string | null>(null);
+    const [status, setStatus] = useState<FetchStatus>("loading");
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [refreshKey, setRefreshKey] = useState(0);
 
     useEffect(() => {
-        // Fetch tracked medicines from API
-        fetch("/api/v1/medicines/tracked")
-            .then((res) => (res.ok ? res.json() : []))
-            .then((data) => setMedicines(Array.isArray(data) ? data : []))
-            .catch(() => setError("Failed to load tracked medicines."));
+        let cancelled = false;
+
+        const fetchTrackedMedicines = async () => {
+            setStatus("loading");
+            setErrorMessage(null);
+
+            try {
+                const apiBaseUrl = getApiBaseUrl();
+                const res = await fetch(`${apiBaseUrl}/api/v1/medicines/tracked`);
+
+                if (!res.ok) {
+                    throw new Error(
+                        `Request failed with status ${res.status}. Please try again.`
+                    );
+                }
+
+                const data = await res.json();
+
+                if (cancelled) return;
+
+                setMedicines(Array.isArray(data) ? data : []);
+                setStatus("success");
+            } catch (err) {
+                if (cancelled) return;
+
+                setMedicines([]);
+                setStatus("error");
+                setErrorMessage(
+                    err instanceof Error
+                        ? err.message
+                        : "Failed to load tracked medicines. Please check your connection and try again."
+                );
+            }
+        };
+
+        fetchTrackedMedicines();
 
         // Load bookmarks from localStorage
         const bookmarks = getSavedMedicineBookmarks();
         setSavedMedicines(bookmarks);
-    }, []);
+
+        return () => {
+            cancelled = true;
+        };
+    }, [refreshKey]);
 
     const removeBookmark = (name: string) => {
         const updated = savedMedicines.filter((item) => item.alternative_name !== name);
@@ -83,8 +123,40 @@ export default function MyMedicinesPage() {
             {/* Tracked Medicines Section */}
             <section>
                 <h1 className="mb-4 text-2xl font-bold">My Tracked Medicines</h1>
-                {medicines.length === 0 ? (
-                    /* --- Centered Empty State Wrapper --- */
+
+                {status === "loading" ? (
+                    <div className="flex flex-col items-center justify-center space-y-3 rounded-2xl border-2 border-dashed border-slate-200 bg-slate-50/50 px-4 py-16 text-center dark:border-slate-800 dark:bg-slate-900/20">
+                        <div className="h-8 w-8 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
+                        <p className="text-sm text-slate-500 dark:text-slate-400">
+                            Loading your tracked medicines...
+                        </p>
+                    </div>
+                ) : status === "error" ? (
+                    /* --- Error State: never conflated with the empty state --- */
+                    <div className="flex flex-col items-center justify-center space-y-4 rounded-2xl border-2 border-dashed border-red-200 bg-red-50/50 px-4 py-16 text-center dark:border-red-900 dark:bg-red-950/20">
+                        <div className="rounded-full bg-red-100 p-4 text-red-600 dark:bg-red-950/40 dark:text-red-400">
+                            <AlertTriangle className="h-8 w-8" />
+                        </div>
+                        <div className="max-w-sm space-y-1.5">
+                            <h3 className="text-xl font-semibold text-slate-800 dark:text-slate-200">
+                                Couldn&apos;t Load Your Medicines
+                            </h3>
+                            <p className="text-sm text-slate-500 dark:text-slate-400">
+                                {errorMessage ??
+                                    "Something went wrong while fetching your tracked medicines."}
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={() => setRefreshKey((k) => k + 1)}
+                            className="inline-flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-all hover:bg-red-700"
+                        >
+                            <RefreshCw className="h-4 w-4" />
+                            Try Again
+                        </button>
+                    </div>
+                ) : medicines.length === 0 ? (
+                    /* --- Centered Empty State Wrapper (only shown on a confirmed empty result) --- */
                     <div className="flex flex-col items-center justify-center space-y-4 rounded-2xl border-2 border-dashed border-slate-200 bg-slate-50/50 px-4 py-16 text-center dark:border-slate-800 dark:bg-slate-900/20">
                         <div className="rounded-full bg-emerald-50 p-4 text-emerald-600 dark:bg-emerald-950/30 dark:text-emerald-400">
                             <Pill className="h-8 w-8" />


### PR DESCRIPTION
## Related Issue
Closes #2921

## Description

Fixed an issue where the **My Medicines** page displayed the empty state when the medicines API request failed.

Previously, any failure while fetching tracked medicines (such as backend downtime, authentication errors, or an invalid API URL) was treated as an empty response. This caused users to see **"No Medicines Tracked Yet"** even though the actual problem was an API failure.

## Changes Made

- Updated the request to use the configured API base URL
- Added proper error handling for failed API requests
- Displayed a clear error message when the request fails
- Preserved the empty state only when the API successfully returns an empty list
- Improved user feedback for network and backend errors

## Steps to Test

1. Open the **My Medicines** page
2. Stop the backend server or configure an invalid API URL
3. Refresh the page
4. Verify an error message is displayed instead of the empty state
5. Restore the backend and reload the page
6. Verify tracked medicines are displayed correctly
7. Verify the empty state appears only when the API returns no tracked medicines

## Expected Result

- API failures display an appropriate error message.
- Empty state is shown only when there are genuinely no tracked medicines.
- Users can distinguish between an empty list and a failed request.

## Files Changed

- `apps/web/app/[locale]/my-medicines/page.tsx`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update