### PR TITLE
Fix/rate limiting medicine schedules and endpoints

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -193,3 +193,21 @@ export const barcodeLimiter = rateLimit({
         });
     },
 });
+
+// Medicine schedule limiter
+export const scheduleLimiter = createLimiter({
+    windowMs: 15 * 60 * 1000,
+    max: 60,
+    message: "Too many schedule requests. Please try again later.",
+    prefix: "schedules",
+});
+
+// Alerts read limiter
+// GET /api/v1/alerts is unauthenticated and runs paginated DB queries with
+// ILIKE filters. Throttle to prevent enumeration and connection pool exhaustion.
+export const alertsReadLimiter = createLimiter({
+    windowMs: 15 * 60 * 1000,
+    max: 60,
+    message: "Too many alerts requests. Please try again later.",
+    prefix: "alerts_read",
+});

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -8,7 +8,7 @@ import { requireApiKey, ApiKeyRequest } from "../middleware/apiKeyAuth";
 import logger from "../utils/logger";
 import { redisClient } from "../utils/redis";
 import { KEY_PREFIXES } from "../services/cache.service";
-import { limiter } from "../middleware/rateLimit";
+import { limiter, alertsReadLimiter } from "../middleware/rateLimit";
 
 const AlertSchema = z
     .object({
@@ -44,7 +44,7 @@ const alertsRouter = Router();
  *     totalPageCount: number,   // ceil(totalCount / limit)
  *   }
  */
-alertsRouter.get("/", async (req: Request, res: Response) => {
+alertsRouter.get("/", alertsReadLimiter, async (req: Request, res: Response) => {
     const rawPage = parseInt(req.query.page as string, 10);
     const rawLimit = parseInt(req.query.limit as string, 10);
     const brand = req.query.brand as string;

--- a/apps/api/src/routes/medicineSchedules.ts
+++ b/apps/api/src/routes/medicineSchedules.ts
@@ -5,8 +5,10 @@ import { requireAuth } from "../middleware/auth";
 import type { AuthenticatedRequest } from "../middleware/auth";
 import logger from "../utils/logger";
 import { redisClient } from "../utils/redis";
+import { scheduleLimiter } from "../middleware/rateLimit";
 
 const router = Router();
+router.use(scheduleLimiter);
 const invalidateUserSummaryCaches = async (userId: string) => {
     if (!redisClient.isOpen) return;
 

--- a/apps/web/app/api/admin/rate-limit-metrics/route.ts
+++ b/apps/web/app/api/admin/rate-limit-metrics/route.ts
@@ -1,9 +1,11 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
 import { cookies } from "next/headers";
 import { getAdminRoleFromSession } from "@/lib/adminAuth";
 import { Redis } from "@upstash/redis";
+import { rateLimit } from "@/lib/rateLimit";
+import { getClientIp } from "@/lib/getClientIp";
 
 /**
  * GET /api/admin/rate-limit-metrics
@@ -20,8 +22,17 @@ const hasRedisCredentials =
 
 const redis = hasRedisCredentials ? Redis.fromEnv() : null;
 
-export async function GET() {
+export async function GET(req: NextRequest) {
     try {
+        const ip = getClientIp(req);
+        const { success } = await rateLimit.limit(ip);
+        if (!success) {
+            return NextResponse.json(
+                { error: "Too many requests. Please try again later." },
+                { status: 429 }
+            );
+        }
+
         // Security: Verify admin session
         const cookieStore = await cookies();
         const supabase = createServerClient(getSupabaseUrl(), getSupabaseAnonKey(), {

--- a/apps/web/app/api/auth/signout/route.ts
+++ b/apps/web/app/api/auth/signout/route.ts
@@ -1,9 +1,20 @@
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
+import { rateLimit } from "@/lib/rateLimit";
+import { getClientIp } from "@/lib/getClientIp";
 
-export async function POST() {
+export async function POST(req: NextRequest) {
+    const ip = getClientIp(req);
+    const { success } = await rateLimit.limit(ip);
+    if (!success) {
+        return NextResponse.json(
+            { error: "Too many requests. Please try again later." },
+            { status: 429 }
+        );
+    }
+
     const cookieStore = await cookies();
 
     const supabase = createServerClient(getSupabaseUrl(), getSupabaseAnonKey(), {


### PR DESCRIPTION
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- Closes #2938

**Summary:**

- Added `scheduleLimiter` and `alertsReadLimiter` to `rateLimit.ts` (60 req/15 
  min, Redis-backed, using existing `createLimiter()` factory)
- Applied `scheduleLimiter` to all 8 `medicineSchedules.ts` endpoints via 
  `router.use()`
- Applied `alertsReadLimiter` to `alerts.ts` `GET /` (previously unauthenticated 
  with no protection on paginated `ILIKE` queries); `POST /ingest` already had 
  a limiter, untouched
- Added `rateLimit.limit(ip)` check to `auth/signout/route.ts` before Supabase 
  signOut call
- Added `rateLimit.limit(ip)` check to `admin/rate-limit-metrics/route.ts`, 
  running before auth so abuse is rejected before hitting Supabase/Redis

## 📸 Proof of Work (Screenshots / Logs)

<img width="796" height="426" alt="Screenshot 2026-07-02 001328" src="https://github.com/user-attachments/assets/4a5f5d6a-5499-4d56-8a66-70b47ec15e98" />
<img width="756" height="252" alt="Screenshot 2026-07-02 001303" src="https://github.com/user-attachments/assets/82e0cbe2-09dd-4f2a-bee9-61e51d2c14f4" />
<img width="787" height="227" alt="Screenshot 2026-07-02 001252" src="https://github.com/user-attachments/assets/ab7e87ae-c34b-4f33-a175-ad792993eb18" />


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2938`)
- [x] I have pulled the latest `main` and resolved any conflicts
