### PR TITLE
fix: check Supabase error and throw on failed medicine deletion in useMedicineTracker

### DIFF
--- a/apps/web/hooks/useMedicineTracker.ts
+++ b/apps/web/hooks/useMedicineTracker.ts
@@ -214,7 +214,11 @@ export function useMedicineTracker(): UseMedicineTrackerReturn {
         async (id: string) => {
             if (userId) {
                 const itemToDelete = medicines.find((med) => med.id === id);
-                await supabase.from("expiry_tracker_items").delete().eq("id", id);
+                const { error } = await supabase.from("expiry_tracker_items").delete().eq("id", id);
+
+                if (error) {
+                    throw new Error("Failed to delete medicine from database");
+                }
 
                 const saved = localStorage.getItem("sahidawa_expiry_tracker");
                 if (saved) {
@@ -255,7 +259,13 @@ export function useMedicineTracker(): UseMedicineTrackerReturn {
     const bulkDeleteMedicines = useCallback(
         async (ids: string[]) => {
             if (userId) {
-                await supabase.from("expiry_tracker_items").delete().in("id", ids);
+                const { error } = await supabase
+                    .from("expiry_tracker_items")
+                    .delete()
+                    .in("id", ids);
+                if (error) {
+                    throw new Error("Failed to delete medicines from database");
+                }
                 setMedicines((prev) => prev.filter((m) => !ids.includes(m.id)));
             } else {
                 setMedicines((prev) => {


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2893 **
- **Summary:**
1. Updated apps/web/hooks/useMedicineTracker.ts deleteMedicine: Destructured { error } from the Supabase .delete() query. If an error is returned, it now throws an error with the message "Failed to delete medicine from database".

2. bulkDeleteMedicines: Similarly restructured the bulk delete operation to check { error } and throw "Failed to delete medicines from database" on failure.
These changes prevent the local state (localStorage and component React state setMedicines) from being updated if the database delete operation fails.

3. Verification of Calling Components: Inspected the calling code inside page.tsx(in confirmDeleteMedicine and confirmBulkDelete). The UI calls are already wrapped in try...catch blocks that display a descriptive error toast (toast.error) if the hook throws an exception. Consequently, throwing on database failure ensures the UI updates are correctly halted and the user is properly notified.
Successfully ran local TypeScript verification/compilation to ensure there are no build/compiler errors.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
