### PR TITLE
Sec : Improved SSRF Protection using DNS Resolution for IP Filtering#3307

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -11,6 +11,7 @@ import {
 } from "../services/reportValidation.service";
 import { triggerRecallAlert } from "../services/notifications";
 import logger from "../utils/logger";
+import dns from "dns/promises";
 
 const reportsRouter = Router();
 const DEFAULT_ADMIN_REPORTS_LIMIT = 20;
@@ -33,12 +34,26 @@ const BLOCKED_IMAGE_URL_PATTERNS = [
     /^::ffff:/i,
 ];
 
-function isPublicImageUrl(rawUrl: string): boolean {
+async function isPublicImageUrl(rawUrl: string): Promise<boolean> {
     try {
         const { protocol, hostname } = new URL(rawUrl);
         if (protocol !== "https:" && protocol !== "http:") return false;
         const normalized = hostname.replace(/^\[|\]$/g, "");
-        return !BLOCKED_IMAGE_URL_PATTERNS.some((p) => p.test(normalized));
+
+        // Initial static regex check
+        if (BLOCKED_IMAGE_URL_PATTERNS.some((p) => p.test(normalized))) {
+            return false;
+        }
+
+        // DNS Resolution for SSRF Protection against DNS rebinding
+        const { address } = await dns.lookup(normalized);
+
+        // Check resolved IP address against blocked patterns
+        if (BLOCKED_IMAGE_URL_PATTERNS.some((p) => p.test(address))) {
+            return false;
+        }
+
+        return true;
     } catch {
         return false;
     }
@@ -110,7 +125,7 @@ reportsRouter.post(
     reportLimiter,
     optionalAuth,
     async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-        const parsed = createReportSchema.safeParse(req.body);
+        const parsed = await createReportSchema.safeParseAsync(req.body);
 
         if (!parsed.success) {
             res.status(400).json({

--- a/apps/api/tests/reports.test.ts
+++ b/apps/api/tests/reports.test.ts
@@ -17,6 +17,10 @@ jest.mock("../src/db/client", () => ({
     },
 }));
 
+jest.mock("dns/promises", () => ({
+    lookup: jest.fn().mockResolvedValue({ address: "8.8.8.8", family: 4 }),
+}));
+
 jest.mock("../src/services/reportValidation.service", () => ({
     validateReport: jest.fn().mockResolvedValue({
         passed: true,
@@ -555,6 +559,37 @@ describe("Reports API Routes", () => {
             expect(response.body.issues[0].message).toBe(
                 "Invalid district 'pune dist' for state 'Maharashtra'"
             );
+        });
+
+        it("blocks SSRF attempts with DNS rebinding/resolution to private IPs", async () => {
+            const dns = require("dns/promises");
+
+            // Mock dns.lookup to resolve to a private IP (e.g. AWS Metadata IP or local)
+            (dns.lookup as jest.Mock).mockResolvedValueOnce({
+                address: "169.254.169.254",
+                family: 4,
+            });
+
+            const payload = {
+                medicineName: "Aspirin 500mg",
+                manufacturer: "TestCo",
+                description: "This is a detailed description of the issue",
+                images: ["https://example-dns-rebind.com/image.jpg"],
+                pharmacyName: "Test Pharmacy",
+                address: "123 Main St",
+                city: "Delhi",
+                state: "Delhi",
+                pincode: "110001",
+            };
+
+            const response = await request(app).post("/api/reports").send(payload);
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe("Invalid report payload");
+            expect(response.body.issues[0].message).toBe(
+                "Image URL must use http(s) and must not point to a private, loopback, or link-local address"
+            );
+            expect(dns.lookup).toHaveBeenCalledWith("example-dns-rebind.com");
         });
     });
 


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3307 **
- **Summary:**
- Inside `apps/api/src/routes/reports.ts`, the `isPublicImageUrl` refinement function is now fully asynchronous and uses `dns.lookup()` from Node's built-in `dns/promises` module. It extracts the hostname and resolves it to its true backend IP address before taking any action.
- The resolved IP is directly validated against `BLOCKED_IMAGE_URL_PATTERNS`. Since the array already contains robust regexes for `10.*, 192.168.*, 127.*, 172.16-31.*, and IPv6 loopback (::1, fc00::, fe80::)`, any attacker trying to use a custom domain that rebinding/points to an internal IP will have their resolved IP blocked immediately.
-  In `apps/api/tests/reports.test.ts`, I globally mocked dns/promises.Normal tests resolve to a mocked public IP (8.8.8.8) and pass successfully.I added a new test called `"blocks SSRF attempts with DNS rebinding/resolution to private IPs"` where `dns.lookup` is explicitly overridden to return a private AWS metadata IP (169.254.169.254). As expected, the Zod schema catches it and returns a 400 with the specific `Image URL must use http(s) and must not point to a private...` error message!

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
