### PR TITLE
[Bug/Security] Add unique constraint to drug_alerts table to prevent duplicate ingestion

### DIFF
--- a/supabase/migrations/20260707133002_add_drug_alerts_unique_constraint.sql
+++ b/supabase/migrations/20260707133002_add_drug_alerts_unique_constraint.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.drug_alerts
+ADD CONSTRAINT unique_drug_alert
+UNIQUE (batch_number, pdf_source_url);

--- a/supabase/migrations/20260707133002_add_drug_alerts_unique_constraint.sql
+++ b/supabase/migrations/20260707133002_add_drug_alerts_unique_constraint.sql
@@ -1,3 +1,4 @@
+-- Prevent duplicate CDSCO drug alerts for the same batch and source.
 ALTER TABLE public.drug_alerts
 ADD CONSTRAINT unique_drug_alert
-UNIQUE (batch_number, pdf_source_url);
+UNIQUE (batch_number, source_url);


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.


## 📋 PR Summary & Link

- **Closes #3097**
- **Summary:** This PR adds a new Supabase migration to enforce a composite UNIQUE constraint on the batch_number and pdf_source_url columns in the public.drug_alerts table. This prevents duplicate drug alert records from being inserted when the CDSCO alert agent is re-run or resumes after an interruption, improving data integrity and ensuring that each alert is uniquely identified by its batch number and source PDF URL.
 The migration introduces the unique_drug_alert constraint using an ALTER TABLE statement without modifying any existing application logic. This change ensures that valid unique alert records continue to be inserted successfully while duplicate (batch_number, pdf_source_url) combinations are rejected at the database level. 

## 📸 Proof of Work (Screenshots / Logs)

<img width="1861" height="760" alt="image" src="https://github.com/user-attachments/assets/e9fa7efb-e286-40b3-8ca1-62f0aaf14768" />


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3097 `)
- [x] I have pulled the latest `main` and resolved any conflicts
