### PR TITLE
fix(#2982): scope pharmacy cache by search parameters

### DIFF
--- a/apps/web/app/[locale]/map/page.tsx
+++ b/apps/web/app/[locale]/map/page.tsx
@@ -36,7 +36,12 @@ import { type AshaWorker } from "./PharmacyMap";
 import MapHeaderLoadingIndicator from "./MapHeaderLoadingIndicator";
 import { useOfflineStatus } from "@/hooks/useOfflineStatus";
 import { getOpenNowStatus } from "../../../lib/openingHours";
-import { buildCacheKey, saveToCache, loadFromCache } from "./usePharmacyCache";
+import {
+    buildNearbyCacheKey,
+    buildBoundsCacheKey,
+    saveToCache,
+    loadFromCache,
+} from "./usePharmacyCache";
 import {
     getCachedPharmacies,
     getLastSyncTimestamp,
@@ -376,7 +381,7 @@ export default function PharmacyMapPage() {
             setShowSearchArea(false);
             try {
                 const radiusKm = Math.round(radius / 1000);
-                const cacheKey = buildCacheKey(lat, lng);
+                const cacheKey = buildNearbyCacheKey(lat, lng, radius);
                 const [verifiedResult, osmResult, ashaResult] = await Promise.allSettled([
                     fetchVerifiedPharmacies(lat, lng, radiusKm),
                     fetchPharmacies(lat, lng, radius),
@@ -426,7 +431,7 @@ export default function PharmacyMapPage() {
                 console.error("Critical error in pharmacy rendering:", err);
 
                 // ── Offline fallback: try loading from IndexedDB ──────────────
-                const cacheKey = buildCacheKey(lat, lng);
+                const cacheKey = buildNearbyCacheKey(lat, lng, radius);
                 if (await restoreFromCache(cacheKey)) {
                     return;
                 }
@@ -495,7 +500,7 @@ export default function PharmacyMapPage() {
                 const centerLat = bounds.center.lat;
                 const centerLng = bounds.center.lng;
                 const radiusKm = 15;
-                const cacheKey = buildCacheKey(centerLat, centerLng);
+                const cacheKey = buildBoundsCacheKey(bounds);
                 const cachedVerified = await getCachedPharmacies(cacheKey);
                 if (cachedVerified.length > 0) {
                     await hydrateSyncedPharmacies(cacheKey);
@@ -574,9 +579,7 @@ export default function PharmacyMapPage() {
                 console.error("Critical error in bound pharmacy rendering:", err);
 
                 // ── Offline fallback for bounds fetch ─────────────────────────
-                const centerLat = bounds.center.lat;
-                const centerLng = bounds.center.lng;
-                const cacheKey = buildCacheKey(centerLat, centerLng);
+                const cacheKey = buildBoundsCacheKey(bounds);
                 if (await restoreFromCache(cacheKey)) {
                     return;
                 }

--- a/apps/web/app/[locale]/map/usePharmacyCache.ts
+++ b/apps/web/app/[locale]/map/usePharmacyCache.ts
@@ -12,6 +12,13 @@ interface CacheEntry {
     timestamp: number;
 }
 
+interface PharmacyBounds {
+    south: number;
+    west: number;
+    north: number;
+    east: number;
+}
+
 function isFresh(entry: CacheEntry | undefined): entry is CacheEntry {
     if (!entry) return false;
     return Date.now() - entry.timestamp <= TTL_MS;
@@ -28,9 +35,24 @@ async function getDB() {
     });
 }
 
-export function buildCacheKey(lat: number, lng: number): string {
-    // Round to 2 decimal places (~1km precision)
-    return `${lat.toFixed(2)}_${lng.toFixed(2)}`;
+function normalizeRadiusKm(radiusMeters: number): number {
+    const radiusKm = Math.round(radiusMeters / 1000);
+    return Number.isFinite(radiusKm) && radiusKm > 0 ? radiusKm : 10;
+}
+
+export function buildNearbyCacheKey(lat: number, lng: number, radiusMeters: number): string {
+    // Round coordinates consistently while keeping radius-specific searches isolated.
+    return `nearby:${lat.toFixed(2)}:${lng.toFixed(2)}:r:${normalizeRadiusKm(radiusMeters)}`;
+}
+
+export function buildBoundsCacheKey(bounds: PharmacyBounds): string {
+    return [
+        "bounds",
+        bounds.south.toFixed(3),
+        bounds.west.toFixed(3),
+        bounds.north.toFixed(3),
+        bounds.east.toFixed(3),
+    ].join(":");
 }
 
 export async function saveToCache(
@@ -53,9 +75,6 @@ export async function loadFromCache(key: string): Promise<CacheEntry | null> {
         const db = await getDB();
         const entry: CacheEntry | undefined = await db.get(STORE, key);
         if (isFresh(entry)) return entry;
-
-        const lastSearchEntry: CacheEntry | undefined = await db.get(STORE, LAST_SEARCH_KEY);
-        if (isFresh(lastSearchEntry)) return lastSearchEntry;
 
         return null;
     } catch (err) {

--- a/apps/web/tests/usePharmacyCache.test.ts
+++ b/apps/web/tests/usePharmacyCache.test.ts
@@ -1,7 +1,8 @@
 import type { AshaWorker, Pharmacy } from "../app/[locale]/map/PharmacyMap";
 import type * as PharmacyCache from "../app/[locale]/map/usePharmacyCache";
 
-let buildCacheKey: typeof PharmacyCache.buildCacheKey;
+let buildNearbyCacheKey: typeof PharmacyCache.buildNearbyCacheKey;
+let buildBoundsCacheKey: typeof PharmacyCache.buildBoundsCacheKey;
 let loadFromCache: typeof PharmacyCache.loadFromCache;
 let saveToCache: typeof PharmacyCache.saveToCache;
 let openDBMock: jest.Mock;
@@ -43,7 +44,7 @@ describe("usePharmacyCache", () => {
             { virtual: true }
         );
 
-        ({ buildCacheKey, loadFromCache, saveToCache } =
+        ({ buildNearbyCacheKey, buildBoundsCacheKey, loadFromCache, saveToCache } =
             await import("../app/[locale]/map/usePharmacyCache"));
         jest.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
     });
@@ -60,7 +61,7 @@ describe("usePharmacyCache", () => {
             createObjectStore: jest.fn(),
         } as never);
 
-        const key = buildCacheKey(28.6139, 77.209);
+        const key = buildNearbyCacheKey(28.6139, 77.209, 10_000);
         await saveToCache(key, samplePharmacies, sampleAshaWorkers);
 
         expect(openDBMock).toHaveBeenCalledWith(
@@ -75,7 +76,7 @@ describe("usePharmacyCache", () => {
                 ashaWorkers: sampleAshaWorkers,
                 timestamp: 1_800_000_000_000,
             },
-            "28.61_77.21"
+            "nearby:28.61:77.21:r:10"
         );
         expect(put).toHaveBeenCalledWith(
             "pharmacy-results",
@@ -88,21 +89,49 @@ describe("usePharmacyCache", () => {
         );
     });
 
-    it("returns cached markers when live network loading fails", async () => {
+    it("returns cached markers for matching search parameters", async () => {
         const entry = {
             pharmacies: samplePharmacies,
             ashaWorkers: sampleAshaWorkers,
             timestamp: 1_800_000_000_000,
         };
-        const get = jest.fn().mockResolvedValueOnce(undefined).mockResolvedValueOnce(entry);
+        const get = jest.fn().mockResolvedValueOnce(entry);
         openDBMock.mockResolvedValue({
             get,
             objectStoreNames: { contains: jest.fn() },
             createObjectStore: jest.fn(),
         } as never);
 
-        await expect(loadFromCache("28.99_77.99")).resolves.toEqual(entry);
-        expect(get).toHaveBeenNthCalledWith(1, "pharmacy-results", "28.99_77.99");
-        expect(get).toHaveBeenNthCalledWith(2, "pharmacy-results", "last-search");
+        const key = buildNearbyCacheKey(28.6139, 77.209, 10_000);
+
+        await expect(loadFromCache(key)).resolves.toEqual(entry);
+        expect(get).toHaveBeenCalledTimes(1);
+        expect(get).toHaveBeenCalledWith("pharmacy-results", "nearby:28.61:77.21:r:10");
+    });
+
+    it("scopes cache keys by radius and bounds", () => {
+        expect(buildNearbyCacheKey(28.6139, 77.209, 1_000)).toBe("nearby:28.61:77.21:r:1");
+        expect(buildNearbyCacheKey(28.6139, 77.209, 25_000)).toBe("nearby:28.61:77.21:r:25");
+        expect(
+            buildBoundsCacheKey({
+                south: 28.60123,
+                west: 77.19876,
+                north: 28.68987,
+                east: 77.27891,
+            })
+        ).toBe("bounds:28.601:77.199:28.690:77.279");
+    });
+
+    it("does not restore an unrelated last-search entry for a scoped cache miss", async () => {
+        const get = jest.fn().mockResolvedValueOnce(undefined);
+        openDBMock.mockResolvedValue({
+            get,
+            objectStoreNames: { contains: jest.fn() },
+            createObjectStore: jest.fn(),
+        } as never);
+
+        await expect(loadFromCache("nearby:28.61:77.21:r:25")).resolves.toBeNull();
+        expect(get).toHaveBeenCalledTimes(1);
+        expect(get).toHaveBeenCalledWith("pharmacy-results", "nearby:28.61:77.21:r:25");
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #2982**
* **Summary:**

  * Fixed Pharmacy Map offline cache collisions by scoping cache keys to search parameters.
  * Added radius-aware cache keys for nearby pharmacy searches.
  * Added bounds-aware cache keys for "Search this area" searches.
  * Removed restoration of unrelated `last-search` cache entries to prevent stale or mismatched pharmacy results from being shown offline.
  * Added tests covering radius-specific cache keys, bounds-specific cache keys, and scoped cache restoration behavior.

## 📸 Proof of Work (Screenshots / Logs)

### Test Results

```text
PASS tests/usePharmacyCache.test.ts

✓ stores successful pharmacy API results in the sahidawa offline cache database
✓ returns cached markers for matching search parameters
✓ scopes cache keys by radius and bounds
✓ does not restore an unrelated last-search entry for a scoped cache miss

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```

## 🏷️ PR Type

* [x] 🐛 `type: bug`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #2982`)
* [x] I have pulled the latest `main` and resolved any conflicts