### PR TITLE
Performance: Add client-side request de-duplication + caching for /api/v1/interactions to prevent bursty re-fetch on Compare page

### DIFF
--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { AlertTriangle, Copy, Loader2, Plus, ShieldCheck, X } from "lucide-react";
 import { toast } from "sonner";
@@ -31,6 +31,66 @@ type InteractionWarning = {
     source?: string;
 };
 
+const INTERACTIONS_CACHE_TTL_MS = 30_000;
+const INTERACTIONS_REQUEST_DEBOUNCE_MS = 150;
+
+const interactionsCache = new Map<
+    string,
+    { expiresAt: number; interactions: InteractionWarning[] }
+>();
+const interactionsInFlight = new Map<string, Promise<InteractionWarning[]>>();
+
+const severityOrder: Record<InteractionSeverity, number> = {
+    "High Risk": 0,
+    Moderate: 1,
+    Safe: 2,
+};
+
+function sortInteractionWarnings(interactions: InteractionWarning[]) {
+    return [...interactions].sort((a, b) => severityOrder[a.severity] - severityOrder[b.severity]);
+}
+
+async function fetchInteractionWarnings(
+    selectedIdsKey: string,
+    fallbackErrorMessage: string
+): Promise<InteractionWarning[]> {
+    const now = Date.now();
+    const cached = interactionsCache.get(selectedIdsKey);
+    if (cached && cached.expiresAt > now) {
+        return cached.interactions;
+    }
+
+    const inFlight = interactionsInFlight.get(selectedIdsKey);
+    if (inFlight) return inFlight;
+
+    const params = new URLSearchParams({ ids: selectedIdsKey });
+    const request = fetch(`${API_BASE}/api/v1/interactions?${params.toString()}`)
+        .then(async (response) => {
+            if (!response.ok) {
+                const body = (await response.json().catch(() => ({}))) as { error?: string };
+                throw new Error(body.error ?? fallbackErrorMessage);
+            }
+
+            return response.json() as Promise<{ interactions: InteractionWarning[] }>;
+        })
+        .then((body) => {
+            const interactions = sortInteractionWarnings(body.interactions ?? []);
+            interactionsCache.set(selectedIdsKey, {
+                expiresAt: Date.now() + INTERACTIONS_CACHE_TTL_MS,
+                interactions,
+            });
+            return interactions;
+        })
+        .finally(() => {
+            if (interactionsInFlight.get(selectedIdsKey) === request) {
+                interactionsInFlight.delete(selectedIdsKey);
+            }
+        });
+
+    interactionsInFlight.set(selectedIdsKey, request);
+    return request;
+}
+
 async function searchMedicines(query: string): Promise<Medicine[]> {
     const filter = buildMedicineNameSearchFilter(query);
     if (!filter) return [];
@@ -58,6 +118,7 @@ export default function ComparePage() {
     const [interactions, setInteractions] = useState<InteractionWarning[]>([]);
     const [interactionsLoading, setInteractionsLoading] = useState(false);
     const [interactionsError, setInteractionsError] = useState<string | null>(null);
+    const latestInteractionRequest = useRef(0);
 
     const medicine1 = selectedMedicines[0] ?? null;
     const medicine2 = selectedMedicines[1] ?? null;
@@ -126,56 +187,40 @@ export default function ComparePage() {
 
     useEffect(() => {
         if (selectedIds.length < 2) {
+            latestInteractionRequest.current += 1;
             setInteractions([]);
             setInteractionsError(null);
             setInteractionsLoading(false);
             return;
         }
 
-        const controller = new AbortController();
-        const params = new URLSearchParams({ ids: selectedIdsKey });
+        const requestId = latestInteractionRequest.current + 1;
+        latestInteractionRequest.current = requestId;
 
-        setInteractionsLoading(true);
-        setInteractionsError(null);
+        const timeoutId = window.setTimeout(() => {
+            setInteractionsLoading(true);
+            setInteractionsError(null);
 
-        fetch(`${API_BASE}/api/v1/interactions?${params.toString()}`, {
-            signal: controller.signal,
-        })
-            .then(async (response) => {
-                if (!response.ok) {
-                    const body = (await response.json().catch(() => ({}))) as { error?: string };
-                    throw new Error(body.error ?? tInteractions("errorMessage"));
-                }
+            fetchInteractionWarnings(selectedIdsKey, tInteractions("errorMessage"))
+                .then((nextInteractions) => {
+                    if (latestInteractionRequest.current !== requestId) return;
+                    setInteractions(nextInteractions);
+                })
+                .catch((error: unknown) => {
+                    if (latestInteractionRequest.current !== requestId) return;
+                    setInteractions([]);
+                    setInteractionsError(
+                        error instanceof Error ? error.message : tInteractions("errorMessage")
+                    );
+                })
+                .finally(() => {
+                    if (latestInteractionRequest.current === requestId) {
+                        setInteractionsLoading(false);
+                    }
+                });
+        }, INTERACTIONS_REQUEST_DEBOUNCE_MS);
 
-                return response.json() as Promise<{ interactions: InteractionWarning[] }>;
-            })
-            .then((body) => {
-                const severityOrder: Record<InteractionSeverity, number> = {
-                    "High Risk": 0,
-                    Moderate: 1,
-                    Safe: 2,
-                };
-
-                setInteractions(
-                    [...(body.interactions ?? [])].sort(
-                        (a, b) => severityOrder[a.severity] - severityOrder[b.severity]
-                    )
-                );
-            })
-            .catch((error: unknown) => {
-                if (error instanceof DOMException && error.name === "AbortError") return;
-                setInteractions([]);
-                setInteractionsError(
-                    error instanceof Error ? error.message : tInteractions("errorMessage")
-                );
-            })
-            .finally(() => {
-                if (!controller.signal.aborted) {
-                    setInteractionsLoading(false);
-                }
-            });
-
-        return () => controller.abort();
+        return () => window.clearTimeout(timeoutId);
     }, [selectedIds.length, selectedIdsKey]);
 
     const handleCopy = (text: string) => {

--- a/apps/web/tests/compare-interactions.test.tsx
+++ b/apps/web/tests/compare-interactions.test.tsx
@@ -34,6 +34,24 @@ const medicines: Record<string, Medicine> = {
     },
 };
 
+function setMedicineIds(first: string, second: string, third: string) {
+    medicines["First medicine"].id = first;
+    medicines["Second medicine"].id = second;
+    medicines["Search Medicine 3"].id = third;
+}
+
+function createDeferredResponse(body: unknown) {
+    let resolve!: (response: Response) => void;
+    const promise = new Promise<Response>((promiseResolve) => {
+        resolve = promiseResolve;
+    });
+
+    return {
+        promise,
+        resolve: () => resolve(jsonResponse(body)),
+    };
+}
+
 const queryBuilder = {
     select: jest.fn(),
     or: jest.fn(),
@@ -124,6 +142,9 @@ function jsonResponse(body: unknown, status = 200) {
 
 describe("ComparePage interaction warnings", () => {
     beforeEach(() => {
+        setMedicineIds("med-a", "med-b", "med-c");
+        window.history.replaceState({}, "", "/en/compare");
+
         queryBuilder.select.mockReturnValue(queryBuilder);
         queryBuilder.or.mockReturnValue(queryBuilder);
         queryBuilder.limit.mockResolvedValue({ data: [], error: null });
@@ -196,5 +217,98 @@ describe("ComparePage interaction warnings", () => {
         expect(screen.getByText("All clear!")).toBeInTheDocument();
         expect(screen.getByText("Crocin + Warfarin")).toBeInTheDocument();
         expect(screen.getByText("Monitor INR and bleeding symptoms.")).toBeInTheDocument();
+    });
+
+    it("keeps stale interaction responses from replacing the latest selection", async () => {
+        setMedicineIds("stale-a", "stale-b", "stale-c");
+
+        const firstResponse = createDeferredResponse({
+            interactions: [
+                {
+                    medicineAId: "stale-a",
+                    medicineBId: "stale-b",
+                    drugA: "Crocin",
+                    drugB: "Warfarin",
+                    severity: "High Risk",
+                    sideEffects: "Outdated warning.",
+                },
+            ],
+        });
+        const latestResponse = createDeferredResponse({
+            interactions: [
+                {
+                    medicineAId: "stale-b",
+                    medicineBId: "stale-c",
+                    drugA: "Warfarin",
+                    drugB: "Brufen",
+                    severity: "Moderate",
+                    sideEffects: "Latest warning.",
+                },
+            ],
+        });
+
+        (global.fetch as jest.Mock)
+            .mockReturnValueOnce(firstResponse.promise)
+            .mockReturnValueOnce(latestResponse.promise);
+
+        render(<ComparePage />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Select First medicine" }));
+        fireEvent.click(screen.getByRole("button", { name: "Select Second medicine" }));
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+        fireEvent.click(screen.getByRole("button", { name: "Add medicine" }));
+        fireEvent.click(screen.getByRole("button", { name: "Select Search Medicine 3" }));
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+
+        latestResponse.resolve();
+        expect(await screen.findByText("Latest warning.")).toBeInTheDocument();
+
+        firstResponse.resolve();
+        await waitFor(() =>
+            expect(screen.queryByText("Outdated warning.")).not.toBeInTheDocument()
+        );
+        expect(screen.getByText("Latest warning.")).toBeInTheDocument();
+    });
+
+    it("uses the short-lived cache for identical selection keys", async () => {
+        setMedicineIds("cache-a", "cache-b", "cache-c");
+
+        const response = createDeferredResponse({
+            interactions: [
+                {
+                    medicineAId: "cache-a",
+                    medicineBId: "cache-b",
+                    drugA: "Crocin",
+                    drugB: "Warfarin",
+                    severity: "High Risk",
+                    sideEffects: "Cached warning.",
+                },
+            ],
+        });
+
+        (global.fetch as jest.Mock).mockReturnValueOnce(response.promise);
+
+        const { unmount } = render(<ComparePage />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Select First medicine" }));
+        fireEvent.click(screen.getByRole("button", { name: "Select Second medicine" }));
+
+        await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+
+        response.resolve();
+        expect(await screen.findByText("Cached warning.")).toBeInTheDocument();
+
+        unmount();
+        window.history.replaceState({}, "", "/en/compare");
+        render(<ComparePage />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Select First medicine" }));
+        fireEvent.click(screen.getByRole("button", { name: "Select Second medicine" }));
+
+        expect(await screen.findByText("Cached warning.")).toBeInTheDocument();
+        expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 });

--- a/apps/web/tests/setupTests.ts
+++ b/apps/web/tests/setupTests.ts
@@ -1,82 +1,84 @@
 // Make React testing utilities know the environment supports act(...)
-;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 // Helpful matchers
-import '@testing-library/jest-dom/extend-expect'
+import "@testing-library/jest-dom";
 
 // Minimal OffscreenCanvas mock used by image processing code
 if (!(globalThis as any).OffscreenCanvas) {
-  class OffscreenCanvasMock {
-    width: number
-    height: number
-    constructor(w = 1, h = 1) {
-      this.width = w
-      this.height = h
+    class OffscreenCanvasMock {
+        width: number;
+        height: number;
+        constructor(w = 1, h = 1) {
+            this.width = w;
+            this.height = h;
+        }
+        getContext() {
+            return {
+                filter: "",
+                drawImage: () => {},
+                putImageData: () => {},
+                getImageData: (_x: number, _y: number, w: number, h: number) => ({
+                    data: new Uint8ClampedArray(w * h * 4),
+                    width: w,
+                    height: h,
+                }),
+                canvas: this,
+                toDataURL: () => "",
+            };
+        }
+        transferToImageBitmap() {
+            return {};
+        }
+        convertToBlob() {
+            return Promise.resolve(new Blob());
+        }
     }
-    getContext(_type?: string) {
-      return {
-        filter: '',
-        drawImage: () => {},
-        putImageData: () => {},
-        getImageData: (_x: number, _y: number, w: number, h: number) => ({
-          data: new Uint8ClampedArray(w * h * 4),
-          width: w,
-          height: h,
-        }),
-        canvas: this,
-        toDataURL: () => '',
-      }
-    }
-    transferToImageBitmap() {
-      return {}
-    }
-    convertToBlob() {
-      return Promise.resolve(new Blob())
-    }
-  }
-  ;(globalThis as any).OffscreenCanvas = OffscreenCanvasMock
+    (globalThis as any).OffscreenCanvas = OffscreenCanvasMock;
 }
 
 // createImageBitmap mock
 if (!(globalThis as any).createImageBitmap) {
-  ;(globalThis as any).createImageBitmap = async (img: any) => img
+    (globalThis as any).createImageBitmap = async (img: any) => img;
 }
 
 // Minimal Worker mock (no-op)
 if (!(globalThis as any).Worker) {
-  class WorkerMock {
-    onmessage: ((ev: any) => void) | null = null
-    onerror: ((ev: any) => void) | null = null
-    constructor(_script?: string) {}
-    postMessage(_msg?: any) {}
-    terminate() {}
-    addEventListener() {}
-    removeEventListener() {}
-  }
-  ;(globalThis as any).Worker = WorkerMock
+    class WorkerMock {
+        onmessage: ((ev: any) => void) | null = null;
+        onerror: ((ev: any) => void) | null = null;
+        constructor() {}
+        postMessage() {}
+        terminate() {}
+        addEventListener() {}
+        removeEventListener() {}
+    }
+    (globalThis as any).Worker = WorkerMock;
 }
 
 // Minimal Image mock
 if (!(globalThis as any).Image) {
-  class ImageMock {
-    src = ''
-    width = 0
-    height = 0
-    onload: (() => void) | null = null
-    onerror: (() => void) | null = null
-    constructor() {}
-  }
-  ;(globalThis as any).Image = ImageMock as any
+    class ImageMock {
+        src = "";
+        width = 0;
+        height = 0;
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        constructor() {}
+    }
+    (globalThis as any).Image = ImageMock as any;
 }
 
 // Ensure HTMLCanvasElement.toBlob exists in jsdom
 if (!HTMLCanvasElement.prototype.toBlob) {
-  HTMLCanvasElement.prototype.toBlob = function (callback: (b: Blob | null) => void) {
-    try {
-      const dataUrl = (this as HTMLCanvasElement).toDataURL ? (this as HTMLCanvasElement).toDataURL() : ''
-      callback(new Blob([dataUrl], { type: 'image/png' }))
-    } catch {
-      callback(null)
-    }
-  }
+    HTMLCanvasElement.prototype.toBlob = function (callback: (b: Blob | null) => void) {
+        try {
+            const dataUrl = (this as HTMLCanvasElement).toDataURL
+                ? (this as HTMLCanvasElement).toDataURL()
+                : "";
+            callback(new Blob([dataUrl], { type: "image/png" }));
+        } catch {
+            callback(null);
+        }
+    };
 }


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3257 **
- **Summary:**

### What changed:

1. Added 150ms debounce, in-flight dedupe, and 30s client cache in [page.tsx (line 34)]
2. Added a latest-request guard so stale responses cannot overwrite newer selections in [page.tsx (line 121)]
3. Added tests for stale response protection and short-lived cache reuse in [compare-interactions.test.tsx (line 222)]
4. Fixed Jest DOM setup import compatibility in [setupTests.ts (line 5)]

### Verified:
```
npx jest --config jest.config.cjs tests/compare-interactions.test.tsx --runInBand --forceExit passes: 3/3 tests.
npx eslint app/[locale]/compare/page.tsx tests/compare-interactions.test.tsx tests/setupTests.ts passes.
```
## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3257 `)
- [x] I have pulled the latest `main` and resolved any conflicts
