### PR TITLE
feat(api): add Zod response-schema validation to triage routes

### DIFF
--- a/apps/api/src/routes/triage.schemas.ts
+++ b/apps/api/src/routes/triage.schemas.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+
+/**
+ * Response contracts for the triage routes.
+ *
+ * The triage endpoints assemble their responses from several sources (the RAG
+ * medicine service, the urgency classifier, and the pharmacy PostGIS RPC).
+ * Validating the assembled payload against these schemas before it is sent
+ * guarantees the client never receives an off-contract body — if an upstream
+ * source returns something unexpected, the route returns a 502 instead of
+ * forwarding malformed data.
+ */
+
+/** A single medicine suggestion, mirroring `MedicineMatch`. */
+export const medicineMatchSchema = z.object({
+    id: z.string(),
+    brand_name: z.string().nullable(),
+    generic_name: z.string(),
+    manufacturer: z.string().nullable(),
+    composition: z.string().nullable(),
+    strength: z.string().nullable(),
+    dosage_form: z.string().nullable(),
+    schedule: z.string().nullable(),
+    mrp: z.number().nullable(),
+    jan_aushadhi_price: z.number().nullable(),
+    monograph: z.string(),
+    similarity: z.number().nullable(),
+});
+
+/** A formatted pharmacy result, mirroring the output of `formatPharmacy`. */
+export const pharmacySchema = z.object({
+    id: z.string().optional(),
+    name: z.string(),
+    address: z.string(),
+    lat: z.number(),
+    lng: z.number(),
+    distance: z.string(),
+    phone_number: z.string().nullable(),
+    is_verified: z.boolean(),
+    district: z.string().nullable(),
+    state: z.string().nullable(),
+});
+
+/** Response body of `POST /api/triage/medicine-query`. */
+export const medicineQueryResponseSchema = z.object({
+    query: z.string(),
+    medicines: z.array(medicineMatchSchema),
+    disclaimer: z.string(),
+});
+
+/** Response body of `POST /api/triage/recommend`. */
+export const recommendResponseSchema = z.object({
+    symptoms: z.string(),
+    emergency: z.boolean(),
+    urgentKeywords: z.array(z.string()),
+    medicines: z.array(medicineMatchSchema),
+    pharmacies: z.array(pharmacySchema),
+    disclaimer: z.string(),
+});
+
+export type MedicineQueryResponse = z.infer<typeof medicineQueryResponseSchema>;
+export type RecommendResponse = z.infer<typeof recommendResponseSchema>;

--- a/apps/api/src/routes/triage.ts
+++ b/apps/api/src/routes/triage.ts
@@ -11,8 +11,36 @@ import {
     type MedicineMatch,
 } from "../services/medicineRag.service";
 import { PharmacyRpcResult, FormattedPharmacy } from "../types/pharmacy.types";
+import { z } from "zod";
+import { medicineQueryResponseSchema, recommendResponseSchema } from "./triage.schemas";
 
 const router = Router();
+
+/**
+ * Validates an assembled triage response against its schema before sending it.
+ * If the payload does not conform (e.g. an upstream source returned an
+ * unexpected shape), it logs the mismatch and returns a 502 rather than
+ * forwarding a malformed body to the client.
+ */
+function sendValidatedResponse<T>(
+    res: Response,
+    route: string,
+    schema: z.ZodType<T>,
+    payload: unknown
+): void {
+    const result = schema.safeParse(payload);
+    if (!result.success) {
+        logger.error("Triage response failed schema validation", {
+            route,
+            issues: result.error.flatten(),
+        });
+        res.status(502).json({
+            error: "Triage service produced an invalid response.",
+        });
+        return;
+    }
+    res.json(result.data);
+}
 
 /** Maximum number of pharmacies returned alongside a recommendation. */
 const MAX_PHARMACY_RESULTS = 5;
