### PR TITLE
docs: add inner page social metadata

### DIFF
--- a/apps/web/app/[locale]/alerts/layout.tsx
+++ b/apps/web/app/[locale]/alerts/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
-const title = "Find Pharmacy — SahiDawa";
+const title = "Medicine Safety Alerts - SahiDawa";
 const description =
-    "Locate verified Jan Aushadhi and trusted pharmacies near you on SahiDawa's live pharmacy map.";
+    "Track counterfeit, banned, and recalled medicine alerts across India with SahiDawa's public safety feed.";
 const image = "/icons/sahidawa-logo.png";
 
 export const metadata: Metadata = {
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
     openGraph: {
         title,
         description,
-        url: "https://sahidawa.in/map",
+        url: "https://sahidawa.in/alerts",
         siteName: "SahiDawa",
         images: [{ url: image, width: 1200, height: 630, alt: title }],
     },
@@ -24,6 +24,6 @@ export const metadata: Metadata = {
     },
 };
 
-export default function MapLayout({ children }: { children: ReactNode }) {
+export default function AlertsLayout({ children }: { children: ReactNode }) {
     return <>{children}</>;
 }

--- a/apps/web/app/[locale]/compare/layout.tsx
+++ b/apps/web/app/[locale]/compare/layout.tsx
@@ -1,10 +1,27 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
+const title = "Compare Medicine Prices - SahiDawa";
+const description =
+    "Print a clean medicine verification and price comparison report for patient handouts.";
+const image = "/icons/sahidawa-logo.png";
+
 export const metadata: Metadata = {
-    title: "Compare Medicine Prices - SahiDawa",
-    description:
-        "Print a clean medicine verification and price comparison report for patient handouts.",
+    title,
+    description,
+    openGraph: {
+        title,
+        description,
+        url: "https://sahidawa.in/compare",
+        siteName: "SahiDawa",
+        images: [{ url: image, width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+        card: "summary_large_image",
+        title,
+        description,
+        images: [image],
+    },
 };
 
 export default function CompareLayout({ children }: { children: ReactNode }) {

--- a/apps/web/app/[locale]/history/layout.tsx
+++ b/apps/web/app/[locale]/history/layout.tsx
@@ -1,3 +1,29 @@
-export default function HistoryLayout({ children }: { children: React.ReactNode }) {
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+const title = "Medicine Scan History - SahiDawa";
+const description =
+    "Review your medicine verification history, past scan results, and saved safety checks in SahiDawa.";
+const image = "/icons/sahidawa-logo.png";
+
+export const metadata: Metadata = {
+    title,
+    description,
+    openGraph: {
+        title,
+        description,
+        url: "https://sahidawa.in/history",
+        siteName: "SahiDawa",
+        images: [{ url: image, width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+        card: "summary_large_image",
+        title,
+        description,
+        images: [image],
+    },
+};
+
+export default function HistoryLayout({ children }: { children: ReactNode }) {
     return children;
 }

--- a/apps/web/app/[locale]/report/layout.tsx
+++ b/apps/web/app/[locale]/report/layout.tsx
@@ -1,22 +1,26 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
+const title = "Report Fake Medicine — SahiDawa";
+const description =
+    "Report suspicious or counterfeit medicines found at pharmacies. Help protect your community.";
+const image = "/icons/sahidawa-logo.png";
+
 export const metadata: Metadata = {
-    title: "Report Fake Medicine — MedWatch",
-    description:
-        "Report suspicious or counterfeit medicines found at pharmacies. Help protect your community.",
+    title,
+    description,
     openGraph: {
-        title: "Report Fake Medicine — MedWatch",
-        description:
-            "Report suspicious or counterfeit medicines found at pharmacies. Help protect your community.",
+        title,
+        description,
         url: "https://sahidawa.in/report",
         siteName: "SahiDawa",
+        images: [{ url: image, width: 1200, height: 630, alt: title }],
     },
     twitter: {
         card: "summary_large_image",
-        title: "Report Fake Medicine — MedWatch",
-        description:
-            "Report suspicious or counterfeit medicines found at pharmacies. Help protect your community.",
+        title,
+        description,
+        images: [image],
     },
 };
 

--- a/apps/web/app/[locale]/scan/layout.tsx
+++ b/apps/web/app/[locale]/scan/layout.tsx
@@ -3,23 +3,26 @@ import type { ReactNode } from "react";
 
 export async function generateMetadata(): Promise<Metadata> {
     const baseUrl = "https://sahidawa.in";
+    const title = "Scan Medicine — SahiDawa";
+    const description =
+        "Scan a medicine barcode or upload a photo to instantly verify its authenticity using India's open-source CDSCO database.";
+    const image = "/icons/sahidawa-logo.png";
 
     return {
-        title: "Scan Medicine — SahiDawa",
-        description:
-            "Scan a medicine barcode or upload a photo to instantly verify its authenticity using India's open-source CDSCO database.",
+        title,
+        description,
         openGraph: {
-            title: "Scan Medicine — SahiDawa",
-            description:
-                "Scan a medicine barcode or upload a photo to instantly verify its authenticity using India's open-source CDSCO database.",
+            title,
+            description,
             url: `${baseUrl}/scan`,
             siteName: "SahiDawa",
+            images: [{ url: image, width: 1200, height: 630, alt: title }],
         },
         twitter: {
             card: "summary_large_image",
-            title: "Scan Medicine — SahiDawa",
-            description:
-                "Scan a medicine barcode or upload a photo to instantly verify its authenticity using India's open-source CDSCO database.",
+            title,
+            description,
+            images: [image],
         },
     };
 }

--- a/apps/web/app/[locale]/voice/layout.tsx
+++ b/apps/web/app/[locale]/voice/layout.tsx
@@ -1,22 +1,26 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
+const title = "Voice Triage — SahiDawa";
+const description =
+    "Speak your symptoms in any Indian language and get AI-powered medicine triage guidance instantly.";
+const image = "/icons/sahidawa-logo.png";
+
 export const metadata: Metadata = {
-    title: "Voice Triage — SahiDawa",
-    description:
-        "Speak your symptoms in any Indian language and get AI-powered medicine triage guidance instantly.",
+    title,
+    description,
     openGraph: {
-        title: "Voice Triage — SahiDawa",
-        description:
-            "Speak your symptoms in any Indian language and get AI-powered medicine triage guidance instantly.",
+        title,
+        description,
         url: "https://sahidawa.in/voice",
         siteName: "SahiDawa",
+        images: [{ url: image, width: 1200, height: 630, alt: title }],
     },
     twitter: {
         card: "summary_large_image",
-        title: "Voice Triage — SahiDawa",
-        description:
-            "Speak your symptoms in any Indian language and get AI-powered medicine triage guidance instantly.",
+        title,
+        description,
+        images: [image],
     },
 };
 


### PR DESCRIPTION
﻿### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## PR Summary & Link

- **Closes #3126**
- **Summary:** Adds Open Graph and Twitter Card metadata coverage for inner pages, including the alerts route, and ensures existing inner page metadata includes share images using the project logo asset.

## Proof of Work (Screenshots / Logs)

Metadata-only SEO/docs change; no visible UI component changed.

Validation run locally:

```text
npx.cmd prettier --check "apps/web/app/[locale]/alerts/layout.tsx" "apps/web/app/[locale]/scan/layout.tsx" "apps/web/app/[locale]/voice/layout.tsx" "apps/web/app/[locale]/map/layout.tsx" "apps/web/app/[locale]/report/layout.tsx" "apps/web/app/[locale]/compare/layout.tsx" "apps/web/app/[locale]/history/layout.tsx"
All matched files use Prettier code style!
```

```text
git diff --check
# no whitespace errors
```

## PR Type

- [ ] `type: bug`
- [ ] `type: feature`
- [x] `type: docs`
- [ ] `type: testing`
- [ ] `type: security`
- [ ] `type: performance`
- [ ] `type: design`
- [ ] `type: refactor`
- [ ] `type: devops`
- [ ] `type: accessibility`

## Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
