### PR TITLE
fix(ml): guard audio.content_type against None in voice_verify router

### DIFF
--- a/apps/ml/routers/voice_verify.py
+++ b/apps/ml/routers/voice_verify.py
@@ -41,7 +41,7 @@ async def verify_medicine_voice(audio: UploadFile = File(...)):
     detects language, and verifies the medicine via LangChain + CDSCO.
     """
     # Validate file type
-    if audio.content_type not in ["audio/webm", "audio/wav", "audio/ogg", "audio/mp4", "audio/mpeg"]:
+    if not audio.content_type or audio.content_type not in ["audio/webm", "audio/wav", "audio/ogg", "audio/mp4", "audio/mpeg"]:
         raise HTTPException(status_code=400, detail="Unsupported audio format. Use webm, wav, ogg, or mp4.")
 
     # Save to temp file for Whisper


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3037**
- **Summary:** Guard `audio.content_type` against `None` before membership test in `voice_verify.py`. When `content_type` is `None` (client omits Content-Type header), `None not in [...]` raises `TypeError`. Fix adds `not audio.content_type` guard to return proper 400 error.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3037`)
- [x] I have pulled the latest `main` and resolved any conflicts