### PR TITLE
Perf :  Debounced/throttle Overpass API calls on map drag#3117

### DIFF
--- a/apps/web/app/[locale]/map/page.tsx
+++ b/apps/web/app/[locale]/map/page.tsx
@@ -634,12 +634,30 @@ export default function PharmacyMapPage() {
         }
     }, [fetchNearby, radiusKm]);
 
-    const handleMapMoveEnd = useCallback((bounds: MapBounds) => {
-        if (initialFetchDone.current) {
-            pendingBoundsRef.current = bounds;
-            setShowSearchArea(true);
-        }
-    }, []);
+    const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+    const handleMapMoveEnd = useCallback(
+        (bounds: MapBounds) => {
+            if (initialFetchDone.current) {
+                pendingBoundsRef.current = bounds;
+
+                // Accurately reflect loading state during debounce delay
+                setIsLoading(true);
+                setShowSearchArea(false);
+
+                if (debounceTimerRef.current) {
+                    clearTimeout(debounceTimerRef.current);
+                }
+
+                debounceTimerRef.current = setTimeout(() => {
+                    if (pendingBoundsRef.current) {
+                        fetchInBounds(pendingBoundsRef.current);
+                    }
+                }, 500);
+            }
+        },
+        [fetchInBounds]
+    );
 
     const handleSearchThisArea = useCallback(() => {
         if (pendingBoundsRef.current) fetchInBounds(pendingBoundsRef.current);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3117**
- **Summary:**
-  Whenever a user drags the map, any pending Overpass API request is canceled. A new request is only allowed to fire after the map has been completely idle (no new drag events) for a full 500ms.
- As soon as the user starts/ends a drag, setIsLoading(true) is immediately invoked, so the UI displays the loading skeleton/indicator during that 500ms wait period. The "Search this area" button has been hidden as the map now smartly auto-fetches without spamming the network.
-  Because of the debounce, rapidly dragging or doing many micro-adjustments to the map will only trigger a single API call once the user finishes adjusting the viewport.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
