### PR TITLE
fix(ml): trim whitespace from CORS origin strings

### DIFF
--- a/apps/ml/main.py
+++ b/apps/ml/main.py
@@ -28,10 +28,13 @@ app = FastAPI(
 FastAPIInstrumentor.instrument_app(app)
 
 # Configure CORS - load dynamically from environment variables
-allowed_origins = os.getenv(
-    "ALLOWED_ORIGINS",
-    "http://localhost:3000,http://localhost:4000,http://localhost:8000"
-).split(",")
+allowed_origins = [
+    o.strip()
+    for o in os.getenv(
+        "ALLOWED_ORIGINS",
+        "http://localhost:3000,http://localhost:4000,http://localhost:8000"
+    ).split(",")
+]
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3039**
- **Summary:** Split `ALLOWED_ORIGINS` by comma and strip whitespace to match Express API CORS behavior (`apps/api/src/config/cors.ts`). Prevents valid origins with leading spaces (e.g., after comma in env var) from being silently rejected.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3039`)
- [x] I have pulled the latest `main` and resolved any conflicts