@@ -110,7 +138,7 @@ router.post(
             const { query, limit } = parsed.data;
             const medicines = await retrieveRelevantMedicines(query, limit);
 
-            res.json({
+            sendValidatedResponse(res, "/medicine-query", medicineQueryResponseSchema, {
                 query,
                 medicines,
                 disclaimer: MEDICINE_RAG_DISCLAIMER,
@@ -189,7 +217,7 @@ router.post(
                     ? await findNearestPharmacies(lat, lng, radius)
                     : [];
 
-            res.json({
+            sendValidatedResponse(res, "/recommend", recommendResponseSchema, {
                 symptoms,
                 emergency: urgency.emergency,
                 urgentKeywords: urgency.matched,

--- a/apps/api/tests/triage.route.test.ts
+++ b/apps/api/tests/triage.route.test.ts
@@ -1,0 +1,139 @@
+import express from "express";
+import request from "supertest";
+
+// The triage route imports the rate-limit middleware, which pulls in Redis.
+// Stub it so the router can mount without that dependency.
+jest.mock("../src/middleware/rateLimit", () => ({
+    triageLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+    limiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+    reportLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+// Keep the real Zod request schemas, urgency classifier, and disclaimer; only
+// control what the RAG lookup returns so we can drive valid vs malformed output.
+const mockRetrieve = jest.fn();
+jest.mock("../src/services/medicineRag.service", () => {
+    const actual = jest.requireActual("../src/services/medicineRag.service");
+    return {
+        ...actual,
+        retrieveRelevantMedicines: (...args: unknown[]) => mockRetrieve(...args),
+    };
+});
+
+import triageRouter from "../src/routes/triage";
+
+function buildApp() {
+    const app = express();
+    app.use(express.json());
+    app.use("/api/triage", triageRouter);
+    return app;
+}
+
+const validMedicine = {
+    id: "m-1",
+    brand_name: "Crocin",
+    generic_name: "Paracetamol",
+    manufacturer: "GSK",
+    composition: "Paracetamol 500mg",
+    strength: "500mg",
+    dosage_form: "tablet",
+    schedule: null,
+    mrp: 30,
+    jan_aushadhi_price: 12,
+    monograph: "Used for fever and pain.",
+    similarity: 0.87,
+};
+
+// generic_name is required by the schema; dropping it models a bad upstream row.
+const malformedMedicine = { ...validMedicine } as Record<string, unknown>;
+delete malformedMedicine.generic_name;
+
+describe("triage routes response validation", () => {
+    const app = buildApp();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe("POST /api/triage/medicine-query", () => {
+        it("returns 200 and passes a well-formed response through unchanged", async () => {
+            mockRetrieve.mockResolvedValue([validMedicine]);
+
+            const res = await request(app)
+                .post("/api/triage/medicine-query")
+                .send({ query: "fever" });
+
+            expect(res.status).toBe(200);
+            expect(res.body.query).toBe("fever");
+            expect(res.body.medicines).toEqual([validMedicine]);
+            expect(typeof res.body.disclaimer).toBe("string");
+        });
+
+        it("returns 502 when the RAG service yields a malformed medicine", async () => {
+            mockRetrieve.mockResolvedValue([malformedMedicine]);
+
+            const res = await request(app)
+                .post("/api/triage/medicine-query")
+                .send({ query: "fever" });
+
+            expect(res.status).toBe(502);
+            expect(res.body).toEqual({
+                error: "Triage service produced an invalid response.",
+            });
+        });
+
+        it("returns 400 on an invalid request body (real Zod schema still runs)", async () => {
+            const res = await request(app).post("/api/triage/medicine-query").send({});
+
+            expect(res.status).toBe(400);
+            expect(mockRetrieve).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("POST /api/triage/recommend", () => {
+        it("returns 200 with a valid response and no coordinates", async () => {
+            mockRetrieve.mockResolvedValue([validMedicine]);
+
+            const res = await request(app)
+                .post("/api/triage/recommend")
+                .send({ symptoms: "mild fever and headache" });
+
+            expect(res.status).toBe(200);
+            expect(res.body.emergency).toBe(false);
+            expect(res.body.pharmacies).toEqual([]);
+            expect(res.body.medicines).toEqual([validMedicine]);
+        });
+
+        it("flags an emergency for urgent symptoms", async () => {
+            mockRetrieve.mockResolvedValue([validMedicine]);
+
+            const res = await request(app)
+                .post("/api/triage/recommend")
+                .send({ symptoms: "chest pain since morning" });
+
+            expect(res.status).toBe(200);
+            expect(res.body.emergency).toBe(true);
+            expect(res.body.urgentKeywords).toContain("chest pain");
+        });
+
+        it("returns 502 when the RAG service yields a malformed medicine", async () => {
+            mockRetrieve.mockResolvedValue([malformedMedicine]);
+
+            const res = await request(app)
+                .post("/api/triage/recommend")
+                .send({ symptoms: "mild fever and headache" });
+
+            expect(res.status).toBe(502);
+            expect(res.body).toEqual({
+                error: "Triage service produced an invalid response.",
+            });
+        });
+
+        it("returns 400 on an invalid request body", async () => {
+            const res = await request(app).post("/api/triage/recommend").send({});
+
+            expect(res.status).toBe(400);
+            expect(mockRetrieve).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/api/tests/triage.schemas.test.ts
+++ b/apps/api/tests/triage.schemas.test.ts
@@ -1,0 +1,101 @@
+import {
+    medicineMatchSchema,
+    pharmacySchema,
+    medicineQueryResponseSchema,
+    recommendResponseSchema,
+} from "../src/routes/triage.schemas";
+
+const validMedicine = {
+    id: "m-1",
+    brand_name: "Crocin",
+    generic_name: "Paracetamol",
+    manufacturer: "GSK",
+    composition: "Paracetamol 500mg",
+    strength: "500mg",
+    dosage_form: "tablet",
+    schedule: null,
+    mrp: 30,
+    jan_aushadhi_price: 12,
+    monograph: "Used for fever and pain.",
+    similarity: 0.87,
+};
+
+const validPharmacy = {
+    id: "p-1",
+    name: "Jan Aushadhi Kendra",
+    address: "MG Road",
+    lat: 28.61,
+    lng: 77.2,
+    distance: "1.2 km",
+    phone_number: null,
+    is_verified: true,
+    district: "New Delhi",
+    state: "Delhi",
+};
+
+describe("triage response schemas", () => {
+    it("accepts a well-formed medicine match", () => {
+        expect(medicineMatchSchema.safeParse(validMedicine).success).toBe(true);
+    });
+
+    it("rejects a medicine missing the required generic_name", () => {
+        const { generic_name, ...bad } = validMedicine;
+        expect(medicineMatchSchema.safeParse(bad).success).toBe(false);
+    });
+
+    it("rejects a medicine whose mrp is a string instead of number|null", () => {
+        expect(medicineMatchSchema.safeParse({ ...validMedicine, mrp: "cheap" }).success).toBe(
+            false
+        );
+    });
+
+    it("accepts a pharmacy without an id (id is optional)", () => {
+        const { id, ...noId } = validPharmacy;
+        expect(pharmacySchema.safeParse(noId).success).toBe(true);
+    });
+
+    it("rejects a pharmacy with non-numeric coordinates", () => {
+        expect(pharmacySchema.safeParse({ ...validPharmacy, lat: "28.61" }).success).toBe(false);
+    });
+
+    it("accepts a valid /medicine-query response", () => {
+        const res = medicineQueryResponseSchema.safeParse({
+            query: "fever",
+            medicines: [validMedicine],
+            disclaimer: "Not medical advice.",
+        });
+        expect(res.success).toBe(true);
+    });
+
+    it("rejects a /medicine-query response with a malformed medicine in the array", () => {
+        const res = medicineQueryResponseSchema.safeParse({
+            query: "fever",
+            medicines: [{ ...validMedicine, id: 123 }],
+            disclaimer: "Not medical advice.",
+        });
+        expect(res.success).toBe(false);
+    });
+
+    it("accepts a valid /recommend response", () => {
+        const res = recommendResponseSchema.safeParse({
+            symptoms: "fever and headache",
+            emergency: false,
+            urgentKeywords: [],
+            medicines: [validMedicine],
+            pharmacies: [validPharmacy],
+            disclaimer: "Not medical advice.",
+        });
+        expect(res.success).toBe(true);
+    });
+
+    it("rejects a /recommend response missing the emergency flag", () => {
+        const res = recommendResponseSchema.safeParse({
+            symptoms: "fever",
+            urgentKeywords: [],
+            medicines: [],
+            pharmacies: [],
+            disclaimer: "Not medical advice.",
+        });
+        expect(res.success).toBe(false);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #** 3139
- **Summary:**

Both triage routes (`/api/triage/medicine-query` and `/api/triage/recommend`) built their response by hand and sent it out with `res.json(...)`. Nothing checked the shape first, so if one of the sources returned something odd, that shape went straight to the client.

One thing to flag on the issue itself: it assumed `triage.ts` proxies the ML service. In the current code it doesn't. It builds the response from the local RAG service (`retrieveRelevantMedicines`), the urgency check, and the pharmacy PostGIS RPC. So I added the validation on that assembled response, which is what the client actually gets. I raised this on the issue before I started.

What I changed:

- Added `apps/api/src/routes/triage.schemas.ts` with Zod schemas for both responses. I kept them in a separate file so the tests can import them without loading the route, which pulls in the rate-limit middleware and Redis.
- Added a small `sendValidatedResponse()` helper in `triage.ts` that runs the payload through `safeParse` right before it goes out. On success it sends the parsed data. On failure it logs the mismatch and returns `502` instead of forwarding a bad body.

I checked the schemas against what the code really returns, from `formatMedicineMatch` and `formatPharmacy`, not just the TypeScript types. So a valid response won't get rejected by mistake.

## 📸 Proof of Work (Screenshots / Logs)

Backend change, no UI. Proof is route-level tests, schema unit tests, and a type-check.

Route tests (supertest, with the rate-limit middleware and the RAG service stubbed) plus the schema unit tests:

```
$ npx jest tests/triage.route.test.ts tests/triage.schemas.test.ts
Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
```

The route tests drive both endpoints end to end: a valid payload returns 200 and comes back unchanged, a malformed medicine from the RAG service returns 502, a bad request body still returns 400, and urgent symptoms like "chest pain" set the emergency flag. The schema tests cover the field rules (missing `generic_name` fails, a string `mrp` fails, a pharmacy with a string `lat` fails, a bad medicine inside the array fails, a `/recommend` response missing `emergency` fails).

```
$ npx tsc --noEmit
clean (no errors in triage.ts or triage.schemas.ts)
```

## 🏷️ PR Type

- [x] ✨ `type: feature`
- [x] 🔒 `type: security`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3139`)
- [x] I have pulled the latest `main` and resolved any conflicts