### PR TITLE
fix(ml): stream OCR uploads to enforce size limit

### DIFF
--- a/apps/ml/routers/ocr.py
+++ b/apps/ml/routers/ocr.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/ocr", tags=["OCR"])
 
 MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024  # 5MB limit
+CHUNK_SIZE = 64 * 1024  # 64 KB
 
 @router.post("/extract")
 async def extract_text(file: UploadFile = File(...)):
@@ -25,16 +26,29 @@ async def extract_text(file: UploadFile = File(...)):
     if not file.content_type or not file.content_type.startswith("image/"):
         raise HTTPException(status_code=400, detail="File uploaded is not an image.")
 
-    # Validate file size to prevent Denial of Service (DoS) via memory exhaustion
-    if file.size and file.size > MAX_IMAGE_SIZE_BYTES:
-        raise HTTPException(
-            status_code=413,
-            detail=f"File too large. Maximum allowed size is {MAX_IMAGE_SIZE_BYTES // (1024 * 1024)}MB."
-        )
-
     try:
-        # Read image content
-        contents = await file.read()
+        # Read the uploaded file incrementally so oversized streamed uploads
+        # can be rejected without loading the entire file into memory.
+        chunks = []
+        total_size = 0
+
+        while True:
+            chunk = await file.read(CHUNK_SIZE)
+
+            if not chunk:
+                break
+
+            total_size += len(chunk)
+
+            if total_size > MAX_IMAGE_SIZE_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail=f"File too large. Maximum allowed size is {MAX_IMAGE_SIZE_BYTES // (1024 * 1024)}MB."
+                )
+
+            chunks.append(chunk)
+
+        contents = b"".join(chunks)
         
         try:
             image_to_verify = Image.open(io.BytesIO(contents))
@@ -75,9 +89,16 @@ async def extract_text(file: UploadFile = File(...)):
             "confidence": confidence,
             "filename": file.filename
         }
+    
+    except HTTPException:
+        raise
+
     except Exception as e:
         logger.error(f"OCR error: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Failed to process image: {str(e)}")
+    
+    finally:
+        await file.close()
 
 # For issue 17: Request payload validation schema
 class MatchRequest(BaseModel):


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

---

## 📋 PR Summary & Link

- **Closes #2821**

### Summary

This PR fixes a security issue in the OCR upload endpoint where `UploadFile.size` could be `None`, allowing oversized streamed uploads to bypass the file size validation.

### Changes made

- Removed the dependency on `UploadFile.size` for upload validation.
- Replaced `await file.read()` with incremental chunked reads (64 KB).
- Tracked the cumulative upload size while reading.
- Return **HTTP 413** immediately when the upload exceeds the configured 5 MB limit.
- Preserved the existing OCR processing flow for valid uploads.

---

## 📸 Proof of Work (Screenshots / Logs)

### Large upload rejected (>5 MB)

- Uploading a file larger than the configured limit now returns **HTTP 413** with the appropriate validation message before OCR processing begins.

<img width="840" height="392" alt="image" src="https://github.com/user-attachments/assets/9c08a19d-a4ae-457f-9983-5a21d79b09fb" />

### Valid upload reaches OCR pipeline

<img width="1690" height="790" alt="image" src="https://github.com/user-attachments/assets/59bddd03-902a-4fa7-82bb-1f084abd9be2" />


---

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] 🔒 `type: security`

---

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2821`)
- [x] I have pulled the latest `main` and resolved any conflicts.