### PR TITLE
fix: sync scan history after verification

### DIFF
--- a/apps/web/lib/scanHistoryUtils.ts
+++ b/apps/web/lib/scanHistoryUtils.ts
@@ -1,5 +1,6 @@
 import { VerifyResult } from "@/lib/api";
 import { saveScanHistory } from "@/lib/db/scanHistory";
+import { syncScanHistoryWithCloud } from "@/lib/scanHistoryCloudSync";
 
 export function getScanHistoryStatus(result: VerifyResult): string {
     if (!result.verified) return "SUSPICIOUS";
@@ -22,5 +23,9 @@ export async function recordScanHistory(result: VerifyResult, fallbackBrandName?
         timestamp: Date.now(),
         medicineName: getScanHistoryMedicineName(result, fallbackBrandName),
         status: getScanHistoryStatus(result),
+    });
+
+    void syncScanHistoryWithCloud().catch(() => {
+        // Cloud sync is best-effort and must not block scan results.
     });
 }


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## PR Summary & Link

- **Closes #3129**
- **Summary:** After scan history is saved locally through `recordScanHistory`, this triggers `syncScanHistoryWithCloud()` in the background. Sync failures are swallowed so the verification result UI is not blocked or interrupted.

## Proof of Work (Screenshots / Logs)

Non-UI logic change; no screenshot required.

```bash
npm.cmd run lint -w web -- --quiet --no-warn-ignored lib/scanHistoryUtils.ts hooks/useMedicineVerification.ts hooks/useMedicineImageUpload.ts lib/scanQueueSync.ts
npm.cmd test -w web -- scanQueueSync.test.ts --runInBand
```

## PR Type

- [x] `type: bug`
- [ ] `type: feature`
- [ ] `type: docs`
- [ ] `type: testing`
- [ ] `type: security`
- [x] `type: performance`
- [ ] `type: design`
- [ ] `type: refactor`
- [ ] `type: devops`
- [ ] `type: accessibility`

## Checklist

- [x] My PR has a linked issue (`Closes #3129`)
- [x] I have pulled the latest `main` and resolved any conflicts