### PR TITLE
fix(vaccine): prevent calendar export timezone date shift

### DIFF
--- a/apps/web/app/[locale]/vaccine-hub/page.tsx
+++ b/apps/web/app/[locale]/vaccine-hub/page.tsx
@@ -91,9 +91,9 @@ export default function VaccineHubPage() {
 
         const dtstamp = new Date();
         const formatICSDate = (d: Date) =>
-            d.getUTCFullYear().toString() +
-            String(d.getUTCMonth() + 1).padStart(2, "0") +
-            String(d.getUTCDate()).padStart(2, "0");
+            d.getFullYear().toString() +
+            String(d.getMonth() + 1).padStart(2, "0") +
+            String(d.getDate()).padStart(2, "0");
 
         const formatICSDateTime = (d: Date) =>
             d.getUTCFullYear().toString() +
@@ -107,11 +107,12 @@ export default function VaccineHubPage() {
 
         const events = vaccine.dosing_intervals_weeks
             .map((weeks, index) => {
-                const date = new Date(initialDate);
-                date.setUTCDate(date.getUTCDate() + weeks * 7);
+                const [year, month, day] = initialDate.split("-").map(Number);
+                const date = new Date(year, month - 1, day);
+                date.setDate(date.getDate() + weeks * 7);
 
-                const endDate = new Date(date);
-                endDate.setUTCDate(endDate.getUTCDate() + 1);
+                const endDate = new Date(date.getTime());
+                endDate.setDate(endDate.getDate() + 1);
 
                 const uidKey = selectedVaccine || vaccine.disease_name.replace(/\s+/g, "-");
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2819**

### Summary

This PR fixes a timezone-related issue in the Vaccine Hub calendar export where all-day (`VALUE=DATE`) events could shift by one day depending on the user's local timezone.

### Changes

- Replaced timezone-dependent parsing of `YYYY-MM-DD` with manual parsing of the year, month, and day components.
- Constructed local `Date` objects from the parsed values.
- Updated the calendar export logic to use local date getters and setters instead of UTC-based methods.
- Preserved the existing UI behavior.
- Limited the implementation to:
  - `apps/web/app/[locale]/vaccine-hub/page.tsx`

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Validation Performed

- Verified that only the required file was modified:
  - `apps/web/app/[locale]/vaccine-hub/page.tsx`
- Reviewed the updated calendar export logic to ensure timezone-dependent parsing was removed.
- Confirmed that exported ICS dates are generated from manually parsed local date components without UTC conversion.

> **Note:** This change affects only the calendar export logic. No UI changes were introduced, so screenshots or screen recordings are not applicable.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2819`)
- [x] I have pulled the latest `main` and resolved any conflicts