### PR TITLE
fix(history): prevent CSV formula injection in exports

### DIFF
--- a/apps/web/app/[locale]/history/ExportModal.tsx
+++ b/apps/web/app/[locale]/history/ExportModal.tsx
@@ -13,6 +13,36 @@ interface ExportModalProps {
     t: (key: string) => string;
 }
 
+// Characters that spreadsheet apps (Excel, Google Sheets, LibreOffice) treat
+// as the start of a formula when they appear as the first character of a cell.
+const FORMULA_TRIGGER_CHARS = ["=", "+", "-", "@", "\t", "\r"];
+
+/**
+ * Safely prepares a value for inclusion in a CSV file.
+ *
+ * 1. Formula-injection guard: if the stringified value starts with a
+ *    character a spreadsheet app would interpret as the start of a formula
+ *    (=, +, -, @, or leading tab/carriage-return tricks), prefix it with a
+ *    single quote. Spreadsheet apps then render the cell as plain text
+ *    instead of evaluating it.
+ * 2. Standard CSV escaping: if the value contains a comma, double quote,
+ *    or newline, wrap it in double quotes and escape any internal double
+ *    quotes by doubling them, per RFC 4180.
+ */
+function sanitizeCsvField(value: unknown): string {
+    let str = value === null || value === undefined ? "" : String(value);
+
+    if (FORMULA_TRIGGER_CHARS.some((char) => str.startsWith(char))) {
+        str = `'${str}`;
+    }
+
+    if (/[",\n\r]/.test(str)) {
+        str = `"${str.replace(/"/g, '""')}"`;
+    }
+
+    return str;
+}
+
 export default function ExportModal({ isOpen, onClose, history, t }: ExportModalProps) {
     const [dateRange, setDateRange] = useState("all");
     const [statusFilter, setStatusFilter] = useState("all");
@@ -51,10 +81,10 @@ export default function ExportModal({ isOpen, onClose, history, t }: ExportModal
             const headers = ["ID", "Date", "Medicine Name", "Status"];
 
             const rows = filtered.map((e) => [
-                e.id,
-                new Date(e.timestamp).toISOString(),
-                `"${e.medicineName}"`,
-                e.status,
+                sanitizeCsvField(e.id),
+                sanitizeCsvField(new Date(e.timestamp).toISOString()),
+                sanitizeCsvField(e.medicineName),
+                sanitizeCsvField(e.status),
             ]);
 
             const csvContent = [headers.join(","), ...rows.map((r) => r.join(","))].join("\n");


### PR DESCRIPTION
## Related Issue
Closes #3020

## Description

Fixed a CSV injection vulnerability in the Scan History export feature by safely escaping values that could be interpreted as spreadsheet formulas.

Previously, medicine names and other exported values were written directly to the CSV file. If a value started with `=`, `+`, `-`, or `@`, spreadsheet applications such as Microsoft Excel or Google Sheets could interpret it as a formula.

## Changes Made

- Added CSV value sanitization before export
- Prefixed values starting with `=`, `+`, `-`, or `@` with a single quote (`'`)
- Preserved the original exported data while preventing formula execution
- Improved the security of exported CSV files

## Steps to Test

1. Save a scan history entry with a medicine name such as:
   ```
   =HYPERLINK("https://example.com")
   ```
2. Open the **History** page
3. Click **Export CSV**
4. Open the exported CSV in Excel or Google Sheets
5. Verify the value is displayed as plain text instead of being executed as a formula
6. Verify normal medicine names continue to export correctly

## Expected Result

- Values beginning with `=`, `+`, `-`, or `@` are treated as plain text.
- No spreadsheet formulas are executed when opening the exported CSV.
- Normal CSV export behavior remains unchanged.

## Files Changed

- `apps/web/app/[locale]/history/ExportModal.tsx`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update