### PR TITLE
fix(#3228): repair scan history rls migration

### DIFF
--- a/apps/api/tests/rls_migration.test.ts
+++ b/apps/api/tests/rls_migration.test.ts
@@ -39,6 +39,27 @@ describe("RLS Migration — tracked_medicines", () => {
     });
 });
 
+describe("RLS Migration - user_scan_history owner policy", () => {
+    const migrationPath = join(MIGRATIONS_DIR, "20260704150905_add_rls_to_scan_history.sql");
+    const sql = readFileSync(migrationPath, "utf8");
+
+    it("targets user_scan_history, which has user_id ownership", () => {
+        expect(sql).toContain("ALTER TABLE public.user_scan_history ENABLE ROW LEVEL SECURITY");
+        expect(sql).toContain("ON public.user_scan_history");
+        expect(sql).not.toContain("ON public.scan_history");
+    });
+
+    it("creates an idempotent authenticated owner policy", () => {
+        expect(sql).toContain(
+            'DROP POLICY IF EXISTS "Users can manage their own scan history" ON public.user_scan_history'
+        );
+        expect(sql).toContain('CREATE POLICY "Users can manage their own scan history"');
+        expect(sql).toContain("TO authenticated");
+        expect(sql).toContain("USING (auth.uid() = user_id)");
+        expect(sql).toContain("WITH CHECK (auth.uid() = user_id)");
+    });
+});
+
 describe("RLS Migration — tracked_medicines guest policy", () => {
     const migrationPath = join(
         MIGRATIONS_DIR,

--- a/supabase/migrations/20260704150905_add_rls_to_scan_history.sql
+++ b/supabase/migrations/20260704150905_add_rls_to_scan_history.sql
@@ -1,7 +1,11 @@
-ALTER TABLE public.scan_history ENABLE ROW LEVEL SECURITY;
+-- User-owned scan records live in user_scan_history. The scan_history table is
+-- an anonymous/service-owned anomaly log and does not have a user_id column.
+ALTER TABLE public.user_scan_history ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "Users can manage their own scan history" ON public.user_scan_history;
 CREATE POLICY "Users can manage their own scan history"
-ON public.scan_history
+ON public.user_scan_history
 FOR ALL
+TO authenticated
 USING (auth.uid() = user_id)
 WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #3228**
* **Summary:**

  * Fixed the broken RLS migration in `20260704150905_add_rls_to_scan_history.sql`.
  * Updated the migration to target `public.user_scan_history`, which contains the `user_id` ownership column used by the policy.
  * Added `DROP POLICY IF EXISTS` to make the migration idempotent.
  * Restricted the policy to authenticated users.
  * Added migration tests to verify the correct table is targeted and the policy definition remains valid.

### Files Changed

* `supabase/migrations/20260704150905_add_rls_to_scan_history.sql`
* `apps/api/tests/rls_migration.test.ts`

## 📸 Proof of Work (Screenshots / Logs)

### Test Results

```text
npm.cmd run check:migrations
✅ Passed

npm.cmd test -- rls_migration -w apps/api
✅ Passed (9 tests)
```

### Notes

```text
supabase --version
❌ Supabase CLI not installed

npm.cmd run lint
❌ Fails due unrelated existing issues in ReportWizard.tsx,
setupTests.ts, and an existing unused eslint-disable directive.

npm.cmd run typecheck
❌ No root typecheck script exists.

npm.cmd run build -w apps/api
❌ Fails due unrelated existing dependency/type issues.
```

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [x] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3228`)
* [x] I have pulled the latest `main` and resolved any conflicts