### PR TITLE
fix(api): add top-level error handling to cron job entry points

### DIFF
--- a/apps/api/src/cron/alert-broadcaster.ts
+++ b/apps/api/src/cron/alert-broadcaster.ts
@@ -527,7 +527,7 @@ export function startAlertBroadcaster(): { stop: () => void } {
 
     logger.info(`Starting Alert Broadcaster periodic loop (interval: ${CHECK_INTERVAL_MS}ms)`);
 
-    /// Run initial execution after a short delay
+    // Run initial execution after a short delay
     setTimeout(() => {
         checkAndBroadcastAll().catch((err) => {
             logger.error("Alert broadcaster: unhandled error during scheduled run", { error: err });

--- a/apps/api/src/cron/alert-broadcaster.ts
+++ b/apps/api/src/cron/alert-broadcaster.ts
@@ -527,13 +527,17 @@ export function startAlertBroadcaster(): { stop: () => void } {
 
     logger.info(`Starting Alert Broadcaster periodic loop (interval: ${CHECK_INTERVAL_MS}ms)`);
 
-    // Run initial execution after a short delay
+    /// Run initial execution after a short delay
     setTimeout(() => {
-        void checkAndBroadcastAll();
+        checkAndBroadcastAll().catch((err) => {
+            logger.error("Alert broadcaster: unhandled error during scheduled run", { error: err });
+        });
     }, 2000);
 
     intervalId = setInterval(() => {
-        void checkAndBroadcastAll();
+        checkAndBroadcastAll().catch((err) => {
+            logger.error("Alert broadcaster: unhandled error during scheduled run", { error: err });
+        });
     }, CHECK_INTERVAL_MS);
 
     return { stop: stopAlertBroadcaster };

--- a/apps/api/src/cron/districtAlertSync.ts
+++ b/apps/api/src/cron/districtAlertSync.ts
@@ -130,7 +130,14 @@ export async function syncDistrictAlertTallies(): Promise<void> {
 export const initDistrictAlertSyncCron = (): void => {
     // Runs every 6 hours
     cron.schedule("0 */6 * * *", async () => {
-        await syncDistrictAlertTallies();
+        try {
+            await syncDistrictAlertTallies();
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            logger.error("District alert tally sync cron: unhandled error during scheduled run", {
+                error: message,
+            });
+        }
     });
     logger.info("District alert tally sync cron initialized (every 6 hours)");
 };

--- a/apps/api/src/cron/expiry-check.ts
+++ b/apps/api/src/cron/expiry-check.ts
@@ -22,151 +22,156 @@ function buildExpiryPayload(medicineName: string, daysLeft: number) {
 export const initExpiryCron = () => {
     // Runs every day at 00:00 (midnight)
     cron.schedule("0 0 * * *", async () => {
-        logger.info("Running medicine expiry check...");
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-        const alertWindows = [
-            { days: 30, min: 15, max: 30 },
-            { days: 14, min: 8, max: 14 },
-            { days: 7, min: 0, max: 7 },
-        ];
-        for (const window of alertWindows) {
-            const days = window.days;
+        try {
+            logger.info("Running medicine expiry check...");
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+            const alertWindows = [
+                { days: 30, min: 15, max: 30 },
+                { days: 14, min: 8, max: 14 },
+                { days: 7, min: 0, max: 7 },
+            ];
+            for (const window of alertWindows) {
+                const days = window.days;
 
-            const minDate = new Date(today);
-            minDate.setDate(today.getDate() + window.min);
-            minDate.setHours(0, 0, 0, 0);
+                const minDate = new Date(today);
+                minDate.setDate(today.getDate() + window.min);
+                minDate.setHours(0, 0, 0, 0);
 
-            const maxDate = new Date(today);
-            maxDate.setDate(today.getDate() + window.max);
-            maxDate.setHours(23, 59, 59, 999);
-            const flagColumn = `notified_${days}d`;
+                const maxDate = new Date(today);
+                maxDate.setDate(today.getDate() + window.max);
+                maxDate.setHours(23, 59, 59, 999);
+                const flagColumn = `notified_${days}d`;
 
-            const { data, error } = await supabase
-                .from("tracked_medicines")
-                .select("*")
-                .gte("expiry_date", minDate.toISOString())
-                .lte("expiry_date", maxDate.toISOString())
-                .eq(flagColumn, false);
+                const { data, error } = await supabase
+                    .from("tracked_medicines")
+                    .select("*")
+                    .gte("expiry_date", minDate.toISOString())
+                    .lte("expiry_date", maxDate.toISOString())
+                    .eq(flagColumn, false);
 
-            if (error) {
-                logger.error(`Error fetching ${days}d expiring medicines`, { error });
-                continue;
-            }
+                if (error) {
+                    logger.error(`Error fetching ${days}d expiring medicines`, { error });
+                    continue;
+                }
 
-            let notifiedCount = 0;
-            const deliveredIds: string[] = [];
+                let notifiedCount = 0;
+                const deliveredIds: string[] = [];
 
-            for (const medicine of data || []) {
-                try {
-                    let delivered = false;
-                    const expiry = new Date(medicine.expiry_date);
+                for (const medicine of data || []) {
+                    try {
+                        let delivered = false;
+                        const expiry = new Date(medicine.expiry_date);
 
-                    const daysLeft = Math.max(
-                        0,
-                        Math.ceil((expiry.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
-                    );
-                    const payload = buildExpiryPayload(medicine.name, daysLeft);
+                        const daysLeft = Math.max(
+                            0,
+                            Math.ceil((expiry.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+                        );
+                        const payload = buildExpiryPayload(medicine.name, daysLeft);
 
-                    // --- Web Push ---
-                    if (isWebPushConfigured()) {
-                        const allSubs = await listPushSubscriptions();
-                        const userSubs = allSubs.filter((s) => s.userId === medicine.user_id);
+                        // --- Web Push ---
+                        if (isWebPushConfigured()) {
+                            const allSubs = await listPushSubscriptions();
+                            const userSubs = allSubs.filter((s) => s.userId === medicine.user_id);
 
-                        if (userSubs.length > 0) {
-                            const results = await Promise.allSettled(
-                                userSubs.map((item) =>
-                                    webPush.sendNotification(
-                                        item.subscription,
-                                        JSON.stringify(payload)
+                            if (userSubs.length > 0) {
+                                const results = await Promise.allSettled(
+                                    userSubs.map((item) =>
+                                        webPush.sendNotification(
+                                            item.subscription,
+                                            JSON.stringify(payload)
+                                        )
                                     )
-                                )
-                            );
+                                );
 
-                            // Record delivery events for analytics
-                            const fakeAlert = {
-                                id: `expiry-${medicine.id}-${days}d`,
-                                medicineName: medicine.name,
-                                reason: payload.body,
-                                severity: "medium" as const,
-                                source: "expiry-cron",
-                            };
-                            const events = results.map((result, i) =>
-                                buildPushDeliveryEvent(fakeAlert, userSubs[i].endpoint, result)
-                            );
-                            await recordPushDeliveryEvents(events);
+                                // Record delivery events for analytics
+                                const fakeAlert = {
+                                    id: `expiry-${medicine.id}-${days}d`,
+                                    medicineName: medicine.name,
+                                    reason: payload.body,
+                                    severity: "medium" as const,
+                                    source: "expiry-cron",
+                                };
+                                const events = results.map((result, i) =>
+                                    buildPushDeliveryEvent(fakeAlert, userSubs[i].endpoint, result)
+                                );
+                                await recordPushDeliveryEvents(events);
 
-                            // Clean up expired subscriptions (404/410 = unsubscribed)
-                            results.forEach((result, i) => {
-                                if (
-                                    result.status === "rejected" &&
-                                    [404, 410].includes(
-                                        (result.reason as { statusCode?: number })?.statusCode ?? -1
-                                    )
-                                ) {
-                                    removePushSubscription(userSubs[i].endpoint);
-                                }
-                            });
+                                // Clean up expired subscriptions (404/410 = unsubscribed)
+                                results.forEach((result, i) => {
+                                    if (
+                                        result.status === "rejected" &&
+                                        [404, 410].includes(
+                                            (result.reason as { statusCode?: number })
+                                                ?.statusCode ?? -1
+                                        )
+                                    ) {
+                                        removePushSubscription(userSubs[i].endpoint);
+                                    }
+                                });
 
-                            const sent = results.filter((r) => r.status === "fulfilled").length;
-                            if (sent > 0) delivered = true;
+                                const sent = results.filter((r) => r.status === "fulfilled").length;
+                                if (sent > 0) delivered = true;
+                            }
                         }
-                    }
 
-                    // --- SMS via notification_subscribers ---
-                    if (medicine.user_id) {
-                        const { data: subscriber } = await supabase
-                            .from("notification_subscribers")
-                            .select("phone, language")
-                            .eq("user_id", medicine.user_id)
-                            .maybeSingle();
+                        // --- SMS via notification_subscribers ---
+                        if (medicine.user_id) {
+                            const { data: subscriber } = await supabase
+                                .from("notification_subscribers")
+                                .select("phone, language")
+                                .eq("user_id", medicine.user_id)
+                                .maybeSingle();
 
-                        if (subscriber?.phone) {
-                            const smsMessage = `SahiDawa Alert: ${medicine.name} expires in ${daysLeft} day${daysLeft === 1 ? "" : "s"}. Please check your stock.`;
-                            const smsSent = await smsService.send(
-                                subscriber.phone,
-                                smsMessage,
-                                subscriber.language ?? "en"
-                            );
-                            if (smsSent) delivered = true;
+                            if (subscriber?.phone) {
+                                const smsMessage = `SahiDawa Alert: ${medicine.name} expires in ${daysLeft} day${daysLeft === 1 ? "" : "s"}. Please check your stock.`;
+                                const smsSent = await smsService.send(
+                                    subscriber.phone,
+                                    smsMessage,
+                                    subscriber.language ?? "en"
+                                );
+                                if (smsSent) delivered = true;
+                            }
                         }
-                    }
 
-                    // Collect delivered IDs for bulk update
-                    if (delivered) {
-                        deliveredIds.push(medicine.id);
-                        notifiedCount++;
-                    } else {
-                        logger.warn(
-                            `No delivery channel available for medicine ${medicine.id} (${days}d alert)`
+                        // Collect delivered IDs for bulk update
+                        if (delivered) {
+                            deliveredIds.push(medicine.id);
+                            notifiedCount++;
+                        } else {
+                            logger.warn(
+                                `No delivery channel available for medicine ${medicine.id} (${days}d alert)`
+                            );
+                        }
+                    } catch (err) {
+                        logger.error(
+                            `Failed to process ${days}d expiry alert for medicine ${medicine.id}`,
+                            { err }
                         );
                     }
-                } catch (err) {
-                    logger.error(
-                        `Failed to process ${days}d expiry alert for medicine ${medicine.id}`,
-                        { err }
-                    );
                 }
-            }
 
-            // Single bulk update after loop — avoids N+1 DB calls
-            if (deliveredIds.length > 0) {
-                const { error: updateError } = await supabase
-                    .from("tracked_medicines")
-                    .update({ [flagColumn]: true })
-                    .in("id", deliveredIds);
+                // Single bulk update after loop — avoids N+1 DB calls
+                if (deliveredIds.length > 0) {
+                    const { error: updateError } = await supabase
+                        .from("tracked_medicines")
+                        .update({ [flagColumn]: true })
+                        .in("id", deliveredIds);
 
-                if (updateError) {
-                    logger.error(
-                        `Error updating notification flags for ${days}d expiring medicines`,
-                        { error: updateError }
-                    );
+                    if (updateError) {
+                        logger.error(
+                            `Error updating notification flags for ${days}d expiring medicines`,
+                            { error: updateError }
+                        );
+                    }
                 }
-            }
 
-            logger.info(
-                `${days}d check done. ${data?.length ?? 0} medicines found, ${notifiedCount} notified.`
-            );
+                logger.info(
+                    `${days}d check done. ${data?.length ?? 0} medicines found, ${notifiedCount} notified.`
+                );
+            }
+        } catch (err) {
+            logger.error("Expiry check cron: unhandled error during scheduled run", { error: err });
         }
     });
 };


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3192**
- **Summary:** None of the three cron job entry points (`districtAlertSync.ts`, `expiry-check.ts`, `alert-broadcaster.ts`) had a top-level `try/catch` (or `.catch()` for the fire-and-forget calls in `alert-broadcaster.ts`) around their async callback. `apps/api/src/index.ts` registers a global `unhandledRejection` handler that calls `createGracefulShutdown()`, which unconditionally calls `process.exit(1)` in its `finally` block — meaning any unhandled rejection anywhere in the process, not just fatal ones, takes down the entire API server. Currently every function these cron jobs call already catches its own errors internally, so nothing throws in practice today — but that safety is purely conventional, not structural. A single future change to any of these files (or anything they call) that forgets an internal catch would become a fatal, process-wide crash instead of a skipped cron run. This PR adds a local safety net at each entry point so a failure is logged and contained instead of propagating to the global handler.

### What changed

| File | Before | After |
|---|---|---|
| `districtAlertSync.ts` | Bare `await syncDistrictAlertTallies();`, no try/catch | Wrapped in `try/catch` with `logger.error` |
| `expiry-check.ts` | Only the inner per-medicine loop was wrapped; the outer loop and initial query were unguarded | Entire cron callback body wrapped in one outer `try/catch` |
| `alert-broadcaster.ts` | Both `setTimeout`/`setInterval` used `void checkAndBroadcastAll();` with no `.catch()` | Both now use `checkAndBroadcastAll().catch(...)` with `logger.error` |

### What didn't change

- No changes to the actual broadcast/sync logic — this is purely additive error handling around existing entry points.
- `checkAndBroadcastAll()`'s internal `try/finally` is left as-is; the new `.catch()` at the call sites is what closes the gap, since `acquireLock`/`releaseLock` already self-catch and never throw.

## 📸 Proof of Work (Screenshots / Logs)

No UI changes — backend-only defensive error handling.

- `npx tsc --noEmit` — compiles clean aside from one unrelated, pre-existing error in `pharmacies.ts` (confirmed present on unmodified `main` via `git stash`, unrelated to this change).
- **Note on test coverage:** `apps/api/src/cron/alert-broadcaster.test.ts` exists but could not be executed to verify against this change. It's written for Node's native test runner (`node:test`), not the project's configured `jest` runner, and its `mock.module()` call is incompatible with the installed Node version (v22.17.1) — confirmed by attempting `node --test`, `npx tsx --test`, and `npx tsx --test --experimental-test-module-mocks`, all failing before reaching any broadcaster logic. This appears to be a pre-existing issue with the test file's compatibility, unrelated to this change. Happy to open a separate issue for this if useful.
- `districtAlertSync.ts` and `expiry-check.ts` have no existing test files to run against.
- Manually traced all three brace/callback structures to confirm correct nesting after edits (pasted full file contents for review during development).

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] ♻️ `type: refactor`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3192`)
- [x] I have pulled the latest `main` and resolved any conflicts