### PR TITLE
fix: persist all selected medicines in compare URL

### DIFF
--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -34,6 +34,10 @@ type InteractionWarning = {
 const INTERACTIONS_CACHE_TTL_MS = 30_000;
 const INTERACTIONS_REQUEST_DEBOUNCE_MS = 150;
 
+// Compare page supports up to this many medicine slots; URL query params
+// m1..MAX_COMPARE_SLOTS are used to persist/restore the full selection.
+const MAX_COMPARE_SLOTS = 6;
+
 const interactionsCache = new Map<
     string,
     { expiresAt: number; interactions: InteractionWarning[] }
@@ -127,12 +131,19 @@ export default function ComparePage() {
         .map((medicine) => medicine.id);
     const selectedIdsKey = selectedIds.join(",");
 
+    // Positional key (keeps empty slots as "") so the URL-sync effect can tell
+    // when a specific slot's medicine actually changed, not just the set of ids.
+    const positionalIdsKey = selectedMedicines.map((medicine) => medicine?.id ?? "").join("|");
+
     useEffect(() => {
         const params = new URLSearchParams(window.location.search);
 
-        const ids = Array.from(new Set([params.get("m1"), params.get("m2"), params.get("m3")]))
-            .filter((id): id is string => Boolean(id))
-            .slice(0, 6);
+        const ids = Array.from(
+            new Set(
+                Array.from({ length: MAX_COMPARE_SLOTS }, (_, i) => params.get(`m${i + 1}`))
+                    .filter((id): id is string => Boolean(id))
+            )
+        ).slice(0, MAX_COMPARE_SLOTS);
 
         if (ids.length < 2) return;
 
@@ -158,32 +169,42 @@ export default function ComparePage() {
         loadMedicines();
     }, []);
 
-    // Keep URL in sync with the currently selected medicines so
-    // browser back/navigation preserves the comparison workflow.
+    // Keep URL in sync with ALL currently selected medicines (up to
+    // MAX_COMPARE_SLOTS) so refreshing or sharing the link restores every
+    // slot, not just the first two.
     useEffect(() => {
         const params = new URLSearchParams(window.location.search);
 
-        const nextM1 = medicine1?.id ?? "";
-        const nextM2 = medicine2?.id ?? "";
+        const ids = selectedMedicines.map((medicine) => medicine?.id ?? "");
+        const filledCount = ids.filter(Boolean).length;
 
-        const currentM1 = params.get("m1") ?? "";
-        const currentM2 = params.get("m2") ?? "";
+        let changed = false;
+        for (let i = 0; i < MAX_COMPARE_SLOTS; i++) {
+            const key = `m${i + 1}`;
+            const value = ids[i] ?? "";
+            const shouldHaveValue = filledCount >= 2 && Boolean(value);
+
+            if (!shouldHaveValue) {
+                if (params.has(key)) {
+                    params.delete(key);
+                    changed = true;
+                }
+                continue;
+            }
+
+            if (params.get(key) !== value) {
+                params.set(key, value);
+                changed = true;
+            }
+        }
 
         // Only update when something actually changes to avoid extra history churn.
-        if (currentM1 === nextM1 && currentM2 === nextM2) return;
-
-        if (!nextM1 || !nextM2) {
-            params.delete("m1");
-            params.delete("m2");
-        } else {
-            params.set("m1", nextM1);
-            params.set("m2", nextM2);
-        }
+        if (!changed) return;
 
         const qs = params.toString();
         const newUrl = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
         window.history.replaceState({}, "", newUrl);
-    }, [medicine1?.id, medicine2?.id]);
+    }, [positionalIdsKey]);
 
     useEffect(() => {
         if (selectedIds.length < 2) {


### PR DESCRIPTION
## Related Issue

Closes #3348

---

## Description

Fixed an issue where the Compare page only stored the first two selected medicines in the URL. As a result, any additional medicines added for comparison were lost after refreshing the page or sharing the link.

This fix updates the URL state management to persist all selected medicines, ensuring that every selected medicine (up to the supported limit of six) is restored correctly when the page is reloaded or accessed through a shared URL.

---

## Changes Made

- Updated URL serialization to include all selected medicines.
- Restored all medicines from the URL during page initialization.
- Ensured support for up to six selected medicines.
- Preserved existing compare functionality and URL sharing behavior.

---

## Steps to Test

1. Open the **Compare** page.
2. Select two medicines.
3. Click **Add Medicine** and add a third (or more) medicine.
4. Verify all selected medicines are displayed.
5. Refresh the page.
6. Confirm all selected medicines are restored.
7. Copy the URL and open it in a new browser tab.
8. Verify the same set of medicines is loaded correctly.

---

## Expected Result

- All selected medicines are saved in the URL.
- Refreshing the page preserves every selected medicine.
- Shared compare links restore the complete comparison state.
- Up to six medicine selections are supported consistently.

---

## Files Changed

- `apps/web/app/[locale]/compare/page.tsx`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update