### PR TITLE
fix(web): validate and sanitize LocalStorage imports and inputs in Interaction Checker(closes #3019)

### DIFF
--- a/apps/web/app/[locale]/interaction-checker/page.tsx
+++ b/apps/web/app/[locale]/interaction-checker/page.tsx
@@ -97,20 +97,35 @@ export default function InteractionCheckerPage() {
         const stored = localStorage.getItem(STORAGE_KEY);
         if (stored) {
             try {
-                const parsed = JSON.parse(stored) as string[];
+                const parsed = JSON.parse(stored);
                 if (Array.isArray(parsed)) {
-                    setSelectedMedicines(parsed);
+                    const validated = parsed
+                        .filter((item): item is string => typeof item === "string")
+                        .map((item) => item.trim().replace(/[\x00-\x1F\x7F-\x9F<>]/g, ""))
+                        .filter((item) => item.length > 0 && item.length <= 100)
+                        .slice(0, 50);
+
+                    setSelectedMedicines(validated);
+
+                    // Sync back to local storage if sanitized/changed
+                    if (
+                        validated.length !== parsed.length ||
+                        validated.some((val, idx) => val !== parsed[idx])
+                    ) {
+                        localStorage.setItem(STORAGE_KEY, JSON.stringify(validated));
+                    }
                 }
             } catch (err) {
                 console.error("Failed to parse stored medicines list:", err);
+                localStorage.removeItem(STORAGE_KEY);
             }
         }
     }, []);
 
     // Debounced autocomplete suggestions
     useEffect(() => {
-        const query = searchQuery.trim();
-        if (query.length < 2) {
+        const query = searchQuery.trim().replace(/[\x00-\x1F\x7F-\x9F<>]/g, "");
+        if (query.length < 2 || query.length > 100) {
             setSuggestions([]);
             return;
         }
@@ -151,13 +166,18 @@ export default function InteractionCheckerPage() {
     };
 
     const handleAddMedicine = (medName: string) => {
-        const formatted = medName.trim();
-        if (!formatted) return;
+        const sanitized = medName.trim().replace(/[\x00-\x1F\x7F-\x9F<>]/g, "");
+        if (!sanitized || sanitized.length > 100) return;
+
+        if (selectedMedicines.length >= 50) {
+            setError("Maximum of 50 medicines can be selected.");
+            return;
+        }
 
         // Prevent duplicates (case-insensitive check)
-        const exists = selectedMedicines.some((m) => m.toLowerCase() === formatted.toLowerCase());
+        const exists = selectedMedicines.some((m) => m.toLowerCase() === sanitized.toLowerCase());
         if (!exists) {
-            const updated = [...selectedMedicines, formatted];
+            const updated = [...selectedMedicines, sanitized];
             saveMedicinesList(updated);
         }
 

--- a/apps/web/tests/interaction-checker-security.test.tsx
+++ b/apps/web/tests/interaction-checker-security.test.tsx
@@ -1,0 +1,108 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import InteractionCheckerPage from "../app/[locale]/interaction-checker/page";
+import { fuzzyMatchBrand } from "@/lib/api";
+
+jest.mock("next-intl", () => ({
+    useLocale: () => "en",
+    useTranslations: () => {
+        const messages: Record<string, string> = {
+            addButton: "Add",
+            checkButton: "Check Interactions",
+            clearAll: "Clear all",
+            myMedicines: "My medicines",
+            noMedicines: "No medicines added yet.",
+            searchLabel: "Search medicine",
+            searchPlaceholder: "Search medicine name",
+            subtitle: "Check potential harmful interactions between multiple medications.",
+            title: "Medicine Interaction Checker",
+        };
+
+        return (key: string) => messages[key] ?? key;
+    },
+}));
+
+jest.mock("@/lib/api", () => ({
+    fuzzyMatchBrand: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("@/lib/api/interactions", () => ({
+    checkInteractions: jest.fn().mockResolvedValue({ interactions: [], verified: true }),
+}));
+
+jest.mock("../app/[locale]/components/PageHeader", () => ({
+    PageHeader: () => <div data-testid="page-header" />,
+}));
+
+describe("InteractionCheckerPage Security & Sanitization", () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        localStorage.clear();
+    });
+
+    it("filters out control characters, HTML tags and keeps only safe values from local storage", async () => {
+        const malformedData = [
+            "Crocin",
+            "Warfarin<script>alert(1)</script>",
+            "A".repeat(150), // too long
+            "   ", // empty
+            "Paracetamol\u0000Special", // control char
+        ];
+        localStorage.setItem("sahidawa-my-medicines", JSON.stringify(malformedData));
+
+        render(<InteractionCheckerPage />);
+
+        // Crocin is valid, should be rendered
+        expect(screen.getByText("Crocin")).toBeInTheDocument();
+
+        // Warfarin<script>alert(1)</script> should be sanitized to "Warfarinscriptalert(1)/script"
+        expect(screen.getByText("Warfarinscriptalert(1)/script")).toBeInTheDocument();
+
+        // The extremely long medicine string should be filtered out
+        expect(screen.queryByText("A".repeat(150))).not.toBeInTheDocument();
+
+        // The control character item "Paracetamol\u0000Special" should become "ParacetamolSpecial"
+        expect(screen.getByText("ParacetamolSpecial")).toBeInTheDocument();
+    });
+
+    it("sanitizes typed input on add medicine action", async () => {
+        render(<InteractionCheckerPage />);
+
+        const input = screen.getByPlaceholderText("Search medicine name");
+
+        // Type a name containing HTML characters
+        fireEvent.change(input, { target: { value: "Aspirin<script>" } });
+        fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+        // Sanitized Aspirinscript should be added
+        expect(screen.getByText("Aspirinscript")).toBeInTheDocument();
+        expect(screen.queryByText("Aspirin<script>")).not.toBeInTheDocument();
+    });
+
+    it("restricts adding more than 50 medicines", async () => {
+        // Manually preset 50 items in local storage
+        const fiftyItems = Array.from({ length: 50 }, (_, i) => `Med-${i}`);
+        localStorage.setItem("sahidawa-my-medicines", JSON.stringify(fiftyItems));
+
+        render(<InteractionCheckerPage />);
+
+        const input = screen.getByPlaceholderText("Search medicine name");
+
+        // Try adding one more
+        fireEvent.change(input, { target: { value: "ExtraMedicine" } });
+        fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+        // Error message should be visible and item not added
+        expect(
+            await screen.findByText("Maximum of 50 medicines can be selected.")
+        ).toBeInTheDocument();
+        expect(screen.queryByText("ExtraMedicine")).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes** #3019
- **Summary:**
  - Sanitized `localStorage` imports by removing control characters, `<` and `>` tag brackets, limiting array size to 50 medicines, and individual string lengths to 100 characters.
  - Sanitized manually entered inputs in `handleAddMedicine` and autocompletion hooks using the same constraints.
  - Added the security test suite `apps/web/tests/interaction-checker-security.test.tsx`.

## 📸 Proof of Work (Screenshots / Logs)

### Unit tests execution:
```bash
PASS tests/interaction-checker-security.test.tsx
  InteractionCheckerPage Security & Sanitization
    ✓ filters out control characters, HTML tags and keeps only safe values from local storage (35 ms)
    ✓ sanitizes typed input on add medicine action (50 ms)
    ✓ restricts adding more than 50 medicines (120 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        1.914 s
```

### Build compilation logs:
```bash
▲ Next.js 16.2.9 (Turbopack)
- Environments: .env

  Creating an optimized production build ...
✓ Compiled successfully in 5.8s
  Running TypeScript ...
  Finished TypeScript in 13.1s ...
  Collecting page data using 15 workers ...
  Generating static pages using 15 workers (0/13) ...
✓ Generating static pages using 15 workers (13/13) in 244ms
  Finalizing page optimization ...
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3019`)
- [x] I have pulled the latest `main` and resolved any conflicts