### PR TITLE
feat(devops): add daily ETL cron workflow

### DIFF
--- a/.github/workflows/etl-cron.yml
+++ b/.github/workflows/etl-cron.yml
@@ -1,0 +1,47 @@
+name: Daily ETL Pipeline
+
+on:
+  schedule:
+    # Runs at 02:00 UTC (7:30 AM IST) every day
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    # Allows manual triggering from the GitHub Actions tab
+
+jobs:
+  run-etl:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip' # Caches dependencies to speed up future runs
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f apps/etl/requirements.txt ]; then
+            pip install -r apps/etl/requirements.txt
+          fi
+
+      - name: Run CDSCO Scraper
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: python apps/etl/cdsco_scraper.py # Note: Apne exact script ka naam/path yahan verify kar lena
+
+      - name: Run Jan Aushadhi Scraper
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: python apps/etl/jan_aushadhi_scraper.py
+
+      - name: Run Supabase Loader
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: python apps/etl/supabase_loader.py

--- a/.github/workflows/etl-cron.yml
+++ b/.github/workflows/etl-cron.yml
@@ -21,27 +21,16 @@ jobs:
           python-version: '3.10'
           cache: 'pip' # Caches dependencies to speed up future runs
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f apps/etl/requirements.txt ]; then
-            pip install -r apps/etl/requirements.txt
-          fi
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
-      - name: Run CDSCO Scraper
+      - name: Install ETL dependencies
+        working-directory: apps/etl
+        run: uv sync
+
+      - name: Run ETL pipeline
+        working-directory: apps/etl
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: python apps/etl/cdsco_scraper.py # Note: Apne exact script ka naam/path yahan verify kar lena
-
-      - name: Run Jan Aushadhi Scraper
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: python apps/etl/jan_aushadhi_scraper.py
-
-      - name: Run Supabase Loader
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: python apps/etl/supabase_loader.py
+        run: uv run python run_all.py


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3108**

### Summary

This PR introduces a dedicated GitHub Actions workflow to automate the ETL pipeline on a daily schedule while also supporting manual execution.

### Changes Made

- Added a new workflow: `.github/workflows/etl-cron.yml`.
- Configured a daily cron trigger (`0 2 * * *`) to run the ETL pipeline automatically.
- Added a `workflow_dispatch` trigger for manual execution.
- Configured Python setup and dependency installation for the ETL project.
- Added steps to execute:
  - CDSCO Scraper
  - Jan Aushadhi Scraper
  - Supabase Loader
- Passed the required Supabase secrets through GitHub Actions environment variables.
- Kept the workflow isolated in a dedicated workflow file for easier maintenance.

## 📸 Proof of Work (Screenshots / Logs)

### Validation Performed

- Verified the workflow YAML syntax.
- Verified both scheduled (`cron`) and manual (`workflow_dispatch`) triggers are configured.
- Confirmed the workflow installs ETL dependencies before execution.
- Confirmed required GitHub Secrets are passed through the workflow environment.
- Confirmed only the required workflow file was modified.

> Workflow execution screenshots/logs will be attached after the GitHub Actions run.

## 🏷️ PR Type

- [x] 🛠️ `type: devops`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3108`)
- [x] I have pulled the latest `main` and resolved any conflicts.