### PR TITLE
fix(db): align medicine search functions with current schema

### DIFF
--- a/supabase/migrations/20260606000000_add_medicine_rag.sql
+++ b/supabase/migrations/20260606000000_add_medicine_rag.sql
@@ -45,9 +45,6 @@ RETURNS TABLE (
   generic_name       VARCHAR(500),
   manufacturer       VARCHAR(255),
   composition        TEXT,
-  strength           VARCHAR(100),
-  dosage_form        VARCHAR(100),
-  schedule           VARCHAR(50),
   mrp                NUMERIC(10, 2),
   jan_aushadhi_price NUMERIC(10, 2),
   similarity         DOUBLE PRECISION
@@ -60,9 +57,6 @@ BEGIN
     m.generic_name,
     m.manufacturer,
     m.composition,
-    m.strength,
-    m.dosage_form,
-    m.schedule,
     m.mrp,
     m.jan_aushadhi_price,
     (1 - (m.embedding <=> query_embedding))::double precision AS similarity
@@ -90,9 +84,6 @@ RETURNS TABLE (
   generic_name       VARCHAR(500),
   manufacturer       VARCHAR(255),
   composition        TEXT,
-  strength           VARCHAR(100),
-  dosage_form        VARCHAR(100),
-  schedule           VARCHAR(50),
   mrp                NUMERIC(10, 2),
   jan_aushadhi_price NUMERIC(10, 2),
   similarity         DOUBLE PRECISION
@@ -105,9 +96,6 @@ BEGIN
     m.generic_name,
     m.manufacturer,
     m.composition,
-    m.strength,
-    m.dosage_form,
-    m.schedule,
     m.mrp,
     m.jan_aushadhi_price,
     GREATEST(

--- a/supabase/migrations/20260627010000_fix_search_medicines_text_trgm_usage.sql
+++ b/supabase/migrations/20260627010000_fix_search_medicines_text_trgm_usage.sql
@@ -48,9 +48,6 @@ RETURNS TABLE (
   generic_name       VARCHAR(500),
   manufacturer       VARCHAR(255),
   composition        TEXT,
-  strength           VARCHAR(100),
-  dosage_form        VARCHAR(100),
-  schedule           VARCHAR(50),
   mrp                NUMERIC(10, 2),
   jan_aushadhi_price NUMERIC(10, 2),
   similarity         DOUBLE PRECISION
@@ -63,9 +60,6 @@ BEGIN
     m.generic_name,
     m.manufacturer,
     m.composition,
-    m.strength,
-    m.dosage_form,
-    m.schedule,
     m.mrp,
     m.jan_aushadhi_price,
     GREATEST(

--- a/supabase/migrations/20260628160000_add_composition_trgm_index.sql
+++ b/supabase/migrations/20260628160000_add_composition_trgm_index.sql
@@ -44,9 +44,6 @@ RETURNS TABLE (
   generic_name       VARCHAR(500),
   manufacturer       VARCHAR(255),
   composition        TEXT,
-  strength           VARCHAR(100),
-  dosage_form        VARCHAR(100),
-  schedule           VARCHAR(50),
   mrp                NUMERIC(10, 2),
   jan_aushadhi_price NUMERIC(10, 2),
   similarity         DOUBLE PRECISION
@@ -59,9 +56,6 @@ BEGIN
     m.generic_name,
     m.manufacturer,
     m.composition,
-    m.strength,
-    m.dosage_form,
-    m.schedule,
     m.mrp,
     m.jan_aushadhi_price,
     GREATEST(


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3008**
- **Summary:**
  - Updated the `match_medicines` RPC and related search functions to align with the current `public.medicines` schema.
  - Removed references to non-existent columns (`strength`, `dosage_form`, and `schedule`) that caused runtime failures during semantic retrieval.
  - Preserved the existing pgvector retrieval logic while restoring compatibility with the current database schema.

## 📸 Proof of Work (Screenshots / Logs)

### Before Fix

Calling the retrieval service resulted in a PostgREST error because the RPC referenced columns that were no longer present in the `medicines` table.

<img width="1300" height="205" alt="image" src="https://github.com/user-attachments/assets/d96db965-1ef3-4d59-8cd2-6add0bc607a2" />

### After Fix

The retrieval pipeline executes successfully and the RPC completes without errors. The current local database contains no populated medicine embeddings, so the expected result is an empty retrieval (`Retrieved medicines: []`).

<img width="1060" height="138" alt="image" src="https://github.com/user-attachments/assets/4ba34a16-979c-4395-a584-a417c2489ea0" />


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3008`)
- [x] I have pulled the latest `main` and resolved any conflicts