### PR TITLE
fix: prevent mobile keyboard overlap in report and medicine search forms

### DIFF
--- a/apps/web/app/[locale]/calculator/page.tsx
+++ b/apps/web/app/[locale]/calculator/page.tsx
@@ -227,14 +227,14 @@ function CalculatorPageContent() {
     const yearlySavings = monthlySavings * 12;
 
     return (
-        <div className="min-h-screen bg-(--color-surface-muted) text-(--color-text-primary)">
+        <div className="min-h-[100dvh] bg-(--color-surface-muted) text-(--color-text-primary)">
             <PageHeader
                 title={translate("pageTitle")}
                 subtitle={translate("pageSubtitle")}
                 backHref="/"
                 variant="light"
             />
-            <main className="container mx-auto max-w-2xl space-y-6 px-4 py-8">
+            <main className="container mx-auto max-w-2xl space-y-6 px-4 py-8 pb-[calc(env(safe-area-inset-bottom)+3rem)]">
                 {/* Search Panel */}
                 <section className="rounded-2xl border border-(--color-border-muted) bg-(--color-surface-page) p-6 shadow-sm">
                     <MedicineSearchSelect

--- a/apps/web/app/[locale]/report/page.tsx
+++ b/apps/web/app/[locale]/report/page.tsx
@@ -6,7 +6,7 @@ import ReportInfoPanel from "./ReportInfoPanel";
 
 export default function ReportPage() {
     return (
-        <div className="flex min-h-screen flex-col overflow-x-hidden bg-(--color-surface-muted) font-sans text-(--color-text-primary) selection:bg-emerald-200">
+        <div className="flex min-h-[100dvh] flex-col overflow-x-hidden bg-(--color-surface-muted) font-sans text-(--color-text-primary) selection:bg-emerald-200">
             {/* Header component */}
             <PageHeader
                 title="Report Incident"
@@ -15,7 +15,7 @@ export default function ReportPage() {
                 variant="light"
             />
 
-            <main className="relative z-10 container mx-auto flex-1 px-4 pt-8 pb-20 md:px-6">
+            <main className="relative z-10 container mx-auto flex-1 min-h-0 px-4 pt-8 pb-[calc(env(safe-area-inset-bottom)+5rem)] md:px-6">
                 {/* Decorative elements */}
                 <div className="pointer-events-none absolute top-0 right-0 -mt-20 -mr-20 h-96 w-96 rounded-full bg-emerald-100/40 blur-3xl dark:bg-emerald-950/10"></div>
                 <div className="pointer-events-none absolute bottom-0 left-0 -mb-20 -ml-20 h-80 w-80 rounded-full bg-teal-100/40 blur-3xl dark:bg-teal-950/10"></div>

--- a/apps/web/components/reports/ReportWizard.tsx
+++ b/apps/web/components/reports/ReportWizard.tsx
@@ -97,6 +97,13 @@ const EMPTY: FormValues = {
     medicineId: undefined,
 };
 
+function handleInputFocus(event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    event.currentTarget.scrollIntoView({
+        block: "nearest",
+        inline: "nearest",
+    });
+}
+
 // ─── Per-step field keys ────────────────────────────────────────────────────────
 const STEP_KEYS: Record<number, (keyof FormValues)[]> = {
     1: ["medicineName", "manufacturer", "description"],
@@ -396,6 +403,7 @@ function Step1() {
                 <FL req>Medicine Name</FL>
                 <input
                     {...register("medicineName")}
+                    onFocus={handleInputFocus}
                     placeholder="e.g. Augmentin 625 Duo"
                     className={inp(!!errors.medicineName)}
                     aria-invalid={errors.medicineName ? "true" : undefined}
@@ -407,6 +415,7 @@ function Step1() {
                 <FL req>Manufacturer</FL>
                 <input
                     {...register("manufacturer")}
+                    onFocus={handleInputFocus}
                     placeholder="e.g. Cipla Ltd."
                     className={inp(!!errors.manufacturer)}
                     aria-invalid={errors.manufacturer ? "true" : undefined}
@@ -418,6 +427,7 @@ function Step1() {
                 <FL req>Description of Concern</FL>
                 <textarea
                     {...register("description")}
+                    onFocus={handleInputFocus}
                     rows={4}
                     placeholder="Describe unusual colour, smell, texture, packaging, reported side-effects…"
                     className={`${inp(!!errors.description)} resize-none`}
@@ -670,6 +680,7 @@ function Step3() {
                 <FL req>Pharmacy / Store Name</FL>
                 <input
                     {...register("pharmacyName")}
+                    onFocus={handleInputFocus}
                     placeholder="e.g. Apollo Pharmacy, MG Road"
                     className={inp(!!errors.pharmacyName)}
                     aria-invalid={errors.pharmacyName ? "true" : undefined}
@@ -681,6 +692,7 @@ function Step3() {
                 <FL req>Street Address</FL>
                 <input
                     {...register("address")}
+                    onFocus={handleInputFocus}
                     placeholder="e.g. 45, Park Street, Near Bus Stand"
                     className={inp(!!errors.address)}
                     aria-invalid={errors.address ? "true" : undefined}
@@ -693,6 +705,7 @@ function Step3() {
                     <FL req>City</FL>
                     <input
                         {...register("city")}
+                        onFocus={handleInputFocus}
                         placeholder="Mumbai"
                         className={inp(!!errors.city)}
                         aria-invalid={errors.city ? "true" : undefined}
@@ -704,6 +717,7 @@ function Step3() {
                     <FL req>State</FL>
                     <input
                         {...register("state")}
+                        onFocus={handleInputFocus}
                         placeholder="Maharashtra"
                         className={inp(!!errors.state)}
                         aria-invalid={errors.state ? "true" : undefined}
@@ -716,6 +730,7 @@ function Step3() {
                 <FL req>Pincode</FL>
                 <input
                     {...register("pincode")}
+                    onFocus={handleInputFocus}
                     placeholder="400001"
                     maxLength={6}
                     inputMode="numeric"
@@ -1019,7 +1034,7 @@ export default function ReportWizard() {
             {/* Semantic form wrapper — enables Enter-to-submit and screen reader identification */}
             <form onSubmit={handleSubmit(onSubmit)} noValidate>
                 {/* Card */}
-                <div className="mx-auto flex w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-(--color-border-muted) bg-(--color-surface-page) font-sans shadow-xl dark:shadow-none">
+                <div className="mx-auto flex w-full max-w-2xl min-h-0 flex-col overflow-hidden rounded-2xl border border-(--color-border-muted) bg-(--color-surface-page) font-sans shadow-xl dark:shadow-none">
                     {/* ── Header band ── */}
                     <div className="relative overflow-hidden bg-slate-900 px-8 pt-8 pb-7">
                         {/* Decorative blur */}
@@ -1053,7 +1068,7 @@ export default function ReportWizard() {
                     </div>
 
                     {/* ── Body ── */}
-                    <div className="flex-1 bg-(--color-surface-page) px-8 py-8">
+                    <div className="flex-1 min-h-0 bg-(--color-surface-page) px-8 py-8">
                         {done ? (
                             <Success
                                 onReset={handleReset}

--- a/apps/web/src/components/MedicineSearchSelect.tsx
+++ b/apps/web/src/components/MedicineSearchSelect.tsx
@@ -206,7 +206,15 @@ export default function MedicineSearchSelect({
                                 setQuery(e.target.value);
                                 setOpen(true);
                             }}
-                            onFocus={() => setOpen(true)}
+                            onFocus={() => {
+                                setOpen(true);
+                                window.setTimeout(() => {
+                                    inputRef.current?.scrollIntoView({
+                                        block: "nearest",
+                                        inline: "nearest",
+                                    });
+                                }, 150);
+                            }}
                             onKeyDown={(e) => {
                                 if (e.key === "Escape") {
                                     // Stop the key from bubbling up and
@@ -314,7 +322,7 @@ export default function MedicineSearchSelect({
                 <ul
                     id={listId}
                     role="listbox"
-                    className="absolute z-50 mt-1 max-h-52 w-full overflow-auto rounded-lg border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900 dark:shadow-slate-900/50"
+                    className="absolute z-50 mt-1 max-h-[40vh] w-full overflow-auto rounded-lg border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900 dark:shadow-slate-900/50"
                 >
                     {loading && (
                         <li


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [X] I am assigned to this issue.
- [X] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2917  **
- **Summary:**
Fix mobile keyboard overlap in SahiDawa report wizard and medicine search pages by adding keyboard-safe viewport layout and input focus scrolling. This includes:
apps/web/components/reports/ReportWizard.tsx
apps/web/src/components/MedicineSearchSelect.tsx
apps/web/app/[locale]/report/page.tsx
apps/web/app/[locale]/calculator/page.tsx

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [X] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [X] 🎨 `type: design`
- [X] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [X] ♿ `type: accessibility`

## ✅ Checklist

- [X] My PR has a linked issue (`Closes #2917 `)
- [X] I have pulled the latest `main` and resolved any conflicts
