### PR TITLE
fix(security): replace pbkdf2Sync with async pbkdf2 in API key middle…

### DIFF
--- a/apps/api/src/middleware/apiKeyAuth.ts
+++ b/apps/api/src/middleware/apiKeyAuth.ts
@@ -1,7 +1,10 @@
 import { Request, Response, NextFunction } from "express";
-import crypto from "crypto";
+import crypto, { pbkdf2 } from "crypto";
+import { promisify } from "util";
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
+
+const pbkdf2Async = promisify(pbkdf2);
 
 export interface ApiKeyInfo {
     keyId: string;
@@ -21,9 +24,12 @@ export const requireApiKey = async (req: ApiKeyRequest, res: Response, next: Nex
         return;
     }
 
-    const keyHash = crypto
-        .pbkdf2Sync(apiKey, "sahidawa-api-key-v1", 100000, 64, "sha512")
-        .toString("hex");
+    // Use the async pbkdf2 variant to avoid blocking the Node.js event loop.
+    // pbkdf2Sync with 100k iterations can stall the server for 200-500ms per
+    // request, creating a CPU-based DoS vector. The async version offloads the
+    // computation to libuv's thread pool, keeping the event loop responsive.
+    const keyHashBuffer = await pbkdf2Async(apiKey, "sahidawa-api-key-v1", 100000, 64, "sha512");
+    const keyHash = keyHashBuffer.toString("hex");
 
     try {
         const { data, error } = await supabase


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #2989**
- **Summary:** The `requireApiKey` middleware was calling `crypto.pbkdf2Sync()` with 100,000 iterations synchronously on the main Node.js event loop thread on every protected API request. This blocks all other request processing for ~200–500ms, creating a CPU-based DoS vector.

  This PR replaces `crypto.pbkdf2Sync` with the async `crypto.pbkdf2` wrapped via `util.promisify`. The async version offloads the computation to **libuv's thread pool**, completely freeing the event loop during hashing. The salt, iteration count, key length, and digest algorithm are all kept identical, so existing hashed keys in the database remain fully compatible.

## 📸 Proof of Work (Screenshots / Logs)

This is a backend security/performance fix with no UI. Verified via:
- `npm run build -w apps/api` — TypeScript compilation passes with 0 errors ✅
- The hashing parameters (`sahidawa-api-key-v1`, 100000 iterations, 64 bytes, sha512) are unchanged, so no database migration or key re-hashing is required.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2989`)
- [x] I have pulled the latest `main` and resolved any conflicts