### PR TITLE
feat(ml): add Redis-backed session persistence for multi-turn triage

### DIFF
--- a/apps/ml/routers/triage.py
+++ b/apps/ml/routers/triage.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, Field
 from typing import List, Dict, Any, Optional
 import logging
 import asyncio
+import uuid
 
 
 from starlette.concurrency import run_in_threadpool
@@ -25,6 +26,12 @@ class ChatMessage(BaseModel):
 class TriageRequest(BaseModel):
     messages: List[ChatMessage] = Field(..., max_length=50, description="The history of chat messages in the session.")
     locale: Optional[str] = Field("en", description="The preferred language/locale code.")
+    session_id: Optional[str] = Field(
+        None,
+        description="Session ID to persist triage state across multiple turns of the "
+        "same conversation. Omit on the first request to start a new session; "
+        "the response will include a session_id to reuse on subsequent requests.",
+    )
 
 class TriageResponse(BaseModel):
     response: str = Field(
@@ -48,6 +55,11 @@ class TriageResponse(BaseModel):
     details: Optional[Dict[str, Any]] = Field(
         {},
         description="Extracted symptom details (onset, severity, location, etc.).",
+    )
+    session_id: str = Field(
+        ...,
+        description="Session ID for this triage conversation. Pass this back in "
+        "subsequent requests to preserve context across turns.",
     )
 
 
@@ -78,10 +90,19 @@ async def triage_chat(payload: TriageRequest):
             detail="Triage service is at maximum capacity. Please try again shortly.",
         )
 
+    # Generate a new session_id if the client didn't supply one (first message
+    # of a new conversation), or reuse theirs to resume an existing session.
+    session_id = payload.session_id or str(uuid.uuid4())
+
     async with _triage_semaphore:
         try:
-            logging.info(f"Invoking triage flow for chat of length {len(messages_list)}")
-            result = await run_in_threadpool(run_triage_flow, messages_list, locale=payload.locale)
+            logging.info(
+                f"Invoking triage flow for chat of length {len(messages_list)} "
+                f"(session_id={session_id})"
+            )
+            result = await run_in_threadpool(
+                run_triage_flow, messages_list, locale=payload.locale, session_id=session_id
+            )
             return TriageResponse(
                 response=result.get("response", ""),
                 emergency=result.get("emergency", False),
@@ -89,7 +110,8 @@ async def triage_chat(payload: TriageRequest):
                 summary=result.get("summary", ""),
                 recommendations=result.get("recommendations", []),
                 disclaimer=result.get("disclaimer", ""),
-                details=result.get("details", {})
+                details=result.get("details", {}),
+                session_id=session_id,
             )
         except Exception as e:
             logging.error(f"Error in triage_chat route execution: {e}")

--- a/apps/ml/services/triage_graph.py
+++ b/apps/ml/services/triage_graph.py
@@ -1,11 +1,68 @@
 import os
+import json
+import asyncio
 import logging
-from typing import List, Dict, Any, TypedDict
+from typing import List, Dict, Any, Optional, TypedDict
 from pydantic import BaseModel, Field
 from dotenv import load_dotenv
 from services.retrieval import retrieve_relevant_medicines
+from utils.database import redis_client
 
 load_dotenv()
