### PR TITLE
fix(api): limit verify-brand input length

### DIFF
--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -774,7 +774,13 @@ router.post("/verify-brand", scanQueryLimiter, async (req: Request, res: Respons
         res.status(400).json({ error: "brandName is required and must be a string" });
         return;
     }
-
+    const MAX_BRAND_NAME_LENGTH = 200;
+    if (brandName.length > MAX_BRAND_NAME_LENGTH) {
+        res.status(400).json({
+            error: `brandName must not exceed ${MAX_BRAND_NAME_LENGTH} characters`,
+        });
+        return;
+    }
     const normalizedBrand = brandName.trim().toLowerCase();
     const cacheKey = `brand_cache:${normalizedBrand}`;
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2820**
- **Summary:**
  - Added a maximum length validation (200 characters) for the `brandName` input in `/api/v1/scan/verify-brand`.
  - Requests exceeding the allowed limit now return **400 Bad Request** before any Redis or Supabase operations are executed.
  - Preserved the existing verification flow for valid brand names.

## 📸 Proof of Work (Screenshots / Logs)

**Manual Testing**

- ✅ `brandName: "Dolo 650"` → Verification succeeds.
- ✅ `brandName` longer than 200 characters → Returns **400 Bad Request**.
- ✅ Oversized input is rejected before Redis cache lookup and database query.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2820`)
- [x] I have pulled the latest `main` and resolved any conflicts
