### PR TITLE
Add request size limit for OCR medicine matching

### DIFF
--- a/apps/ml/routers/ocr.py
+++ b/apps/ml/routers/ocr.py
@@ -5,7 +5,7 @@ import pytesseract
 import io
 import logging
 #Added for the fuzz string matching 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing import List
 from services.matcher import find_matches
 # Configure logging
@@ -82,7 +82,7 @@ async def extract_text(file: UploadFile = File(...)):
 # For issue 17: Request payload validation schema
 class MatchRequest(BaseModel):
     query: str
-    medicines: List[str]
+    medicines: List[str] = Field(..., max_length=1000)
 
 # Response validation schema
 class MatchResponse(BaseModel):


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2851 **
- **Summary:**
1. Added a maximum length validation (max_length=1000) to the medicines list.
2. Prevents oversized payloads from reaching the fuzzy matching logic.
3. Oversized requests now return a 422 Unprocessable Entity.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2851 `)
- [x] I have pulled the latest `main` and resolved any conflicts
