### PR TITLE
fix(api): extract and validate rows in bulk-upload handler (#3237)

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -1139,6 +1139,39 @@ router.post(
                 transform: (v) => v.trim(),
             });
 
+            const { data: parsedRows } = parseResult;
+            const rowsToInsert: any[] = [];
+            const failedRows: Array<{ row: number; reason: string }> = [];
+
+            for (let i = 0; i < parsedRows.length; i++) {
+                const rowData = parsedRows[i];
+                const logicalRow = i + 2;
+
+                const normalised: Record<string, any> = {};
+                for (const key of Object.keys(rowData)) {
+                    const val = rowData[key];
+                    normalised[key] = val === "" ? undefined : val;
+                }
+
+                const validationResult = inventoryRowSchema.safeParse(normalised);
+                if (!validationResult.success) {
+                    const reason = validationResult.error.issues.map((i) => i.message).join(", ");
+                    failedRows.push({ row: logicalRow, reason });
+                    continue;
+                }
+
+                rowsToInsert.push({
+                    pharmacy_id: pharmacy.id,
+                    medicine_name: validationResult.data.medicine_name,
+                    batch_number: validationResult.data.batch_number,
+                    expiry_date: validationResult.data.expiry_date,
+                    quantity: validationResult.data.quantity,
+                    mrp: validationResult.data.mrp,
+                });
+            }
+
+            const totalRows = parsedRows.length;
+
             if (totalRows === 0) {
                 res.status(400).json({ error: "The file appears empty or is missing rows." });
                 return;


### PR DESCRIPTION
## Description

Fixes #3237

The `POST /api/pharmacies/bulk-upload` handler used `Papa.parse()` synchronously but referenced undefined variables `totalRows`, `rowsToInsert`, and `failedRows`, causing a `ReferenceError` at runtime.

### Changes

- Extract `parsedRows` from the Papa.parse result
- Validate each row using `inventoryRowSchema` (same validation as `POST /:id/inventory/upload`)
- Build `rowsToInsert` (valid rows) and `failedRows` (validation errors)
- Compute `totalRows` from parsed row count

### Testing

- Rows with invalid data are rejected with descriptive error messages
- Bulk insert only proceeds when valid rows exist
- Response includes accurate `totalRows`, `successCount`, `failedCount`, and `errors`