### PR TITLE
refactor(api): Use centralised cacheMiddleware in pharmacy routes

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -8,6 +8,7 @@ import { limiter } from "../middleware/rateLimit";
 import { requireAuth, AuthenticatedRequest } from "../middleware/auth";
 import { FormattedPharmacy, PharmacyRpcResult } from "../types/pharmacy.types";
 import { redisCache } from "../middleware/redisCache";
+import { cacheMiddleware } from "../middleware/cache";
 import multer from "multer";
 import { buildOrConditions } from "../utils/db";
 import Papa from "papaparse";
@@ -20,14 +21,6 @@ const router = Router();
 
 /** Maximum number of pharmacies returned per request */
 const MAX_RESULTS = 200;
-
-const GEOSPATIAL_CACHE_CONTROL = "public, max-age=300, s-maxage=300, stale-while-revalidate=600";
-
-const setGeospatialCacheHeaders = (res: Response) => {
-    res.setHeader("Cache-Control", GEOSPATIAL_CACHE_CONTROL);
-};
-
-import { cacheMiddleware } from "../middleware/cache";
 
 // ── TypeScript interfaces ────────────────────────────────────────────────────
 
@@ -1002,7 +995,6 @@ router.get(
                         timezone: p.timezone ?? null,
                     }))
                     .slice(0, MAX_RESULTS);
-                setGeospatialCacheHeaders(res);
                 return res.json({
                     pharmacies,
                     syncedAt,
@@ -1085,7 +1077,6 @@ router.get(
                 .slice(0, MAX_RESULTS)
                 .map(({ coords, ...rest }) => rest);
 
-            setGeospatialCacheHeaders(res);
             res.json({
                 pharmacies,
                 syncedAt,

--- a/apps/api/tests/pharmacies.test.ts
+++ b/apps/api/tests/pharmacies.test.ts
@@ -26,9 +26,20 @@ jest.mock("../src/middleware/auth", () => ({
 import request from "supertest";
 import app from "../src/app";
 import { supabase } from "../src/db/client";
+import { cacheMiddleware } from "../src/middleware/cache";
 
 const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
-const GEOSPATIAL_CACHE_CONTROL = "public, max-age=300, s-maxage=300, stale-while-revalidate=600";
+
+// Derived from the shared middleware (rather than a hardcoded literal) so this
+// stays correct if cacheMiddleware's header format ever changes.
+function cacheControlFor(durationSeconds: number, staleWhileRevalidateSeconds: number): string {
+    let headerValue = "";
+    const fakeRes = { setHeader: (name: string, value: string) => (headerValue = value) } as never;
+    cacheMiddleware(durationSeconds, staleWhileRevalidateSeconds)({} as never, fakeRes, () => {});
+    return headerValue;
+}
+
+const GEOSPATIAL_CACHE_CONTROL = cacheControlFor(300, 600);
 
 describe("GET /api/pharmacies/nearest", () => {
     beforeEach(() => {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #2852 
- - Removed the hardcoded GEOSPATIAL_CACHE_CONTROL constant and setGeospatialCacheHeaders helper from `apps/api/src/routes/pharmacies.ts` since both `/nearest` and `/in-bounds` already had `cacheMiddleware(300, 600)` wired in at the router level, so the manual header calls in `/in-bounds`'s two response branches were dead and not reasonable.
- Consolidated cache-header handling behind the existing `cacheMiddleware` in `apps/api/src/middleware/cache.ts`, removing route-level duplication.
- Rewrites the Cache-Control assertions in `apps/api/tests/pharmacies.test.ts` to derive the expected header value from `cacheMiddleware` itself instead of a hardcoded string literal, so the test can't silently drift out of sync with the middleware's actual output format.


## 📸 Proof of Work (Screenshots / Logs)

<img width="875" height="726" alt="image" src="https://github.com/user-attachments/assets/80bd4e2a-9093-42d9-bd43-213dd22f8827" />

Test run for pharmacy.test.ts:

GET /api/pharmacies/nearest
    √ should return Cache-Control header (95 ms)
    √ returns 400 when latitude or longitude is missing (26 ms)
    √ returns 400 for out-of-bounds coordinates (13 ms)
    √ returns 400 when non-numeric coordinates are provided (11 ms)
    √ returns pharmacies from PostGIS RPC when available (15 ms)
    √ passes search_radius_km to the PostGIS RPC call (27 ms)
    √ uses default radius of 50 km when not specified (12 ms)
    √ returns empty array when no pharmacies are within radius (14 ms)
    √ does not expose rawDistance in the response (10 ms)
    √ falls back to Haversine distance filtering and sorts nearby pharmacies (11 ms)
  GET /api/pharmacies/in-bounds
    √ should return Cache-Control header (13 ms)
    √ returns 400 when bounds are missing (12 ms)
    √ returns 400 for out-of-range bounds (9 ms)
    √ returns 400 when south >= north or west >= east (9 ms)
    √ returns pharmacies from PostGIS bounds RPC when available (16 ms)
    √ falls back to in-memory filter when bounds RPC is unavailable (11 ms)
  POST /api/pharmacies
    √ registers a new pharmacy successfully (36 ms)
    √ returns 409 when the license ID already exists (10 ms)
    √ returns 400 for invalid payload (10 ms)
  POST /api/pharmacies/bulk-upload — BOM stripping
    √ parses CSV with UTF-8 BOM marker correctly (15 ms)
    √ parses CSV without BOM marker correctly (12 ms)
  POST /api/pharmacies/bulk-upload — Robust CSV Parsing
    √ handles quoted commas, escaped quotes, and embedded newlines (10 ms)
    √ maintains correct row numbering with empty records and captures validation failures (8 ms)
    √ catches parser-level malformed records (10 ms)
  POST /api/pharmacies/:id/inventory/upload — Multer file-buffer path
    √ parses a valid CSV uploaded as a multipart file and returns correct counts (28 ms)
    √ correctly excludes empty rows from totalRows and the 500-row limit (15 ms)
    √ reports validation failures with correct logical row numbers via Multer path (10 ms)

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
