### PR TITLE
Fixed: Scan submission fails due to CHECK constraint violation on scan_submission_parts status field when parts are skipped

### DIFF
--- a/supabase/migrations/20260702000000_offline_scan_sync.sql
+++ b/supabase/migrations/20260702000000_offline_scan_sync.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS public.scan_submission_parts (
   id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   scan_id           TEXT NOT NULL REFERENCES public.user_scan_history(id) ON DELETE CASCADE,
   part_type         TEXT NOT NULL CHECK (part_type IN ('metadata', 'image', 'voice')),
-  status            TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'synced', 'failed')),
+  status            TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'synced', 'failed', 'skipped')),
   attempt_count     INT NOT NULL DEFAULT 0,
   last_error        TEXT,
   updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2976 **
- **Summary:**
1. Schema Check Constraint Update: Updated 
20260702000000_offline_scan_sync.sql to include 'skipped' as an allowed value in the check constraint on the status column.
`sql
status            TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'synced', 'failed', 'skipped'))`
2. Validation: Ran the test suite to ensure that submitting offline scans works correctly. The offline sync test tests/scans.sync.test.ts passed successfully.



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2976 `)
- [x] I have pulled the latest `main` and resolved any conflicts
