### PR TITLE
fix(#3025): abort losing Overpass mirror requests

### DIFF
--- a/apps/web/app/[locale]/map/overpassApi.ts
+++ b/apps/web/app/[locale]/map/overpassApi.ts
@@ -15,40 +15,47 @@ const OVERPASS_MIRRORS = [
 async function queryOverpass(query: string): Promise<any> {
     // 1. Primary Path: Parallel client-side GET requests (races the first 2 mirrors for maximum speed)
     const clientMirrors = OVERPASS_MIRRORS.slice(0, 2);
-    const fetchPromises = clientMirrors.map(async (mirror) => {
+    const requests = clientMirrors.map((mirror) => {
         const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 4000); // 4s timeout per mirror client-side
+        const promise = (async () => {
+            const timeoutId = setTimeout(() => controller.abort(), 4000); // 4s timeout per mirror client-side
 
-        try {
-            const url = `${mirror}?data=${encodeURIComponent(query)}`;
-            const response = await fetch(url, {
-                method: "GET",
-                headers: {
-                    Accept: "*/*",
-                },
-                signal: controller.signal,
-            });
+            try {
+                const url = `${mirror}?data=${encodeURIComponent(query)}`;
+                const response = await fetch(url, {
+                    method: "GET",
+                    headers: {
+                        Accept: "*/*",
+                    },
+                    signal: controller.signal,
+                });
 
-            clearTimeout(timeoutId);
+                if (!response.ok) {
+                    throw new Error(`Mirror ${mirror} returned status ${response.status}`);
+                }
 
-            if (!response.ok) {
-                throw new Error(`Mirror ${mirror} returned status ${response.status}`);
+                const data = await response.json();
+                if (!data || !data.elements) {
+                    throw new Error(`Mirror ${mirror} returned invalid data structure`);
+                }
+
+                return { controller, data };
+            } finally {
+                clearTimeout(timeoutId);
             }
+        })();
 
-            const data = await response.json();
-            if (!data || !data.elements) {
-                throw new Error(`Mirror ${mirror} returned invalid data structure`);
-            }
-
-            return data;
-        } catch (err) {
-            clearTimeout(timeoutId);
-            throw err;
-        }
+        return { controller, promise };
     });
 
     try {
-        return await Promise.any(fetchPromises);
+        const winner = await Promise.any(requests.map((request) => request.promise));
+        requests.forEach((request) => {
+            if (request.controller !== winner.controller && !request.controller.signal.aborted) {
+                request.controller.abort();
+            }
+        });
+        return winner.data;
     } catch {
         // Silent fallback — direct browser calls failed (e.g., CORS or adblocker). Proceeding to proxy.
     }

--- a/apps/web/tests/overpassApi.test.ts
+++ b/apps/web/tests/overpassApi.test.ts
@@ -1,0 +1,126 @@
+import { fetchPharmacies } from "../app/[locale]/map/overpassApi";
+
+function createJsonResponse(body: unknown, ok = true, status = 200) {
+    return {
+        ok,
+        status,
+        json: jest.fn().mockResolvedValue(body),
+    } as unknown as Response;
+}
+
+describe("overpassApi", () => {
+    afterEach(() => {
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+    });
+
+    it("aborts slower client mirror requests after the first valid response is parsed", async () => {
+        let loserSignal: AbortSignal | null = null;
+
+        const fetchMock = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
+            const url = String(input);
+
+            if (url.includes("overpass.private.coffee")) {
+                return Promise.resolve(
+                    createJsonResponse({
+                        elements: [
+                            {
+                                type: "node",
+                                id: 101,
+                                lat: 28.6139,
+                                lon: 77.209,
+                                tags: { name: "Fast Pharmacy" },
+                            },
+                        ],
+                    })
+                );
+            }
+
+            if (url.includes("overpass-api.de")) {
+                loserSignal = init?.signal ?? null;
+                return new Promise<Response>((_, reject) => {
+                    init?.signal?.addEventListener("abort", () => {
+                        const error = new Error("Aborted");
+                        error.name = "AbortError";
+                        reject(error);
+                    });
+                });
+            }
+
+            throw new Error(`Unexpected fetch URL: ${url}`);
+        });
+
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        const pharmacies = await fetchPharmacies(28.6139, 77.209);
+
+        expect(pharmacies).toEqual([
+            expect.objectContaining({
+                id: 101,
+                name: "Fast Pharmacy",
+            }),
+        ]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(loserSignal?.aborted).toBe(true);
+    });
+
+    it("falls back to the proxy and preserves the final failure when all mirrors fail", async () => {
+        const fetchMock = jest.fn((input: RequestInfo | URL) => {
+            const url = String(input);
+
+            if (url.startsWith("https://")) {
+                return Promise.reject(new Error("Direct mirror failed"));
+            }
+
+            if (url === "/api/overpass") {
+                return Promise.resolve(createJsonResponse({ error: "proxy failed" }, false, 503));
+            }
+
+            throw new Error(`Unexpected fetch URL: ${url}`);
+        });
+
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        await expect(fetchPharmacies(28.6139, 77.209)).rejects.toThrow(
+            "All Overpass mirrors and proxy failed to respond"
+        );
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("keeps timeout abort behavior for direct mirrors before proxy fallback", async () => {
+        jest.useFakeTimers();
+        const directSignals: AbortSignal[] = [];
+
+        const fetchMock = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
+            const url = String(input);
+
+            if (url.startsWith("https://")) {
+                if (init?.signal) directSignals.push(init.signal);
+
+                return new Promise<Response>((_, reject) => {
+                    init?.signal?.addEventListener("abort", () => {
+                        const error = new Error("Timed out");
+                        error.name = "AbortError";
+                        reject(error);
+                    });
+                });
+            }
+
+            if (url === "/api/overpass") {
+                return Promise.resolve(createJsonResponse({ elements: [] }));
+            }
+
+            throw new Error(`Unexpected fetch URL: ${url}`);
+        });
+
+        global.fetch = fetchMock as unknown as typeof fetch;
+
+        const resultPromise = fetchPharmacies(28.6139, 77.209);
+        await Promise.resolve();
+        jest.advanceTimersByTime(4000);
+
+        await expect(resultPromise).resolves.toEqual([]);
+        expect(directSignals).toHaveLength(2);
+        expect(directSignals.every((signal) => signal.aborted)).toBe(true);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #3025**
* **Summary:**

  * Added an `AbortController` for each Overpass mirror request.
  * Updated the mirror race logic to abort losing in-flight requests after the first valid response has been fully parsed.
  * Preserved existing timeout cleanup and proxy fallback behavior.
  * Added automated tests covering mirror cancellation, timeout handling, and fallback behavior.

## 📸 Proof of Work (Screenshots / Logs)

### Test Results

```text
PASS tests/overpassApi.test.ts

✓ aborts slower client mirror requests after the first valid response is parsed
✓ falls back to the proxy and preserves the final failure when all mirrors fail
✓ keeps timeout abort behavior for direct mirrors before proxy fallback

Test Suites: 1 passed, 1 total
Tests: 3 passed, 3 total
```

> No UI changes were made. Verification was performed through automated tests.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [x] 🧪 `type: testing`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3025`)
* [x] I have pulled the latest `main` and resolved any conflicts