### PR TITLE
devops: automate locust html report generation and upload artifact #3387

### DIFF
--- a/.github/workflows/ml-load-test.yml
+++ b/.github/workflows/ml-load-test.yml
@@ -30,7 +30,15 @@ jobs:
           timeout 60 bash -c 'until curl -f http://localhost:8000/docs >/dev/null 2>&1; do sleep 2; done' || (docker compose logs ml && exit 1)
 
       - name: 🚀 Run Locust Load Tests
-        run: locust -f apps/ml/tests/locustfile.py --headless -u 10 -r 2 -t 1m --host=http://localhost:8000
+        run: locust -f apps/ml/tests/locustfile.py --headless -u 10 -r 2 -t 1m --host=http://localhost:8000 --html report.html
+
+      - name: 📊 Upload Locust HTML Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: locust-nightly-report
+          path: report.html
+          retention-days: 7
 
       - name: 🛑 Stop ML Service
         if: always()


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3387**

### Summary

This PR automates Locust HTML report generation in the ML load testing workflow.

Changes include:

- Added `--html report.html` to the Locust command.
- Added an `actions/upload-artifact@v4` step to upload the generated HTML report.
- Configured the artifact name as **locust-nightly-report**.
- Used `if: always()` so the report is uploaded even when load tests fail.
- Preserved the existing workflow failure behavior while making performance reports available for inspection.

## 📸 Proof of Work (Screenshots / Logs)

### Validation Performed

- Verified that Locust generates `report.html`.
- Verified the workflow uploads the report as a GitHub Actions artifact.
- Verified artifact upload runs even if the load test fails (`if: always()`).
- Confirmed only the required workflow file was modified.

## 🏷️ PR Type

- [x] 🛠️ `type: devops`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3387`)
- [x] I have pulled the latest `main` and resolved any conflicts.