### PR TITLE
fix: use proper INR currency formatting

### DIFF
--- a/apps/web/app/[locale]/calculator/page.tsx
+++ b/apps/web/app/[locale]/calculator/page.tsx
@@ -13,6 +13,15 @@ import { Pill, AlertCircle, DollarSign, Calendar, MapPin, ArrowRight } from "luc
 import GenericAlternativeCard from "@/components/GenericAlternativeCard";
 import GenericAlternativeCardSkeleton from "@/components/GenericAlternativeCardSkeleton";
 
+const INR_FORMATTER = new Intl.NumberFormat("en-IN", {
+    style: "currency",
+    currency: "INR",
+});
+
+function formatINR(value: number): string {
+    return INR_FORMATTER.format(value);
+}
+
 async function searchMedicines(query: string): Promise<Medicine[]> {
     const q = query.trim();
     if (q.length < 2) return [];
@@ -339,7 +348,7 @@ function CalculatorPageContent() {
                                         {translate("perPurchaseSavings")}
                                     </span>
                                     <span className="mt-1 block text-lg font-black text-slate-800 dark:text-slate-200">
-                                        Γé╣{savingsPerPurchase.toFixed(2)}
+                                        {formatINR(savingsPerPurchase)}
                                     </span>
                                 </div>
 
@@ -349,7 +358,7 @@ function CalculatorPageContent() {
                                         {translate("monthlySavings")}
                                     </span>
                                     <span className="mt-1 block text-xl font-extrabold text-emerald-700 dark:text-emerald-400">
-                                        Γé╣{monthlySavings.toFixed(2)}
+                                        {formatINR(monthlySavings)}
                                     </span>
                                 </div>
 
@@ -359,7 +368,7 @@ function CalculatorPageContent() {
                                         {translate("yearlySavings")}
                                     </span>
                                     <span className="mt-1 block text-xl font-extrabold text-teal-700 dark:text-teal-400">
-                                        Γé╣{yearlySavings.toFixed(2)}
+                                        {formatINR(yearlySavings)}
                                     </span>
                                 </div>
                             </div>
@@ -370,7 +379,7 @@ function CalculatorPageContent() {
                                     <div className="flex justify-between text-xs font-bold text-slate-500 dark:text-slate-400">
                                         <span>{translate("costPerMonthBrand")}</span>
                                         <span className="font-extrabold text-slate-800 dark:text-slate-200">
-                                            Γé╣{brandMonthlyCost.toFixed(2)}
+                                            {formatINR(brandMonthlyCost)}
                                         </span>
                                     </div>
                                     <div className="h-3 w-full rounded-full bg-slate-100 dark:bg-slate-800">
@@ -385,7 +394,7 @@ function CalculatorPageContent() {
                                     <div className="flex justify-between text-xs font-bold text-slate-500 dark:text-slate-400">
                                         <span>{translate("costPerMonthGeneric")}</span>
                                         <span className="font-extrabold text-slate-800 dark:text-slate-200">
-                                            Γé╣{genericMonthlyCost.toFixed(2)}
+                                            {formatINR(genericMonthlyCost)}
                                         </span>
                                     </div>
                                     <div className="h-3 w-full rounded-full bg-slate-100 dark:bg-slate-800">
@@ -405,7 +414,7 @@ function CalculatorPageContent() {
                                     <div className="flex justify-between text-xs font-bold text-slate-500 dark:text-slate-400">
                                         <span>{translate("costPerMonthJanAushadhi")}</span>
                                         <span className="font-extrabold text-slate-800 dark:text-slate-200">
-                                            Γé╣{janAushadhiMonthlyCost.toFixed(2)}
+                                            {formatINR(janAushadhiMonthlyCost)}
                                         </span>
                                     </div>
                                     <div className="h-3 w-full rounded-full bg-slate-100 dark:bg-slate-800">


### PR DESCRIPTION
## Related Issue

Closes #3275

---

## Description

Fixed an issue where savings values on the calculator page displayed a corrupted rupee symbol (`Γé╣`) instead of the correct Indian Rupee symbol (`₹`).

Previously, the savings values relied on a hardcoded, incorrectly encoded currency symbol, resulting in broken text being displayed to users.

This fix replaces the corrupted symbol with proper INR currency formatting using `Intl.NumberFormat("en-IN", { style: "currency", currency: "INR" })`, ensuring prices are rendered consistently and correctly across the application.

---

## Changes Made

- Replaced the corrupted hardcoded rupee symbol.
- Implemented `Intl.NumberFormat` for INR currency formatting.
- Applied consistent formatting to per-purchase, monthly, and yearly savings values.
- Improved currency display consistency and localization.

---

## Steps to Test

1. Open the **Calculator** page.
2. Search for and select any medicine.
3. Wait for the savings cards to load.
4. Verify the **Per Purchase**, **Monthly**, and **Yearly** savings values display the correct `₹` symbol.
5. Confirm values are formatted correctly (e.g., `₹120.00`).

---

## Expected Result

- Savings values display the correct Indian Rupee symbol (`₹`).
- Currency values are formatted using the Indian locale.
- No corrupted characters appear in the UI.
- All savings cards display consistent INR formatting.

---

## Files Changed

- `apps/web/app/[locale]/calculator/page.tsx`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update