### PR TITLE
fix: SSRF bypass in counterfeit report image URL validation via IPv6 addresses

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -30,13 +30,15 @@ const BLOCKED_IMAGE_URL_PATTERNS = [
     /^::1$/,
     /^fc00:/i,
     /^fe80:/i,
+    /^::ffff:/i,
 ];
 
 function isPublicImageUrl(rawUrl: string): boolean {
     try {
         const { protocol, hostname } = new URL(rawUrl);
         if (protocol !== "https:" && protocol !== "http:") return false;
-        return !BLOCKED_IMAGE_URL_PATTERNS.some((p) => p.test(hostname));
+        const normalized = hostname.replace(/^\[|\]$/g, "");
+        return !BLOCKED_IMAGE_URL_PATTERNS.some((p) => p.test(normalized));
     } catch {
         return false;
     }


### PR DESCRIPTION
Fixes #3291

## Changes
- Strip brackets from IPv6 hostnames before pattern matching
- Add IPv4-mapped IPv6 pattern (`::ffff:`) to blocklist

## Verification
Node.js `new URL()` returns IPv6 hostnames with `[` prefix (e.g., `[::1]`, `[fc00::1]`, `[::ffff:a00:1]`). Previously, patterns like `/^::1$/` and `/^fc00:/i` never matched because they don't account for the bracket prefix. IPv4-mapped IPv6 addresses (e.g., `[::ffff:10.0.0.1]`) were also fully unblocked.

- `[::1]` → normalized to `::1` → matched by `/^::1$/`
- `[fc00::1]` → normalized to `fc00::1` → matched by `/^fc00:/i`
- `[::ffff:10.0.0.1]` → normalized to `::ffff:10.0.0.1` → matched by `/^::ffff:/i`