### PR TITLE
fix: reject oversized ML audio uploads early

### DIFF
--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -29,6 +29,7 @@ from services.telemetry import (
     log_transcription_finished,
     start_timer,
 )
+from utils.audio_upload import read_audio_upload_limited
 
 logger = logging.getLogger(__name__)
 telemetry_logger = get_telemetry_logger()
@@ -890,7 +891,7 @@ async def transcribe_audio(
     Returns transcription text, detected language code, language confidence,
     the echoed filename, and any extracted medicine entities.
     """
-    contents = await file.read()
+    contents = await read_audio_upload_limited(file)
     original_name = file.filename or "upload"
     return transcribe_uploaded_bytes(
         contents,

--- a/apps/ml/routers/voice_verify.py
+++ b/apps/ml/routers/voice_verify.py
@@ -3,6 +3,7 @@ from fastapi.responses import JSONResponse
 import whisper
 import tempfile
 import os
+from utils.audio_upload import read_audio_upload_limited
 
 router = APIRouter(prefix="/voice", tags=["Voice Verification"])
 
@@ -44,9 +45,11 @@ async def verify_medicine_voice(audio: UploadFile = File(...)):
     if not audio.content_type or audio.content_type not in ["audio/webm", "audio/wav", "audio/ogg", "audio/mp4", "audio/mpeg"]:
         raise HTTPException(status_code=400, detail="Unsupported audio format. Use webm, wav, ogg, or mp4.")
 
+    contents = await read_audio_upload_limited(audio)
+
     # Save to temp file for Whisper
     with tempfile.NamedTemporaryFile(delete=False, suffix=".webm") as tmp:
-        tmp.write(await audio.read())
+        tmp.write(contents)
         tmp_path = tmp.name
 
     try:

--- a/apps/ml/tests/test_asr.py
+++ b/apps/ml/tests/test_asr.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from main import app
 from routers import asr as asr_router
+from utils import audio_upload
 import services.medicine_ner as medicine_ner
 
 client = TestClient(app)
@@ -148,6 +149,24 @@ def test_missing_file_returns_422():
     """FastAPI must return 422 when required 'file' field is absent."""
     response = client.post("/asr/transcribe")
     assert response.status_code == 422
+
+
+def test_rejects_oversized_audio_before_transcription(monkeypatch):
+    monkeypatch.setattr(audio_upload, "MAX_AUDIO_SIZE_BYTES", 10)
+
+    class FailingModel:
+        def transcribe(self, audio, **kwargs):
+            raise AssertionError("Oversized upload should be rejected before transcription")
+
+    monkeypatch.setattr(asr_router, "get_model", lambda: FailingModel())
+
+    response = client.post(
+        "/asr/transcribe",
+        files={"file": ("large.webm", io.BytesIO(b"x" * 11), "audio/webm")},
+    )
+
+    assert response.status_code == 413
+    assert "Audio file too large" in response.json()["detail"]
 
 
 def test_language_hint_is_passed_to_whisper(monkeypatch):

--- a/apps/ml/tests/test_voice_verify.py
+++ b/apps/ml/tests/test_voice_verify.py
@@ -1,0 +1,33 @@
+import io
+import os
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from main import app
+from routers import voice_verify
+from utils import audio_upload
+
+
+client = TestClient(app)
+
+
+def test_voice_verify_rejects_oversized_audio_before_transcription(monkeypatch):
+    monkeypatch.setattr(audio_upload, "MAX_AUDIO_SIZE_BYTES", 10)
+    monkeypatch.setattr(
+        voice_verify,
+        "get_whisper_model",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("Oversized upload should be rejected before transcription")
+        ),
+    )
+
+    response = client.post(
+        "/voice/verify",
+        files={"audio": ("large.webm", io.BytesIO(b"x" * 11), "audio/webm")},
+    )
+
+    assert response.status_code == 413
+    assert "Audio file too large" in response.json()["detail"]

--- a/apps/ml/utils/audio_upload.py
+++ b/apps/ml/utils/audio_upload.py
@@ -1,0 +1,45 @@
+import math
+import os
+
+from fastapi import HTTPException, UploadFile
+
+
+CHUNK_SIZE = 64 * 1024
+MAX_AUDIO_SIZE_BYTES = int(os.getenv("MAX_AUDIO_SIZE_BYTES", str(20 * 1024 * 1024)))
+
+
+def _format_size_mb(size_bytes: int) -> int:
+    return max(1, math.ceil(size_bytes / (1024 * 1024)))
+
+
+async def read_audio_upload_limited(
+    upload: UploadFile,
+    *,
+    max_size_bytes: int | None = None,
+) -> bytes:
+    """Read an uploaded audio file in chunks and reject oversized payloads early."""
+    limit = MAX_AUDIO_SIZE_BYTES if max_size_bytes is None else max_size_bytes
+    chunks: list[bytes] = []
+    total_size = 0
+
+    try:
+        while True:
+            chunk = await upload.read(CHUNK_SIZE)
+            if not chunk:
+                break
+
+            total_size += len(chunk)
+            if total_size > limit:
+                raise HTTPException(
+                    status_code=413,
+                    detail=(
+                        "Audio file too large. "
+                        f"Maximum allowed size is {_format_size_mb(limit)}MB."
+                    ),
+                )
+
+            chunks.append(chunk)
+
+        return b"".join(chunks)
+    finally:
+        await upload.close()


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3338**
- **Summary:**
  - Added a shared chunked audio upload reader with configurable upload size limits.
  - Prevented `/asr/transcribe` from reading entire audio uploads into memory before validation.
  - Prevented `/voice/verify` from reading entire audio uploads into memory before validation.
  - Added HTTP `413 Payload Too Large` responses for oversized audio uploads.
  - Added regression tests to verify oversized uploads are rejected before transcription is attempted.

## 📸 Proof of Work (Screenshots / Logs)

### Code Changes
- Added `apps/ml/utils/audio_upload.py`
- Updated `apps/ml/routers/asr.py`
- Updated `apps/ml/routers/voice_verify.py`
- Added/updated ML upload validation tests

### Test Evidence

Attempted to run:

```bash
python3 -m pytest apps/ml/tests/test_asr.py apps/ml/tests/test_voice_verify.py
```

Environment limitation:

```text
ModuleNotFoundError: No module named 'numpy'
```

The local ML test environment is missing required dependencies, preventing full test execution. Static verification confirmed that unbounded `await file.read()` / `await audio.read()` calls were removed from the affected routes and replaced with chunked size-limited reads.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [x] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [x] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3338`)
* [x] I have pulled the latest `main` and resolved any conflicts