### PR TITLE
feat: add CSV/PDF export for medicine comparison grid (#2889)

### DIFF
--- a/apps/web/src/components/ComparisonGrid.tsx
+++ b/apps/web/src/components/ComparisonGrid.tsx
@@ -1,4 +1,5 @@
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Download, FileSpreadsheet } from "lucide-react";
+import { exportComparisonToCSV, exportComparisonToPDF } from "@/src/lib/comparisonExport";
 
 export interface Medicine {
     id: string;
@@ -207,6 +208,20 @@ function shareComparison(medicine1: Medicine | null, medicine2: Medicine | null)
     navigator.clipboard.writeText(url);
 }
 
+function handleExportCSV(
+    medicines: Medicine[],
+    rows: { label: string; getValue: (m: Medicine) => string }[]
+) {
+    exportComparisonToCSV(medicines, rows);
+}
+
+function handleExportPDF(
+    medicines: Medicine[],
+    rows: { label: string; getValue: (m: Medicine) => string }[]
+) {
+    exportComparisonToPDF(medicines, rows);
+}
+
 export default function ComparisonGrid({
     medicines,
     labels = defaultLabels,
@@ -330,7 +345,25 @@ export default function ComparisonGrid({
                     </tbody>
                 </table>
                 {validMedicines.length >= 2 && (
-                    <div className="flex justify-end border-t border-slate-200 p-4">
+                    <div className="flex flex-wrap justify-end gap-2 border-t border-slate-200 p-4 print:hidden">
+                        <button
+                            type="button"
+                            onClick={() => handleExportCSV(validMedicines, rows)}
+                            className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+                            aria-label="Export comparison as CSV"
+                        >
+                            <FileSpreadsheet size={16} />
+                            Export CSV
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => handleExportPDF(validMedicines, rows)}
+                            className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+                            aria-label="Export comparison as PDF"
+                        >
+                            <Download size={16} />
+                            Export PDF
+                        </button>
                         <button
                             type="button"
                             onClick={() => shareComparison(validMedicines[0], validMedicines[1])}

--- a/apps/web/src/lib/comparisonExport.ts
+++ b/apps/web/src/lib/comparisonExport.ts
@@ -1,0 +1,82 @@
+import { jsPDF } from "jspdf";
+import autoTable from "jspdf-autotable";
+import type { Medicine } from "@/src/components/ComparisonGrid";
+
+export interface ComparisonExportRow {
+    label: string;
+    getValue: (m: Medicine) => string;
+}
+
+function displayName(m: Medicine): string {
+    return m.brand_name?.trim() || m.generic_name;
+}
+
+function escapeCsvValue(value: string): string {
+    if (/[",\n]/.test(value)) {
+        return `"${value.replace(/"/g, '""')}"`;
+    }
+    return value;
+}
+
+export function buildComparisonTable(
+    medicines: Medicine[],
+    rows: ComparisonExportRow[]
+): { headers: string[]; body: string[][] } {
+    const headers = ["Field", ...medicines.map(displayName)];
+    const body = rows.map(({ label, getValue }) => [
+        label,
+        ...medicines.map((m) => getValue(m)),
+    ]);
+    return { headers, body };
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
+
+export function exportComparisonToCSV(
+    medicines: Medicine[],
+    rows: ComparisonExportRow[],
+    filename = "medicine-comparison.csv"
+): void {
+    const { headers, body } = buildComparisonTable(medicines, rows);
+    const lines = [headers, ...body].map((row) =>
+        row.map((cell) => escapeCsvValue(cell)).join(",")
+    );
+    const csvContent = lines.join("\n");
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    downloadBlob(blob, filename);
+}
+
+export function exportComparisonToPDF(
+    medicines: Medicine[],
+    rows: ComparisonExportRow[],
+    filename = "medicine-comparison.pdf"
+): void {
+    const { headers, body } = buildComparisonTable(medicines, rows);
+    const doc = new jsPDF({
+        orientation: medicines.length > 3 ? "landscape" : "portrait",
+    });
+
+    doc.setFontSize(14);
+    doc.text("Medicine Comparison Report", 14, 15);
+    doc.setFontSize(9);
+    doc.text(`Generated on ${new Date().toLocaleDateString()}`, 14, 21);
+
+    autoTable(doc, {
+        head: [headers],
+        body,
+        startY: 26,
+        styles: { fontSize: 8, cellPadding: 3 },
+        headStyles: { fillColor: [16, 185, 129] },
+    });
+
+    doc.save(filename);
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2889**
- **Summary:** Adds an "Export Report" feature to the medicine comparison grid at `/compare`. Users can now download the comparison as a CSV or a formatted PDF once at least 2 medicines are selected. Added a new `comparisonExport.ts` utility that builds the comparison table (headers + rows) once and reuses it for both export formats, avoiding duplicated data-extraction logic between CSV and PDF. CSV export generates a properly escaped CSV blob and triggers a browser download. PDF export uses `jspdf` + `jspdf-autotable` to render a clean, printable table with a title and generation date, switching to landscape orientation automatically when comparing more than 3 medicines. Export buttons are hidden during print (`print:hidden`) so the existing browser print-to-PDF flow is unaffected.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts