### PR TITLE
Add client-side validation for voice recording length/size

### DIFF
--- a/apps/web/app/[locale]/voice/lib/recording.ts
+++ b/apps/web/app/[locale]/voice/lib/recording.ts
@@ -1,4 +1,6 @@
 const PREFERRED_RECORDING_TYPES = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"] as const;
+export const MAX_RECORDING_DURATION_MS = 60_000;
+export const MAX_RECORDING_SIZE_BYTES = 20 * 1024 * 1024;
 
 type MediaRecorderConstructorLike = {
     isTypeSupported?: (mimeType: string) => boolean;
@@ -23,4 +25,8 @@ export function getPreferredRecordingMimeType(
             recorderConstructor.isTypeSupported?.(mimeType)
         ) ?? ""
     );
+}
+
+export function isRecordingBlobTooLarge(blob: Blob): boolean {
+    return blob.size > MAX_RECORDING_SIZE_BYTES;
 }

--- a/apps/web/app/[locale]/voice/page.tsx
+++ b/apps/web/app/[locale]/voice/page.tsx
@@ -27,7 +27,12 @@ import {
     VOICE_LANGUAGE_OPTIONS,
 } from "./lib/languages";
 import { formatVoiceShareReport } from "./lib/report";
-import { getPreferredRecordingMimeType, supportsAudioRecording } from "./lib/recording";
+import {
+    getPreferredRecordingMimeType,
+    isRecordingBlobTooLarge,
+    MAX_RECORDING_DURATION_MS,
+    supportsAudioRecording,
+} from "./lib/recording";
 import {
     shouldReviewTranscription,
     transcribeRecordedAudio,
@@ -56,6 +61,11 @@ import { useLocale, useTranslations } from "next-intl";
 
 const DEFAULT_FLOW_CONFIDENCE = getConfidenceMeta(undefined);
 const VOICE_ANIMATION_STORAGE_KEY = "sahidawa.voice.animations";
+const RECORDING_DURATION_LIMIT_MESSAGE =
+    "Recording stopped after 60 seconds. Please keep voice checks under one minute.";
+const RECORDING_SIZE_LIMIT_TITLE = "Recording too large";
+const RECORDING_SIZE_LIMIT_MESSAGE =
+    "Recording is too large. Please record a shorter clip under 20MB.";
 
 function getRecognitionErrorState(
     errorCode: string,
@@ -172,6 +182,7 @@ export default function VoiceTriagePage() {
     const audioStreamRef = useRef<MediaStream | null>(null);
     const recordingChunksRef = useRef<Blob[]>([]);
     const pendingRecordedBlobRef = useRef<Blob | null>(null);
+    const recordingLimitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const latestTranscriptRef = useRef("");
     const latestDisplayedTranscriptRef = useRef("");
     const latestConfidenceRef = useRef<number | undefined>(undefined);
@@ -213,6 +224,15 @@ export default function VoiceTriagePage() {
         const session = streamingSessionRef.current;
         streamingSessionRef.current = null;
         session?.close();
+    }
+
+    function clearRecordingLimitTimer() {
+        if (!recordingLimitTimerRef.current) {
+            return;
+        }
+
+        clearTimeout(recordingLimitTimerRef.current);
+        recordingLimitTimerRef.current = null;
     }
 
     function detachRecognitionHandlers(recognition: SpeechRecognitionLike | null) {
@@ -265,6 +285,7 @@ export default function VoiceTriagePage() {
     useEffect(() => {
         return () => {
             startSessionIdRef.current += 1;
+            clearRecordingLimitTimer();
             const recognition = recognitionRef.current;
             recognitionRef.current = null;
             detachRecognitionHandlers(recognition);
@@ -426,6 +447,7 @@ export default function VoiceTriagePage() {
 
     function resetFlow(nextStep: VoiceStep = "initial") {
         startSessionIdRef.current += 1;
+        clearRecordingLimitTimer();
         const recognition = recognitionRef.current;
         recognitionRef.current = null;
         detachRecognitionHandlers(recognition);
@@ -551,6 +573,19 @@ export default function VoiceTriagePage() {
             closeStreamingSession();
             setStreamingStatusValue("idle");
             setError(getRecognitionErrorState("no-speech", t));
+            setStep("error");
+            return;
+        }
+
+        if (isRecordingBlobTooLarge(mediaBlob)) {
+            pendingRecordedBlobRef.current = null;
+            closeStreamingSession();
+            setStreamingStatusValue("idle");
+            setError({
+                type: "generic",
+                title: RECORDING_SIZE_LIMIT_TITLE,
+                message: RECORDING_SIZE_LIMIT_MESSAGE,
+            });
             setStep("error");
             return;
         }
@@ -807,6 +842,7 @@ export default function VoiceTriagePage() {
         isStreamingStopRequestedRef.current = true;
         setIsListening(false);
         setIsVisualizerFading(true);
+        clearRecordingLimitTimer();
 
         if (mediaRecorderRef.current) {
             if (mediaRecorderRef.current.state !== "inactive") {
@@ -958,6 +994,7 @@ export default function VoiceTriagePage() {
         detachRecognitionHandlers(recognition);
         recognition?.stop();
 
+        clearRecordingLimitTimer();
         const mediaRecorder = mediaRecorderRef.current;
         mediaRecorderRef.current = null;
         detachMediaRecorderHandlers(mediaRecorder);
@@ -1070,6 +1107,18 @@ export default function VoiceTriagePage() {
             setIsListening(true);
             setIsVisualizerFading(false);
             setStep("listening");
+            clearRecordingLimitTimer();
+            recordingLimitTimerRef.current = setTimeout(() => {
+                if (mediaRecorderInstance.state === "inactive") {
+                    return;
+                }
+
+                isStreamingStopRequestedRef.current = true;
+                setIsListening(false);
+                setIsVisualizerFading(true);
+                toast.warning(RECORDING_DURATION_LIMIT_MESSAGE);
+                mediaRecorderInstance.stop();
+            }, MAX_RECORDING_DURATION_MS);
         };
 
         mediaRecorderInstance.ondataavailable = async (event) => {
@@ -1088,6 +1137,7 @@ export default function VoiceTriagePage() {
         };
 
         mediaRecorderInstance.onerror = () => {
+            clearRecordingLimitTimer();
             if (mediaRecorderRef.current === mediaRecorderInstance) {
                 mediaRecorderRef.current = null;
             }
@@ -1103,6 +1153,7 @@ export default function VoiceTriagePage() {
         };
 
         mediaRecorderInstance.onstop = async () => {
+            clearRecordingLimitTimer();
             if (mediaRecorderRef.current === mediaRecorderInstance) {
                 mediaRecorderRef.current = null;
             }

--- a/apps/web/src/hooks/useVoiceVerification.ts
+++ b/apps/web/src/hooks/useVoiceVerification.ts
@@ -1,7 +1,16 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
-import { getPreferredRecordingMimeType } from "@/app/[locale]/voice/lib/recording";
+import {
+    getPreferredRecordingMimeType,
+    isRecordingBlobTooLarge,
+    MAX_RECORDING_DURATION_MS,
+} from "@/app/[locale]/voice/lib/recording";
+
+const RECORDING_DURATION_LIMIT_MESSAGE =
+    "Recording stopped after 60 seconds. Please keep voice checks under one minute.";
+const RECORDING_SIZE_LIMIT_MESSAGE =
+    "Recording is too large. Please record a shorter clip under 20MB.";
 
 type VerificationResult = {
     medicine_name_original: string;
@@ -49,9 +58,23 @@ export function useVoiceVerification(): UseVoiceVerificationReturn {
     const chunksRef = useRef<Blob[]>([]);
     const animFrameRef = useRef<number | null>(null);
     const analyserRef = useRef<AnalyserNode | null>(null);
+    const recordingLimitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const clearRecordingLimitTimer = useCallback(() => {
+        if (recordingLimitTimerRef.current) {
+            clearTimeout(recordingLimitTimerRef.current);
+            recordingLimitTimerRef.current = null;
+        }
+    }, []);
 
     // Send audio to API
     const sendAudioToApi = useCallback(async (blob: Blob) => {
+        if (isRecordingBlobTooLarge(blob)) {
+            setError(RECORDING_SIZE_LIMIT_MESSAGE);
+            window.alert(RECORDING_SIZE_LIMIT_MESSAGE);
+            return;
+        }
+
         setIsLoading(true);
         setError(null);
         try {
@@ -82,6 +105,7 @@ export function useVoiceVerification(): UseVoiceVerificationReturn {
     const startRecording = useCallback(async () => {
         setError(null);
         setResult(null);
+        clearRecordingLimitTimer();
 
         try {
             const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
@@ -113,6 +137,7 @@ export function useVoiceVerification(): UseVoiceVerificationReturn {
             };
 
             recorder.onstop = async () => {
+                clearRecordingLimitTimer();
                 stream.getTracks().forEach((t) => t.stop());
                 if (animFrameRef.current) cancelAnimationFrame(animFrameRef.current);
                 setAudioLevel(0);
@@ -124,18 +149,30 @@ export function useVoiceVerification(): UseVoiceVerificationReturn {
             recorder.start();
             mediaRecorderRef.current = recorder;
             setIsRecording(true);
+            recordingLimitTimerRef.current = setTimeout(() => {
+                if (recorder.state === "inactive") {
+                    return;
+                }
+
+                setError(RECORDING_DURATION_LIMIT_MESSAGE);
+                window.alert(RECORDING_DURATION_LIMIT_MESSAGE);
+                recorder.stop();
+                setIsRecording(false);
+            }, MAX_RECORDING_DURATION_MS);
         } catch {
+            clearRecordingLimitTimer();
             setError("Microphone access denied. Please allow microphone access and try again.");
         }
-    }, [sendAudioToApi]);
+    }, [clearRecordingLimitTimer, sendAudioToApi]);
 
     // Stop recording
     const stopRecording = useCallback(() => {
         if (mediaRecorderRef.current && isRecording) {
+            clearRecordingLimitTimer();
             mediaRecorderRef.current.stop();
             setIsRecording(false);
         }
-    }, [isRecording]);
+    }, [clearRecordingLimitTimer, isRecording]);
 
     // Reset
     const reset = useCallback(() => {
@@ -144,7 +181,8 @@ export function useVoiceVerification(): UseVoiceVerificationReturn {
         setIsRecording(false);
         setIsLoading(false);
         setAudioLevel(0);
-    }, []);
+        clearRecordingLimitTimer();
+    }, [clearRecordingLimitTimer]);
 
     return {
         isRecording,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3356 **

## Summary
- Added shared frontend voice recording limits: 60 seconds max duration and 20MB max blob size.
- Auto-stop MediaRecorder when the 60-second limit is reached and notify the user.
- Prevent oversized recorded blobs from being uploaded to the backend.

## Testing
```
- npx prettier --check apps/web/src/hooks/useVoiceVerification.ts apps/web/app/[locale]/voice/lib/recording.ts apps/web/app/[locale]/voice/page.tsx
- npx eslint apps/web/src/hooks/useVoiceVerification.ts apps/web/app/[locale]/voice/lib/recording.ts apps/web/app/[locale]/voice/page.tsx
- ```


## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3356`)
- [x] I have pulled the latest `main` and resolved any conflicts
