### PR TITLE
feat(ml): add Redis cache for TTS audio

### DIFF
--- a/apps/ml/routers/tts.py
+++ b/apps/ml/routers/tts.py
@@ -70,6 +70,26 @@ if SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY:
 else:
     logger.info("Supabase Storage not configured. Using local TTS cache only.")
 
+# Redis configuration for shared TTS cache
+REDIS_URL = os.getenv("REDIS_URL")
+REDIS_CACHE_TTL_SECONDS = int(os.getenv("REDIS_CACHE_TTL_SECONDS", "86400"))  # 24 hours
+
+redis_client = None
+
+if REDIS_URL:
+    try:
+        import redis
+        redis_client = redis.from_url(REDIS_URL)
+        redis_client.ping()  # verify connectivity at startup
+        logger.info("Redis client initialized for TTS cache")
+    except ImportError:
+        logger.warning("redis package not installed. Install with: pip install redis")
+    except Exception as e:
+        logger.warning(f"Redis initialization failed: {e}")
+        redis_client = None
+else:
+    logger.info("Redis not configured. Skipping Redis TTS cache.")
+
 
 def prune_cache():
     """Prune oldest cache files if cache limits (size or file count) are exceeded."""
@@ -198,6 +218,30 @@ def upload_to_supabase_cache(cache_key: str, compressed_audio: bytes) -> None:
         logger.warning(f"TTS cloud cache upload failed: {e}")
 
 
+def download_from_redis_cache(cache_key: str) -> Optional[bytes]:
+    """Download compressed TTS audio from Redis."""
+    if not redis_client:
+        return None
+
+    try:
+        return redis_client.get(f"tts:{cache_key}")
+    except Exception as e:
+        logger.info(f"TTS Redis cache miss or fetch failed: {e}")
+        return None
+
+
+def upload_to_redis_cache(cache_key: str, compressed_audio: bytes) -> None:
+    """Upload compressed TTS audio to Redis with a 24-hour TTL."""
+    if not redis_client:
+        return
+
+    try:
+        redis_client.setex(f"tts:{cache_key}", REDIS_CACHE_TTL_SECONDS, compressed_audio)
+        logger.info(f"Cached TTS result to Redis: tts:{cache_key}")
+    except Exception as e:
+        logger.warning(f"TTS Redis cache upload failed: {e}")
+
+
 def generate_with_google(text: str, language_code: str, gender: str) -> tuple[bytes, str]:
     """Generate TTS using Google Cloud Text-to-Speech"""
     if not tts_google_client:
