### PR TITLE
ci: make Prettier check fail on formatting errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,5 +121,5 @@ jobs:
               run: |
                   FILES="${{ steps.changed-files.outputs.all_changed_files }}"
                   if [ -n "$FILES" ]; then
-                      npx prettier --ignore-unknown --check $FILES || echo "Prettier found issues. Ignoring failure as requested."
+                      npx prettier --ignore-unknown --check $FILES
                   fi


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #3157**
* **Summary:**

  * Removed the `|| echo "Ignoring failure"` bypass from the Prettier check in `.github/workflows/test.yml`.
  * The workflow now correctly fails when Prettier detects formatting issues, enforcing code formatting in CI.

## 🏷️ PR Type

* [ ] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [x] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3157`)
* [x] I have pulled the latest `main` and resolved any conflicts.
