### PR TITLE
feat: notify users on admin OCR verification approval/rejection (#3082)

### DIFF
--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { supabase } from "../db/client";
 import { logAdminAction } from "../services/audit.service";
 import { AuthenticatedRequest } from "../middleware/auth";
-import { triggerRecallAlert } from "../services/notifications";
+import { triggerRecallAlert, sendNotificationToUser, buildVerificationReviewPayload } from "../services/notifications";
 import logger from "../utils/logger";
 
 const reportStatusSchema = z
@@ -618,7 +618,7 @@ export const reviewVerificationRequest = async (
         // Fetch the request first to get medicine_id
         const { data: request, error: fetchError } = await supabase
             .from("medicine_verification_requests")
-            .select("id, medicine_id, medicine_name")
+            .select("id, medicine_id, medicine_name, submitted_by")
             .eq("id", id)
             .single();
 
@@ -677,6 +677,25 @@ export const reviewVerificationRequest = async (
                 rejection_reason: rejection_reason ?? null,
             }
         );
+
+        // Notify the submitting user (fire-and-log, non-blocking).
+        // A failed push send should NOT turn a successful review into a 500.
+        if (request.submitted_by) {
+            try {
+                const notifyPayload = buildVerificationReviewPayload(
+                    request.medicine_name,
+                    status,
+                    rejection_reason ?? null
+                );
+                await sendNotificationToUser(request.submitted_by, notifyPayload);
+            } catch (notifyErr) {
+                logger.error({
+                    message: "Failed to send verification review notification",
+                    error: notifyErr,
+                    submitted_by: request.submitted_by,
+                });
+            }
+        }
 
         res.json({ message: `Verification request ${status}`, request: updated });
     } catch (err) {

--- a/apps/api/src/services/notifications.ts
+++ b/apps/api/src/services/notifications.ts
@@ -185,6 +185,11 @@ export async function listPushSubscriptions() {
     return [...memorySubscriptions.values()];
 }
 
+export async function listPushSubscriptionsForUser(userId: string) {
+    const all = await listPushSubscriptions();
+    return all.filter((sub) => sub.userId === userId);
+}
+
 export function buildRecallPayload(alert: RecallAlert) {
     return {
         title: `${alert.medicineName} recalled`,
@@ -197,6 +202,35 @@ export function buildRecallPayload(alert: RecallAlert) {
         source: alert.source,
         url: "/alerts",
         recalledAt: alert.recalledAt ?? new Date().toISOString(),
+    };
+}
+
+export type VerificationReviewPayload = {
+    title: string;
+    body: string;
+    medicineName: string;
+    status: "approved" | "rejected";
+    rejectionReason: string | null;
+    url: string;
+};
+
+export function buildVerificationReviewPayload(
+    medicineName: string,
+    status: "approved" | "rejected",
+    rejectionReason?: string | null
+): VerificationReviewPayload {
+    const approved = status === "approved";
+    return {
+        title: approved ? "Verification Approved" : "Verification Rejected",
+        body: approved
+            ? `Your medicine verification for ${medicineName} was approved.`
+            : `Your medicine verification for ${medicineName} was rejected.${
+                  rejectionReason ? ` Reason: ${rejectionReason}` : ""
+              }`,
+        medicineName,
+        status,
+        rejectionReason: rejectionReason ?? null,
+        url: "/verifications",
     };
 }
 
@@ -413,6 +447,52 @@ export async function triggerRecallAlert(alert: RecallAlert) {
         attempted: subscriptions.length,
         sent: results.filter((result) => result.status === "fulfilled").length,
         failed: results.filter((result) => result.status === "rejected").length,
+        payload,
+    };
+    
+}
+
+export async function sendNotificationToUser(
+    userId: string,
+    payload: Record<string, unknown>
+) {
+    const configured = configureWebPush();
+
+    if (!configured) {
+        return { configured: false, attempted: 0, sent: 0, failed: 0, payload };
+    }
+
+    const subscriptions = await listPushSubscriptionsForUser(userId);
+
+    if (subscriptions.length === 0) {
+        return { configured: true, attempted: 0, sent: 0, failed: 0, payload };
+    }
+
+    const results = await Promise.allSettled(
+        subscriptions.map((item) =>
+            webPush.sendNotification(item.subscription, JSON.stringify(payload))
+        )
+    );
+
+    const expiredEndpoints: string[] = [];
+    results.forEach((result, index) => {
+        if (result.status === "rejected") {
+            const endpoint = subscriptions[index].endpoint;
+            if (shouldRemovePushSubscription(result.reason)) {
+                expiredEndpoints.push(endpoint);
+            } else {
+                logRetainedPushFailure(endpoint, result.reason);
+            }
+        }
+    });
+
+    await Promise.all(expiredEndpoints.map(removePushSubscription));
+
+    return {
+        configured: true,
+        attempted: subscriptions.length,
+        sent: results.filter((r) => r.status === "fulfilled").length,
+        failed: results.filter((r) => r.status === "rejected").length,
         payload,
     };
 }


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3082**
- **Summary:** Adds push notifications to users when an admin approves or rejects their medicine OCR verification request via `/verifications/:id/review`. Extended `reviewVerificationRequest` to fetch `submitted_by` and send a targeted push notification after the review completes. Added `buildVerificationReviewPayload`, `listPushSubscriptionsForUser`, and `sendNotificationToUser` in `notifications.ts`, reusing the batching/error-handling patterns already established in `triggerRecallAlert`. Scoped to in-app push notifications only (no email infra exists in `apps/api` currently). Notification failures are logged but never fail the review request itself (non-blocking, per issue requirements).

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

This is a backend-only API change (no UI). Verified via:
- Manual code trace of `reviewVerificationRequest` approve/reject paths.
- Confirmed `submitted_by` column exists on `medicine_verification_requests` (see `supabase/migrations/20260703000000_create_medicine_verification_requests.sql`).
- `npm run build` on `main` (before my changes) produces 10 pre-existing TypeScript errors unrelated to this PR (`@sahidawa/shared` module resolution + undefined variables in `pharmacies.ts`). Confirmed by stashing my changes and reproducing the identical error set — my two changed files are not part of any error.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts