### PR TITLE
feat(chatbot): close chat window when clicking outside container

### DIFF
--- a/apps/web/app/[locale]/components/Chatbot.tsx
+++ b/apps/web/app/[locale]/components/Chatbot.tsx
@@ -55,6 +55,7 @@ export default function Chatbot() {
     const [input, setInput] = useState("");
     const [isConfirmingClear, setIsConfirmingClear] = useState(false);
     const messagesEndRef = useRef<HTMLDivElement>(null);
+    const chatbotRef = useRef<HTMLDivElement>(null);
     const activeRequestRef = useRef<AbortController | null>(null);
 
     const scrollToBottom = () => {
@@ -85,6 +86,21 @@ export default function Chatbot() {
 
         return () => clearTimeout(timer);
     }, []);
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (chatbotRef.current && !chatbotRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+
+        if (isOpen) {
+            document.addEventListener("mousedown", handleClickOutside);
+        }
+
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, [isOpen]);
 
     useEffect(() => {
         return () => {
@@ -166,6 +182,7 @@ export default function Chatbot() {
     return (
         <div className={getChatbotPositionClasses({ pathname, isOpen })}>
             <div
+            ref={chatbotRef}
                 className={`${getChatbotPanelClasses({ pathname })} ${
                     isOpen
                         ? "pointer-events-auto scale-100 opacity-100"
@@ -280,7 +297,10 @@ export default function Chatbot() {
                 )}
 
                 <button
-                    onClick={() => setIsOpen(!isOpen)}
+                    onClick={(e) => {
+    e.stopPropagation();
+    setIsOpen(!isOpen);
+}}
                     className="relative z-10 flex h-14 w-14 items-center justify-center rounded-full bg-green-600 text-white shadow-[0_8px_20px_rgba(22,163,74,0.3)] transition-all hover:scale-105 hover:shadow-[0_8px_25px_rgba(22,163,74,0.4)] active:scale-95 dark:bg-green-700 dark:hover:bg-green-800"
                     aria-label={isOpen ? tA11y("closeAiChat") : tA11y("openAiChat")}
                 >


### PR DESCRIPTION
## Description
This PR resolves a UX gap where the chatbot panel remains open indefinitely unless the explicit toggle/close button is clicked. It introduces an event listener to detect clicks outside the chatbot container component and seamlessly transitions the panel closed.
closes #3055 
## Changes
* **Outside Click Detection:** Added a `useRef` hook (`chatbotRef`) to track the main chatbot panel wrapper and a `useEffect` hook to manage a global `mousedown` event listener.
* **State Updates:** Automatically invokes `setIsOpen(false)` when a click is registered outside the component boundary.
* **Event Propagation Handling:** Applied `e.stopPropagation()` on the floating toggle action button's `onClick` handler to prevent immediate re-closing conflicts when opening the panel.
* **Animation Preservation:** Leveraged the existing Tailwind UI layout rules (`opacity-0`, `pointer-events-none`) to ensure the entry/exit transitions remain smooth.

## Testing Locally
1. Opened the chatbot by clicking the green floating action button.
2. Verified clicking inside the chat window, header, or text input allows interaction without closing the panel.
3. Verified clicking anywhere on the background landing page immediately transitions the chatbot to its closed state.
4. Confirmed the toggle button opens and closes the menu seamlessly without state locking.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] Tested changes locally and verified they work as intended.
<img width="1366" height="768" alt="testedok" src="https://github.com/user-attachments/assets/7eef166b-d09e-4e19-986b-d02e761a4ed2" />
