### PR TITLE
fix(#3028): use local date for vaccine picker max value

### DIFF
--- a/apps/web/components/vaccine/DateInitializer.tsx
+++ b/apps/web/components/vaccine/DateInitializer.tsx
@@ -37,6 +37,13 @@ function parseIsoLocal(iso: string): Date | null {
     return new Date(y, m - 1, d); // Local timezone — no UTC shift
 }
 
+function formatLocalDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+}
+
 export function DateInitializer({ vaccine, value, onChange }: DateInitializerProps) {
     const t = useTranslations("vaccineHub");
 
@@ -73,7 +80,7 @@ export function DateInitializer({ vaccine, value, onChange }: DateInitializerPro
 
     const parsedDate = value ? parseIsoLocal(value) : null;
 
-    const todayIso = new Date().toISOString().split("T")[0];
+    const todayIso = formatLocalDate(new Date());
 
     return (
         <div className="space-y-2">


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3028**
- **Summary:**
  - Replaced UTC-based date generation in `DateInitializer`.
  - Added a local date formatter that uses `getFullYear()`, `getMonth() + 1`, and `getDate()`.
  - Ensures the Vaccine Hub native date picker `max` value reflects the user's local calendar date.
  - Prevents today's date from being incorrectly blocked in UTC-positive timezones shortly after midnight.

## 📸 Proof of Work (Screenshots / Logs)

### Code Change

```diff
- const todayIso = new Date().toISOString().split("T")[0];
+ const todayIso = formatLocalDate(new Date());
```

### Lint Output

```bash
npm run lint

> sahidawa-india@1.0.0 lint
> npm run lint --workspaces --if-present

> web@0.1.0 lint
> eslint .
```

### Test Notes

```text
npm.cmd run test -w web -- vaccine-hub.test.tsx

Test execution was blocked by an existing dependency resolution issue:
@testing-library/dom/dist/queries/label-text.js
cannot resolve ../config

No project code changes were required to reproduce this failure.
```

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3028`)
* [x] I have pulled the latest `main` and resolved any conflicts