### PR TITLE
fix: apply non-numeric OCR misread substitutions in fixOcrMisreads

### DIFF
--- a/apps/api/src/utils/medicineNameNormalizer.ts
+++ b/apps/api/src/utils/medicineNameNormalizer.ts
@@ -174,15 +174,22 @@ class MedicineNameNormalizer {
      */
     private fixOcrMisreads(text: string): string {
         let result = text;
+        const numericKeys = new Set(["0", "1", "5", "8"]);
 
-        // Apply substitutions carefully to avoid over-correction
-        // Check each character pair for likely OCR errors
         for (const [from, to] of this.commonOcrMisreads) {
-            // Only replace if it looks like an OCR error (e.g., standalone "0" as word, not in numbers)
-            if (from === "0" || from === "1" || from === "5" || from === "8") {
-                // Skip numeric-looking patterns
+            if (numericKeys.has(from)) {
+                // Only replace standalone digits used as words, not digits inside numbers
                 result = result.replace(new RegExp(`\\b${from}\\b`, "g"), to);
+            } else if (from.length > 1) {
+                // Multi-character OCR confusions (e.g. "rn" -> "m") are safe to apply
+                // directly: they're unlikely to appear as a false-positive substring.
+                result = result.split(from).join(to);
             }
+            // NOTE: single-character non-numeric keys (e.g. "l" -> "I", "O" -> "0")
+            // are intentionally NOT applied here. A blind replace corrupts extremely
+            // common, legitimate letters in real medicine names (e.g. "paracetamol"
+            // -> "paracetamoI", "lisinopril" -> "IisinopriI"). Enabling these safely
+            // would need a smarter, context-aware check, which is out of scope here.
         }
 
         return result;

--- a/apps/api/tests/medicineNameNormalizer.test.ts
+++ b/apps/api/tests/medicineNameNormalizer.test.ts
@@ -182,6 +182,16 @@ describe("MedicineNameNormalizer", () => {
             expect(result.normalized).toContain("metformin");
         });
 
+        it("should correct 'rn' misread as 'm'", () => {
+            const result = medicineNameNormalizer.normalize("Warndin");
+            expect(result.normalized).toBe("wamdin");
+        });
+
+        it("should NOT corrupt legitimate lowercase 'l' occurrences (single-char substitutions intentionally disabled)", () => {
+            const result = medicineNameNormalizer.normalize("Lisinopril");
+            expect(result.normalized).toBe("lisinopril");
+        });
+
         it("should handle OCR output with mixed punctuation", () => {
             const result = medicineNameNormalizer.normalize("Aspirin-500|mg_(Brand)");
             expect(result.normalized).toBe("aspirin 500 mg");


### PR DESCRIPTION
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #2832**
- **Summary:** fixOcrMisreads only applied substitutions for the numeric keys
  (0, 1, 5, 8), silently skipping every non-numeric OCR pair in the map
  (rn->m, l->I, O->0) due to a missing else branch. Fixed the loop so
  multi-character non-numeric keys (rn->m) are applied directly. Intentionally
  did NOT enable the single-character keys (l->I, O->0) as literal
  substitutions — doing so corrupts common medicine names containing those
  letters (e.g. "paracetamol" -> "paracetamoI", "lisinopril" -> "IisinopriI").
  Flagging this for discussion: a safe fix for single-character OCR confusions
  would need context-aware matching (e.g. only within OCR-flagged tokens),
  which is out of scope for this PR.
  
## 📸 Proof of Work (Screenshots / Logs)
Backend-only fix, no UI changes. Full test suite for this file passes,
including new tests for the rn->m correction and a regression guard
ensuring "l" is not blindly replaced:
PASS  tests/medicineNameNormalizer.test.ts
Test Suites: 1 passed, 1 total
Tests:       38 passed, 38 total

## 🏷️ PR Type
- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
