### PR TITLE
fix(ml): guard file.content_type against None in OCR router

### DIFF
--- a/apps/ml/routers/ocr.py
+++ b/apps/ml/routers/ocr.py
@@ -22,7 +22,7 @@ async def extract_text(file: UploadFile = File(...)):
     Extracts text from an uploaded medicine strip image using Tesseract OCR.
     """
     # Validate file type
-    if not file.content_type.startswith("image/"):
+    if not file.content_type or not file.content_type.startswith("image/"):
         raise HTTPException(status_code=400, detail="File uploaded is not an image.")
 
     # Validate file size to prevent Denial of Service (DoS) via memory exhaustion


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3038**
- **Summary:** Guard `file.content_type` against `None` before `.startswith("image/")` in `ocr.py`. When `content_type` is `None` (client omits Content-Type header), `.startswith()` raises `AttributeError`. Fix adds `not file.content_type` guard to return proper 400 error.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3038`)
- [x] I have pulled the latest `main` and resolved any conflicts