### PR TITLE
Feat/correlation id middleware

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -10,6 +10,7 @@ import { redisClient } from "./utils/redis";
 import cookieParser from "cookie-parser";
 import { doubleCsrf } from "csrf-csrf";
 import { httpsRedirect } from "./middleware/httpsRedirect";
+import { requestIdMiddleware, getRequestId } from "./middleware/requestId";
 import mapRouter from "./routes/map";
 import medicineSchedulesRouter from "./routes/medicineSchedules";
 
@@ -79,6 +80,11 @@ import { errorHandler } from "./middleware/errorHandler";
 // ── Application Initialization ─────────────────────────────────────────────
 const app: Express = express();
 app.set("trust proxy", 1); // Trust first proxy (Nginx) — fixes req.ip for rate limiters
+
+// ── Request Correlation ID ─────────────────────────────────────────────────
+// Must be the first middleware so every downstream handler and log entry
+// can access the x-request-id via AsyncLocalStorage.
+app.use(requestIdMiddleware);
 
 // ── Security: Enforce HTTPS in production ──────────────────────────────────
 // Redirects all HTTP requests to HTTPS (301) to protect sensitive healthcare data
@@ -164,9 +170,11 @@ app.use(
     morgan((tokens, req: Request, res: Response) => {
         const status = res.statusCode;
         const level = status >= 500 ? "error" : status >= 400 ? "warn" : "info";
+        const requestId = getRequestId() ?? (req as Request & { requestId?: string }).requestId;
         logger.log({
             level,
             message: `${tokens.method(req, res)} ${tokens.url(req, res)} ${status} - ${tokens["response-time"](req, res)} ms`,
+            ...(requestId && { requestId }),
         });
         return undefined;
     })

--- a/apps/api/src/middleware/errorHandler.ts
+++ b/apps/api/src/middleware/errorHandler.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import logger from '../utils/logger';
 import { getDbErrorStatus } from '../utils/dbErrors';
+import { getRequestId } from './requestId';
 
 const SENSITIVE_FIELDS = ['password', 'apiKey', 'api_key', 'token', 'secret', 'authorization', 'cookie'];
 
@@ -35,6 +36,8 @@ export function errorHandler(
 
   const level = statusCode >= 500 ? 'error' : 'warn';
 
+  const requestId = getRequestId();
+
   logger.log({
     level,
     message: `${req.method} ${req.originalUrl} - ${err.message}`,
@@ -43,6 +46,7 @@ export function errorHandler(
     body: req.body ? sanitize(req.body as Record<string, unknown>) : undefined,
     query: req.query,
     params: req.params,
+    ...(requestId && { requestId }),
   });
 
   const isProduction = process.env.NODE_ENV === 'production';
@@ -54,5 +58,6 @@ export function errorHandler(
       message: clientMessage,
       ...(!isProduction && { stack: err.stack }),
     },
+    ...(requestId && { requestId }),
   });
 }

--- a/apps/api/src/middleware/requestId.ts
+++ b/apps/api/src/middleware/requestId.ts
@@ -1,0 +1,50 @@
+import { Request, Response, NextFunction } from "express";
+import crypto from "crypto";
+import { AsyncLocalStorage } from "async_hooks";
+
+// ── Request Context (AsyncLocalStorage) ────────────────────────────────────
+// Stores per-request metadata so any downstream code
+
+interface RequestContext {
+   
+    requestId: string;
+}
+
+const requestContext = new AsyncLocalStorage<RequestContext>();
+
+// ── Public helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Returns the `x-request-id` for the currently-executing request, or
+ * `undefined` when called outside a request context
+ */
+export function getRequestId(): string | undefined {
+    return requestContext.getStore()?.requestId;
+}
+
+// ── Middleware ──────────────────────────────────────────────────────────────
+
+const REQUEST_ID_HEADER = "x-request-id";
+
+/**
+ * Express middleware
+ */
+export function requestIdMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const id =
+        (typeof req.headers[REQUEST_ID_HEADER] === "string" && req.headers[REQUEST_ID_HEADER]) ||
+        crypto.randomUUID();
+
+    // Attach to the request object for direct access in handlers
+    (req as Request & { requestId: string }).requestId = id;
+
+    // Echo the correlation ID back in the response headers
+    res.setHeader(REQUEST_ID_HEADER, id);
+
+    // Run the remainder of the middleware stack inside an AsyncLocalStorage
+    // context so getRequestId() works everywhere downstream.
+    requestContext.run({ requestId: id }, () => {
+        next();
+    });
+}
+
+export { REQUEST_ID_HEADER };

