### PR TITLE
fix: pin GitHub Actions to stable action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: ⬇️ Checkout Code
-              uses: actions/checkout@v7
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 2
 
             - name: ⚙️ Setup Node.js 24
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v4
               with:
                   node-version: 24
                   cache: "npm"
@@ -71,7 +71,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: ⬇️ Checkout Code
-              uses: actions/checkout@v7
+              uses: actions/checkout@v4
 
             - name: ⚙️ Setup Python 3.12
               uses: actions/setup-python@v6
@@ -95,7 +95,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: ⬇️ Checkout Code
-              uses: actions/checkout@v7
+              uses: actions/checkout@v4
 
             - name: 🐳 Build Docker Images
               run: docker compose build
@@ -105,7 +105,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: ⬇️ Checkout Code
-              uses: actions/checkout@v7
+              uses: actions/checkout@v4
 
             - name: 🔍 Get Changed Files
               id: changed-files


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3153**
- **Summary:**
  Updated the GitHub Actions workflow to use stable, officially supported versions of `actions/checkout` and `actions/setup-node`. This replaces unsupported action versions with their latest stable releases while preserving the existing CI workflow behavior.

## 📸 Proof of Work (Screenshots / Logs)

**Changes made**
- Updated `actions/checkout` from `@v7` to `@v4` in all workflow jobs.
- Updated `actions/setup-node` from `@v6` to `@v4`.

**Testing**
- Verified the workflow configuration after the version updates.
- Confirmed only `.github/workflows/test.yml` was modified.

> _No UI changes. Screenshots are not applicable for this workflow configuration update._

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [x] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts