### PR TITLE
fix(cron): optimize district alert sync query performance

### DIFF
--- a/apps/api/src/cron/districtAlertSync.ts
+++ b/apps/api/src/cron/districtAlertSync.ts
@@ -49,74 +49,82 @@ export async function syncDistrictAlertTallies(): Promise<void> {
             }
         }
 
-        // 3. Upsert into district_alerts
-        let synced = 0;
-        let errors = 0;
+        // 3. Bulk Upsert into district_alerts
+
+        // Fetch all existing active alerts upfront to map previous_alert_level
+        const { data: allAlerts } = await supabase
+            .from("district_alerts")
+            .select("id, district, medicine_name, alert_level")
+            .eq("is_active", true);
+
+        const existingAlertsMap = new Map<string, string>();
+        if (allAlerts) {
+            for (const alert of allAlerts) {
+                existingAlertsMap.set(
+                    `${alert.district}::${alert.medicine_name}`,
+                    alert.alert_level
+                );
+            }
+        }
+
+        const upsertPayload = [];
+        const timestamp = new Date().toISOString();
 
         for (const { district, medicine_name, count } of tally.values()) {
             const alert_level = computeAlertLevel(count);
+            const key = `${district}::${medicine_name}`;
+            const previous_alert_level = existingAlertsMap.get(key) ?? null;
 
-            // Fetch existing alert level for audit trail
-            const { data: existing } = await supabase
-                .from("district_alerts")
-                .select("alert_level")
-                .eq("district", district)
-                .eq("medicine_name", medicine_name)
-                .maybeSingle();
+            upsertPayload.push({
+                district,
+                medicine_name,
+                alert_level,
+                previous_alert_level,
+                is_active: true,
+                updated_at: timestamp,
+            });
+        }
 
-            const previous_alert_level = existing?.alert_level ?? null;
+        let synced = 0;
+        let errors = 0;
 
+        if (upsertPayload.length > 0) {
             const { error: upsertError } = await supabase
                 .from("district_alerts")
-                .upsert(
-                    {
-                        district,
-                        medicine_name,
-                        alert_level,
-                        previous_alert_level,
-                        is_active: true,
-                        updated_at: new Date().toISOString(),
-                    },
-                    { onConflict: "district,medicine_name" }
-                );
+                .upsert(upsertPayload, { onConflict: "district,medicine_name" });
 
             if (upsertError) {
-                logger.error("District alert sync: upsert failed", {
-                    district,
-                    medicine_name,
+                logger.error("District alert sync: bulk upsert failed", {
                     error: upsertError.message,
                 });
-                errors += 1;
+                errors += upsertPayload.length;
             } else {
-                synced += 1;
+                synced += upsertPayload.length;
             }
         }
 
         // 4. Deactivate stale district_alerts with no remaining verified reports
-        const activeKeys = Array.from(tally.keys()).map((key) => {
-            const [district, medicine_name] = key.split("::");
-            return { district, medicine_name };
-        });
-
-        const { data: allAlerts } = await supabase
-            .from("district_alerts")
-            .select("id, district, medicine_name")
-            .eq("is_active", true);
+        const staleIds = [];
 
         if (allAlerts) {
             for (const alert of allAlerts) {
-                const stillActive = activeKeys.some(
-                    (k) =>
-                        k.district === alert.district &&
-                        k.medicine_name === alert.medicine_name
-                );
-
+                const stillActive = tally.has(`${alert.district}::${alert.medicine_name}`);
                 if (!stillActive) {
-                    await supabase
-                        .from("district_alerts")
-                        .update({ is_active: false, updated_at: new Date().toISOString() })
-                        .eq("id", alert.id);
+                    staleIds.push(alert.id);
                 }
+            }
+        }
+
+        if (staleIds.length > 0) {
+            const { error: updateError } = await supabase
+                .from("district_alerts")
+                .update({ is_active: false, updated_at: timestamp })
+                .in("id", staleIds);
+
+            if (updateError) {
+                logger.error("District alert sync: bulk deactivate failed", {
+                    error: updateError.message,
+                });
             }
         }
 


### PR DESCRIPTION
Refactored districtAlertSync to use batched supabase operations, replacing O(N) sequential queries with bulk SELECT, UPSERT, and UPDATE queries. This resolves the query explosion issue.

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3211**
- **Summary:** Refactored `districtAlertSync.ts` to use batched `supabase` operations. Replaced the highly unoptimized `O(N)` sequential loops with bulk `SELECT`, `UPSERT`, and `UPDATE` operations. This limits the total query count to exactly 4 queries regardless of dataset size and resolves the query explosion issue.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_
*(No frontend changes. The background cron job was verified locally using `npm test -- districtAlertSync` to ensure no regressions in behavior).*

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3211`)
- [x] I have pulled the latest `main` and resolved any conflicts