--- a/apps/api/src/utils/logger.ts
+++ b/apps/api/src/utils/logger.ts
@@ -2,6 +2,7 @@ import winston from 'winston';
 import DailyRotateFile from 'winston-daily-rotate-file';
 import fs from 'fs';
 import path from 'path';
+import { getRequestId } from '../middleware/requestId';
 
 const logDir = path.join(process.cwd(), 'logs');
 if (!fs.existsSync(logDir)) {
@@ -10,11 +11,23 @@ if (!fs.existsSync(logDir)) {
 
 const { combine, timestamp, printf, colorize, json, errors } = winston.format;
 
-const logFormat = printf(({ level, message, timestamp, stack }) => {
-  if (stack) {
-    return `${timestamp} ${level}: ${message}\n${stack}`;
+// ── Custom format: inject the current request's correlation ID ─────────────
+// Uses AsyncLocalStorage under the hood so existing `logger.info(…)` calls
+// automatically include `requestId` — no caller changes required.
+const injectRequestId = winston.format((info) => {
+  const requestId = getRequestId();
+  if (requestId) {
+    info.requestId = requestId;
   }
-  return `${timestamp} ${level}: ${message}`;
+  return info;
+});
+
+const logFormat = printf(({ level, message, timestamp, stack, requestId }) => {
+  const reqIdTag = requestId ? ` [${requestId}]` : '';
+  if (stack) {
+    return `${timestamp} ${level}:${reqIdTag} ${message}\n${stack}`;
+  }
+  return `${timestamp} ${level}:${reqIdTag} ${message}`;
 });
 
 const errorTransport = new DailyRotateFile({
@@ -39,6 +52,7 @@ const logger = winston.createLogger({
   format: combine(
     errors({ stack: true }),
     timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+    injectRequestId(),
     process.env.NODE_ENV === 'production' ? json() : combine(colorize(), logFormat)
   ),
   transports: [

--- a/apps/api/src/utils/serviceClient.ts
+++ b/apps/api/src/utils/serviceClient.ts
@@ -1,0 +1,66 @@
+import { getRequestId } from "../middleware/requestId";
+import logger from "./logger";
+
+/**
+ * Default timeout for outgoing service calls (milliseconds).
+ */
+export const SERVICE_TIMEOUT_MS = 15_000;
+
+/**
+ * A thin wrapper around the global `fetch` that automatically propagates the
+ * current request's `x-request-id` header to downstream services.
+ *
+ * Usage is identical to `fetch()`:
+ * ```ts
+ * import { serviceFetch } from "../utils/serviceClient";
+ * const res = await serviceFetch(`${mlUrl}/analyze`, { method: "POST", body });
+ * ```
+ *
+ * The caller can still pass their own `x-request-id` header — the explicitly
+ * supplied value takes precedence over the one from AsyncLocalStorage.
+ */
+export async function serviceFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit
+): Promise<Response> {
+    const requestId = getRequestId();
+    const headers = new Headers(init?.headers);
+
+    // Only inject if the caller didn't already set one
+    if (requestId && !headers.has("x-request-id")) {
+        headers.set("x-request-id", requestId);
+    }
+
+    logger.debug("Outgoing service call", {
+        url: typeof input === "string" ? input : input.toString(),
+        method: init?.method ?? "GET",
+        requestId,
+    });
+
+    return fetch(input, { ...init, headers });
+}
+
+export async function serviceFetchWithTimeout(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+    timeoutMs: number = SERVICE_TIMEOUT_MS
+): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    // If the caller supplied their own signal, abort our controller when it fires
+    if (init?.signal) {
+        init.signal.addEventListener("abort", () => controller.abort(), { once: true });
+    }
+
+    try {
+        return await serviceFetch(input, { ...init, signal: controller.signal });
+    } catch (err) {
+        if ((err as Error).name === "AbortError") {
+            throw new Error(`Service request timed out after ${timeoutMs}ms`);
+        }
+        throw err;
+    } finally {
+        clearTimeout(timeout);
+    }
+}

--- a/apps/api/tests/requestId.test.ts
+++ b/apps/api/tests/requestId.test.ts
@@ -1,0 +1,202 @@
+import { Request, Response, NextFunction } from "express";
+import { requestIdMiddleware, getRequestId, REQUEST_ID_HEADER } from "../src/middleware/requestId";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function mockReqResNext(headerValue?: string) {
+    const req = {
+        headers: headerValue ? { [REQUEST_ID_HEADER]: headerValue } : {},
+    } as unknown as Request;
+
+    const resHeaders: Record<string, string> = {};
+    const res = {
+        setHeader: jest.fn((name: string, value: string) => {
+            resHeaders[name] = value;
+        }),
+        getHeader: (name: string) => resHeaders[name],
+    } as unknown as Response;
+
+    let nextCalled = false;
+    const next: NextFunction = (() => {
+        nextCalled = true;
+    }) as NextFunction;
+
+    return { req, res, next, resHeaders, isNextCalled: () => nextCalled };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("requestIdMiddleware", () => {
+    it("generates a UUID v4 when no x-request-id header is provided", () => {
+        const { req, res, next } = mockReqResNext();
+        requestIdMiddleware(req, res, next);
+
+        const id = (req as Request & { requestId: string }).requestId;
+        expect(id).toMatch(UUID_RE);
+    });
+
+    it("preserves the incoming x-request-id header when present", () => {
+        const customId = "upstream-trace-abc-123";
+        const { req, res, next } = mockReqResNext(customId);
+        requestIdMiddleware(req, res, next);
+
+        const id = (req as Request & { requestId: string }).requestId;
+        expect(id).toBe(customId);
+    });
+
+    it("sets x-request-id on the response header", () => {
+        const { req, res, next, resHeaders } = mockReqResNext();
+        requestIdMiddleware(req, res, next);
+
+        expect(res.setHeader).toHaveBeenCalledWith(REQUEST_ID_HEADER, expect.any(String));
+        expect(resHeaders[REQUEST_ID_HEADER]).toMatch(UUID_RE);
+    });
+
+    it("echoes the same ID on the response when an incoming ID is provided", () => {
+        const customId = "incoming-request-id-999";
+        const { req, res, next, resHeaders } = mockReqResNext(customId);
+        requestIdMiddleware(req, res, next);
+
+        expect(resHeaders[REQUEST_ID_HEADER]).toBe(customId);
+    });
+
+    it("calls next() to pass control to the next middleware", () => {
+        const { req, res, next, isNextCalled } = mockReqResNext();
+        requestIdMiddleware(req, res, next);
+
+        expect(isNextCalled()).toBe(true);
+    });
+
+    it("makes getRequestId() return the correct ID inside the request context", (done) => {
+        const customId = "context-test-id";
+        const req = {
+            headers: { [REQUEST_ID_HEADER]: customId },
+        } as unknown as Request;
+
+        const res = {
+            setHeader: jest.fn(),
+        } as unknown as Response;
+
+        const next: NextFunction = (() => {
+            // Inside the AsyncLocalStorage context, getRequestId() should work
+            expect(getRequestId()).toBe(customId);
+            done();
+        }) as NextFunction;
+
+        requestIdMiddleware(req, res, next);
+    });
+
+    it("returns undefined from getRequestId() outside any request context", () => {
+        expect(getRequestId()).toBeUndefined();
+    });
+
+    it("assigns unique IDs to concurrent requests", () => {
+        const ids: string[] = [];
+        for (let i = 0; i < 50; i++) {
+            const { req, res, next } = mockReqResNext();
+            requestIdMiddleware(req, res, next);
+            ids.push((req as Request & { requestId: string }).requestId);
+        }
+
+        const uniqueIds = new Set(ids);
+        expect(uniqueIds.size).toBe(50);
+    });
+});
+
+describe("getRequestId (context isolation)", () => {
+    it("isolates request IDs across nested contexts", (done) => {
+        const id1 = "request-1";
+        const id2 = "request-2";
+        let innerResolved = false;
+
+        const req1 = { headers: { [REQUEST_ID_HEADER]: id1 } } as unknown as Request;
+        const res1 = { setHeader: jest.fn() } as unknown as Response;
+
+        const req2 = { headers: { [REQUEST_ID_HEADER]: id2 } } as unknown as Request;
+        const res2 = { setHeader: jest.fn() } as unknown as Response;
+
+        requestIdMiddleware(req1, res1, (() => {
+            expect(getRequestId()).toBe(id1);
+
+            // Simulate a second concurrent request
+            requestIdMiddleware(req2, res2, (() => {
+                expect(getRequestId()).toBe(id2);
+                innerResolved = true;
+            }) as NextFunction);
+
+            // After inner context exits, outer context should still be id1
+            expect(getRequestId()).toBe(id1);
+            expect(innerResolved).toBe(true);
+            done();
+        }) as NextFunction);
+    });
+});
+
+describe("serviceFetch x-request-id propagation", () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        global.fetch = jest.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    it("propagates x-request-id on outgoing calls inside a request context", (done) => {
+        const testId = "propagation-test-id";
+        const req = { headers: { [REQUEST_ID_HEADER]: testId } } as unknown as Request;
+        const res = { setHeader: jest.fn() } as unknown as Response;
+
+        requestIdMiddleware(req, res, (async () => {
+            // Dynamically import to ensure the mock is in place
+            const { serviceFetch } = await import("../src/utils/serviceClient");
+            await serviceFetch("https://ml-service.example.com/analyze", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ test: true }),
+            });
+
+            const fetchMock = global.fetch as jest.Mock;
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+
+            const [, init] = fetchMock.mock.calls[0];
+            const headers = new Headers(init.headers);
+            expect(headers.get("x-request-id")).toBe(testId);
+            expect(headers.get("Content-Type")).toBe("application/json");
+            done();
+        }) as NextFunction);
+    });
+
+    it("does not set x-request-id outside a request context", async () => {
+        const { serviceFetch } = await import("../src/utils/serviceClient");
+        await serviceFetch("https://example.com/health");
+
+        const fetchMock = global.fetch as jest.Mock;
+        const [, init] = fetchMock.mock.calls[0];
+        const headers = new Headers(init.headers);
+        expect(headers.get("x-request-id")).toBeNull();
+    });
+
+    it("does not overwrite an explicitly set x-request-id header", (done) => {
+        const contextId = "context-id";
+        const explicitId = "explicit-override-id";
+        const req = { headers: { [REQUEST_ID_HEADER]: contextId } } as unknown as Request;
+        const res = { setHeader: jest.fn() } as unknown as Response;
+
+        requestIdMiddleware(req, res, (async () => {
+            const { serviceFetch } = await import("../src/utils/serviceClient");
+            await serviceFetch("https://example.com/api", {
+                headers: { "x-request-id": explicitId },
+            });
+
+            const fetchMock = global.fetch as jest.Mock;
+            const [, init] = fetchMock.mock.calls[0];
+            const headers = new Headers(init.headers);
+            expect(headers.get("x-request-id")).toBe(explicitId);
+            done();
+        }) as NextFunction);
+    });
+});


### PR DESCRIPTION
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3135**

### Summary:

- Added correlation-ID middleware (AsyncLocalStorage-based) generating/reusing x-request-id per request
- Wired it first in app.ts so it's available everywhere downstream
- Logger auto-injects requestId into all log lines (no per-file changes needed)
- Error responses and Morgan logs now include requestId
- Added serviceFetch utils to propagate the header to downstream service calls
- Added tests for uniqueness, context isolation, and propagation

## 📸 Proof of Work (Screenshots / Logs)

<img width="866" height="845" alt="image" src="https://github.com/user-attachments/assets/90b0d4b2-b830-4fd4-870f-9059e1e028f0" />
<img width="930" height="647" alt="image" src="https://github.com/user-attachments/assets/6c2bb29d-c32e-4a61-a7d6-8b87b29f9d30" />


## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [x] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3135`)
- [x] I have pulled the latest `main` and resolved any conflicts
