### PR TITLE
feat: [Feature/Performance] Add ML response caching strategy for comp…

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import logger from "./utils/logger";
 import { jobScheduler } from "./services/jobScheduler.service";
 import { connectRedis } from "./utils/redis";
 import { warmCache } from "./services/cache.service";
+import compareRouter from "./routes/compare";
 
 const port = process.env.PORT || 4000;
 
@@ -48,6 +49,9 @@ if (process.env.BYPASS_AUTH_FOR_TESTING === "true") {
         "SECURITY WARNING: BYPASS_AUTH_FOR_TESTING is active. Authentication is disabled for local testing."
     );
 }
+
+// Register ML medicine comparison and similarity caching routes
+app.use("/api/compare", compareRouter);
 
 if (process.env.NODE_ENV !== "test") {
     const server = app.listen(port, async () => {

--- a/apps/api/src/routes/compare.ts
+++ b/apps/api/src/routes/compare.ts
@@ -1,0 +1,85 @@
+import { Router, Response, NextFunction } from "express";
+import { z } from "zod";
+import crypto from "crypto";
+import axios from "axios";
+import { redisClient } from "../utils/redis";
+import logger from "../utils/logger"; // Destructured template fixed based on your previous logs
+import { requireAuth } from "../middleware/auth"; // Fixed paths matching your exact structure
+import { limiter } from "../middleware/rateLimit"; // Fixed middleware import token maps
+
+const ML_SERVICE_URL = process.env.ML_SERVICE_URL || "http://localhost:8000";
+
+const router = Router();
+
+const compareRequestSchema = z.object({
+    medicine_a: z.string().min(1, "Medicine A is required"),
+    medicine_b: z.string().min(1, "Medicine B is required"),
+});
+
+function getCacheKey(medA: string, medB: string): string {
+    const sorted = [medA.trim().toLowerCase(), medB.trim().toLowerCase()].sort();
+    const hash = crypto.createHash("sha256").update(sorted.join("||")).digest("hex");
+    return `cmp_result:${hash}`;
+}
+
+router.post(
+    "/",
+    requireAuth,
+    limiter,
+    async (req: any, res: Response, next: NextFunction): Promise<void> => {
+        try {
+            const parsed = compareRequestSchema.safeParse(req.body);
+            if (!parsed.success) {
+                res.status(400).json({ error: "Invalid payload", issues: parsed.error.issues });
+                return;
+            }
+
+            const { medicine_a, medicine_b } = parsed.data;
+            const cacheKey = getCacheKey(medicine_a, medicine_b);
+
+            // 1. Check Redis Cache for pre-computed similarity
+            if (redisClient) {
+                const cachedResult = await redisClient.get(cacheKey);
+                if (cachedResult) {
+                    logger.info(
+                        `Cache hit for medicine comparison: ${medicine_a} vs ${medicine_b}`
+                    );
+                    res.status(200).json(JSON.parse(cachedResult));
+                    return;
+                }
+            }
+
+            // 2. Cache Miss: Forward request to Python ML service with timeout protection
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 8000); // 8 seconds timeout
+
+            try {
+                const mlResponse = await axios.post(
+                    `${ML_SERVICE_URL}/compare`,
+                    { medicine_a, medicine_b },
+                    { signal: controller.signal }
+                );
+                clearTimeout(timeoutId);
+
+                const resultData = mlResponse.data;
+
+                // 3. Save result to Redis with 24 hours TTL (86400 seconds)
+                if (redisClient) {
+                    await redisClient.set(cacheKey, JSON.stringify(resultData), {
+                        EX: 86400,
+                    });
+                }
+
+                res.status(200).json(resultData);
+            } catch (mlError: any) {
+                clearTimeout(timeoutId);
+                logger.error(`Failed to connect or fetch from ML Service: ${mlError.message}`);
+                res.status(502).json({ error: "ML service comparison failed or timed out." });
+            }
+        } catch (error) {
+            next(error);
+        }
+    }
+);
+
+export default router;

--- a/apps/ml/main.py
+++ b/apps/ml/main.py
@@ -17,6 +17,7 @@ RequestsInstrumentor().instrument()
 
 from services.telemetry import configure_telemetry_logging
 from services.router_loader import include_router_if_available
+from routers.verify import router as verify_router
 
 configure_telemetry_logging()
 logger = logging.getLogger(__name__)
@@ -76,6 +77,29 @@ if not tts_loaded:
     )
 include_router_if_available(app, "routers.voice_verify", required=True)
 
+# Directly attach the ML comparison computation layer to structural router
+@verify_router.post("/compare")
+async def compare_medicines(payload: dict):
+    medicine_a = payload.get("medicine_a", "")
+    medicine_b = payload.get("medicine_b", "")
+    
+    if not medicine_a or not medicine_b:
+        return {"error": "Both medicine names are required"}, 400
+        
+    from services.embedding import embed_query
+    from services.similarity import cosine_similarity
+    
+    emb_a = embed_query(medicine_a)
+    emb_b = embed_query(medicine_b)
+    
+    score = cosine_similarity(emb_a, emb_b)
+    
+    return {
+        "medicine_a": medicine_a,
+        "medicine_b": medicine_b,
+        "similarity_score": score,
+        "verdict": "highly_similar" if score >= 0.92 else "different"
+    }
 
 @app.get("/")
 def read_root():

--- a/apps/ml/services/similarity.py
+++ b/apps/ml/services/similarity.py
@@ -1,0 +1,9 @@
+import numpy as np
+
+def cosine_similarity(embedding_a, embedding_b):
+    dot_product = np.dot(embedding_a, embedding_b)
+    norm_a = np.linalg.norm(embedding_a)
+    norm_b = np.linalg.norm(embedding_b)
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return float(dot_product / (norm_a * norm_b))


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link

- Closes #3140

- Summary:
  - Added `/api/compare` route.
  - Implemented Redis caching for medicine comparison results.
  - Added ML comparison endpoint.
  - Added cosine similarity helper.
  - Added timeout handling for ML service requests.

## 📸 Proof of Work

- Tested compare endpoint locally.
- Verified Redis cache hit/miss.
- Verified repeated requests return cached results.

## 🏷️ PR Type

- [x] ✨ type: feature
- [x] ⚡ type: performance

## ✅ Checklist

- [x] My PR has a linked issue (Closes #3140)
- [x] I have pulled the latest main and resolved conflicts.