### PR TITLE
fix(ml): allow localhost ML_SERVICE_URL in non-production (#3235)

### DIFF
--- a/apps/api/src/config/mlService.ts
+++ b/apps/api/src/config/mlService.ts
@@ -24,6 +24,9 @@ const BLOCKED_HOSTNAME_PATTERNS = [
  * private, loopback, or link-local hostname.
  */
 function isAllowedHostname(hostname: string): boolean {
+    if (process.env.NODE_ENV !== "production" && /^localhost$/i.test(hostname)) {
+        return true;
+    }
     return !BLOCKED_HOSTNAME_PATTERNS.some((pattern) => pattern.test(hostname));
 }
 


### PR DESCRIPTION
## Description

Fixes #3235

The `validateMlServiceUrl()` function blocked `localhost` hostname via SSRF protection, but `.env.example` sets `ML_SERVICE_URL=http://localhost:8000` for local development, creating a contradiction that breaks all ML-backed API routes in development.

### Changes

- Modified `isAllowedHostname()` in `apps/api/src/config/mlService.ts` to allow `localhost` when `NODE_ENV` is not `"production"`
- Production retains full SSRF protection — localhost remains blocked

### Rationale

Developers run the ML service locally. Blocking `localhost` in development prevents the app from working with its documented `.env.example` setup, while the SSRF threat only applies in production.