### PR TITLE
fix: filter guest wishlist product IDs against medicines table before…

### DIFF
--- a/apps/api/src/routes/wishlist.ts
+++ b/apps/api/src/routes/wishlist.ts
@@ -55,12 +55,24 @@ export async function mergeGuestWishlist(
             )
         );
         const newProductIds = guestProductIds.filter((id) => !existingProductIds.has(id));
-
         if (newProductIds.length === 0) {
             return [];
         }
+        const { data: existingMedicines } = await supabase
+            .from("medicines")
+            .select("id")
+            .in("id", newProductIds);
 
-        const insertData = newProductIds.map((product_id) => ({
+        const verifiedProductIds = new Set(
+            (existingMedicines || []).map((m: { id: string }) => m.id)
+        );
+        const filteredProductIds = newProductIds.filter((id) => verifiedProductIds.has(id));
+
+        if (filteredProductIds.length === 0) {
+            return [];
+        }
+
+        const insertData = filteredProductIds.map((product_id) => ({
             user_id: userId,
             product_id,
         }));

--- a/apps/api/tests/wishlist.test.ts
+++ b/apps/api/tests/wishlist.test.ts
@@ -1,0 +1,60 @@
+import { mergeGuestWishlist } from "../src/routes/wishlist";
+
+jest.mock("../src/db/client", () => {
+    const mock = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        in: jest.fn().mockReturnThis(),
+        insert: jest.fn().mockReturnThis(),
+    };
+
+    return { supabase: mock };
+});
+
+import { supabase } from "../src/db/client";
+
+const mockedSupabase = supabase as any;
+
+describe("mergeGuestWishlist", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("merges only the valid product IDs when one guest product ID is invalid/deleted", async () => {
+        const userId = "user-1";
+        const validId = "11111111-1111-1111-1111-111111111111";
+        const invalidId = "22222222-2222-2222-2222-222222222222";
+
+        // 1st call: fetch existing wishlist for user (empty — nothing merged yet)
+        mockedSupabase.eq.mockResolvedValueOnce({ data: [], error: null });
+
+        // 2nd call: query medicines table for which of the newProductIds exist
+        mockedSupabase.in.mockResolvedValueOnce({
+            data: [{ id: validId }],
+            error: null,
+        });
+
+        // 3rd call: insert filtered product IDs
+        mockedSupabase.select.mockResolvedValueOnce({
+            data: [{ product_id: validId }],
+            error: null,
+        });
+
+        const result = await mergeGuestWishlist(userId, [validId, invalidId]);
+
+        expect(result).toEqual([validId]);
+    });
+
+    it("returns an empty array when all guest product IDs are invalid", async () => {
+        const userId = "user-1";
+        const invalidId = "33333333-3333-3333-3333-333333333333";
+
+        mockedSupabase.eq.mockResolvedValueOnce({ data: [], error: null });
+        mockedSupabase.in.mockResolvedValueOnce({ data: [], error: null });
+
+        const result = await mergeGuestWishlist(userId, [invalidId]);
+
+        expect(result).toEqual([]);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #2825**
- **Summary:** `mergeGuestWishlist()` in `wishlist.ts` only deduped incoming guest product IDs against the user's existing wishlist, never against whether those IDs still exist in the `medicines` table. Since `wishlists.product_id` has a foreign key to `medicines.id`, a single stale/deleted product ID in the batch caused the entire bulk insert to fail with an FK violation — the existing error handling then just logged and returned `[]`, silently dropping every valid item along with the invalid one.

  Fixed by querying `medicines` for the IDs actually present before building the insert payload, and filtering `newProductIds` down to only verified IDs. Stale/invalid IDs are now silently skipped instead of failing the whole batch, and all valid items merge successfully. Added `wishlist.test.ts` covering both the mixed valid/invalid ID case and the all-invalid case.

## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #2825`)
- [x] I have pulled the latest `main` and resolved any conflicts