### PR TITLE
fix(#3226): return 404 for missing schedule deletes

### DIFF
--- a/apps/api/src/routes/medicineSchedules.ts
+++ b/apps/api/src/routes/medicineSchedules.ts
@@ -232,14 +232,19 @@ router.delete("/:id", requireAuth, async (req: AuthenticatedRequest, res: Respon
         return;
     }
     try {
-        const { error } = await supabase
+        const { data, error } = await supabase
             .from("medicine_schedules")
             .delete()
             .eq("id", req.params.id)
-            .eq("user_id", req.user!.id);
+            .eq("user_id", req.user!.id)
+            .select("id");
 
         if (error) {
             res.status(500).json({ error: "Failed to delete schedule" });
+            return;
+        }
+        if (!data || data.length === 0) {
+            res.status(404).json({ error: "Schedule not found" });
             return;
         }
         await invalidateUserSummaryCaches(req.user!.id);

--- a/apps/api/tests/medicineSchedules.test.ts
+++ b/apps/api/tests/medicineSchedules.test.ts
@@ -1,14 +1,13 @@
 process.env.SUPABASE_URL = process.env.SUPABASE_URL || "http://localhost:54321";
 process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "test-anon-key";
 
-(global as any).WebSocket = (global as any).WebSocket || class {};
-
-jest.mock("csrf-csrf", () => ({
-    doubleCsrf: () => ({
-        doubleCsrfProtection: (_req: any, _res: any, next: any) => next(),
-        generateToken: () => "mocked-csrf-token",
+jest.mock(
+    "rate-limit-redis",
+    () => ({
+        RedisStore: jest.fn(),
     }),
-}));
+    { virtual: true }
+);
 
 const mockSupabaseChain = {
     from: jest.fn().mockReturnThis(),
@@ -47,7 +46,12 @@ jest.mock("../src/middleware/auth", () => ({
 }));
 
 import request from "supertest";
-import app from "../src/app";
+import express from "express";
+import medicineSchedulesRouter from "../src/routes/medicineSchedules";
+
+const app = express();
+app.use(express.json());
+app.use("/api/schedules", medicineSchedulesRouter);
 
 const mockedSupabase = mockSupabaseChain as jest.Mocked<typeof mockSupabaseChain>;
 
@@ -237,7 +241,10 @@ describe("DELETE /api/schedules/:id", () => {
         (mockedSupabase.from as jest.Mock).mockReturnValue(mockedSupabase);
         (mockedSupabase.delete as jest.Mock).mockReturnValue(mockedSupabase);
         (mockedSupabase.eq as jest.Mock).mockReturnValue(mockedSupabase);
-        mockedSupabase.error = null;
+        (mockedSupabase.select as jest.Mock).mockResolvedValue({
+            data: [{ id: "00000000-0000-4000-8000-000000000001" }],
+            error: null,
+        });
 
         const res = await request(app)
             .delete("/api/schedules/00000000-0000-4000-8000-000000000001")
@@ -245,6 +252,42 @@ describe("DELETE /api/schedules/:id", () => {
 
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);
+        expect(mockedSupabase.select).toHaveBeenCalledWith("id");
+    });
+
+    it("returns 404 when no matching schedule is deleted", async () => {
+        (mockedSupabase.from as jest.Mock).mockReturnValue(mockedSupabase);
+        (mockedSupabase.delete as jest.Mock).mockReturnValue(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockReturnValue(mockedSupabase);
+        (mockedSupabase.select as jest.Mock).mockResolvedValue({
+            data: [],
+            error: null,
+        });
+
+        const res = await request(app)
+            .delete("/api/schedules/00000000-0000-4000-8000-000000000999")
+            .set("Authorization", "Bearer test-token");
+
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe("Schedule not found");
+    });
+
+    it("returns 404 when a schedule is not owned by the user", async () => {
+        (mockedSupabase.from as jest.Mock).mockReturnValue(mockedSupabase);
+        (mockedSupabase.delete as jest.Mock).mockReturnValue(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockReturnValue(mockedSupabase);
+        (mockedSupabase.select as jest.Mock).mockResolvedValue({
+            data: [],
+            error: null,
+        });
+
+        const res = await request(app)
+            .delete("/api/schedules/00000000-0000-4000-8000-000000000002")
+            .set("Authorization", "Bearer test-token");
+
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe("Schedule not found");
+        expect(mockedSupabase.eq).toHaveBeenCalledWith("user_id", "test-user-id");
     });
 });
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #3226**
* **Summary:**

  * Fixed the `DELETE /api/schedules/:id` endpoint to return `404 Not Found` when no schedule is actually deleted.
  * Updated the delete query to verify that a matching owned schedule row was removed before returning success.
  * Preserved existing error-handling behavior for Supabase failures.
  * Added test coverage for:

    * successful deletion of an owned schedule
    * deletion of a non-existent schedule
    * deletion of a schedule that does not belong to the authenticated user

## 📸 Proof of Work (Screenshots / Logs)

### Test Results

```bash
npm.cmd test -- medicineSchedules.test.ts --runInBand

PASS apps/api/tests/medicineSchedules.test.ts

Test Suites: 1 passed
Tests: 14 passed
```

> No frontend/UI changes were made. This PR only modifies backend API behavior and backend tests.

## 🏷️ PR Type

* [x] 🐛 `type: bug`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3226`)
* [x] I have pulled the latest `main` and resolved any conflicts