### PR TITLE
Fix: close idempotency middleware TOCTOU race allowing duplicate scan submissions

### DIFF
--- a/apps/api/src/middleware/idempotency.ts
+++ b/apps/api/src/middleware/idempotency.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { redisClient } from "../utils/redis";
 import { supabase } from "../db/client";
+import logger from "../utils/logger";
 
 export const idempotencyMiddleware = async (req: Request, res: Response, next: NextFunction) => {
     const rawKey = req.headers["idempotency-key"] as string;
@@ -25,20 +26,51 @@ export const idempotencyMiddleware = async (req: Request, res: Response, next: N
         // If Redis fails, gracefully fall back to Supabase
     }
 
-    // Durable fallback check in case Redis evicted the key or is unavailable
+    // Durable reservation: rely on the PRIMARY KEY constraint on idempotency_key
+    // to atomically claim this key before any processing begins. This closes the
+    // TOCTOU window that previously existed between a "does this key exist?"
+    // read here and the write at the end of the /submit handler — two concurrent
+    // requests for the same key can no longer both pass this check.
+    //
+    // scan_id is not yet known at this point (the handler derives/generates it
+    // from the request body), so we reserve with scan_id: null and the handler
+    // fills it in once the submission is resolved.
+    const { error: reserveError } = await supabase
+        .from("submission_idempotency")
+        .insert({ idempotency_key: key, scan_id: null });
+
+    if (!reserveError) {
+        // We won the race — this request owns the key.
+        (req as any).idempotencyKey = key;
+        return next();
+    }
+
+    if (reserveError.code !== "23505") {
+        // Unexpected DB failure — fail closed rather than silently letting the
+        // request proceed without a durable idempotency guarantee.
+        logger.error("Idempotency reservation failed", { error: reserveError, key });
+        return res.status(500).json({ error: "Server error while checking Idempotency-Key" });
+    }
+
+    // Unique violation: another request already reserved (or completed) this key.
     const { data } = await supabase
         .from("submission_idempotency")
         .select("scan_id")
         .eq("idempotency_key", key)
         .maybeSingle();
 
-    if (data) {
+    if (data?.scan_id) {
+        // The prior request has already finished — return its durable result.
         const parts = await getPartsStatus(data.scan_id);
         return res.status(200).json({ scanId: data.scan_id, parts });
     }
 
-    (req as any).idempotencyKey = key;
-    next();
+    // scan_id is still null: another request with the same key is currently
+    // in-flight. Short-circuit instead of letting this request also run the
+    // submission pipeline.
+    return res.status(409).json({
+        error: "A request with this Idempotency-Key is already being processed",
+    });
 };
 
 async function getPartsStatus(scanId: string) {

--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -980,15 +980,36 @@ router.post(
                 });
             }
 
-            await supabase
+            const { error: idemUpdateError } = await supabase
                 .from("submission_idempotency")
-                .insert({ idempotency_key: idempotencyKey, scan_id: resolvedScanId });
+                .update({ scan_id: resolvedScanId })
+                .eq("idempotency_key", idempotencyKey);
+
+            if (idemUpdateError) {
+                logger.error("Failed to persist idempotency record", {
+                    error: idemUpdateError,
+                    idempotencyKey,
+                    scanId: resolvedScanId,
+                });
+            }
 
             res.status(200).json(result);
         } catch (err) {
             logger.error(
                 `Error during offline scan submit: ${err instanceof Error ? err.message : err}`
             );
+
+            if (idempotencyKey) {
+                try {
+                    await supabase
+                        .from("submission_idempotency")
+                        .delete()
+                        .eq("idempotency_key", idempotencyKey);
+                } catch {
+                    /* best-effort cleanup; ignore secondary failures */
+                }
+            }
+
             res.status(500).json({ error: "Server error during scan submission" });
         }
     }

--- a/apps/api/tests/scans.sync.test.ts
+++ b/apps/api/tests/scans.sync.test.ts
@@ -2,7 +2,6 @@ import request from "supertest";
 import app from "../src/app"; // Assuming the express app is exported from src/app
 import { supabase } from "../src/db/client";
 import { redisClient } from "../src/utils/redis";
