### PR TITLE
feat: Implemented idempotent alert queue for CDSCO alert agent#3111

### DIFF
--- a/apps/ml/agent/cdsco_alert_agent.py
+++ b/apps/ml/agent/cdsco_alert_agent.py
@@ -4,6 +4,9 @@ from bs4 import BeautifulSoup
 import pdfplumber
 import logging
 import sys
+import sqlite3
+import hashlib
+import json
 from io import BytesIO
 from urllib.parse import urljoin
 
@@ -20,6 +23,79 @@ API_SECRET_KEY = os.getenv("API_SECRET_KEY")
 
 INGEST_API_URL = API_BASE_URL + "/api/v1/alerts/ingest" if API_BASE_URL else ""
 ALERTS_API_URL = API_BASE_URL + "/api/v1/alerts" if API_BASE_URL else ""
+
+QUEUE_DB_PATH = os.path.join(os.path.dirname(__file__), 'alert_queue.db')
+
+def init_db():
+    with sqlite3.connect(QUEUE_DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS pending_alerts (
+                idempotency_key TEXT PRIMARY KEY,
+                pdf_url TEXT,
+                alert_data TEXT,
+                status TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+        conn.commit()
+
+def generate_idempotency_key(pdf_url: str, alert: dict) -> str:
+    batch_number = alert.get('batch_number', 'unknown')
+    raw_str = f"{pdf_url}_{batch_number}"
+    return hashlib.sha256(raw_str.encode('utf-8')).hexdigest()
+
+def enqueue_alerts(pdf_url: str, alerts: list):
+    with sqlite3.connect(QUEUE_DB_PATH) as conn:
+        cursor = conn.cursor()
+        for alert in alerts:
+            key = generate_idempotency_key(pdf_url, alert)
+            alert_json = json.dumps(alert)
+            cursor.execute('''
+                INSERT OR IGNORE INTO pending_alerts (idempotency_key, pdf_url, alert_data, status)
+                VALUES (?, ?, ?, 'pending')
+            ''', (key, pdf_url, alert_json))
+        conn.commit()
+
+def process_pending_queue():
+    with sqlite3.connect(QUEUE_DB_PATH) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT idempotency_key, alert_data FROM pending_alerts WHERE status = 'pending'")
+        rows = cursor.fetchall()
+        
+    if not rows:
+        logging.info("No pending alerts in local queue.")
+        return
+        
+    logging.info(f"Found {len(rows)} pending alerts in local queue. Processing...")
+    
+    pending_alerts_map = {row[0]: json.loads(row[1]) for row in rows}
+    
+    new_alerts_map, skipped_keys = deduplicate_alerts_with_keys(pending_alerts_map)
+    
+    if skipped_keys:
+        with sqlite3.connect(QUEUE_DB_PATH) as conn:
+            cursor = conn.cursor()
+            cursor.executemany("UPDATE pending_alerts SET status = 'processed' WHERE idempotency_key = ?", [(k,) for k in skipped_keys])
+            conn.commit()
+            
+    if not new_alerts_map:
+        logging.info("All pending alerts were duplicates. Queue cleared.")
+        return
+        
+    logging.info(f"{len(new_alerts_map)} new alert(s) to ingest.")
+    
+    success = ingest_alerts(list(new_alerts_map.values()))
+    
+    if success:
+        keys_to_mark = list(new_alerts_map.keys())
+        with sqlite3.connect(QUEUE_DB_PATH) as conn:
+            cursor = conn.cursor()
+            cursor.executemany("UPDATE pending_alerts SET status = 'processed' WHERE idempotency_key = ?", [(k,) for k in keys_to_mark])
+            conn.commit()
+        logging.info("Successfully marked ingested alerts as processed in local queue.")
+    else:
+        logging.warning("Failed to ingest alerts. They will remain pending in the local queue for the next run.")
 
 def scrape_cdsco_alerts():
     logging.info(f"Checking {CDSCO_ALERTS_URL} for new alerts...")
@@ -49,6 +125,9 @@ def scrape_cdsco_alerts():
     for pdf_url in pdf_links:
         logging.info(f"Processing alert PDF: {pdf_url}")
         process_alert_pdf(pdf_url)
+        
+    logging.info("Finished processing all PDFs. Processing pending queue...")
+    process_pending_queue()
 
 def process_alert_pdf(pdf_url: str):
     try:
@@ -80,27 +159,21 @@ def process_alert_pdf(pdf_url: str):
         logging.warning("No alerts extracted from the text by LangChain.")
         return
         
-    logging.info(f"Extracted {len(alerts)} alerts. Sending to Ingest API...")
-    
-    # Deduplicate against existing DB records
-    new_alerts = deduplicate_alerts(alerts)
-    if not new_alerts:
-        logging.info("All extracted alerts already exist in the database. Skipping ingest.")
-        return
-    
-    logging.info(f"{len(new_alerts)} new alert(s) to ingest after deduplication.")
-    ingest_alerts(new_alerts)
+    logging.info(f"Extracted {len(alerts)} alerts. Enqueuing to local database...")
+    enqueue_alerts(pdf_url, alerts)
 
-def deduplicate_alerts(alerts: list) -> list:
+def deduplicate_alerts_with_keys(pending_alerts_map: dict):
     """
     Checks the drug_alerts table via the API for each alert's batch number
     to see if it already exists, avoiding full-table scanning limit issues.
+    Returns (alerts_to_ingest_map, keys_of_already_ingested_alerts).
     """
-    new_alerts = []
-    for a in alerts:
+    new_alerts_map = {}
+    skipped_keys = []
+    for key, a in pending_alerts_map.items():
         batch = a.get("batch_number")
         if not batch:
-            new_alerts.append(a)
+            new_alerts_map[key] = a
             continue
         try:
             # Query by batch_number specifically
@@ -108,17 +181,18 @@ def deduplicate_alerts(alerts: list) -> list:
             response.raise_for_status()
             existing = response.json().get("data", [])
             if not existing:
-                new_alerts.append(a)
+                new_alerts_map[key] = a
             else:
                 logging.info(f"Skipping already-ingested alert with batch number: {batch}")
+                skipped_keys.append(key)
         except Exception as e:
             logging.warning(f"Could not verify existing alert for batch {batch}: {e}. Proceeding as new.")
-            new_alerts.append(a)
+            new_alerts_map[key] = a
             
-    skipped = len(alerts) - len(new_alerts)
+    skipped = len(pending_alerts_map) - len(new_alerts_map)
     if skipped:
         logging.info(f"Deduplicated: skipped {skipped} already-ingested alert(s).")
-    return new_alerts
+    return new_alerts_map, skipped_keys
 
 
 def ingest_alerts(alerts: list):
@@ -147,4 +221,8 @@ if __name__ == "__main__":
     if not API_SECRET_KEY:
         logging.error("API_SECRET_KEY is not set in environment. Exiting.")
         sys.exit(1)
+        
+    init_db()
+    logging.info("Starting up. Attempting to clear pending queue before scraping new PDFs...")
+    process_pending_queue()
     scrape_cdsco_alerts()


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3111**
- **Summary:**
- Before any network request is made to the main API, the `enqueue_alerts` function uses the PDF URL and the drug's batch number to generate a unique SHA-256 idempotency key. The alert is saved to the local SQLite database (alert_queue.db) using `INSERT OR IGNORE` with a default status of pending.
-  During ingestion, the script runs` ingest_alerts()`. If the API or database is down, `ingest_alerts` catches the exception and returns False. Because it failed, the script skips marking the records as processed, leaving them as pending in SQLite.
- The script is structured so that on the next run (triggered at the very start of the` __main__ `execution via `process_pending_queue())`, it will fetch all rows that still say pending and try to send them to the API again.
- During the queue processing step, the agent checks the remote `ALERTS_API_URL` to verify if the alert's batch number already exists (`deduplicate_alerts_with_keys`).

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
