### PR TITLE
refactor: unify medicine bookmarks into global Zustand store

### DIFF
--- a/apps/web/app/[locale]/my-medicines/page.tsx
+++ b/apps/web/app/[locale]/my-medicines/page.tsx
@@ -6,39 +6,13 @@ import { Badge } from "@/components/ui/Badge";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog";
 import { RequestVerificationModal } from "@/components/RequestVerificationModal";
 import { API_BASE } from "@/lib/api";
+import { useBookmarksStore } from "@/stores/useBookmarksStore";
 
 interface TrackedMedicine {
     id: string;
     medicine_name: string;
     expiry_date: string;
     is_verified: boolean;
-}
-
-// Updated interface to include bookmark data structure
-interface BookmarkedMedicine {
-    alternative_name: string;
-    brand_name: string;
-    jan_aushadhi_price: number;
-}
-
-function getSavedMedicineBookmarks(): BookmarkedMedicine[] {
-    if (typeof window === "undefined") return [];
-
-    try {
-        const stored = localStorage.getItem("medicine-bookmarks");
-        if (!stored) return [];
-
-        const parsed = JSON.parse(stored);
-        if (!Array.isArray(parsed)) {
-            localStorage.setItem("medicine-bookmarks", "[]");
-            return [];
-        }
-
-        return parsed;
-    } catch {
-        localStorage.setItem("medicine-bookmarks", "[]");
-        return [];
-    }
 }
 
 function getDaysUntilExpiry(expiryDate: string): number {
@@ -57,7 +31,9 @@ type FetchStatus = "loading" | "success" | "error";
 
 export default function MyMedicinesPage() {
     const [medicines, setMedicines] = useState<TrackedMedicine[]>([]);
-    const [savedMedicines, setSavedMedicines] = useState<BookmarkedMedicine[]>([]);
+    const bookmarks = useBookmarksStore((state) => state.bookmarks);
+    const removeBookmarkFromStore = useBookmarksStore((state) => state.removeBookmark);
+
     const [confirmDialog, setConfirmDialog] = useState<{
         isOpen: boolean;
         bookmarkName?: string;
@@ -111,10 +87,6 @@ export default function MyMedicinesPage() {
 
         fetchTrackedMedicines();
 
-        // Load bookmarks from localStorage
-        const bookmarks = getSavedMedicineBookmarks();
-        setSavedMedicines(bookmarks);
-
         return () => {
             cancelled = true;
         };
@@ -127,17 +99,11 @@ export default function MyMedicinesPage() {
         });
     };
 
-    const confirmRemoveBookmark = async () => {
+    const confirmRemoveBookmark = () => {
         if (!confirmDialog.bookmarkName) return;
         setIsDeleting(true);
         try {
-            const updated = savedMedicines.filter(
-                (item) => item.alternative_name !== confirmDialog.bookmarkName
-            );
-            localStorage.setItem("medicine-bookmarks", JSON.stringify(updated));
-            setSavedMedicines(updated);
-        } catch (error) {
-            console.error("Failed to remove bookmark:", error);
+            removeBookmarkFromStore(confirmDialog.bookmarkName);
         } finally {
             setIsDeleting(false);
             setConfirmDialog({ isOpen: false });
@@ -269,11 +235,11 @@ export default function MyMedicinesPage() {
                 <h2 className="mb-4 flex items-center gap-2 text-xl font-bold">
                     <Bookmark className="text-emerald-600" /> Saved Alternatives
                 </h2>
-                {savedMedicines.length === 0 ? (
+                {bookmarks.length === 0 ? (
                     <p className="text-slate-500 italic">No bookmarks yet.</p>
                 ) : (
                     <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                        {savedMedicines.map((med) => (
+                        {bookmarks.map((med) => (
                             <div
                                 key={med.alternative_name}
                                 className="flex items-center justify-between rounded-2xl border bg-white p-4 shadow-sm"

--- a/apps/web/components/GenericAlternativeCard.tsx
+++ b/apps/web/components/GenericAlternativeCard.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { TrendingDown, MapPin, Sparkles, ArrowRight, Pill, Bookmark } from "lucide-react";
 import { useRouter, useParams } from "next/navigation";
+import { useBookmarksStore } from "@/stores/useBookmarksStore";
 
 export interface NearestStore {
     name: string;
@@ -23,53 +24,23 @@ interface GenericAlternativeCardProps {
     alternative: GenericAlternative;
 }
 
-function getSavedMedicineBookmarks(): GenericAlternative[] {
-    if (typeof window === "undefined") return [];
-
-    try {
-        const stored = localStorage.getItem("medicine-bookmarks");
-        if (!stored) return [];
-
-        const parsed = JSON.parse(stored);
-        if (!Array.isArray(parsed)) {
-            localStorage.setItem("medicine-bookmarks", "[]");
-            return [];
-        }
-
-        return parsed;
-    } catch {
-        localStorage.setItem("medicine-bookmarks", "[]");
-        return [];
-    }
-}
-
 export default function GenericAlternativeCard({ alternative }: GenericAlternativeCardProps) {
     const router = useRouter();
     const params = useParams();
     const locale = Array.isArray(params.locale) ? params.locale[0] : params.locale || "en";
 
-    const [isBookmarked, setIsBookmarked] = useState(false);
-
-    useEffect(() => {
-        const saved = getSavedMedicineBookmarks();
-        const exists = saved.some(
-            (item: GenericAlternative) => item.alternative_name === alternative.alternative_name
-        );
-        setIsBookmarked(exists);
-    }, [alternative.alternative_name]);
+    const isBookmarked = useBookmarksStore((state) =>
+        state.isBookmarked(alternative.alternative_name)
+    );
+    const addBookmark = useBookmarksStore((state) => state.addBookmark);
+    const removeBookmark = useBookmarksStore((state) => state.removeBookmark);
 
     const handleBookmark = () => {
-        const saved = getSavedMedicineBookmarks();
         if (isBookmarked) {
-            const filtered = saved.filter(
-                (item: GenericAlternative) => item.alternative_name !== alternative.alternative_name
-            );
-            localStorage.setItem("medicine-bookmarks", JSON.stringify(filtered));
+            removeBookmark(alternative.alternative_name);
         } else {
-            saved.push(alternative);
-            localStorage.setItem("medicine-bookmarks", JSON.stringify(saved));
+            addBookmark(alternative);
         }
-        setIsBookmarked(!isBookmarked);
     };
 
     const brandPrice = alternative.brand_price;

--- a/apps/web/src/stores/useBookmarksStore.ts
+++ b/apps/web/src/stores/useBookmarksStore.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { GenericAlternative } from "@/components/GenericAlternativeCard";
+
+interface BookmarksState {
+    bookmarks: GenericAlternative[];
+    addBookmark: (medicine: GenericAlternative) => void;
+    removeBookmark: (medicineName: string) => void;
+    isBookmarked: (medicineName: string) => boolean;
+}
+
+export const useBookmarksStore = create<BookmarksState>()(
+    persist(
+        (set, get) => ({
+            bookmarks: [],
+
+            addBookmark: (medicine) =>
+                set((state) => {
+                    const alreadyExists = state.bookmarks.some(
+                        (item) => item.alternative_name === medicine.alternative_name
+                    );
+                    if (alreadyExists) return state;
+                    return { bookmarks: [...state.bookmarks, medicine] };
+                }),
+
+            removeBookmark: (medicineName) =>
+                set((state) => ({
+                    bookmarks: state.bookmarks.filter(
+                        (item) => item.alternative_name !== medicineName
+                    ),
+                })),
+
+            isBookmarked: (medicineName) =>
+                get().bookmarks.some((item) => item.alternative_name === medicineName),
+        }),
+        {
+            name: "medicine-bookmarks",
+        }
+    )
+);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [X] I am assigned to this issue.
- [X] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2813**
- **Summary:**
-  Unified medicine bookmark logic into a single Zustand store (`useBookmarksStore`) with persist middleware, replacing duplicated localStorage parsing across `MyMedicinesPage` and `GenericAlternativeCard`. Bookmarking a medicine now reflects instantly across both views without a page reload.

## 📸 Proof of Work (Screenshots / Logs)
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/4e48c7eb-f07e-41aa-b1d0-3cf0628baa64" />


> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [X] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [X] My PR has a linked issue (`Closes #2813`)
- [X] I have pulled the latest `main` and resolved any conflicts