-import crypto from "crypto";
 
 jest.mock("../src/utils/redis", () => ({
     redisClient: {
@@ -31,6 +30,7 @@ jest.mock("../src/db/client", () => {
     mockBuilder.insert = jest.fn().mockReturnValue(mockBuilder);
     mockBuilder.update = jest.fn().mockReturnValue(mockBuilder);
     mockBuilder.upsert = jest.fn().mockReturnValue(mockBuilder);
+    mockBuilder.delete = jest.fn().mockReturnValue(mockBuilder);
     mockBuilder.maybeSingle = jest.fn();
     mockBuilder.single = jest.fn();
     return { supabase: mockBuilder };
@@ -39,6 +39,8 @@ jest.mock("../src/db/client", () => {
 describe("POST /api/v1/scan/submit — offline sync", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        // Default: reservation INSERT succeeds (no error) unless a test overrides it.
+        (supabase.insert as jest.Mock).mockReturnValue(supabase);
     });
 
     it("returns cached result if Idempotency-Key already processed in Redis", async () => {
@@ -62,19 +64,30 @@ describe("POST /api/v1/scan/submit — offline sync", () => {
         expect(supabase.from).not.toHaveBeenCalledWith("submission_idempotency");
     });
 
-    it("inserts a new scan and returns parts status if not seen before", async () => {
+    it("reserves the key atomically, processes the submission, and persists the durable record", async () => {
         const mockKey = "new-idem-key";
         (redisClient.get as jest.Mock).mockResolvedValue(null);
 
-        // Mock fallback idempotency check
-        (supabase.maybeSingle as jest.Mock).mockResolvedValueOnce({ data: null, error: null });
+        // Reservation INSERT in the middleware succeeds (no unique-violation) — this
+        // request wins the race and is allowed to proceed to the handler.
+        (supabase.insert as jest.Mock).mockReturnValueOnce(
+            Promise.resolve({ data: null, error: null })
+        );
 
-        // Mock conflict resolution (new record)
+        // Conflict resolution (new record): no existing row, then a successful insert.
         (supabase.maybeSingle as jest.Mock).mockResolvedValueOnce({ data: null, error: null });
         (supabase.single as jest.Mock).mockResolvedValueOnce({
             data: { id: "new-scan-id" },
             error: null,
         });
+
+        // .eq() is called twice: once inside resolveConflict's existence check
+        // (chained into .maybeSingle(), so it must stay chainable), and once as
+        // the terminal call of the final reservation UPDATE.
+        (supabase.eq as jest.Mock)
+            .mockReturnValueOnce(supabase)
+            .mockReturnValueOnce(Promise.resolve({ error: null }));
+        (supabase.update as jest.Mock).mockReturnValueOnce(supabase);
 
         const res = await request(app)
             .post("/api/v1/scan/submit")
@@ -93,5 +106,77 @@ describe("POST /api/v1/scan/submit — offline sync", () => {
         expect(redisClient.set).toHaveBeenCalled();
         expect(supabase.from).toHaveBeenCalledWith("scan_submission_parts");
         expect(supabase.from).toHaveBeenCalledWith("submission_idempotency");
+        // Only one durable write against submission_idempotency — the reservation
+        // INSERT. Fill-in is an UPDATE, not a second INSERT, so a concurrent
+        // duplicate can never silently fail an insert the way the old code did.
+        expect(supabase.insert).toHaveBeenCalledTimes(2); // reservation + user_scan_history insert
+        expect(supabase.update).toHaveBeenCalledWith({ scan_id: "new-scan-id" });
+    });
+
+    it("short-circuits with 409 when a concurrent request for the same key is still in-flight", async () => {
+        const mockKey = "racing-idem-key";
+        (redisClient.get as jest.Mock).mockResolvedValue(null);
+
+        // Reservation INSERT fails: another request already holds the primary key.
+        (supabase.insert as jest.Mock).mockReturnValueOnce(
+            Promise.resolve({ data: null, error: { code: "23505", message: "duplicate key" } })
+        );
+
+        // The winning request hasn't finished yet, so scan_id is still null.
+        (supabase.maybeSingle as jest.Mock).mockResolvedValueOnce({
+            data: { scan_id: null },
+            error: null,
+        });
+
+        const res = await request(app)
+            .post("/api/v1/scan/submit")
+            .set("Idempotency-Key", mockKey)
+            .send({
+                deviceId: "device-1",
+                clientUpdatedAt: Date.now().toString(),
+                metadata: JSON.stringify({ name: "Ibuprofen" }),
+            });
+
+        expect(res.status).toBe(409);
+        expect(res.body.error).toMatch(/already being processed/i);
+        // Never reaches the handler, so the submission pipeline never runs twice.
+        expect(supabase.upsert).not.toHaveBeenCalled();
+    });
+
+    it("returns the durable cached result when the winning request already completed", async () => {
+        const mockKey = "completed-idem-key";
+        (redisClient.get as jest.Mock).mockResolvedValue(null);
+
+        (supabase.insert as jest.Mock).mockReturnValueOnce(
+            Promise.resolve({ data: null, error: { code: "23505", message: "duplicate key" } })
+        );
+
+        (supabase.maybeSingle as jest.Mock).mockResolvedValueOnce({
+            data: { scan_id: "already-done-scan-id" },
+            error: null,
+        });
+
+        // .eq() is called twice: once inside the middleware's fallback lookup
+        // (chained into .maybeSingle()), and once as the terminal call of
+        // getPartsStatus(), which awaits .eq() directly.
+        (supabase.eq as jest.Mock)
+            .mockReturnValueOnce(supabase)
+            .mockReturnValueOnce(
+                Promise.resolve({ data: [{ part_type: "metadata", status: "synced" }] })
+            );
+
+        const res = await request(app)
+            .post("/api/v1/scan/submit")
+            .set("Idempotency-Key", mockKey)
+            .send({
+                deviceId: "device-1",
+                clientUpdatedAt: Date.now().toString(),
+                metadata: JSON.stringify({ name: "Ibuprofen" }),
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.scanId).toBe("already-done-scan-id");
+        expect(res.body.parts).toEqual({ metadata: "synced" });
+        expect(supabase.upsert).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary
Closes #3393. `idempotencyMiddleware` only performed reads (Redis GET, then a Supabase SELECT) before calling `next()`. The durable write into `submission_idempotency` happened at the end of the `/submit` handler, *after* upload validation, `resolveConflict`, and part-status upserts — and its result was never checked. Two concurrent requests carrying the same `Idempotency-Key` (a normal retry pattern on flaky mobile networks) could both pass the middleware, both run the full pipeline, and the loser's insert would fail silently on the primary-key conflict.

## Fix
The durable reservation now happens atomically in the middleware, before any processing begins:

1. Middleware attempts `INSERT INTO submission_idempotency (idempotency_key, scan_id: null)`.
   - **Insert succeeds** → this request owns the key → proceeds to the handler.
   - **Insert fails, `error.code === '23505'`, `scan_id` present** → a prior request already finished → return its cached result (`200`).
   - **Insert fails, `error.code === '23505'`, `scan_id` still `null`** → a prior request for the same key is currently in-flight → short-circuit with `409` instead of letting this request also run the pipeline.
   - **Any other DB error** → fail closed (`500`), logged instead of discarded.
2. The `/submit` handler no longer inserts a second time. Once `resolveConflict` and the part upserts complete, it `UPDATE`s the pre-reserved row's `scan_id` and logs (rather than swallows) any error.
3. On a genuine handler failure, the reservation row is deleted so a crashed/failed attempt doesn't permanently lock out legitimate retries of the same `Idempotency-Key`.

This relies on the existing `idempotency_key TEXT PRIMARY KEY` constraint on `submission_idempotency`, so the race is closed at the database level, not just in application logic.

## Why this is safe
- `scan_id` on `submission_idempotency` is nullable, so reserving with `scan_id: null` before it's known is a valid write.
- `resolveConflict`, part-status upserts, and the final Redis cache write are unchanged.
- Failure-path cleanup (`DELETE` in the `catch` block) is best-effort and wrapped so a secondary failure there can't mask the original error response.

## Testing
`apps/api/tests/scans.sync.test.ts` rewritten to cover:
- Redis cache hit (unchanged behavior).
- Happy path: reservation succeeds, submission completes, reservation row updated with the resolved `scan_id` (not a second insert).
- Concurrent duplicate still in-flight → `409` before the handler runs (`scan_submission_parts` upsert never called).
- Concurrent duplicate that already completed → `200` with the durable cached result and parts status.