### PR TITLE
fix: improve medicine photo preview alt text

### DIFF
--- a/apps/web/components/medicine/MedicinePhotoUpload.tsx
+++ b/apps/web/components/medicine/MedicinePhotoUpload.tsx
@@ -168,7 +168,7 @@ function ImagePreview({ src, onRemove }: ImagePreviewProps) {
         <div className="space-y-3">
             <img
                 src={src}
-                alt="Uploaded medicine packaging"
+                alt="Uploaded medicine preview"
                 className="max-h-64 w-full rounded-xl border border-slate-200 object-contain"
             />
             <button


### PR DESCRIPTION
## Summary
- update the medicine upload preview image alt text to `Uploaded medicine preview`
- keep the existing remove button `aria-label="Remove uploaded photo"` intact

## Related Issue
Fixes #3271

## Verification
- Confirmed `alt="Uploaded medicine preview"` is present in `apps/web/components/medicine/MedicinePhotoUpload.tsx`
- Confirmed `aria-label="Remove uploaded photo"` remains present on the remove button
- `git diff --check`
- `npx.cmd eslint apps/web/components/medicine/MedicinePhotoUpload.tsx`
