### PR TITLE
Sec : Added API key rotation endpoint and key expiry TTL#3134

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -73,6 +73,7 @@ import alternativesRouter from "./routes/alternatives";
 import eligibilityRouter from "./routes/eligibility";
 import wishlistRouter from "./routes/wishlist";
 import webhooksRouter from "./routes/webhooks";
+import apiKeysRouter from "./routes/apiKeys";
 import { supabase } from "./db/client";
 import { createCorsOptions } from "./config/cors";
 import { errorHandler } from "./middleware/errorHandler";
@@ -295,6 +296,7 @@ app.use("/api/v1/scheme-eligibility", eligibilityRouter);
 app.use("/api/webhooks", webhooksRouter);
 app.use("/api/v1/medicines", trackingRouter);
 app.use("/api/v1/wishlist", wishlistRouter);
+app.use("/api/keys", apiKeysRouter);
 
 // ── Swagger UI Documentation (/api/docs) ──────────────────────────────────
 app.use(

--- a/apps/api/src/middleware/apiKeyAuth.ts
+++ b/apps/api/src/middleware/apiKeyAuth.ts
@@ -38,7 +38,7 @@ export const requireApiKey = async (req: ApiKeyRequest, res: Response, next: Nex
     try {
         const { data, error } = await supabase
             .from("api_keys")
-            .select("id, caller_name, scopes, is_active, key_hash, key_salt")
+            .select("id, caller_name, scopes, is_active, key_hash, key_salt, expires_at")
             .eq("id", keyId)
             .maybeSingle();
 
@@ -50,6 +50,11 @@ export const requireApiKey = async (req: ApiKeyRequest, res: Response, next: Nex
 
         if (!data || !data.is_active || !data.key_salt) {
             res.status(401).json({ error: "Invalid or inactive API key" });
+            return;
+        }
+
+        if (data.expires_at && new Date(data.expires_at) < new Date()) {
+            res.status(401).json({ error: "API key has expired" });
             return;
         }
 

--- a/apps/api/src/routes/apiKeys.ts
+++ b/apps/api/src/routes/apiKeys.ts
@@ -1,0 +1,77 @@
+import { Router, Response } from "express";
+import crypto, { pbkdf2 } from "crypto";
+import { promisify } from "util";
+import { requireApiKey, ApiKeyRequest } from "../middleware/apiKeyAuth";
+import { supabase } from "../db/client";
+import logger from "../utils/logger";
+
+const router = Router();
+const pbkdf2Async = promisify(pbkdf2);
+
+/**
+ * @swagger
+ * /api/keys/rotate:
+ *   post:
+ *     summary: Rotate API key
+ *     description: Rotates the current API key by generating a new secret, updating the hash in the database, and returning the new secret. The existing key ID remains the same. Requires the current API key to be passed in the `x-api-secret` header.
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Successfully rotated API key
+ *       401:
+ *         description: Unauthorized
+ *       500:
+ *         description: Internal server error
+ */
+router.post("/rotate", requireApiKey, async (req: ApiKeyRequest, res: Response) => {
+    try {
+        const keyId = req.apiKey?.keyId;
+        if (!keyId) {
+            res.status(401).json({ error: "Unauthorized" });
+            return;
+        }
+
+        // Generate a new secret and salt
+        const newSecret = crypto.randomBytes(32).toString("base64url");
+        const newSalt = crypto.randomBytes(16).toString("hex");
+
+        // Hash the new secret
+        const hashBuffer = await pbkdf2Async(newSecret, newSalt, 100000, 64, "sha512");
+        const newHash = hashBuffer.toString("hex");
+
+        // Calculate new expiry (30 days from now)
+        const expiresAt = new Date();
+        expiresAt.setDate(expiresAt.getDate() + 30);
+
+        // Update the key in the database
+        const { error } = await supabase
+            .from("api_keys")
+            .update({
+                key_hash: newHash,
+                key_salt: newSalt,
+                expires_at: expiresAt.toISOString(),
+            })
+            .eq("id", keyId);
+
+        if (error) {
+            logger.error("Failed to update API key during rotation", { error, keyId });
+            res.status(500).json({ error: "Internal server error" });
+            return;
+        }
+
+        logger.info("API key rotated successfully", { keyId });
+
+        res.status(200).json({
+            message: "API key rotated successfully",
+            keyId: keyId,
+            newSecret: newSecret,
+            expiresAt: expiresAt.toISOString(),
+        });
+    } catch (error) {
+        logger.error("Unexpected error during API key rotation", { error });
+        res.status(500).json({ error: "Internal server error" });
+    }
+});
+
+export default router;

--- a/supabase/migrations/20260705000000_add_expires_at_to_api_keys.sql
+++ b/supabase/migrations/20260705000000_add_expires_at_to_api_keys.sql
@@ -1,0 +1,9 @@
+-- =============================================================================
+-- Add expires_at to api_keys
+-- =============================================================================
+
+ALTER TABLE public.api_keys
+ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ;
+
+-- Add an index to efficiently query non-expired keys (or prune expired ones)
+CREATE INDEX IF NOT EXISTS idx_api_keys_expires_at ON public.api_keys (expires_at);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3134**
- **Summary:**
- Created a new Supabase migration `20260705000000_add_expires_at_to_api_keys.sql` to add an expires_at column (type TIMESTAMPTZ) to the `api_keys` table. Added an index `idx_api_keys_expires_at` to efficiently query or prune keys based on their expiration date.
- The middleware now correctly rejects requests with a `401 Unauthorized` status if the API key's `expires_at` timestamp is in the past.
- Created a new router in apps/api/src/routes/apiKeys.ts containing the POST /rotate endpoint.
    Rotation Flow:
    - The caller authenticates using their current valid API key.
    - A new random 32-byte secret and 16-byte salt are generated.
   - The new secret is hashed using pbkdf2 (matching the existing security parameters).
    - The database record for the caller's keyId is updated with the new hash, salt, and a new expires_at set to 30 days in the future.
    - The new plaintext secret is returned to the caller to replace their old one.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
