### PR TITLE
refactor(api): centralize outbound URL/SSRF validation into a shared util

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -11,67 +11,16 @@ import {
 } from "../services/reportValidation.service";
 import { triggerRecallAlert } from "../services/notifications";
 import logger from "../utils/logger";
-import dns from "dns/promises";
+import { validateOutboundUrl } from "../utils/security/urlValidator";
 
 const reportsRouter = Router();
 const DEFAULT_ADMIN_REPORTS_LIMIT = 20;
 const MAX_ADMIN_REPORTS_LIMIT = 100;
 
-// Blocked hostname patterns for image URL SSRF protection.
-// z.string().url() only validates URL format, not destination.
-// An attacker could supply cloud metadata or internal service URLs that may be
-// fetched server-side when the image is processed.
-const BLOCKED_IMAGE_URL_PATTERNS = [
-    /^localhost$/i,
-    /^127\./,
-    /^10\./,
-    /^172\.(1[6-9]|2\d|3[01])\./,
-    /^192\.168\./,
-    /^169\.254\./,
-    /^::1$/,
-    /^fc00:/i,
-    /^fe80:/i,
-    /^::ffff:/i,
-];
-
-import dns from "dns";
-
-const DNS_TIMEOUT_MS = parseInt(process.env.DNS_LOOKUP_TIMEOUT_MS ?? "3000", 10);
-
-async function isPublicImageUrl(rawUrl: string): Promise<boolean> {
-    try {
-        const { protocol, hostname } = new URL(rawUrl);
-        if (protocol !== "https:" && protocol !== "http:") return false;
-        const normalized = hostname.replace(/^\[|\]$/g, "");
-
-        if (BLOCKED_IMAGE_URL_PATTERNS.some((p) => p.test(normalized))) {
-            return false;
-        }
-
-        // Race DNS lookup against a hard timeout to prevent DoS via slow DNS
-        const dnsResult = (await Promise.race([
-            // Use the promises API to get a proper Promise-returning lookup
-            (dns.promises.lookup as any)(normalized),
-            new Promise<never>((_, reject) =>
-                setTimeout(() => reject(new Error("DNS lookup timeout")), DNS_TIMEOUT_MS)
-            ),
-        ])) as { address: string };
-
-        if (BLOCKED_IMAGE_URL_PATTERNS.some((p) => p.test(dnsResult.address))) {
-            return false;
-        }
-
-        return true;
-    } catch {
-        // Treat DNS failures and timeouts as unsafe — block the URL
-        return false;
-    }
-}
-
 const safeImageUrl = z
     .string()
     .url()
