### PR TITLE
fix(ui): make medicine detail cards stack properly on mobile

### DIFF
--- a/apps/web/components/ExpandableDetails.tsx
+++ b/apps/web/components/ExpandableDetails.tsx
@@ -42,7 +42,7 @@ export function ExpandableDetails({ medicine }: { medicine: VerifiedMedicine }) 
                         </span>
                         <CopyButton text={copyText} toastMessage="Medicine info copied!" />
                     </div>
-                    <div className="grid w-full grid-cols-2 gap-3">
+                    <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
                         <div className="rounded-2xl border border-(--color-border-muted) bg-(--color-surface-muted) p-3">
                             <span className="block text-[10px] font-bold tracking-wider text-(--color-text-muted) uppercase">
                                 {tScan("genericName")}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3231**
- **Summary:** Updated `ExpandableDetails.tsx` to use a mobile-first responsive grid (`grid-cols-1 sm:grid-cols-2`). This ensures the medicine detail cards stack vertically on smaller screens and display side-by-side on larger screens, preventing text overflow and cramped UI.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

<img width="1920" height="1024" alt="Screenshot 2026-07-05 185345" src="https://github.com/user-attachments/assets/2f60c433-fdbc-4a4a-996d-0998e1325b6c" />



## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [x] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts