### PR TITLE
fix: batch stale district alert deactivation

### DIFF
--- a/apps/api/src/cron/districtAlertSync.ts
+++ b/apps/api/src/cron/districtAlertSync.ts
@@ -91,10 +91,7 @@ export async function syncDistrictAlertTallies(): Promise<void> {
         }
 
         // 4. Deactivate stale district_alerts with no remaining verified reports
-        const activeKeys = Array.from(tally.keys()).map((key) => {
-            const [district, medicine_name] = key.split("::");
-            return { district, medicine_name };
-        });
+        const activeKeys = new Set(tally.keys());
 
         const { data: allAlerts } = await supabase
             .from("district_alerts")
@@ -102,16 +99,22 @@ export async function syncDistrictAlertTallies(): Promise<void> {
             .eq("is_active", true);
 
         if (allAlerts) {
-            for (const alert of allAlerts) {
-                const stillActive = activeKeys.some(
-                    (k) => k.district === alert.district && k.medicine_name === alert.medicine_name
-                );
+            const staleAlertIds = allAlerts
+                .filter((alert) => !activeKeys.has(`${alert.district}::${alert.medicine_name}`))
+                .map((alert) => alert.id);
 
-                if (!stillActive) {
-                    await supabase
-                        .from("district_alerts")
-                        .update({ is_active: false, updated_at: new Date().toISOString() })
-                        .eq("id", alert.id);
+            if (staleAlertIds.length > 0) {
+                const { error: deactivateError } = await supabase
+                    .from("district_alerts")
+                    .update({ is_active: false, updated_at: new Date().toISOString() })
+                    .in("id", staleAlertIds);
+
+                if (deactivateError) {
+                    logger.error("District alert sync: stale alert deactivation failed", {
+                        staleAlertCount: staleAlertIds.length,
+                        error: deactivateError.message,
+                    });
+                    errors += 1;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- collect stale district alert IDs during the sync deactivation phase
- replace per-alert sequential updates with one bulk `.in("id", staleAlertIds)` update
- keep the existing inactive payload and add scoped logging if bulk deactivation fails

## Validation
- `npx.cmd prettier --check apps/api/src/cron/districtAlertSync.ts`
- `git diff --check`
- `npm.cmd run build -w apps/api` *(fails on existing unrelated TypeScript error in `src/routes/pharmacies.ts(1323,21)`: `string | string[]` is not assignable to `string`)*

Fixes #3000
