### PR TITLE
fix: validate medicineName input in LASA check to prevent empty strin…

### DIFF
--- a/apps/api/src/routes/lasa.ts
+++ b/apps/api/src/routes/lasa.ts
@@ -45,7 +45,7 @@ router.post("/check", lasaLimiter, async (req: Request, res: Response): Promise<
     try {
         const checkSchema = z
             .object({
-                medicineName: z.string().max(MAX_MEDICINE_NAME_LENGTH),
+                medicineName: z.string().trim().min(1).max(MAX_MEDICINE_NAME_LENGTH),
             })
             .strict();
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] My PR only touches the files requested by the maintainer.

## 📋 PR Summary & Link
- **Closes #3215 
- **Summary:** The `/check` endpoint for checking sound-alike/look-alike medicine conflicts allowed empty strings or whitespace-only inputs. This triggered resource-heavy database queries to find similar medicines. Adding Zod's `.trim().min(1)` rejects these empty payloads early at the route layer.

**Files changed (1):**
- `apps/api/src/routes/lasa.ts`

## 🧪 Proof of Work
- Passing `medicineName: ""` now fails schema validation and returns `400 Bad Request` instead of executing expensive database queries.

## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue.
- [x] I have pulled the latest `main` and resolved any conflicts.
