### PR TITLE
Fix schedule summary cache staleness

### DIFF
--- a/apps/api/src/routes/medicineSchedules.ts
+++ b/apps/api/src/routes/medicineSchedules.ts
@@ -10,6 +10,9 @@ import { scheduleLimiter } from "../middleware/rateLimit";
 
 const router = Router();
 router.use(scheduleLimiter);
+const SUMMARY_CACHE_BUCKET_MINUTES = 5;
+const SUMMARY_CACHE_TTL_SECONDS = SUMMARY_CACHE_BUCKET_MINUTES * 60;
+
 const invalidateUserSummaryCaches = async (userId: string) => {
     if (!redisClient.isOpen) return;
 
@@ -26,6 +29,13 @@ const invalidateUserSummaryCaches = async (userId: string) => {
         });
     }
 };
+
+const getSummaryCacheBucket = (time: string) => {
+    const [hours, minutes] = time.split(":").map(Number);
+    const totalMinutes = hours * 60 + minutes;
+    return Math.floor(totalMinutes / SUMMARY_CACHE_BUCKET_MINUTES);
+};
+
 const createScheduleSchema = z
     .object({
         medicine_name: z.string().min(1, "Medicine name is required"),
@@ -308,14 +318,7 @@ router.post("/:id/doses", requireAuth, async (req: AuthenticatedRequest, res: Re
             return;
         }
 
-        if (redisClient.isOpen) {
-            const cacheKey = `schedules:summary:${req.user!.id}:${parsed.data.log_date}`;
-            try {
-                await redisClient.del(cacheKey);
-            } catch (redisErr) {
-                logger.error("Failed to invalidate cache", { error: redisErr, cacheKey });
-            }
-        }
+        await invalidateUserSummaryCaches(req.user!.id);
 
         res.json({ dose: data });
     } catch (err) {
@@ -450,7 +453,8 @@ router.get("/today/summary", requireAuth, async (req: AuthenticatedRequest, res:
         const today = queryResult.data.date || istToday;
         const nowTime = queryResult.data.time || istNowTime;
 
-        const cacheKey = `schedules:summary:${req.user!.id}:${today}`;
+        const cacheBucket = getSummaryCacheBucket(nowTime);
+        const cacheKey = `schedules:summary:${req.user!.id}:${today}:${cacheBucket}`;
         if (redisClient.isOpen) {
             try {
                 const cached = await redisClient.get(cacheKey);
@@ -534,7 +538,9 @@ router.get("/today/summary", requireAuth, async (req: AuthenticatedRequest, res:
 
         if (redisClient.isOpen) {
             try {
-                await redisClient.set(cacheKey, JSON.stringify(responseData), { EX: 86400 });
+                await redisClient.set(cacheKey, JSON.stringify(responseData), {
+                    EX: SUMMARY_CACHE_TTL_SECONDS,
+                });
             } catch (redisErr) {
                 logger.error("Redis set error for today/summary", { error: redisErr, cacheKey });
             }

--- a/apps/api/tests/medicineSchedules.test.ts
+++ b/apps/api/tests/medicineSchedules.test.ts
@@ -32,6 +32,18 @@ jest.mock("../src/db/client", () => ({
     supabase: mockSupabaseChain,
 }));
 
+const mockRedisClient = {
+    isOpen: false,
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    scanIterator: jest.fn(() => (async function* () {})()),
+};
+
+jest.mock("../src/utils/redis", () => ({
+    redisClient: mockRedisClient,
+}));
+
 jest.mock("../src/middleware/auth", () => ({
     requireAuth: (req: any, _res: any, next: any) => {
         req.user = { id: "test-user-id", email: "test@example.com", role: "user" };
@@ -48,6 +60,7 @@ jest.mock("../src/middleware/auth", () => ({
 import request from "supertest";
 import express from "express";
 import medicineSchedulesRouter from "../src/routes/medicineSchedules";
+import { redisClient } from "../src/utils/redis";
 
 const app = express();
 app.use(express.json());
@@ -57,6 +70,28 @@ const mockedSupabase = mockSupabaseChain as jest.Mocked<typeof mockSupabaseChain
 
 beforeEach(() => {
     jest.clearAllMocks();
+    Object.values(mockedSupabase).forEach((value) => {
+        if (jest.isMockFunction(value)) {
+            value.mockReset();
+        }
+    });
+    mockedSupabase.from.mockReturnValue(mockedSupabase);
+    mockedSupabase.select.mockReturnValue(mockedSupabase);
+    mockedSupabase.insert.mockReturnValue(mockedSupabase);
+    mockedSupabase.update.mockReturnValue(mockedSupabase);
+    mockedSupabase.delete.mockReturnValue(mockedSupabase);
+    mockedSupabase.upsert.mockReturnValue(mockedSupabase);
+    mockedSupabase.eq.mockReturnValue(mockedSupabase);
+    mockedSupabase.order.mockReturnValue(mockedSupabase);
+    mockedSupabase.gte.mockReturnValue(mockedSupabase);
+    mockedSupabase.lte.mockReturnValue(mockedSupabase);
+    mockedSupabase.or.mockReturnValue(mockedSupabase);
+    mockedSupabase.in.mockReturnValue(mockedSupabase);
+    (redisClient as any).isOpen = false;
+    (redisClient.get as jest.Mock).mockResolvedValue(null);
+    (redisClient.set as jest.Mock).mockResolvedValue("OK");
+    (redisClient.del as jest.Mock).mockResolvedValue(1);
+    (redisClient.scanIterator as jest.Mock).mockReturnValue((async function* () {})());
 });
 
 afterEach(() => {
@@ -327,6 +362,57 @@ describe("POST /api/schedules/:id/doses", () => {
         expect(res.status).toBe(200);
         expect(res.body.dose.status).toBe("taken");
     });
+
+    it("invalidates all bucketed summary caches after logging a dose", async () => {
+        (redisClient as any).isOpen = true;
+        (redisClient.scanIterator as jest.Mock).mockReturnValue(
+            (async function* () {
+                yield "schedules:summary:test-user-id:2026-06-10:96";
+                yield "schedules:summary:test-user-id:2026-06-10:97";
+            })()
+        );
+
+        const doseEntry = {
+            id: "dose-1",
+            schedule_id: "sched-1",
+            user_id: "test-user-id",
+            log_date: "2026-06-10",
+            log_time: "08:00",
+            status: "taken",
+            taken_at: null,
+            created_at: "2026-06-10T08:05:00Z",
+        };
+
+        (mockedSupabase.from as jest.Mock).mockReturnValue(mockedSupabase);
+        (mockedSupabase.select as jest.Mock).mockReturnValue(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockReturnValue(mockedSupabase);
+        mockedSupabase.maybeSingle.mockResolvedValueOnce({
+            data: { id: "sched-1" },
+            error: null,
+        });
+        mockedSupabase.single.mockResolvedValue({ data: doseEntry, error: null });
+
+        const res = await request(app)
+            .post("/api/schedules/00000000-0000-4000-8000-000000000001/doses")
+            .set("Authorization", "Bearer test-token")
+            .send({
+                log_date: "2026-06-10",
+                log_time: "08:00",
+                status: "taken",
+            });
+
+        expect(res.status).toBe(200);
+        expect(redisClient.scanIterator).toHaveBeenCalledWith({
+            MATCH: "schedules:summary:test-user-id:*",
+            COUNT: 100,
+        });
+        expect(redisClient.del).toHaveBeenCalledWith(
+            "schedules:summary:test-user-id:2026-06-10:96"
+        );
+        expect(redisClient.del).toHaveBeenCalledWith(
+            "schedules:summary:test-user-id:2026-06-10:97"
+        );
+    });
 });
 
 describe("GET /api/schedules/today/summary", () => {
@@ -443,6 +529,60 @@ describe("GET /api/schedules/today/summary", () => {
             { time: "08:00", status: "upcoming" },
         ]);
         jest.useRealTimers();
+    });
+
+    it("uses a 5-minute time bucket and short TTL for Redis summary cache", async () => {
+        (redisClient as any).isOpen = true;
+        (redisClient.get as jest.Mock).mockResolvedValue(null);
+
+        const activeSchedules = [
+            {
+                id: "sched-1",
+                medicine_name: "Paracetamol",
+                dosage: "1 tablet",
+                times: ["01:00", "08:00"],
+                frequency: 2,
+                user_id: "test-user-id",
+                start_date: "2026-06-14",
+                end_date: null,
+                notes: null,
+                is_active: true,
+                created_at: "2026-06-14T00:00:00Z",
+                updated_at: "2026-06-14T00:00:00Z",
+            },
+        ];
+
+        (mockedSupabase.from as jest.Mock).mockReturnValue(mockedSupabase);
+        (mockedSupabase.select as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.lte as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.or as jest.Mock).mockResolvedValueOnce({
+            data: activeSchedules,
+            error: null,
+        });
+
+        (mockedSupabase.select as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.in as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockReturnValueOnce(mockedSupabase);
+        (mockedSupabase.eq as jest.Mock).mockResolvedValueOnce({
+            data: [],
+            error: null,
+        });
+
+        const res = await request(app)
+            .get("/api/schedules/today/summary?date=2026-06-14&time=01:34")
+            .set("Authorization", "Bearer test-token");
+
+        expect(res.status).toBe(200);
+        expect(redisClient.get).toHaveBeenCalledWith(
+            "schedules:summary:test-user-id:2026-06-14:18"
+        );
+        expect(redisClient.set).toHaveBeenCalledWith(
+            "schedules:summary:test-user-id:2026-06-14:18",
+            expect.any(String),
+            { EX: 300 }
+        );
     });
 });
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3340**
- **Summary:**
  - Add a 5-minute time bucket to `GET /api/schedules/today/summary` Redis cache keys.
  - Reduce summary cache TTL from 24 hours to 5 minutes to prevent stale time-sensitive statuses.
  - Reuse the existing scan-based cache invalidation helper when dose logs are created/updated.
  - Add regression tests covering bucketed cache keys, TTL behavior, and cache invalidation.

## 📸 Proof of Work (Screenshots / Logs)

### Test Results

```text
npm.cmd test -- --runTestsByPath tests\medicineSchedules.test.ts

PASS tests/medicineSchedules.test.ts

16 passed
```

### Build Check

```text
npm.cmd run build
```

Build currently fails due existing repository setup/type issues unrelated to this PR, including missing modules:

* @supabase/supabase-js
* @sahidawa/shared
* rate-limit-redis
* bullmq
* ioredis

and existing implicit `any` TypeScript errors.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3340`)
* [x] I have pulled the latest `main` and resolved any conflicts