-    .refine(async (v) => await isPublicImageUrl(v), {
+    .refine(async (v) => await validateOutboundUrl(v), {
         message:
             "Image URL must use http(s) and must not point to a private, loopback, or link-local address",
     });

--- a/apps/api/src/utils/security/urlValidator.ts
+++ b/apps/api/src/utils/security/urlValidator.ts
@@ -1,0 +1,77 @@
+import dns from "dns/promises";
+
+/**
+ * Hostname / IP-literal patterns that must never be the destination of a
+ * server-side outbound request.
+ *
+ * `z.string().url()` only validates URL *format*, not where it points, so an
+ * attacker could otherwise supply a cloud-metadata address (169.254.169.254),
+ * a loopback address, or an internal service URL that gets fetched by the
+ * server (SSRF). These cover loopback, the RFC 1918 private ranges,
+ * link-local, and their IPv6 equivalents.
+ */
+export const BLOCKED_OUTBOUND_URL_PATTERNS = [
+    /^localhost$/i,
+    /^127\./,
+    /^10\./,
+    /^172\.(1[6-9]|2\d|3[01])\./,
+    /^192\.168\./,
+    /^169\.254\./,
+    /^::1$/,
+    /^fc00:/i,
+    /^fe80:/i,
+    /^::ffff:/i,
+];
+
+/**
+ * Hard cap on how long a DNS lookup is allowed to take. Without this a slow or
+ * malicious resolver could hang the request indefinitely (DoS). Configurable
+ * via `DNS_LOOKUP_TIMEOUT_MS` so tests can shorten it.
+ */
+const DNS_TIMEOUT_MS = parseInt(process.env.DNS_LOOKUP_TIMEOUT_MS ?? "3000", 10);
+
+function isBlockedHost(host: string): boolean {
+    return BLOCKED_OUTBOUND_URL_PATTERNS.some((pattern) => pattern.test(host));
+}
+
+/**
+ * Validates that `rawUrl` is safe to fetch from the server.
+ *
+ * Returns `true` only when the URL uses http(s), its hostname is not in a
+ * blocked range, and the address it resolves to is also not in a blocked range
+ * (so a public hostname that resolves to an internal IP is still rejected).
+ * Any parse error, DNS failure, or DNS timeout resolves to `false` — the URL
+ * is treated as unsafe by default.
+ */
+export async function validateOutboundUrl(rawUrl: string): Promise<boolean> {
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    try {
+        const { protocol, hostname } = new URL(rawUrl);
+        if (protocol !== "https:" && protocol !== "http:") return false;
+
+        // Strip the brackets around IPv6 literals (e.g. "[::1]" -> "::1").
+        const normalizedHost = hostname.replace(/^\[|\]$/g, "");
+        if (isBlockedHost(normalizedHost)) return false;
+
+        // Race the DNS lookup against a hard timeout so a slow resolver can't
+        // hang the request.
+        const { address } = (await Promise.race([
+            dns.lookup(normalizedHost),
+            new Promise<never>((_, reject) => {
+                timeoutHandle = setTimeout(
+                    () => reject(new Error("DNS lookup timeout")),
+                    DNS_TIMEOUT_MS
+                );
+            }),
+        ])) as { address: string };
+
+        if (isBlockedHost(address)) return false;
+
+        return true;
+    } catch {
+        // Parse errors, DNS failures, and timeouts all mean "not verified safe".
+        return false;
+    } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+    }
+}

--- a/apps/api/tests/urlValidator.test.ts
+++ b/apps/api/tests/urlValidator.test.ts
@@ -1,0 +1,72 @@
+process.env.DNS_LOOKUP_TIMEOUT_MS = process.env.DNS_LOOKUP_TIMEOUT_MS || "50";
+
+import dns from "dns/promises";
+import {
+    validateOutboundUrl,
+    BLOCKED_OUTBOUND_URL_PATTERNS,
+} from "../src/utils/security/urlValidator";
+
+jest.mock("dns/promises", () => ({
+    lookup: jest.fn(),
+}));
+
+const mockedLookup = dns.lookup as jest.MockedFunction<typeof dns.lookup>;
+
+describe("validateOutboundUrl", () => {
+    beforeEach(() => {
+        // Default: hostname resolves to a public address.
+        mockedLookup.mockResolvedValue({ address: "8.8.8.8", family: 4 } as any);
+    });
+
+    it("accepts a public https URL", async () => {
+        await expect(validateOutboundUrl("https://res.cloudinary.com/x.jpg")).resolves.toBe(true);
+    });
+
+    it("accepts a public http URL", async () => {
+        await expect(validateOutboundUrl("http://example.com/a.png")).resolves.toBe(true);
+    });
+
+    it("rejects non-http(s) protocols without doing a lookup", async () => {
+        await expect(validateOutboundUrl("ftp://example.com/a.png")).resolves.toBe(false);
+        await expect(validateOutboundUrl("file:///etc/passwd")).resolves.toBe(false);
+        expect(mockedLookup).not.toHaveBeenCalled();
+    });
+
+    it("rejects a malformed URL", async () => {
+        await expect(validateOutboundUrl("not a url")).resolves.toBe(false);
+    });
+
+    it.each([
+        "http://localhost/x",
+        "http://127.0.0.1/x",
+        "http://10.0.0.5/x",
+        "http://172.16.0.1/x",
+        "http://192.168.1.1/x",
+        "http://169.254.169.254/latest/meta-data",
+        "http://[::1]/x",
+    ])("rejects blocked literal host %s before lookup", async (url) => {
+        await expect(validateOutboundUrl(url)).resolves.toBe(false);
+        expect(mockedLookup).not.toHaveBeenCalled();
+    });
+
+    it("rejects a public hostname that resolves to a private address", async () => {
+        mockedLookup.mockResolvedValue({ address: "169.254.169.254", family: 4 } as any);
+        await expect(validateOutboundUrl("https://evil.example.com/x.jpg")).resolves.toBe(false);
+    });
+
+    it("rejects when the DNS lookup rejects", async () => {
+        mockedLookup.mockRejectedValue(new Error("ENOTFOUND"));
+        await expect(validateOutboundUrl("https://nope.example.com/x.jpg")).resolves.toBe(false);
+    });
+
+    it("rejects when the DNS lookup exceeds the timeout", async () => {
+        // A lookup that never settles — the internal DNS timeout must win.
+        mockedLookup.mockImplementation(() => new Promise(() => {}));
+        await expect(validateOutboundUrl("https://slow.example.com/x.jpg")).resolves.toBe(false);
+    });
+
+    it("exposes the blocked-pattern list for reuse", () => {
+        expect(BLOCKED_OUTBOUND_URL_PATTERNS.some((p) => p.test("127.0.0.1"))).toBe(true);
+        expect(BLOCKED_OUTBOUND_URL_PATTERNS.some((p) => p.test("8.8.8.8"))).toBe(false);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #** 3361
- **Summary:**

PR #3328 fixed an SSRF and DNS-timeout hole in `/api/reports` by adding an `isPublicImageUrl` check straight inside `apps/api/src/routes/reports.ts`. It worked, but it sat in the route file. Any other route that needs to fetch an outside URL would have to copy that check or risk bringing the same bug back.

I pulled the logic out into a new utility, `apps/api/src/utils/security/urlValidator.ts`, and exported `validateOutboundUrl(url: string): Promise<boolean>`, the exact name the issue asked for. The behaviour is unchanged: http(s) only, block loopback, private and link-local ranges for both IPv4 and IPv6, resolve the hostname, then block again if the resolved IP is private. The DNS lookup still races a hard timeout so a slow resolver can't hang the request. `reports.ts` now just calls the utility inside its Zod `.refine()`.

Two small clean-ups came out of the move:

- `reports.ts` was importing `dns` twice, once as `dns/promises` and once as `dns`. Both are gone now. The utility owns the DNS import.
- The old timeout timer was never cleared when the lookup won the race, so it left a dangling timer. The utility clears it in a `finally` block.

## 📸 Proof of Work (Screenshots / Logs)

No UI here, it's a backend security refactor. Proof is the unit tests and a type-check.

Unit tests for the new utility:

```
$ npx jest tests/urlValidator.test.ts
Test Suites: 1 passed, 1 total
Tests:       15 passed, 15 total
```

They cover public http and https URLs passing, non-http(s) schemes and malformed URLs rejected with no lookup, every blocked literal range (localhost, 127, 10, 172.16-31, 192.168, 169.254, ::1) rejected before any DNS call, a public hostname that resolves to a private IP still rejected, and DNS errors or timeouts resolving to false.

Type-check on the files this PR touches:

```
$ npx tsc --noEmit
clean (no errors in urlValidator.ts or reports.ts)
```

One note for review: the existing `apps/api/tests/reports.test.ts` won't run in my local setup because it loads the rate-limit middleware, which needs `rate-limit-redis`, and I have no network to install it. It fails the same way on a clean `main`, so it's an environment gap and not this change. It runs fine in CI where the deps install. This change actually makes that test's `dns/promises` mock take effect, since the old code read DNS through the `dns` core module instead.

## 🏷️ PR Type

- [x] 🔒 `type: security`
- [x] ♻️ `type: refactor`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3361`)
- [x] I have pulled the latest `main` and resolved any conflicts