### PR TITLE
fix: remove dead code block causing TypeScript compilation error in pharmacies.ts bulk-upload route

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -1139,39 +1139,6 @@ router.post(
                 pharmacy.id
             );
 
-            const { data: parsedRows } = parseResult;
-            const rowsToInsert: any[] = [];
-            const failedRows: Array<{ row: number; reason: string }> = [];
-
-            for (let i = 0; i < parsedRows.length; i++) {
-                const rowData = parsedRows[i];
-                const logicalRow = i + 2;
-
-                const normalised: Record<string, any> = {};
-                for (const key of Object.keys(rowData)) {
-                    const val = rowData[key];
-                    normalised[key] = val === "" ? undefined : val;
-                }
-
-                const validationResult = inventoryRowSchema.safeParse(normalised);
-                if (!validationResult.success) {
-                    const reason = validationResult.error.issues.map((i) => i.message).join(", ");
-                    failedRows.push({ row: logicalRow, reason });
-                    continue;
-                }
-
-                rowsToInsert.push({
-                    pharmacy_id: pharmacy.id,
-                    medicine_name: validationResult.data.medicine_name,
-                    batch_number: validationResult.data.batch_number,
-                    expiry_date: validationResult.data.expiry_date,
-                    quantity: validationResult.data.quantity,
-                    mrp: validationResult.data.mrp,
-                });
-            }
-
-            const totalRows = parsedRows.length;
-
             if (totalRows === 0) {
                 res.status(400).json({ error: "The file appears empty or is missing rows." });
                 return;


### PR DESCRIPTION
Fixes #3292

## Changes
Removed stale code block (lines 1142–1173) left over from prior refactoring of `POST /bulk-upload`:
- Referenced undefined `parseResult` variable
- Redeclared `const rowsToInsert`, `const failedRows`, `const totalRows` — causing TS redeclaration errors
- Code was unreachable (no conditional guard after `parseCsvIncremental()` call)

## Verification
`parseCsvIncremental()` on line 1137 already handles full CSV parsing with proper typed return values. The dead code block was completely unreachable and served no purpose.