### PR TITLE
test: add integration tests for offline queue sync

### DIFF
--- a/apps/web/tests/integration/offline-queue.test.ts
+++ b/apps/web/tests/integration/offline-queue.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock("uuid", () => ({
+    v4: () => "test-uuid",
+}));
+import { enqueueScan, flushQueue, initOnlineListener } from "../../lib/offline/queue";
+import { getSyncDB } from "../../lib/offline/db";
+
+describe("Offline Queue Integration", () => {
+    // Mock network requuest made during queue synchronization.
+    const fetchMock = jest.fn();
+
+    beforeEach(async () => {
+        // Rset fetch mock before every test.
+        globalThis.fetch = fetchMock as any;
+        fetchMock.mockReset();
+
+        // Start every test in offline mode.
+        Object.defineProperty(navigator, "onLine", {
+            configurable: true,
+            writable: true,
+            value: false,
+        });
+
+        // Clear IndexedDB , so tests dont affect each other.
+        const db = await getSyncDB();
+        await db.clear("pendingScans");
+
+        localStorage.clear();
+    });
+
+    afterEach(async () => {
+        const db = await getSyncDB();
+        await db.clear("pendingScans");
+    });
+
+    it("queues a scan while offline", async () => {
+        await enqueueScan({
+            metadata: {
+                barcode: "123456",
+            },
+        });
+
+        const db = await getSyncDB();
+        const items = await db.getAll("pendingScans");
+
+        // The scan should be stored locally.
+        expect(items).toHaveLength(1);
+
+        // No network request should be attempted while offline.
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("flushes queued scans when back online", async () => {
+        await enqueueScan({
+            metadata: {
+                barcode: "654321",
+            },
+        });
+
+        // Mock a successful server response.
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                parts: {
+                    metadata: "synced",
+                    image: "skipped",
+                    voice: "skipped",
+                },
+            }),
+        });
+
+        // Simulate reconnecting.
+        Object.defineProperty(navigator, "onLine", {
+            configurable: true,
+            writable: true,
+            value: true,
+        });
+
+        await flushQueue();
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        const db = await getSyncDB();
+        const items = await db.getAll("pendingScans");
+
+        // Successfully synced entries should be removed.
+        expect(items).toHaveLength(0);
+    });
+
+    it("syncs automatically when the browser comes online", async () => {
+        await enqueueScan({
+            metadata: {
+                barcode: "999999",
+            },
+        });
+
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                parts: {
+                    metadata: "synced",
+                    image: "skipped",
+                    voice: "skipped",
+                },
+            }),
+        });
+
+        // Register the online event listener.
+        initOnlineListener();
+
+        Object.defineProperty(navigator, "onLine", {
+            configurable: true,
+            writable: true,
+            value: true,
+        });
+
+        window.dispatchEvent(new Event("online"));
+
+        // Allow async event handlers to complete.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(fetchMock).toHaveBeenCalled();
+
+        const db = await getSyncDB();
+        const items = await db.getAll("pendingScans");
+
+        expect(items).toHaveLength(0);
+    });
+
+    it("keeps the scan in the queue when sync fails", async () => {
+        await enqueueScan({
+            metadata: {
+                barcode: "111111",
+            },
+        });
+
+        // Simulate a server error.
+        fetchMock.mockResolvedValue({
+            ok: false,
+            status: 500,
+        });
+
+        Object.defineProperty(navigator, "onLine", {
+            configurable: true,
+            writable: true,
+            value: true,
+        });
+
+        await flushQueue();
+
+        const db = await getSyncDB();
+        const items = await db.getAll("pendingScans");
+        // Failed entries should remain in the queue
+        expect(items).toHaveLength(1);
+
+        // Retry count should increase after a failed sync
+        expect(items[0].attemptCount).toBe(1);
+    });
+});

--- a/apps/web/tests/setupTests.ts
+++ b/apps/web/tests/setupTests.ts
@@ -2,7 +2,12 @@
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 // Helpful matchers
+import "fake-indexeddb/auto";
 import "@testing-library/jest-dom";
+
+if (!(globalThis as any).structuredClone) {
+    (globalThis as any).structuredClone = (value: any) => JSON.parse(JSON.stringify(value));
+}
 
 // Minimal OffscreenCanvas mock used by image processing code
 if (!(globalThis as any).OffscreenCanvas) {
@@ -13,7 +18,7 @@ if (!(globalThis as any).OffscreenCanvas) {
             this.width = w;
             this.height = h;
         }
-        getContext() {
+        getContext(_type?: string) {
             return {
                 filter: "",
                 drawImage: () => {},
@@ -47,8 +52,8 @@ if (!(globalThis as any).Worker) {
     class WorkerMock {
         onmessage: ((ev: any) => void) | null = null;
         onerror: ((ev: any) => void) | null = null;
-        constructor() {}
-        postMessage() {}
+        constructor(_script?: string) {}
+        postMessage(_msg?: any) {}
         terminate() {}
         addEventListener() {}
         removeEventListener() {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
                 "@types/node": "^26.1.0",
                 "@types/winston": "^2.4.4",
                 "eslint": "^10.6.0",
+                "fake-indexeddb": "^6.2.5",
                 "husky": "^9.1.7",
                 "lint-staged": "^17.0.8",
                 "next": "^16.2.9",
@@ -5094,7 +5095,7 @@
             "version": "1.61.1",
             "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
             "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "playwright": "1.61.1"
@@ -6990,7 +6991,7 @@
             "version": "19.2.17",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
             "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.2.2"
@@ -6998,7 +6999,7 @@
         },
         "node_modules/@types/react-dom": {
             "version": "19.2.3",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
@@ -9011,7 +9012,7 @@
         },
         "node_modules/csstype": {
             "version": "3.2.3",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/d3-array": {
@@ -10032,6 +10033,16 @@
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "license": "MIT"
         },
+        "node_modules/fake-indexeddb": {
+            "version": "6.2.5",
+            "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+            "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "license": "MIT"
@@ -10399,7 +10410,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -14849,7 +14859,7 @@
             "version": "1.61.1",
             "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
             "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "playwright-core": "1.61.1"
@@ -14868,7 +14878,7 @@
             "version": "1.61.1",
             "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
             "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
@@ -15300,7 +15310,6 @@
             "version": "19.2.7",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
             "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/react-is-18": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "@types/node": "^26.1.0",
         "@types/winston": "^2.4.4",
         "eslint": "^10.6.0",
+        "fake-indexeddb": "^6.2.5",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
         "next": "^16.2.9",


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3206**
- **Summary:**
Added integration tests for the offline queue and IndexedDB synchronization flow.
### Changes
- Added integration tests covering:
  - Queueing scans while offline
  - Flushing queued scans after reconnecting.
  - Automatic synchronization on the browers `online` event.
  -  Retrying failed synchronizations while preserving queued items.
  -  Added 'fake-indexeddb` for IndexedDB mocking in the jest environment.
  -  Updated `setupTests.ts` with IndexedDB setup and a `structuredClone` polyfill required for the tests

## 📸 Proof of Work (Screenshots / Logs)
<img width="475" height="155" alt="image" src="https://github.com/user-attachments/assets/170855f4-b68a-40cf-a2d1-3c47bd79fd1e" />
<img width="835" height="304" alt="image" src="https://github.com/user-attachments/assets/099aa0c4-15f7-4edc-933b-25678c5028dc" />

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3206 `)
- [x] I have pulled the latest `main` and resolved any conflicts
##  Additional Note
Verified offline queuing, manual flush, automatic synchronization via the brower `online` event, and failed sync retry behaviour using a fake IndexedDV-backedn integration test environment.