### PR TITLE
fix(i18n): add mni and sd locale codes to routing config (#3236)

### DIFF
--- a/apps/web/i18n/routing.ts
+++ b/apps/web/i18n/routing.ts
@@ -20,6 +20,8 @@ export const routing = defineRouting({
         "mai",
         "ml",
         "sa",
+        "mni",
+        "sd",
     ],
     defaultLocale: "en",
 });


### PR DESCRIPTION
## Description

Fixes #3236

Translation message files for Manipuri (`mni`) and Sindhi (`sd`) exist at `apps/web/messages/mni.json` and `apps/web/messages/sd.json`, but their locale codes were not registered in the i18n routing configuration, making them unreachable.

### Changes

- Added `"mni"` and `"sd"` to the `locales` array in `apps/web/i18n/routing.ts`

### Verification

- Language switcher will now include Manipuri (মৈতৈলোন্) and Sindhi (سنڌي)
- i18n middleware will route `/mni/...` and `/sd/...` URL prefixes correctly