### PR TITLE
fix(ml): handle nullable UploadFile.content_type and trim CORS origins

### DIFF
--- a/apps/ml/main.py
+++ b/apps/ml/main.py
@@ -28,10 +28,13 @@ app = FastAPI(
 FastAPIInstrumentor.instrument_app(app)
 
 # Configure CORS - load dynamically from environment variables
-allowed_origins = os.getenv(
-    "ALLOWED_ORIGINS",
-    "http://localhost:3000,http://localhost:4000,http://localhost:8000"
-).split(",")
+allowed_origins = [
+    o.strip()
+    for o in os.getenv(
+        "ALLOWED_ORIGINS",
+        "http://localhost:3000,http://localhost:4000,http://localhost:8000"
+    ).split(",")
+]
 
 app.add_middleware(
     CORSMiddleware,

--- a/apps/ml/routers/ocr.py
+++ b/apps/ml/routers/ocr.py
@@ -22,7 +22,7 @@ async def extract_text(file: UploadFile = File(...)):
     Extracts text from an uploaded medicine strip image using Tesseract OCR.
     """
     # Validate file type
-    if not file.content_type.startswith("image/"):
+    if not file.content_type or not file.content_type.startswith("image/"):
         raise HTTPException(status_code=400, detail="File uploaded is not an image.")
 
     # Validate file size to prevent Denial of Service (DoS) via memory exhaustion

--- a/apps/ml/routers/voice_verify.py
+++ b/apps/ml/routers/voice_verify.py
@@ -41,7 +41,7 @@ async def verify_medicine_voice(audio: UploadFile = File(...)):
     detects language, and verifies the medicine via LangChain + CDSCO.
     """
     # Validate file type
-    if audio.content_type not in ["audio/webm", "audio/wav", "audio/ogg", "audio/mp4", "audio/mpeg"]:
+    if not audio.content_type or audio.content_type not in ["audio/webm", "audio/wav", "audio/ogg", "audio/mp4", "audio/mpeg"]:
         raise HTTPException(status_code=400, detail="Unsupported audio format. Use webm, wav, ogg, or mp4.")
 
     # Save to temp file for Whisper


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3037, #3038, #3039**
- **Summary:** Three ML service bug fixes:
  1. `voice_verify.py`: Guard `audio.content_type` against `None` before membership test to prevent `TypeError`
  2. `ocr.py`: Guard `file.content_type` against `None` before `.startswith()` call to prevent `AttributeError`
  3. `main.py`: Strip whitespace around CORS origin strings to match Express API behavior

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

Bug 3 is a config parsing fix (no UI/logs). For Bugs 1 & 2, the fix is a one-line guard — behavior is unchanged when `content_type` is present; when absent, a 400 error is returned instead of a 500 crash. Verified by reading the diff.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3037, #3038, #3039`)
- [x] I have pulled the latest `main` and resolved any conflicts