### PR TITLE
fix(api): add Zod schema validation to ABHA link/verify-otp/upload-verification routes

### DIFF
--- a/apps/api/src/routes/abha.ts
+++ b/apps/api/src/routes/abha.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import { requireAuth, AuthenticatedRequest } from "../middleware/auth";
 import { limiter } from "../middleware/rateLimit";
+import { z } from "zod";
 import {
     generateOTP,
     verifyOTP,
@@ -9,20 +10,44 @@ import {
     unlinkABHA,
 } from "../services/abha.service";
 
+// Zod schemas for validating ABHA route request bodies.
+// abhaAddress format is ultimately validated by ABDM itself (see
+// "Invalid ABHA address:" error in abha.service.ts) — we only guard
+// against wrong types / empty values here, not ABDM's exact format rules.
+const linkSchema = z.object({
+    abhaAddress: z.string().trim().min(1).max(256),
+});
+
+const verifyOtpSchema = z.object({
+    txnId: z.string().trim().min(1),
+    otp: z
+        .string()
+        .trim()
+        .regex(/^\d{4,8}$/, "OTP must be 4-8 digits"),
+});
+
+const uploadVerificationSchema = z.object({
+    medicineId: z.string().trim().min(1),
+    verificationResult: z.string().trim().min(1),
+    scannedAt: z.string().datetime(),
+});
+
 const router = Router();
 
 // POST /api/v1/abha/link
 // Initiates ABHA linking by generating an OTP for the given ABHA address
 router.post("/link", limiter, async (req: Request, res: Response): Promise<void> => {
     try {
-        const { abhaAddress } = req.body;
-
-        if (!abhaAddress) {
-            res.status(400).json({ error: "abhaAddress is required" });
+        const parsed = linkSchema.safeParse(req.body);
+        if (!parsed.success) {
+            res.status(400).json({
+                error: "Invalid link payload",
+                issues: parsed.error.issues,
+            });
             return;
         }
 
-        const result = await generateOTP(abhaAddress);
+        const result = await generateOTP(parsed.data.abhaAddress);
         res.status(200).json(result);
     } catch (error) {
         res.status(500).json({
@@ -35,14 +60,16 @@ router.post("/link", limiter, async (req: Request, res: Response): Promise<void>
 // Verifies the OTP and returns an ABHA token
 router.post("/verify-otp", limiter, async (req: Request, res: Response): Promise<void> => {
     try {
-        const { txnId, otp } = req.body;
-
-        if (!txnId || !otp) {
-            res.status(400).json({ error: "txnId and otp are required" });
+        const parsed = verifyOtpSchema.safeParse(req.body);
+        if (!parsed.success) {
+            res.status(400).json({
+                error: "Invalid OTP verification payload",
+                issues: parsed.error.issues,
+            });
             return;
         }
 
-        const result = await verifyOTP(txnId, otp);
+        const result = await verifyOTP(parsed.data.txnId, parsed.data.otp);
         res.status(200).json(result);
     } catch (error) {
         res.status(500).json({
@@ -87,20 +114,16 @@ router.post(
                 return;
             }
 
-            const { medicineId, verificationResult, scannedAt } = req.body;
-
-            if (!medicineId || !verificationResult || !scannedAt) {
+            const parsed = uploadVerificationSchema.safeParse(req.body);
+            if (!parsed.success) {
                 res.status(400).json({
-                    error: "medicineId, verificationResult, and scannedAt are required",
+                    error: "Invalid verification upload payload",
+                    issues: parsed.error.issues,
                 });
                 return;
             }
 
-            const result = await uploadVerification(userId, {
-                medicineId,
-                verificationResult,
-                scannedAt,
-            });
+            const result = await uploadVerification(userId, parsed.data);
 
             res.status(200).json(result);
         } catch (error) {

--- a/apps/api/tests/abha.routes.test.ts
+++ b/apps/api/tests/abha.routes.test.ts
@@ -1,0 +1,106 @@
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || "http://localhost:54321";
+process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "test-anon-key";
+(global as any).WebSocket = (global as any).WebSocket || class {};
+
+jest.mock("../src/db/client", () => ({
+    supabase: {
+        from: jest.fn().mockReturnThis(),
+        insert: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn(),
+    },
+}));
+
+jest.mock("../src/middleware/auth", () => ({
+    requireAuth: (req: any, _res: any, next: any) => {
+        req.user = { id: "test-user-uuid", role: "user", email: "user@example.com" };
+        next();
+    },
+    optionalAuth: (_req: any, _res: any, next: any) => next(),
+    requireRole: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock("../src/services/abha.service", () => ({
+    generateOTP: jest.fn().mockResolvedValue({ txnId: "mock-txn-id" }),
+    verifyOTP: jest.fn().mockResolvedValue({ token: "mock-token" }),
+    uploadVerification: jest.fn().mockResolvedValue({ success: true }),
+    getPrescriptions: jest.fn().mockResolvedValue([]),
+    unlinkABHA: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+import request from "supertest";
+import app from "../src/app";
+
+describe("POST /api/v1/abha/link", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("rejects a missing abhaAddress", async () => {
+        const response = await request(app).post("/api/v1/abha/link").send({});
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe("Invalid link payload");
+    });
+
+    it("rejects a non-string abhaAddress", async () => {
+        const response = await request(app).post("/api/v1/abha/link").send({ abhaAddress: 12345 });
+        expect(response.status).toBe(400);
+    });
+
+    it("accepts a valid abhaAddress", async () => {
+        const response = await request(app)
+            .post("/api/v1/abha/link")
+            .send({ abhaAddress: "testuser@abdm" });
+        expect(response.status).toBe(200);
+        expect(response.body.txnId).toBe("mock-txn-id");
+    });
+});
+
+describe("POST /api/v1/abha/verify-otp", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("rejects a malformed otp", async () => {
+        const response = await request(app)
+            .post("/api/v1/abha/verify-otp")
+            .send({ txnId: "txn-1", otp: "abc" });
+        expect(response.status).toBe(400);
+    });
+
+    it("rejects a missing txnId", async () => {
+        const response = await request(app).post("/api/v1/abha/verify-otp").send({ otp: "123456" });
+        expect(response.status).toBe(400);
+    });
+
+    it("accepts a valid txnId and otp", async () => {
+        const response = await request(app)
+            .post("/api/v1/abha/verify-otp")
+            .send({ txnId: "txn-1", otp: "123456" });
+        expect(response.status).toBe(200);
+        expect(response.body.token).toBe("mock-token");
+    });
+});
+
+describe("POST /api/v1/abha/upload-verification", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("rejects an invalid scannedAt", async () => {
+        const response = await request(app)
+            .post("/api/v1/abha/upload-verification")
+            .send({ medicineId: "med-1", verificationResult: "real", scannedAt: "banana" });
+        expect(response.status).toBe(400);
+    });
+
+    it("accepts a valid payload", async () => {
+        const response = await request(app).post("/api/v1/abha/upload-verification").send({
+            medicineId: "med-1",
+            verificationResult: "real",
+            scannedAt: new Date().toISOString(),
+        });
+        expect(response.status).toBe(200);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3050**
- **Summary:** Previously the ABHA `link`, `verify-otp`, and `upload-verification` routes only checked that request body fields were present (truthy), not that they were the correct type, format, or length. This PR adds explicit Zod schemas for all three routes and replaces the manual truthy checks with `.safeParse()`, matching the validation convention already used throughout the rest of `apps/api/src/routes` (e.g. `registerPharmacySchema`, `eligibilitySchema`, `trackSchema`).

### What was wrong

| Route | Old check | Gap |
|---|---|---|
| `POST /link` | `if (!abhaAddress)` | A number, array, or object would pass since they're all truthy. Only rejects `undefined`/`null`/`""`. |
| `POST /verify-otp` | `if (!txnId \|\| !otp)` | No length or format constraint on `otp` — a 1-character or 30-character string both pass. |
| `POST /upload-verification` | `if (!medicineId \|\| !verificationResult \|\| !scannedAt)` | `scannedAt` isn't checked as a real date — the literal string `"banana"` would pass and get written to `abha_records` as-is. |

In all three cases, unvalidated input was forwarded directly to `abha.service.ts`, which either sends it to the ABDM sandbox (RSA-encrypted, so malformed input surfaces as a confusing downstream error rather than a clean 400) or writes it straight into `abha_records`. Since ABHA is India's national digital health ID system, this data is more sensitive than an average field.

### What changed

Added three schemas near the top of `abha.ts`:

- **`linkSchema`** — `abhaAddress` must be a non-empty string, max 256 chars. Note: I deliberately did *not* impose a strict format regex (e.g. `name@abdm`) — `abha.service.ts` already forwards `abhaAddress` to ABDM's sandbox, which returns its own `"Invalid ABHA address: ..."` error for malformed addresses. Guessing at ABDM's exact format rule risks rejecting valid addresses that ABDM would accept; this schema only closes the "wrong type entirely" gap.
- **`verifyOtpSchema`** — `txnId` non-empty string; `otp` constrained to `4–8` digits via regex. This bound is a reasonable assumption based on common OTP conventions, not a documented ABDM spec — flagging this for reviewers in case ABDM's actual OTP length differs.
- **`uploadVerificationSchema`** — mirrors the `ABHAVerificationData` interface already defined in `abha.service.ts` exactly (`medicineId`, `verificationResult`, `scannedAt` — all strings), with `scannedAt` upgraded to `z.string().datetime()` so malformed timestamps are rejected before insertion.

Each route now does `schema.safeParse(req.body)` → returns `400` with the specific Zod validation issues on failure → uses the validated
Test Suites: 2 passed, 2 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Ran all test suites matching abha.

(6 pre-existing tests in `abha.service.test.ts` + 8 new tests in `abha.routes.test.ts`, run via `npm test -- abha`)

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] 🔒 `type: security`
- [x] 🧪 `type: testing`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3050`)
- [x] I have pulled the latest `main` and resolved any conflicts