### PR TITLE
fix(interaction-checker): prevent stale autocomplete results

### DIFF
--- a/apps/web/app/[locale]/interaction-checker/page.tsx
+++ b/apps/web/app/[locale]/interaction-checker/page.tsx
@@ -115,19 +115,30 @@ export default function InteractionCheckerPage() {
             return;
         }
 
+        // Guards against out-of-order responses: if the search text changes
+        // (or this effect re-runs/unmounts) before the request resolves,
+        // `isStale` is flipped to true and the stale response is discarded
+        // instead of overwriting the suggestions for the current query.
+        let isStale = false;
+
         const delayId = setTimeout(() => {
             fuzzyMatchBrand(query)
                 .then((res) => {
+                    if (isStale) return;
                     // Filter duplicates and map names
                     const names = Array.from(new Set(res.map((s) => s.name)));
                     setSuggestions(names);
                 })
                 .catch((err) => {
+                    if (isStale) return;
                     console.error("Suggestions lookup failed:", err);
                 });
         }, 250);
 
-        return () => clearTimeout(delayId);
+        return () => {
+            isStale = true;
+            clearTimeout(delayId);
+        };
     }, [searchQuery]);
 
     // Handle clicks outside suggestions dropdown to close it


### PR DESCRIPTION
## Related Issue
Closes #3021

## Description

Fixed a race condition in the Interaction Checker autocomplete that could display outdated suggestions when users typed quickly.

Previously, multiple autocomplete requests could be in flight at the same time. If an older request completed after a newer one, its response could overwrite the latest suggestions, causing the dropdown to display results for an outdated query.

## Changes Made

- Added protection against stale autocomplete responses
- Ensured only the latest request updates the suggestions list
- Prevented outdated API responses from overriding newer results
- Improved autocomplete reliability during fast typing
- Preserved existing search functionality and user experience

## Steps to Test

1. Open the **Interaction Checker** page
2. Type a medicine name quickly (e.g., `para`)
3. Immediately replace it with another query (e.g., `crocin`)
4. Verify the suggestions correspond only to the latest query
5. Repeat with different medicine names and varying typing speeds
6. Confirm no stale suggestions appear

## Expected Result

- Suggestions always match the most recent search query.
- Older API responses are ignored.
- Users no longer see outdated autocomplete results.

## Files Changed

- `apps/web/app/[locale]/interaction-checker/page.tsx`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update