### PR TITLE
test(api): add e2e database webhook trigger delivery verification tes…

### DIFF
--- a/apps/api/tests/e2e/webhook-delivery.test.ts
+++ b/apps/api/tests/e2e/webhook-delivery.test.ts
@@ -1,0 +1,55 @@
+import { supabase } from "../../src/db/client";
+import crypto from "crypto";
+
+describe("E2E Webhook Delivery Verification", () => {
+    const testUUID = crypto.randomUUID();
+    const schemeName = `E2E_Test_Scheme_${testUUID}`;
+    let insertedSchemeId: string | null = null;
+
+    afterAll(async () => {
+        if (insertedSchemeId) {
+            await supabase.from("health_schemes").delete().eq("id", insertedSchemeId);
+        }
+    });
+
+    it("should successfully trigger and deliver a webhook upon record insertion in health_schemes", async () => {
+        const { data: insertData, error: insertError } = await supabase
+            .from("health_schemes")
+            .insert([
+                {
+                    name: schemeName,
+                    description:
+                        "Temporary scheme created for CI/Staging E2E webhook delivery test verification.",
+                    coverage_details: { testId: testUUID },
+                    is_active: true,
+                },
+            ])
+            .select()
+            .single();
+
+        expect(insertError).toBeNull();
+        expect(insertData).toBeTruthy();
+        insertedSchemeId = insertData.id as string;
+
+        const maxRetries = 10;
+        const delayMs = 1500;
+        let webhookDelivered = false;
+
+        for (let i = 0; i < maxRetries; i++) {
+            const { data: auditData, error: auditError } = await supabase
+                .from("webhook_logs")
+                .select("*")
+                .contains("payload", { coverage_details: { testId: testUUID } })
+                .maybeSingle();
+
+            if (!auditError && auditData) {
+                webhookDelivered = true;
+                break;
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+
+        expect(webhookDelivered).toBe(true);
+    }, 25000);
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required file.

> [!WARNING]
> This PR only adds the requested E2E webhook verification test under `apps/api/tests/e2e/webhook-delivery.test.ts`.

---

## 📋 PR Summary & Link

- **Closes #3311**

### Summary

This PR adds an end-to-end webhook delivery verification test for the database trigger flow.

Implemented:

- Added `apps/api/tests/e2e/webhook-delivery.test.ts`
- Inserts a uniquely identifiable dummy record into the `health_schemes` table.
- Uses a unique UUID to correlate the generated webhook event.
- Polls for webhook delivery verification before timing out.
- Cleans up the temporary record after the test completes.
- Keeps the implementation isolated from production code.

---

## 📸 Proof of Work (Screenshots / Logs)

Testing performed:

- Added and executed the new E2E test.
- The test currently requires a reachable Supabase environment and webhook infrastructure.
- In the current local environment the test could not complete because the Supabase connection was unavailable (`ECONNREFUSED`), so webhook delivery could not be verified locally.

Error observed during execution:

```text
TypeError: fetch failed
ECONNREFUSED