### PR TITLE
fix(web): gracefully catch clipboard writeText promise rejection in handleShareAlert(closes #3018)

### DIFF
--- a/apps/web/app/[locale]/alerts/page.tsx
+++ b/apps/web/app/[locale]/alerts/page.tsx
@@ -189,14 +189,24 @@ export default function FullAlertsLogPage() {
             alert.reported_brand_name || alert.brand_name || alert.brand || "SYSTEM_UPDATE";
         const shareText = `⚠️ SahiDawa CDSCO Drug Safety Alert:\n\nBrand: ${brand}\nBatch: ${alert.batch_number || "N/A"}\n\nPlease check safety logs.`;
 
+        const writeToClipboard = () => {
+            navigator.clipboard
+                .writeText(shareText)
+                .then(() => {
+                    toast.success("Alert details copied to clipboard!");
+                })
+                .catch((err) => {
+                    console.error("Clipboard copy failed:", err);
+                    toast.error("Failed to copy alert details to clipboard.");
+                });
+        };
+
         if (navigator.share) {
             navigator.share({ title: `Safety Alert: ${brand}`, text: shareText }).catch(() => {
-                navigator.clipboard.writeText(shareText);
-                toast.success("Alert details copied to clipboard!");
+                writeToClipboard();
             });
         } else {
-            navigator.clipboard.writeText(shareText);
-            toast.success("Alert details copied to clipboard!");
+            writeToClipboard();
         }
     };
 


### PR DESCRIPTION
 ### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes** #3018
- **Summary:**
  - Introduced a `writeToClipboard` helper function that wraps `navigator.clipboard.writeText` inside `handleShareAlert`.
  - Added `.then` and `.catch` error handling to display proper toast notifications and log to console on write rejections instead of generating unhandled promise rejection warnings in non-secure or blocked browser contexts.

## 📸 Proof of Work (Screenshots / Logs)

### Build compilation logs:
```bash
▲ Next.js 16.2.9 (Turbopack)
- Environments: .env

  Creating an optimized production build ...
✓ Compiled successfully in 8.3s
  Running TypeScript ...
  Finished TypeScript in 17.1s ...
  Collecting page data using 15 workers ...
✓ Generating static pages using 15 workers (13/13) in 249ms
  Finalizing page optimization ...
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3018`)
- [x] I have pulled the latest `main` and resolved any conflicts