@@ -216,7 +260,7 @@ def generate_with_google(text: str, language_code: str, gender: str) -> tuple[by
         from google.cloud import texttospeech
 
         synthesis_input = texttospeech.SynthesisInput(text=text)
-        
+
         gender_enum = {
             "MALE": texttospeech.SsmlVoiceGender.MALE,
             "FEMALE": texttospeech.SsmlVoiceGender.FEMALE,
@@ -281,9 +325,9 @@ def generate_with_azure(text: str, language_code: str, gender: str) -> tuple[byt
         }
 
         endpoint = f"https://{azure_tts_region}.tts.speech.microsoft.com/cognitiveservices/v1"
-        
+
         response = requests.post(endpoint, headers=headers, data=ssml_text.encode('utf-8'), timeout=30)
-        
+
         if response.status_code != 200:
             raise Exception(f"Azure API returned {response.status_code}: {response.text}")
 
@@ -299,7 +343,7 @@ def generate_with_azure(text: str, language_code: str, gender: str) -> tuple[byt
 async def generate_tts(request: TTSRequest):
     """
     Generate speech audio from text.
-    
+
     Supported languages:
     - en-IN: English (Indian)
     - hi-IN: हिन्दी (Hindi)
@@ -307,7 +351,7 @@ async def generate_tts(request: TTSRequest):
     - bn-IN: বাংলা (Bengali)
     - mr-IN: मराठी (Marathi)
     - te-IN: తెలుగు (Telugu)
-    
+
     Returns:
     - audio_base64: MP3 audio encoded as Base64 string (standard for web clients)
     - provider: Which service generated the audio
@@ -329,7 +373,7 @@ async def generate_tts(request: TTSRequest):
             with open(cache_file, "rb") as f:
                 compressed_data = f.read()
             audio_data = gzip.decompress(compressed_data)
-            
+
             return TTSResponse(
                 audio_base64=base64.b64encode(audio_data).decode('utf-8'),
                 language_code=request.language_code,
@@ -339,6 +383,27 @@ async def generate_tts(request: TTSRequest):
             )
         except Exception as e:
             logger.warning(f"Cache read failed: {e}")
+    # Check Redis cache
+    compressed_redis_data = download_from_redis_cache(cache_key)
+    if compressed_redis_data:
+        try:
+            audio_data = gzip.decompress(compressed_redis_data)
+
+            try:
+                with open(cache_file, "wb") as f:
+                    f.write(compressed_redis_data)
+            except Exception as e:
+                logger.warning(f"Failed to write Redis cache to local disk: {e}")
+
+            return TTSResponse(
+                audio_base64=base64.b64encode(audio_data).decode('utf-8'),
+                language_code=request.language_code,
+                provider="redis-cache",
+                cached=True,
+                character_count=len(request.text)
+            )
+        except Exception as e:
+            logger.warning(f"Redis cache decompress failed: {e}")
     # Check Supabase Storage cache
     compressed_cloud_data = download_from_supabase_cache(cache_key)
     if compressed_cloud_data:
@@ -381,6 +446,7 @@ async def generate_tts(request: TTSRequest):
             with open(cache_file, "wb") as f:
                 f.write(compressed_audio)
             logger.info(f"✓ Cached TTS result to {cache_file}")
+            upload_to_redis_cache(cache_key, compressed_audio)
             upload_to_supabase_cache(cache_key, compressed_audio)
             try:
                 prune_cache()
@@ -415,5 +481,6 @@ def tts_health():
         "provider": TTS_PROVIDER,
         "google_available": tts_google_client is not None,
         "azure_available": azure_tts_key is not None,
+        "redis_cache_available": redis_client is not None,
         "supported_languages": list(GOOGLE_VOICES_MAP.keys()) if TTS_PROVIDER == "google" else list(AZURE_VOICES_MAP.keys())
     }

--- a/apps/ml/tests/test_tts.py
+++ b/apps/ml/tests/test_tts.py
@@ -66,3 +66,99 @@ def test_prune_cache_by_size(monkeypatch):
         assert not file1.exists()
         assert file2.exists()
         assert file3.exists()
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in for a redis.Redis client, used to test
+    the TTS Redis cache helpers without a real Redis server."""
+
+    def __init__(self):
+        self.store = {}
+        self.ttls = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def setex(self, key, ttl, value):
+        self.store[key] = value
+        self.ttls[key] = ttl
+
+
+def test_redis_cache_roundtrip(monkeypatch):
+    from routers.tts import get_cache_key, upload_to_redis_cache, download_from_redis_cache
+
+    fake_redis = FakeRedis()
+    monkeypatch.setattr("routers.tts.redis_client", fake_redis)
+
+    cache_key = get_cache_key("Hello world", "en-IN", "FEMALE")
+
+    # Nothing cached yet
+    assert download_from_redis_cache(cache_key) is None
+
+    upload_to_redis_cache(cache_key, b"fake-audio-bytes")
+
+    # Repeated request should now be served from Redis
+    assert download_from_redis_cache(cache_key) == b"fake-audio-bytes"
+
+
+def test_redis_cache_sets_24_hour_ttl(monkeypatch):
+    from routers.tts import get_cache_key, upload_to_redis_cache, REDIS_CACHE_TTL_SECONDS
+
+    fake_redis = FakeRedis()
+    monkeypatch.setattr("routers.tts.redis_client", fake_redis)
+
+    cache_key = get_cache_key("TTL check", "hi-IN", "FEMALE")
+    upload_to_redis_cache(cache_key, b"audio-bytes")
+
+    assert fake_redis.ttls[f"tts:{cache_key}"] == REDIS_CACHE_TTL_SECONDS
+    assert REDIS_CACHE_TTL_SECONDS == 86400
+
+
+def test_redis_cache_noop_when_client_missing(monkeypatch):
+    from routers.tts import upload_to_redis_cache, download_from_redis_cache
+
+    monkeypatch.setattr("routers.tts.redis_client", None)
+
+    # Should safely no-op instead of raising when Redis isn't configured
+    assert download_from_redis_cache("some-key") is None
+    upload_to_redis_cache("some-key", b"data")
+
+
+def test_generate_endpoint_uses_redis_cache_and_skips_cloud_tts(monkeypatch):
+    """Proves the acceptance criterion: a Redis cache hit must short-circuit
+    the request before any external TTS provider is called, and the audio
+    returned to the client is exactly the cached audio."""
+    import gzip
+    import base64
+    from routers import tts as tts_module
+
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(tts_module, "redis_client", fake_redis)
+    monkeypatch.setattr(tts_module, "supabase_client", None)
+
+    def _fail_if_called(*args, **kwargs):
+        raise AssertionError("Cloud TTS provider should not be called on a Redis cache hit")
+
+    monkeypatch.setattr(tts_module, "generate_with_google", _fail_if_called)
+    monkeypatch.setattr(tts_module, "generate_with_azure", _fail_if_called)
+
+    text, language_code, gender = "Hello world", "en-IN", "FEMALE"
+    cache_key = tts_module.get_cache_key(text, language_code, gender)
+    fake_audio = b"fake-audio-bytes"
+    fake_redis.setex(f"tts:{cache_key}", tts_module.REDIS_CACHE_TTL_SECONDS, gzip.compress(fake_audio))
+
+    # Make sure local disk is a miss so the Redis path is exercised, and clean
+    # up the temp cache dir automatically afterwards
+    with tempfile.TemporaryDirectory() as temp_dir:
+        monkeypatch.setattr(tts_module, "CACHE_DIR", Path(temp_dir))
+
+        res = client.post(
+            "/voice/tts/generate",
+            json={"text": text, "language_code": language_code, "gender": gender},
+        )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["cached"] is True
+    assert body["provider"] == "redis-cache"
+    assert base64.b64decode(body["audio_base64"]) == fake_audio


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* Closes #3145
* Summary: Adds a Redis-based caching layer for TTS audio in `apps/ml/routers/tts.py`. Generates a SHA-256 cache key from the request text, language, and gender, checks Redis before invoking external TTS providers, and returns cached audio when available. Newly synthesized audio is stored in Redis with a configurable 24-hour TTL (`REDIS_CACHE_TTL_SECONDS`). Also adds tests covering Redis cache helpers, TTL behavior, missing Redis configuration, and endpoint-level verification that Redis cache hits bypass external TTS providers and return the expected cached audio.

## 🏷️ PR Type

* [ ] 🐛 `type: bug`
* [x] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [x] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [x] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3145`)
* [ ] I have pulled the latest `main` and resolved any conflicts.