### PR TITLE
Fix/reports duplicate upsert clean

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -141,7 +141,8 @@ reportsRouter.post(
                 req.user?.id ?? null
             );
 
-            const { data: report, error } = await supabase
+            const reportHash = computeReportHash(validationPayload);
+            const { data: reports, error } = await supabase
                 .from("counterfeit_reports")
                 .upsert(
                     {
@@ -159,7 +160,7 @@ reportsRouter.post(
                         report_location: buildReportLocation(data.latitude, data.longitude),
                         reporter_id: req.user?.id ?? null,
                         ip_address: ipAddress,
-                        report_hash: computeReportHash(validationPayload),
+                        report_hash: reportHash,
                         risk_score: validation.riskScore,
                         is_escalated: !validation.passed,
                         duplicate_group_id: validation.duplicateGroupId ?? null,
@@ -171,12 +172,36 @@ reportsRouter.post(
                 )
                 .select(
                     "id, reported_brand_name, status, district, created_at, scanned_barcode, medicine_id"
-                )
-                .single();
+                );
 
             if (error) {
-                res.status(500).json({ error: "Failed to submit counterfeit report" });
+                res.status(500).json({
+                    error: "Failed to submit counterfeit report",
+                });
                 return;
+            }
+
+            let report = reports?.[0];
+
+            let statusCode = 201;
+            if (!report) {
+                const { data: existingReport, error: fetchError } = await supabase
+                    .from("counterfeit_reports")
+                    .select(
+                        "id, reported_brand_name, status, district, created_at, scanned_barcode, medicine_id"
+                    )
+                    .eq("report_hash", reportHash)
+                    .single();
+
+                if (fetchError) {
+                    res.status(500).json({
+                        error: "Failed to fetch existing report",
+                    });
+                    return;
+                }
+
+                report = existingReport;
+                statusCode = 200;
             }
 
             const response: Record<string, unknown> = { report };
@@ -190,7 +215,7 @@ reportsRouter.post(
                 };
             }
 
-            res.status(201).json(response);
+            res.status(statusCode).json(response);
         } catch (err) {
             next(err);
         }

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -191,11 +191,18 @@ reportsRouter.post(
                         "id, reported_brand_name, status, district, created_at, scanned_barcode, medicine_id"
                     )
                     .eq("report_hash", reportHash)
-                    .single();
+                    .maybeSingle();
 
                 if (fetchError) {
                     res.status(500).json({
                         error: "Failed to fetch existing report",
+                    });
+                    return;
+                }
+
+                if (!existingReport) {
+                    res.status(500).json({
+                        error: "Existing report could not be retrieved",
                     });
                     return;
                 }
@@ -366,7 +373,7 @@ reportsRouter.patch(
                 .from("counterfeit_reports")
                 .select("id")
                 .eq("id", req.params.id)
-                .single();
+                .maybeSingle();
 
             if (fetchError || !existing) {
                 res.status(404).json({ error: "Report not found" });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2833**

- **Summary:**
  - Removed `.single()` from the `upsert(..., { ignoreDuplicates: true })` flow.
  - Handled the empty result returned when duplicate reports are ignored.
  - Queried the existing report using `report_hash` when no rows were returned by the upsert.
  - Replaced `.single()` with `.maybeSingle()` where appropriate and added defensive null checks to avoid `PGRST116` errors.

## 📸 Proof of Work (Screenshots / Logs)

- Screenshot of successful `npm run lint`
- Relevant startup logs from the local environment (if required)

<img width="386" height="113" alt="image" src="https://github.com/user-attachments/assets/d2a6ed66-a6d0-4f9b-94d1-df39bd79c551" />

<img width="643" height="304" alt="image" src="https://github.com/user-attachments/assets/30621405-993c-4511-b15c-ec9d21051028" />


### Local verification

- ✅ Verified the route changes compile successfully.
- ✅ Confirmed the fix matches the issue acceptance criteria through code review.

### Note

I attempted to perform end-to-end local verification of the duplicate report flow. However, testing was blocked by unrelated local environment issues, including startup failures caused by local Supabase schema mismatches and initialization of background services (cache warming, medicine normalizer, and scheduled jobs). These issues are outside the scope of this PR and were not introduced by the changes in `reports.ts`.

All temporary debugging changes used during local verification were reverted before opening this PR.

_Logs/screenshots of the local environment issue can be provided if needed._

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2833`)
- [x] I have pulled the latest `main` and resolved any conflicts