+
+# ── Session Persistence (Redis) ──────────────────────────────────────────────
+# Persists non-message triage state (language, collected symptom info,
+# emergency flag, retrieved medicines) across turns of the same conversation,
+# keyed by a client-supplied session_id. Sessions expire automatically after
+# SESSION_TTL_SECONDS so we don't need a separate cleanup job.
+
+SESSION_TTL_SECONDS = 30 * 60  # 30 minutes, per acceptance criteria
+SESSION_KEY_PREFIX = "triage_session:"
+
+# Fields carried over between turns for the same session_id. "messages" is
+# deliberately excluded — the caller is expected to keep sending the message
+# history, so we only rehydrate the derived/extracted state here.
+_PERSISTED_STATE_FIELDS = (
+    "language",
+    "emergency_detected",
+    "collected_info",
+    "retrieved_medicines",
+)
+
+
+def _session_key(session_id: str) -> str:
+    return f"{SESSION_KEY_PREFIX}{session_id}"
+
+
+async def _load_session_state(session_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch previously persisted triage state for a session_id, if any."""
+    try:
+        raw = await redis_client.get(_session_key(session_id))
+    except Exception:
+        logging.exception("Failed to load triage session '%s' from Redis.", session_id)
+        return None
+
+    if not raw:
+        return None
+
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError):
+        logging.warning("Corrupt triage session state for '%s'; starting fresh.", session_id)
+        return None
+
+
+async def _save_session_state(session_id: str, state: Dict[str, Any]) -> None:
+    """Persist the relevant subset of triage state for session_id with a TTL."""
+    to_store = {field: state.get(field) for field in _PERSISTED_STATE_FIELDS}
+    try:
+        await redis_client.set(
+            _session_key(session_id),
+            json.dumps(to_store),
+            ex=SESSION_TTL_SECONDS,
+        )
+    except Exception:
+        logging.exception("Failed to save triage session '%s' to Redis.", session_id)
 
 # Check if LangChain and LangGraph are available
 try:
@@ -424,9 +481,19 @@ def build_triage_graph():
 # Instantiated compiled graph
 triage_app = build_triage_graph() if LANGGRAPH_AVAILABLE else None
 
-def run_triage_flow(messages: List[Dict[str, str]], locale: str = "en") -> Dict[str, Any]:
+def run_triage_flow(
+    messages: List[Dict[str, str]],
+    locale: str = "en",
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
     """
     Interface function to run the compiled LangGraph triage workflow.
+
+    If session_id is provided, previously persisted triage state (language,
+    collected symptom info, emergency flag, retrieved medicines) is loaded
+    from Redis and used as the starting point, so multi-turn conversations
+    don't lose context between requests. Missing or expired sessions simply
+    fall back to a fresh state instead of raising an error.
     """
     if not LANGGRAPH_AVAILABLE or triage_app is None:
         logging.warning("LangGraph is unavailable. Returning mock triage response.")
@@ -437,7 +504,15 @@ def run_triage_flow(messages: List[Dict[str, str]], locale: str = "en") -> Dict[
             "language": "English",
             "details": {}
         }
-        
+
+    persisted_state = None
+    if session_id:
+        try:
+            persisted_state = asyncio.run(_load_session_state(session_id))
+        except Exception:
+            logging.exception("Unexpected error loading session '%s'; starting fresh.", session_id)
+            persisted_state = None
+
     initial_state = {
         "messages": messages,
         "language": "English",
@@ -450,9 +525,20 @@ def run_triage_flow(messages: List[Dict[str, str]], locale: str = "en") -> Dict[
         "disclaimer": "",
         "response": ""
     }
-    
+
+    if persisted_state:
+        initial_state.update(persisted_state)
+        initial_state["messages"] = messages  # always use this request's messages
+
     try:
         final_state = triage_app.invoke(initial_state)
+
+        if session_id:
+            try:
+                asyncio.run(_save_session_state(session_id, final_state))
+            except Exception:
+                logging.exception("Unexpected error saving session '%s'.", session_id)
+
         return {
             "response": final_state.get("response", ""),
             "emergency": final_state.get("emergency_detected", False),

--- a/apps/ml/tests/test_triage_session_persistence.py
+++ b/apps/ml/tests/test_triage_session_persistence.py
@@ -1,0 +1,210 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+import services.triage_graph as triage_graph
+
+client = TestClient(app)
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in for the async Redis client used in tests."""
+
+    def __init__(self):
+        self.store = {}
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, ex=None):
+        self.store[key] = value
+        return True
+
+
+# ---------------------------------------------------------------------------
+# services.triage_graph — unit-level tests
+# ---------------------------------------------------------------------------
+
+def test_save_and_load_session_state_roundtrip(monkeypatch):
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(triage_graph, "redis_client", fake_redis)
+
+    state = {
+        "language": "Hindi",
+        "emergency_detected": False,
+        "collected_info": {"onset": "2 days ago", "severity": "mild"},
+        "retrieved_medicines": [{"brand_name": "Crocin"}],
+        "messages": [{"role": "user", "content": "should not be persisted"}],
+    }
+
+    asyncio.run(triage_graph._save_session_state("session-abc", state))
+    loaded = asyncio.run(triage_graph._load_session_state("session-abc"))
+
+    assert loaded["language"] == "Hindi"
+    assert loaded["collected_info"]["onset"] == "2 days ago"
+    assert loaded["retrieved_medicines"] == [{"brand_name": "Crocin"}]
+    # messages are intentionally excluded from persisted state
+    assert "messages" not in loaded
+
+
+def test_load_session_state_missing_session_returns_none(monkeypatch):
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(triage_graph, "redis_client", fake_redis)
+
+    assert asyncio.run(triage_graph._load_session_state("does-not-exist")) is None
+
+
+def test_load_session_state_corrupt_json_returns_none(monkeypatch):
+    fake_redis = FakeRedis()
+    fake_redis.store[triage_graph._session_key("bad-session")] = "not valid json {"
+    monkeypatch.setattr(triage_graph, "redis_client", fake_redis)
+
+    assert asyncio.run(triage_graph._load_session_state("bad-session")) is None
+
+
+def test_load_session_state_redis_error_returns_none(monkeypatch):
+    class BrokenRedis:
+        async def get(self, key):
+            raise ConnectionError("redis unavailable")
+
+    monkeypatch.setattr(triage_graph, "redis_client", BrokenRedis())
+
+    # Should not raise — gracefully falls back to a fresh session.
+    assert asyncio.run(triage_graph._load_session_state("session-x")) is None
+
+
+def test_run_triage_flow_reuses_persisted_state(monkeypatch):
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(triage_graph, "redis_client", fake_redis)
+    monkeypatch.setattr(triage_graph, "LANGGRAPH_AVAILABLE", True)
+
+    # Pre-populate a session with prior collected_info, as if turn 1 already ran.
+    asyncio.run(
+        triage_graph._save_session_state(
+            "session-continue",
+            {
+                "language": "English",
+                "emergency_detected": False,
+                "collected_info": {"onset": "yesterday", "severity": "unknown"},
+                "retrieved_medicines": [],
+            },
+        )
+    )
+
+    captured_initial_state = {}
+
+    def fake_invoke(initial_state):
+        captured_initial_state.update(initial_state)
+        return {
+            "response": "Got it, thanks.",
+            "emergency_detected": False,
+            "language": "English",
+            "final_summary": "ok",
+            "recommendations": [],
+            "disclaimer": "",
+            "collected_info": initial_state["collected_info"],
+        }
+
+    fake_app = MagicMock()
+    fake_app.invoke.side_effect = fake_invoke
+    monkeypatch.setattr(triage_graph, "triage_app", fake_app)
+
+    new_messages = [{"role": "user", "content": "it's also severe now"}]
+    result = triage_graph.run_triage_flow(new_messages, session_id="session-continue")
+
+    # Prior turn's collected_info should have been rehydrated into the graph's
+    # starting state instead of being lost.
+    assert captured_initial_state["collected_info"]["onset"] == "yesterday"
+    # This request's messages always take precedence over any stored ones.
+    assert captured_initial_state["messages"] == new_messages
+    assert result["response"] == "Got it, thanks."
+
+
+def test_run_triage_flow_missing_session_starts_fresh(monkeypatch):
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(triage_graph, "redis_client", fake_redis)
+    monkeypatch.setattr(triage_graph, "LANGGRAPH_AVAILABLE", True)
+
+    captured_initial_state = {}
+
+    def fake_invoke(initial_state):
+        captured_initial_state.update(initial_state)
+        return {
+            "response": "Hello, how can I help?",
+            "emergency_detected": False,
+            "language": "English",
+            "final_summary": "",
+            "recommendations": [],
+            "disclaimer": "",
+            "collected_info": {},
+        }
+
+    fake_app = MagicMock()
+    fake_app.invoke.side_effect = fake_invoke
+    monkeypatch.setattr(triage_graph, "triage_app", fake_app)
+
+    result = triage_graph.run_triage_flow(
+        [{"role": "user", "content": "hi"}], session_id="brand-new-or-expired-session"
+    )
+
+    # No prior state existed, so it should fall back to defaults, not error out.
+    assert captured_initial_state["collected_info"] == {}
+    assert result["response"] == "Hello, how can I help?"
+
+
+# ---------------------------------------------------------------------------
+# routers.triage — endpoint-level tests
+# ---------------------------------------------------------------------------
+
+@patch("routers.triage.run_triage_flow")
+def test_triage_chat_generates_session_id_when_omitted(mock_run_triage):
+    mock_run_triage.return_value = {
+        "response": "How long have you had this pain?",
+        "emergency": False,
+        "language": "English",
+        "summary": "Mild headache symptoms",
+        "recommendations": ["Rest"],
+        "disclaimer": "Informational only",
+        "details": {"onset": "unknown"},
+    }
+
+    payload = {"messages": [{"role": "user", "content": "I have a headache."}]}
+    response = client.post("/triage/chat", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "session_id" in data and data["session_id"]
+
+    # The generated session_id should have been forwarded to run_triage_flow.
+    _, kwargs = mock_run_triage.call_args
+    assert kwargs["session_id"] == data["session_id"]
+
+
+@patch("routers.triage.run_triage_flow")
+def test_triage_chat_reuses_supplied_session_id(mock_run_triage):
+    mock_run_triage.return_value = {
+        "response": "Thanks, noted.",
+        "emergency": False,
+        "language": "English",
+        "summary": "",
+        "recommendations": [],
+        "disclaimer": "",
+        "details": {},
+    }
+
+    payload = {
+        "messages": [{"role": "user", "content": "it's worse now"}],
+        "session_id": "existing-session-123",
+    }
+    response = client.post("/triage/chat", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == "existing-session-123"
+
+    _, kwargs = mock_run_triage.call_args
+    assert kwargs["session_id"] == "existing-session-123"


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link
- **Closes #3142**
- **Summary:**
  Added Redis-backed session persistence for the multi-turn medical triage workflow so the AI no longer forgets prior symptom context between requests.

  - `apps/ml/services/triage_graph.py`: Added `_load_session_state()` / `_save_session_state()` helpers that read/write triage state (language, emergency flag, collected symptom info, retrieved medicines) to Redis via the existing `redis_client` in `utils/database.py`, keyed as `triage_session:{session_id}` with a 30-minute TTL for automatic expiration. Updated `run_triage_flow()` to accept an optional `session_id`, rehydrate persisted state on subsequent turns, and re-save state after each graph invocation. Missing/expired/corrupt sessions fall back gracefully to a fresh state instead of erroring.
  - `apps/ml/routers/triage.py`: Added `session_id` to `TriageRequest` (optional) and `TriageResponse` (required). The endpoint generates a new `session_id` via `uuid4()` if the client doesn't supply one, and always returns it so the client can pass it back on the next message to resume the same session.
  - `apps/ml/tests/test_triage_session_persistence.py` (new): Covers save/load roundtrip, missing/corrupt/Redis-error fallback behavior, state rehydration in `run_triage_flow`, and endpoint-level session_id generation/reuse — all mocked, no real Redis or LLM calls needed.

  **Implementation note:** I used a plain JSON-blob-in-Redis approach (reusing the existing `redis_client`) rather than LangGraph's built-in `checkpointer=` mechanism, since that would require an extra dependency (`langgraph-checkpoint-redis`) and additional thread/version bookkeeping that isn't needed for this issue's scope. Redis's native `EX` TTL handles the 30-minute expiration requirement for free, without a separate cleanup job.

## 🏷️ PR Type
- [x] ✨ `type: feature`
- [ ] 🐛 `type: bug`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #3142`)
- [x] I have pulled the latest `main` and resolved any conflicts