### PR TITLE
feat(ml): add Whisper small vs medium benchmark script for medicine n…

### DIFF
--- a/apps/ml/requirements.txt
+++ b/apps/ml/requirements.txt
@@ -31,6 +31,7 @@ openai-whisper>=20240930
 soundfile>=0.12.1
 noisereduce>=3.0.0
 numpy>=1.26.0
+pyttsx3>=2.90
 
 # TTS (Text-to-Speech) - Optional
 # Google Cloud TTS

--- a/apps/ml/scripts/benchmark_asr.py
+++ b/apps/ml/scripts/benchmark_asr.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import re
+import sys
+import time
+import unicodedata
+import wave
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger("benchmark_asr")
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ML_APP_DIR = SCRIPT_DIR.parent
+REPO_ROOT = ML_APP_DIR.parent.parent
+DEFAULT_OUTPUT_DIR = SCRIPT_DIR / "benchmark_results"
+CDSCO_REFERENCE_CSV = REPO_ROOT / "data" / "seeds" / "cdsco_reference.csv"
+
+DEFAULT_WHISPER_DEVICE = "cpu"
+DEFAULT_WHISPER_COMPUTE_TYPE = "int8"
+DEFAULT_MODELS = ["small", "medium"]
+SYNTH_SAMPLE_RATE = 16000
+
+# ---------------------------------------------------------------------------
+# Mocked fallback dataset
+# ---------------------------------------------------------------------------
+# Used when the CDSCO scraper output isn't available (e.g. fresh clone, no
+# network access to the CDSCO portal, or running in CI). Names are picked to
+# be representative of real-world difficulty: multi-syllable brand names,
+# combination drugs, and names that are easy to mis-hear in Indian accents.
+MOCK_MEDICINE_NAMES: list[str] = [
+    "Dolo 650",
+    "Augmentin 625 Duo",
+    "Allegra 120",
+    "Pan 40",
+    "Crocin Advance",
+    "Azithromycin 500",
+    "Metformin 500",
+    "Amoxicillin 250",
+    "Ibuprofen 400",
+    "Paracetamol 650",
+    "Combiflam",
+    "Voveran SR",
+    "Calpol",
+    "Zerodol P",
+    "Montair LC",
+    "Telma 40",
+    "Glimepiride 2",
+    "Rosuvastatin 10",
+    "Pantoprazole 40",
+    "Cetirizine 10",
+    "Levocetirizine 5",
+    "Amlodipine 5",
+    "Ecosprin 75",
+    "Thyronorm 50",
+    "Shelcal 500",
+    "Becosules Capsule",
+    "Digene Gel",
+    "Sinarest",
+    "Ondansetron 4",
+    "Domperidone 10",
+]
+
+
+def normalize_text(text: str) -> str:
+    """Lowercase, strip accents/punctuation, and collapse whitespace so that
+    WER/exact-match comparisons aren't skewed by casing or formatting noise.
+    """
+    text = unicodedata.normalize("NFKD", text or "")
+    text = text.encode("ascii", "ignore").decode("ascii")
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9\s]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def word_error_rate(reference: str, hypothesis: str) -> float:
+    """Classic WER = (S + D + I) / N, computed via Levenshtein distance over
+    word sequences. Returns a value >= 0.0 (can exceed 1.0 if the hypothesis
+    has far more insertions than the reference has words).
+    """
+    ref_words = normalize_text(reference).split()
+    hyp_words = normalize_text(hypothesis).split()
+
+    if not ref_words:
+        return 0.0 if not hyp_words else 1.0
+
+    n, m = len(ref_words), len(hyp_words)
+    dp = [[0] * (m + 1) for _ in range(n + 1)]
+    for i in range(n + 1):
+        dp[i][0] = i
+    for j in range(m + 1):
+        dp[0][j] = j
+
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            if ref_words[i - 1] == hyp_words[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1]
+            else:
+                dp[i][j] = 1 + min(
+                    dp[i - 1][j],      # deletion
+                    dp[i][j - 1],      # insertion
+                    dp[i - 1][j - 1],  # substitution
+                )
+
+    return dp[n][m] / n
+
+
+def is_exact_match(reference: str, hypothesis: str) -> bool:
+    return normalize_text(reference) == normalize_text(hypothesis)
+
+
+# ---------------------------------------------------------------------------
+# Medicine name loading
+# ---------------------------------------------------------------------------
+
+def load_medicine_names(num_samples: int | None = None) -> list[str]:
+    """Load medicine names from the CDSCO scraper output if it exists,
+    otherwise fall back to the bundled mock dataset.
+    """
+    names: list[str] = []
+
+    if CDSCO_REFERENCE_CSV.exists():
+        try:
+            import pandas as pd
+
+            df = pd.read_csv(CDSCO_REFERENCE_CSV)
+            # CDSCO portal rows are lists under "aaData"; the brand name is
+            # typically the first or second column depending on the search
+            # endpoint used — try common column names, then fall back to the
+            # first text-like column.
+            for candidate in ("BrandName", "brand_name", "medicineName", "0", "1"):
+                if candidate in df.columns:
+                    names = [str(v).strip() for v in df[candidate].dropna().tolist()]
+                    break
+            if not names and len(df.columns) > 0:
+                names = [str(v).strip() for v in df.iloc[:, 0].dropna().tolist()]
+
+            names = [n for n in names if n and n.lower() != "nan"]
+            if names:
+                logger.info(
+                    "Loaded %d medicine names from CDSCO reference CSV (%s)",
+                    len(names),
+                    CDSCO_REFERENCE_CSV,
+                )
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            logger.warning("Failed to read CDSCO reference CSV, using mock data: %s", exc)
+
+    if not names:
+        logger.info(
+            "CDSCO reference CSV not found at %s — using %d bundled mock medicine names. "
+            "Run the ETL scraper (apps/etl/src/scrapers/cdsco.py) to benchmark against "
+            "live data instead.",
+            CDSCO_REFERENCE_CSV,
+            len(MOCK_MEDICINE_NAMES),
+        )
+        names = list(MOCK_MEDICINE_NAMES)
+
+    # De-duplicate while preserving order.
+    seen: set[str] = set()
+    deduped = []
+    for name in names:
+        key = normalize_text(name)
+        if key and key not in seen:
+            seen.add(key)
+            deduped.append(name)
+    names = deduped
+
+    if num_samples is not None:
+        names = names[:num_samples]
+
+    if not names:
+        raise RuntimeError("No medicine names available to benchmark.")
+
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Audio acquisition (synthetic TTS or pre-recorded)
+# ---------------------------------------------------------------------------
+
+def _safe_filename(name: str) -> str:
+    return re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_") + ".wav"
+
+
+def synthesize_audio_clips(names: list[str], out_dir: Path) -> dict[str, Path]:
+    """Generate one WAV clip per medicine name using an offline TTS engine
+    (pyttsx3), caching clips on disk so repeated runs are fast. Offline TTS
+    is deliberately used instead of the project's Google Cloud TTS router so
+    this script can run without cloud credentials or network access.
+    """
+    try:
+        import pyttsx3
+    except ImportError as exc:
+        raise RuntimeError(
+            "pyttsx3 is required to synthesize audio. Install it with "
+            "`pip install pyttsx3`, or pass --audio-dir with pre-recorded clips."
+        ) from exc
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    clips: dict[str, Path] = {}
+
+    engine = pyttsx3.init()
+    engine.setProperty("rate", 150)
+
+    for name in names:
+        clip_path = out_dir / _safe_filename(name)
+        if not clip_path.exists():
+            engine.save_to_file(name, str(clip_path))
+        clips[name] = clip_path
+
+    engine.runAndWait()
+
+    missing = [name for name, path in clips.items() if not path.exists()]
+    if missing:
+        raise RuntimeError(f"TTS synthesis failed to produce audio for: {missing}")
+
+    return clips
+
+
+def load_prerecorded_clips(names: list[str], audio_dir: Path) -> dict[str, Path]:
+    clips: dict[str, Path] = {}
+    missing = []
+    for name in names:
+        clip_path = audio_dir / _safe_filename(name)
+        if clip_path.exists():
+            clips[name] = clip_path
+        else:
+            missing.append(name)
+
+    if missing:
+        raise FileNotFoundError(
+            f"Missing pre-recorded clips in {audio_dir} for: {missing}. "
+            f"Expected files named like '{_safe_filename(missing[0])}'."
+        )
+
+    return clips
+
+
+def get_wav_duration_seconds(path: Path) -> float:
+    try:
+        with wave.open(str(path), "rb") as wav_file:
+            return wav_file.getnframes() / float(wav_file.getframerate())
+    except (wave.Error, EOFError):
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Benchmark execution
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SampleResult:
+    medicine_name: str
+    model_size: str
+    transcript: str
+    wer: float
+    exact_match: bool
+    latency_seconds: float
+    audio_duration_seconds: float
+
+
+@dataclass
+class ModelSummary:
+    model_size: str
+    num_samples: int
+    mean_wer: float
+    exact_match_accuracy: float
+    mean_latency_seconds: float
+    real_time_factor: float
+    results: list[SampleResult] = field(default_factory=list)
+
+
+def run_model_benchmark(
+    model_size: str,
+    clips: dict[str, Path],
+    *,
+    device: str = DEFAULT_WHISPER_DEVICE,
+    compute_type: str = DEFAULT_WHISPER_COMPUTE_TYPE,
+) -> ModelSummary:
+    from faster_whisper import WhisperModel
+
+    logger.info("Loading Whisper model '%s' (device=%s, compute_type=%s)...", model_size, device, compute_type)
+    model = WhisperModel(model_size, device=device, compute_type=compute_type)
+
+    results: list[SampleResult] = []
+    for reference_name, clip_path in clips.items():
+        audio_duration = get_wav_duration_seconds(clip_path)
+
+        started_at = time.perf_counter()
+        segments, _info = model.transcribe(str(clip_path), task="transcribe", beam_size=5)
+        transcript = " ".join(seg.text for seg in segments).strip()
+        latency = time.perf_counter() - started_at
+
+        wer = word_error_rate(reference_name, transcript)
+        exact = is_exact_match(reference_name, transcript)
+
+        logger.info(
+            "[%s] '%s' -> '%s' | WER=%.2f exact=%s latency=%.2fs",
+            model_size,
+            reference_name,
+            transcript,
+            wer,
+            exact,
+            latency,
+        )
+
+        results.append(
+            SampleResult(
+                medicine_name=reference_name,
+                model_size=model_size,
+                transcript=transcript,
+                wer=wer,
+                exact_match=exact,
+                latency_seconds=latency,
+                audio_duration_seconds=audio_duration,
+            )
+        )
+
+    return summarize_results(model_size, results)
+
+
+def summarize_results(model_size: str, results: list[SampleResult]) -> ModelSummary:
+    n = len(results)
+    mean_wer = sum(r.wer for r in results) / n if n else 0.0
+    exact_accuracy = sum(1 for r in results if r.exact_match) / n if n else 0.0
+    mean_latency = sum(r.latency_seconds for r in results) / n if n else 0.0
+    total_audio = sum(r.audio_duration_seconds for r in results)
+    total_latency = sum(r.latency_seconds for r in results)
+    rtf = (total_latency / total_audio) if total_audio > 0 else 0.0
+
+    return ModelSummary(
+        model_size=model_size,
+        num_samples=n,
+        mean_wer=mean_wer,
+        exact_match_accuracy=exact_accuracy,
+        mean_latency_seconds=mean_latency,
+        real_time_factor=rtf,
+        results=results,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+def write_csv_report(summaries: list[ModelSummary], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "medicine_name",
+                "model_size",
+                "transcript",
+                "wer",
+                "exact_match",
+                "latency_seconds",
+                "audio_duration_seconds",
+            ]
+        )
+        for summary in summaries:
+            for r in summary.results:
+                writer.writerow(
+                    [
+                        r.medicine_name,
+                        r.model_size,
+                        r.transcript,
+                        f"{r.wer:.4f}",
+                        r.exact_match,
+                        f"{r.latency_seconds:.4f}",
+                        f"{r.audio_duration_seconds:.4f}",
+                    ]
+                )
+    logger.info("Wrote per-sample CSV results to %s", output_path)
+
+
+def generate_markdown_report(summaries: list[ModelSummary]) -> str:
+    lines = [
+        "# ASR Benchmark Report — Whisper `small` vs `medium`",
+        "",
+        "Benchmarking Whisper model sizes against Indian medicine names, per issue #3144.",
+        "",
+        "## Summary",
+        "",
+        "| Model | Samples | Mean WER | Exact Match Accuracy | Mean Latency (s) | Real-Time Factor |",
+        "|---|---|---|---|---|---|",
+    ]
+    for s in summaries:
+        lines.append(
+            f"| {s.model_size} | {s.num_samples} | {s.mean_wer:.3f} | "
+            f"{s.exact_match_accuracy:.1%} | {s.mean_latency_seconds:.3f} | {s.real_time_factor:.2f}x |"
+        )
+
+    if len(summaries) >= 2:
+        by_size = {s.model_size: s for s in summaries}
+        if "small" in by_size and "medium" in by_size:
+            small, medium = by_size["small"], by_size["medium"]
+            wer_delta = small.mean_wer - medium.mean_wer
+            acc_delta = medium.exact_match_accuracy - small.exact_match_accuracy
+            latency_delta = medium.mean_latency_seconds - small.mean_latency_seconds
+            lines += [
+                "",
+                "## `small` -> `medium` Delta",
+                "",
+                f"- WER improvement: **{wer_delta:+.3f}** (positive = medium is better)",
+                f"- Exact-match accuracy change: **{acc_delta:+.1%}**",
+                f"- Extra latency per clip: **{latency_delta:+.3f}s**",
+            ]
+
+    lines += ["", "## Per-Sample Results", ""]
+    for s in summaries:
+        lines.append(f"### Model: `{s.model_size}`")
+        lines.append("")
+        lines.append("| Medicine Name | Transcript | WER | Exact Match | Latency (s) |")
+        lines.append("|---|---|---|---|---|")
+        for r in s.results:
+            lines.append(
+                f"| {r.medicine_name} | {r.transcript} | {r.wer:.2f} | "
+                f"{'✅' if r.exact_match else '❌'} | {r.latency_seconds:.2f} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def write_markdown_report(summaries: list[ModelSummary], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(generate_markdown_report(summaries), encoding="utf-8")
+    logger.info("Wrote Markdown summary report to %s", output_path)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=20,
+        help="Number of medicine names to benchmark (default: 20).",
+    )
+    parser.add_argument(
+        "--models",
+        nargs="+",
+        default=DEFAULT_MODELS,
+        help="Whisper model sizes to benchmark (default: small medium).",
+    )
+    parser.add_argument(
+        "--audio-dir",
+        type=Path,
+        default=None,
+        help="Directory of pre-recorded WAV clips (one per medicine name). "
+        "If omitted, audio is synthesized offline via pyttsx3.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Directory to write CSV/Markdown reports to (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument(
+        "--device",
+        default=DEFAULT_WHISPER_DEVICE,
+        help="Device to run inference on (default: cpu).",
+    )
+    parser.add_argument(
+        "--compute-type",
+        default=DEFAULT_WHISPER_COMPUTE_TYPE,
+        help="faster-whisper compute type (default: int8, matching production).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    names = load_medicine_names(num_samples=args.num_samples)
+    logger.info("Benchmarking %d medicine names: %s", len(names), ", ".join(names[:5]) + ("..." if len(names) > 5 else ""))
+
+    if args.audio_dir:
+        clips = load_prerecorded_clips(names, args.audio_dir)
+    else:
+        tts_cache_dir = args.output_dir / "synthetic_audio"
+        clips = synthesize_audio_clips(names, tts_cache_dir)
+
+    summaries: list[ModelSummary] = []
+    for model_size in args.models:
+        summary = run_model_benchmark(
+            model_size,
+            clips,
+            device=args.device,
+            compute_type=args.compute_type,
+        )
+        summaries.append(summary)
+
+    write_csv_report(summaries, args.output_dir / "benchmark_asr_results.csv")
+    write_markdown_report(summaries, args.output_dir / "benchmark_asr_report.md")
+
+    print("\n" + generate_markdown_report(summaries).split("## Per-Sample Results")[0])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/ml/tests/test_benchmark_asr.py
+++ b/apps/ml/tests/test_benchmark_asr.py
@@ -1,0 +1,121 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import benchmark_asr as bench  # noqa: E402
+
+
+def test_normalize_text_strips_punctuation_and_case():
+    assert bench.normalize_text("Dolo-650!") == "dolo 650"
+    assert bench.normalize_text("  Pan   40  ") == "pan 40"
+
+
+def test_word_error_rate_perfect_match_is_zero():
+    assert bench.word_error_rate("Dolo 650", "dolo 650") == 0.0
+
+
+def test_word_error_rate_single_substitution():
+    # 1 substitution out of 2 reference words -> WER 0.5
+    assert bench.word_error_rate("Dolo 650", "Zolo 650") == 0.5
+
+
+def test_word_error_rate_empty_reference():
+    assert bench.word_error_rate("", "") == 0.0
+    assert bench.word_error_rate("", "hello") == 1.0
+
+
+def test_is_exact_match_ignores_case_and_punctuation():
+    assert bench.is_exact_match("Augmentin 625 Duo", "augmentin 625 duo") is True
+    assert bench.is_exact_match("Augmentin 625 Duo", "augmentin 625") is False
+
+
+def test_load_medicine_names_falls_back_to_mock_when_csv_missing(monkeypatch, tmp_path):
+    fake_csv = tmp_path / "cdsco_reference.csv"
+    monkeypatch.setattr(bench, "CDSCO_REFERENCE_CSV", fake_csv)
+
+    names = bench.load_medicine_names(num_samples=5)
+
+    assert len(names) == 5
+    assert names[0] in bench.MOCK_MEDICINE_NAMES
+
+
+def test_load_medicine_names_deduplicates():
+    monkeypatch_names = bench.MOCK_MEDICINE_NAMES + [bench.MOCK_MEDICINE_NAMES[0].lower()]
+    deduped = []
+    seen = set()
+    for name in monkeypatch_names:
+        key = bench.normalize_text(name)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(name)
+    assert len(deduped) == len(bench.MOCK_MEDICINE_NAMES)
+
+
+def test_summarize_results_computes_aggregate_metrics():
+    results = [
+        bench.SampleResult(
+            medicine_name="Dolo 650",
+            model_size="small",
+            transcript="dolo 650",
+            wer=0.0,
+            exact_match=True,
+            latency_seconds=0.5,
+            audio_duration_seconds=1.0,
+        ),
+        bench.SampleResult(
+            medicine_name="Pan 40",
+            model_size="small",
+            transcript="pant 40",
+            wer=0.5,
+            exact_match=False,
+            latency_seconds=0.5,
+            audio_duration_seconds=1.0,
+        ),
+    ]
+
+    summary = bench.summarize_results("small", results)
+
+    assert summary.num_samples == 2
+    assert summary.mean_wer == 0.25
+    assert summary.exact_match_accuracy == 0.5
+    assert summary.mean_latency_seconds == 0.5
+    assert summary.real_time_factor == 0.5  # 1.0s total latency / 2.0s total audio
+
+
+def test_generate_markdown_report_includes_delta_section():
+    small = bench.summarize_results(
+        "small",
+        [
+            bench.SampleResult("Dolo 650", "small", "dolo 650", 0.2, False, 0.3, 1.0),
+        ],
+    )
+    medium = bench.summarize_results(
+        "medium",
+        [
+            bench.SampleResult("Dolo 650", "medium", "dolo 650", 0.0, True, 0.6, 1.0),
+        ],
+    )
+
+    report = bench.generate_markdown_report([small, medium])
+
+    assert "small -> medium" in report or "small` -> `medium" in report
+    assert "Dolo 650" in report
+    assert "Mean WER" in report
+
+
+def test_write_csv_report_creates_file(tmp_path):
+    summary = bench.summarize_results(
+        "small",
+        [
+            bench.SampleResult("Dolo 650", "small", "dolo 650", 0.0, True, 0.3, 1.0),
+        ],
+    )
+    out_path = tmp_path / "results.csv"
+
+    bench.write_csv_report([summary], out_path)
+
+    assert out_path.exists()
+    content = out_path.read_text()
+    assert "Dolo 650" in content
+    assert "medicine_name" in content


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link
- **Closes #3144**
- **Summary:**
  Added a benchmarking script (`apps/ml/scripts/benchmark_asr.py`) that compares Whisper `small` vs `medium` on Indian medicine name recognition accuracy.

  - Loads medicine names from the CDSCO scraper output (`data/seeds/cdsco_reference.csv`) if available, falling back to a bundled list of 30 curated Indian medicine names otherwise.
  - Synthesizes audio for each name offline via `pyttsx3` (no cloud API/network needed), or accepts pre-recorded clips via `--audio-dir`.
  - Runs both Whisper models via `faster-whisper` using the same `device`/`compute_type` defaults as production (`cpu`/`int8`).
  - Computes Word Error Rate (WER) and exact-match accuracy per model.
  - Outputs a per-sample CSV (`benchmark_asr_results.csv`) and a Markdown summary report (`benchmark_asr_report.md`), including a `small -> medium` delta section (WER, accuracy, latency).
  - Added `apps/ml/tests/test_benchmark_asr.py` covering the WER/exact-match/report logic, so tests run fast in CI without loading real models or generating audio.
  - Added `pyttsx3>=2.90` to `apps/ml/requirements.txt` (ASR section) as the only new dependency.

## 🏷️ PR Type
- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #3144`)
- [x] I have pulled the latest `main` and resolved any conflicts