### PR TITLE
refactor: move pharmacy search-radius bounds into @sahidawa/shared

### DIFF
--- a/apps/api/src/routes/pharmacies.ts
+++ b/apps/api/src/routes/pharmacies.ts
@@ -13,7 +13,13 @@ import multer from "multer";
 import { buildOrConditions } from "../utils/db";
 import Papa from "papaparse";
 import { Readable } from "stream";
-import { MAX_BULK_UPLOAD_ITEMS, MAX_BULK_UPLOAD_FILE_SIZE_BYTES } from "@sahidawa/shared";
+import {
+    MAX_BULK_UPLOAD_ITEMS,
+    MAX_BULK_UPLOAD_FILE_SIZE_BYTES,
+    PHARMACY_SEARCH_RADIUS_DEFAULT_KM,
+    PHARMACY_SEARCH_RADIUS_MIN_KM,
+    PHARMACY_SEARCH_RADIUS_MAX_KM,
+} from "@sahidawa/shared";
 
 const upload = multer({
     storage: multer.memoryStorage(),
@@ -281,7 +287,11 @@ router.post(
 const nearestQuerySchema = z.object({
     lat: z.coerce.number().min(-90).max(90),
     lng: z.coerce.number().min(-180).max(180),
-    radius: z.coerce.number().min(1).max(200).default(50),
+    radius: z.coerce
+        .number()
+        .min(PHARMACY_SEARCH_RADIUS_MIN_KM)
+        .max(PHARMACY_SEARCH_RADIUS_MAX_KM)
+        .default(PHARMACY_SEARCH_RADIUS_DEFAULT_KM),
 });
 
 const boundsQuerySchema = z
@@ -714,7 +724,7 @@ router.get(
     redisCache(3600, (req: Request) => {
         const lat = Number(req.query.lat);
         const lng = Number(req.query.lng);
-        const radius = Number(req.query.radius ?? 50);
+        const radius = Number(req.query.radius ?? PHARMACY_SEARCH_RADIUS_DEFAULT_KM);
 
         return `pharmacies:nearest:${lat.toFixed(3)}:${lng.toFixed(3)}:${radius}`;
     }),

--- a/apps/api/src/services/medicineRag.service.ts
+++ b/apps/api/src/services/medicineRag.service.ts
@@ -2,6 +2,11 @@ import { z } from "zod";
 import { anonSupabase } from "../db/supabase";
 import logger from "../utils/logger";
 import { escapeIlike, escapePostgrest } from "../utils/db";
+import {
+    PHARMACY_SEARCH_RADIUS_DEFAULT_KM,
+    PHARMACY_SEARCH_RADIUS_MIN_KM,
+    PHARMACY_SEARCH_RADIUS_MAX_KM,
+} from "@sahidawa/shared";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -109,7 +114,11 @@ export const recommendSchema = z.object({
     symptoms: z.string().trim().min(2).max(500),
     lat: z.coerce.number().min(-90).max(90).optional(),
     lng: z.coerce.number().min(-180).max(180).optional(),
-    radius: z.coerce.number().min(1).max(200).default(50),
+    radius: z.coerce
+        .number()
+        .min(PHARMACY_SEARCH_RADIUS_MIN_KM)
+        .max(PHARMACY_SEARCH_RADIUS_MAX_KM)
+        .default(PHARMACY_SEARCH_RADIUS_DEFAULT_KM),
     limit: z.coerce.number().int().min(1).max(20).default(DEFAULT_MATCH_COUNT),
 });
 

--- a/apps/api/tests/pharmacyRadius.shared.test.ts
+++ b/apps/api/tests/pharmacyRadius.shared.test.ts
@@ -1,0 +1,35 @@
+import { recommendSchema } from "../src/services/medicineRag.service";
+import {
+    PHARMACY_SEARCH_RADIUS_DEFAULT_KM,
+    PHARMACY_SEARCH_RADIUS_MIN_KM,
+    PHARMACY_SEARCH_RADIUS_MAX_KM,
+} from "@sahidawa/shared";
+
+describe("shared pharmacy-radius constants", () => {
+    it("exposes the expected bounds", () => {
+        expect(PHARMACY_SEARCH_RADIUS_DEFAULT_KM).toBe(50);
+        expect(PHARMACY_SEARCH_RADIUS_MIN_KM).toBe(1);
+        expect(PHARMACY_SEARCH_RADIUS_MAX_KM).toBe(200);
+    });
+
+    it("applies the shared default radius when omitted", () => {
+        const parsed = recommendSchema.parse({ symptoms: "fever" });
+        expect(parsed.radius).toBe(PHARMACY_SEARCH_RADIUS_DEFAULT_KM);
+    });
+
+    it("rejects a radius above the shared maximum", () => {
+        const result = recommendSchema.safeParse({
+            symptoms: "fever",
+            radius: PHARMACY_SEARCH_RADIUS_MAX_KM + 1,
+        });
+        expect(result.success).toBe(false);
+    });
+
+    it("rejects a radius below the shared minimum", () => {
+        const result = recommendSchema.safeParse({
+            symptoms: "fever",
+            radius: PHARMACY_SEARCH_RADIUS_MIN_KM - 1,
+        });
+        expect(result.success).toBe(false);
+    });
+});

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,5 +1,6 @@
 import { fetchWithRetry } from "./apiWithRetry";
 import { createSWRCache } from "./cacheUtils";
+import { PHARMACY_SEARCH_RADIUS_DEFAULT_KM } from "@sahidawa/shared";
 
 const DEFAULT_API_ORIGIN = "http://localhost:4000";
 const configuredApiUrl = (process.env.NEXT_PUBLIC_API_URL ?? DEFAULT_API_ORIGIN).trim();
@@ -252,7 +253,7 @@ export type VerifiedPharmacy = {
 export async function fetchVerifiedPharmacies(
     lat: number,
     lng: number,
-    radiusKm: number = 50,
+    radiusKm: number = PHARMACY_SEARCH_RADIUS_DEFAULT_KM,
     signal?: AbortSignal
 ): Promise<VerifiedPharmacy[]> {
     try {

--- a/apps/web/tests/fetchVerifiedPharmacies.test.ts
+++ b/apps/web/tests/fetchVerifiedPharmacies.test.ts
@@ -1,0 +1,42 @@
+import { PHARMACY_SEARCH_RADIUS_DEFAULT_KM } from "@sahidawa/shared";
+
+// Isolate the network layer so we can inspect the request URL that
+// fetchVerifiedPharmacies builds.
+jest.mock("../lib/apiWithRetry", () => ({
+    fetchWithRetry: jest.fn(),
+    offlineRequestQueue: { enqueue: jest.fn() },
+}));
+
+import { fetchVerifiedPharmacies } from "../lib/api";
+import { fetchWithRetry } from "../lib/apiWithRetry";
+
+const mockFetch = fetchWithRetry as jest.MockedFunction<typeof fetchWithRetry>;
+
+function okResponse() {
+    return {
+        ok: true,
+        json: async () => ({ pharmacies: [] }),
+    } as unknown as Response;
+}
+
+describe("fetchVerifiedPharmacies radius", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockFetch.mockResolvedValue(okResponse());
+    });
+
+    it("requests the shared default radius when none is passed", async () => {
+        await fetchVerifiedPharmacies(28.61, 77.2);
+
+        const url = mockFetch.mock.calls[0][0] as string;
+        expect(url).toContain(`radius=${PHARMACY_SEARCH_RADIUS_DEFAULT_KM}`);
+        expect(url).toContain("radius=50");
+    });
+
+    it("uses an explicit radius when one is passed", async () => {
+        await fetchVerifiedPharmacies(28.61, 77.2, 123);
+
+        const url = mockFetch.mock.calls[0][0] as string;
+        expect(url).toContain("radius=123");
+    });
+});

--- a/packages/shared/src/limits.ts
+++ b/packages/shared/src/limits.ts
@@ -15,3 +15,14 @@ export const MAX_BULK_UPLOAD_ITEMS = 500;
 
 /** Max file size (in bytes) for bulk upload files. */
 export const MAX_BULK_UPLOAD_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
+
+/**
+ * Radius bounds (in km) for the "nearby pharmacies" geospatial search.
+ *
+ * Shared so the web client's default request radius stays in step with the
+ * range the API's Zod schemas actually accept — previously both sides
+ * hardcoded 50/1/200 independently.
+ */
+export const PHARMACY_SEARCH_RADIUS_DEFAULT_KM = 50;
+export const PHARMACY_SEARCH_RADIUS_MIN_KM = 1;
+export const PHARMACY_SEARCH_RADIUS_MAX_KM = 200;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3076
- **Summary:**

Same idea as the bulk-upload and interaction-checker limits that already live in `@sahidawa/shared`. I looked for other hardcoded numbers that both `apps/web` and `apps/api` use for the same thing.

The clear one is the nearby-pharmacy search radius. Each side set it on its own: the web client defaulted to `50` km in `lib/api.ts`, and the API used `min(1).max(200).default(50)` in two Zod schemas plus a `?? 50` in the Redis cache key. If someone changed one side, the client could ask for a radius the API rejects.

I moved the three bounds into `packages/shared/src/limits.ts`:

- `PHARMACY_SEARCH_RADIUS_DEFAULT_KM = 50`
- `PHARMACY_SEARCH_RADIUS_MIN_KM = 1`
- `PHARMACY_SEARCH_RADIUS_MAX_KM = 200`

and pointed all four spots at them: web `lib/api.ts`, the recommend schema in `medicineRag.service.ts`, and the nearest schema and cache key in `pharmacies.ts`.

One thing I chose not to do. There are other repeated numbers like `20` and `100`, but they mean different things on each side: API pagination versus a UI `slice(0, 20)` versus a database connection cap. Tying those together would couple unrelated code, so I left them alone. The radius is the one value that means the same thing in both apps.

## 📸 Proof of Work (Screenshots / Logs)

Backend change plus a one-line web default. Both sides are tested, and both apps type-check.

API side, the recommend schema uses the shared bounds:

```
$ (cd apps/api && npx jest tests/pharmacyRadius.shared.test.ts)
Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```

It checks the constant values, that the schema falls back to the shared default when radius is left out, and that it rejects a radius above the max or below the min.

Web side, the client requests the shared default:

```
$ (cd apps/web && npx jest tests/fetchVerifiedPharmacies.test.ts)
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

It asserts `fetchVerifiedPharmacies` sends `radius=50` (the shared default) when no radius is passed, and uses an explicit radius when one is given.

```
$ (cd apps/api && npx tsc --noEmit)   # clean on the touched files
$ (cd apps/web && npx tsc --noEmit)   # clean on lib/api.ts
```

Note: `@sahidawa/shared` needs its `dist` built before a plain `tsc` resolves it (`npm run build -w @sahidawa/shared`), which CI does as part of the workspace build.

## 🏷️ PR Type

- [x] ♻️ `type: refactor`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3076`)
- [x] I have pulled the latest `main` and resolved any conflicts