### PR TITLE
feat(webhook): add real-time medicine cache invalidation trigger

### DIFF
--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -83,4 +83,95 @@ router.post(
     }
 );
 
+/**
+ * POST /api/webhooks/supabase/medicines
+ *
+ * Supabase Database Webhook endpoint — triggered on INSERT, UPDATE, or DELETE
+ * on the medicines table. Invalidates all matching Redis cache keys.
+ *
+ * Secured via SUPABASE_WEBHOOK_SECRET environment variable.
+ */
+router.post(
+    "/supabase/medicines",
+    webhookLimiter,
+    async (req: Request, res: Response): Promise<void> => {
+        // Verify secret token using a timing-safe comparison
+        const secret = process.env.SUPABASE_WEBHOOK_SECRET;
+        const authHeader = req.headers["authorization"];
+
+        const isValid =
+            typeof secret === "string" &&
+            typeof authHeader === "string" &&
+            safeCompare(authHeader, `Bearer ${secret}`);
+
+        if (!isValid) {
+            logger.warn("Unauthorized webhook attempt on /api/webhooks/supabase/medicines", {
+                ip: req.ip,
+                headers: req.headers,
+            });
+            res.status(401).json({ error: "Unauthorized" });
+            return;
+        }
+
+        try {
+            if (!redisClient.isOpen) {
+                logger.warn("Redis not connected — skipping cache invalidation");
+                res.status(200).json({ invalidated: 0, message: "Redis unavailable" });
+                return;
+            }
+
+            const payload = req.body;
+            const record = payload.record || payload.old_record || {};
+            const batchNumber = record.batch_number;
+            const brandName = record.brand_name;
+            const genericName = record.generic_name;
+
+            const keysToDelete: string[] = [];
+
+            // 1. Invalidate drug lookup cache by scanning for keys starting with the batch number
+            if (batchNumber) {
+                let cursor: any = 0;
+                do {
+                    const result = await redisClient.scan(cursor, {
+                        MATCH: `drug:batch:${batchNumber}*`,
+                        COUNT: 100,
+                    });
+                    cursor = result.cursor;
+                    keysToDelete.push(...result.keys);
+                } while (cursor !== 0);
+            }
+
+            // 2. Invalidate voice search cache for matching brand and generic names
+            if (brandName) {
+                const normalizedBrand = brandName.toLowerCase().replace(/\s+/g, "_");
+                keysToDelete.push(`medicine:voice:${normalizedBrand}`);
+            }
+            if (genericName) {
+                const normalizedGeneric = genericName.toLowerCase().replace(/\s+/g, "_");
+                keysToDelete.push(`medicine:voice:${normalizedGeneric}`);
+            }
+
+            // 3. Perform deletion if keys exist
+            const uniqueKeys = Array.from(new Set(keysToDelete));
+            if (uniqueKeys.length > 0) {
+                await redisClient.del(uniqueKeys);
+                logger.info(`Medicine cache invalidated — deleted ${uniqueKeys.length} key(s)`, {
+                    keys: uniqueKeys,
+                });
+            } else {
+                logger.info("Medicine webhook fired — no cache keys found to invalidate");
+            }
+
+            res.status(200).json({
+                invalidated: uniqueKeys.length,
+                keys: uniqueKeys,
+            });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            logger.error("Failed to invalidate medicine cache via webhook", { error: message });
+            res.status(500).json({ error: "Cache invalidation failed" });
+        }
+    }
+);
+
 export default router;


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #3200 **
- **Summary:** Implements a real-time cache invalidation webhook handler at `/api/webhooks/supabase/medicines`. When a medicine is modified, inserted, or deleted in Supabase, the handler verifies the signature, scans for matching Redis cache keys (`drug:batch:*` and `medicine:voice:*`), and deletes them. This prevents the application from serving stale data (up to 24 hours) for updated, recalled, or counterfeit medicines

## Proof of Work
When the webhook is triggered by a database event and matches cached entries:
```text
info: Medicine cache invalidated — deleted 2 key(s)
```

If the webhook runs but no keys are found in cache:
```text
info: Medicine webhook fired — no cache keys found to invalidate
```

## 🏷️ PR Type
- [x] ✨ `type: feature`
- [x] ⚡ `type: performance`

## ✅ Checklist
- [x] My PR has a linked issue.
- [x] I have pulled the latest `main` and resolved any conflicts.
- [x] Webhook endpoint is secured using a timing-safe bearer token check matching `SUPABASE_WEBHOOK_SECRET`.
```