### PR TITLE
test(api): verify mock mode is disabled in production

### DIFF
--- a/apps/api/tests/verify.test.ts
+++ b/apps/api/tests/verify.test.ts
@@ -139,4 +139,28 @@ describe("POST /api/verify", () => {
         expect(res.status).toBe(400);
         expect(res.body.error).toBe("Invalid request body");
     });
+
+    it("should not return mock data in production even when VERIFY_ENABLE_MOCKS is enabled", async () => {
+        const originalNodeEnv = process.env.NODE_ENV;
+        const originalVerifyEnableMocks = process.env.VERIFY_ENABLE_MOCKS;
+
+        process.env.NODE_ENV = "production";
+        process.env.VERIFY_ENABLE_MOCKS = "true";
+
+        ((supabase as any).maybeSingle as jest.Mock).mockResolvedValue({
+            data: null,
+            error: null,
+        });
+
+        const res = await request(app).post("/api/verify").set("X-Forwarded-Proto", "https").send({
+            batchNumber: "BN2024001",
+            brandName: "Dolo 650",
+        });
+
+        expect(res.status).toBe(404);
+        expect(res.body.verified).toBe(false);
+
+        process.env.NODE_ENV = originalNodeEnv;
+        process.env.VERIFY_ENABLE_MOCKS = originalVerifyEnableMocks;
+    });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [ ] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3130**
- **Summary:**
  - Added a production test to verify that mock mode cannot be triggered when `NODE_ENV=production`.
  - Ensured that enabling `VERIFY_ENABLE_MOCKS=true` does not return mock data in production.
  - Added the `X-Forwarded-Proto: https` header in the test to allow the request to reach the verification route without HTTPS redirection.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3130`)
- [x] I have pulled the latest `main` and resolved any conflicts