### PR TITLE
FEAT : Admin Dashboard Panel to Flush Old Interaction Cache Versions#2890

### DIFF
--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -16,7 +16,11 @@ import {
     deletePharmacy,
     restorePharmacy,
 } from "../controllers/admin.controller";
-import { invalidateDrugCache, KEY_PREFIXES } from "../services/cache.service";
+import {
+    invalidateDrugCache,
+    flushInteractionCache,
+    KEY_PREFIXES,
+} from "../services/cache.service";
 import { redisClient } from "../utils/redis";
 import { getPushNotificationAnalytics } from "./analytics";
 import { limiter } from "../middleware/rateLimit";
@@ -201,6 +205,33 @@ router.post(
             res.status(200).json({
                 success: true,
                 message: "OCR Synonyms cache invalidated and reloaded successfully",
+            });
+        } catch (err) {
+            res.status(500).json({
+                success: false,
+                error: (err as Error).message,
+            });
+        }
+    }
+);
+
+router.post(
+    "/cache/flush-interactions",
+    requireAuth,
+    requireRole("admin", "moderator"),
+    async (req: AuthenticatedRequest, res: Response) => {
+        try {
+            const count = await flushInteractionCache();
+
+            await logAdminAction(req.user!.id, "FLUSH_INTERACTIONS", "MEDICINE", "cache", {
+                total_keys_invalidated: count,
+                timestamp: new Date().toISOString(),
+            });
+
+            res.status(200).json({
+                success: true,
+                message: "Interaction cache flushed successfully",
+                invalidated: count,
             });
         } catch (err) {
             res.status(500).json({

--- a/apps/api/src/services/cache.service.ts
+++ b/apps/api/src/services/cache.service.ts
@@ -265,6 +265,49 @@ export async function invalidateDrugCache(drugIds: string[]): Promise<string[]> 
 }
 
 /**
+ * Iterates through Redis and deletes all keys matching the interaction cache prefix.
+ * Uses SCAN to avoid blocking the event loop and deletes in chunks.
+ * Returns the number of keys deleted.
+ */
+export async function flushInteractionCache(): Promise<number> {
+    if (!redisClient.isOpen) return 0;
+    try {
+        let cursor = 0;
+        let totalDeleted = 0;
+        const scanIterator = redisClient.scanIterator({
+            MATCH: "interactions:*",
+            COUNT: 100,
+        });
+
+        let chunk: string[] = [];
+        for await (const key of scanIterator) {
+            if (Array.isArray(key)) {
+                chunk.push(...key);
+            } else {
+                chunk.push(key as any);
+            }
+            if (chunk.length >= CACHE_INVALIDATION_CHUNK_SIZE) {
+                await redisClient.del(chunk as any);
+                totalDeleted += chunk.length;
+                chunk = [];
+            }
+        }
+
+        // Delete any remaining keys in the last chunk
+        if (chunk.length > 0) {
+            await redisClient.del(chunk as any);
+            totalDeleted += chunk.length;
+        }
+
+        logger.info(`Successfully flushed ${totalDeleted} interaction cache keys`);
+        return totalDeleted;
+    } catch (err) {
+        logger.error("Error flushing interaction cache", err);
+        return 0;
+    }
+}
+
+/**
  * Returns cache performance stats: hit/miss counts, tier breakdown, top drugs.
  */
 export async function getCacheStats(): Promise<{

--- a/apps/web/app/[locale]/admin/dashboard/page.tsx
+++ b/apps/web/app/[locale]/admin/dashboard/page.tsx
@@ -28,7 +28,7 @@ import { useSession } from "@/src/components/AuthProvider";
 
 type ReportStatus = "pending" | "verified_fake" | "false_alarm";
 type MedicineStatus = "approved" | "recalled" | "banned";
-type Tab = "reports" | "medicine" | "logs";
+type Tab = "reports" | "medicine" | "logs" | "maintenance";
 
 interface Report {
     id: string;
@@ -80,6 +80,7 @@ export default function AdminDashboard() {
     const [acting, setActing] = useState<string | null>(null);
     const [authError, setAuthError] = useState<string | null>(null);
     const [showForm, setShowForm] = useState(false);
+    const [isFlushingInteractions, setIsFlushingInteractions] = useState(false);
     const [adminRole, setAdminRole] = useState<AdminRole | null>(null);
     const [newMed, setNewMed] = useState<Omit<Medicine, "id">>({
         brand_name: "",
@@ -241,6 +242,36 @@ export default function AdminDashboard() {
         }
     };
 
+    const handleFlushInteractions = async () => {
+        if (!canMutate) return;
+        setIsFlushingInteractions(true);
+        try {
+            const res = await fetch(`${ADMIN_API_BASE}/cache/flush-interactions`, {
+                method: "POST",
+                headers: authHeaders(),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || "Failed to flush cache");
+
+            notify(
+                <>
+                    <CheckCircle className="mr-1 inline h-4 w-4" /> Cleared {data.invalidated} cache
+                    keys!
+                </>
+            );
+        } catch (err: any) {
+            notify(
+                <>
+                    <XCircle className="mr-1 inline h-4 w-4" />{" "}
+                    {err.message || "Cache flush failed"}
+                </>,
+                false
+            );
+        } finally {
+            setIsFlushingInteractions(false);
+        }
+    };
+
     const pendingCount = reports.length;
     const resolvedCount = resolved.length;
     const districtCount = new Set(reports.map((r) => r.district).filter(Boolean)).size;
@@ -275,6 +306,12 @@ export default function AdminDashboard() {
                         label={t("nav.logs")}
                         active={tab === "logs"}
                         onClick={() => setTab("logs")}
+                    />
+                    <NavItem
+                        icon={RefreshCw}
+                        label="System Maintenance"
+                        active={tab === "maintenance"}
+                        onClick={() => setTab("maintenance")}
                     />
                     <Link
                         href="/admin/pharmacies/pending"
@@ -569,6 +606,43 @@ export default function AdminDashboard() {
                                     })}
                                 </div>
                             )}
+                        </div>
+                    )}
+
+                    {/* System Maintenance Tab */}
+                    {tab === "maintenance" && (
+                        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+                            <div className="border-b border-slate-100 px-6 py-4">
+                                <h2 className="font-semibold text-slate-800">System Maintenance</h2>
+                                <p className="mt-0.5 text-xs text-slate-400">
+                                    Administrative tools to manage system health and caches.
+                                </p>
+                            </div>
+                            <div className="p-6">
+                                <div className="flex items-center justify-between rounded-xl border border-slate-100 bg-slate-50 p-4">
+                                    <div>
+                                        <h3 className="font-semibold text-slate-800">
+                                            Interaction Cache
+                                        </h3>
+                                        <p className="mt-1 text-sm text-slate-500">
+                                            Purge old versions of interaction caches from Redis to
+                                            free up memory.
+                                        </p>
+                                    </div>
+                                    <button
+                                        onClick={handleFlushInteractions}
+                                        disabled={isFlushingInteractions || !canMutate}
+                                        className="flex items-center gap-2 rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-red-700 disabled:opacity-50"
+                                    >
+                                        {isFlushingInteractions ? (
+                                            <Loader2 className="h-4 w-4 animate-spin" />
+                                        ) : (
+                                            <AlertTriangle className="h-4 w-4" />
+                                        )}
+                                        Flush Interaction Cache
+                                    </button>
+                                </div>
+                            </div>
                         </div>
                     )}
                 </div>


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2890 **
- **Summary:**
- Implemented the flushInteractionCache function in the `cache.service.ts`.
- The function efficiently uses the `redisClient.scanIterator` to search for all keys matching the interactions:* prefix.
- Keys are batched and deleted in chunks to ensure the Redis event loop is not blocked during mass invalidations.
- Created a secure `POST /cache/flush-interactions` endpoint.
- Restricted access to users with admin or moderator roles using the `requireAuth` and `requireRole` middleware.
- Ensured any cache flushes are logged as an audit trail entry, recording the time and total keys invalidated.
- Added a new System Maintenance section tab to the Admin Dashboard interface.
- Built the "Interaction Cache" maintenance card featuring a clear description and a prominent action button to "Flush Interaction Cache".
- Integrated interactive loading states (spinners) during the API request and success/error toasts displaying the exact number of deleted cache keys using react-hot-toast.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [x] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
