### PR TITLE
fix: chain .select().single() on tracked_medicines insert to return i…

### DIFF
--- a/apps/api/src/routes/tracking.ts
+++ b/apps/api/src/routes/tracking.ts
@@ -49,7 +49,9 @@ router.post(
         const userId = req.user!.id;
         const { data, error } = await supabase
             .from("tracked_medicines")
-            .insert([{ ...result.data, user_id: userId, is_verified: isVerified }]);
+            .insert([{ ...result.data, user_id: userId, is_verified: isVerified }])
+            .select()
+            .single();
 
         if (error) return res.status(500).json({ error: error.message });
         res.status(201).json({ message: "Medicine tracked successfully", data });


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #3214
- **Summary:** `POST /api/tracking/track` was returning `data: null` on every successful insert. In Supabase JS v2, `.insert()` does not return the inserted row unless `.select()` is chained. Added `.select().single()` to return the newly created tracked medicine record to the client.

**Files changed (1):**
- `apps/api/src/routes/tracking.ts`

## Proof of Work
**Before fix:**
```json
{ "message": "Medicine tracked successfully", "data": null }
```
**After fix:**
```json
{ "message": "Medicine tracked successfully", "data": { "id": "...", "medicine_name": "Paracetamol", ... } }
```

## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue.
- [x] I have pulled the latest `main` and resolved any conflicts.
```