### PR TITLE
fix(api): add distributed Redis lock to medicine expiry cron

### DIFF
--- a/apps/api/src/cron/expiry-check.ts
+++ b/apps/api/src/cron/expiry-check.ts
@@ -2,6 +2,7 @@ const cron = require("node-cron");
 import webPush from "web-push";
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
+import { redisClient } from "../utils/redis";
 import { smsService } from "../services/sms-service";
 import {
     listPushSubscriptions,
@@ -10,6 +11,58 @@ import {
     recordPushDeliveryEvents,
     removePushSubscription,
 } from "../services/notifications";
+
+const LOCK_KEY = "expiry-check:lock";
+const LOCK_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const LOCK_VALUE = `${process.env.HOSTNAME ?? "api"}:${process.pid}`;
+
+async function acquireLock(): Promise<boolean> {
+    if (!redisClient.isOpen) {
+        // Redis unavailable — fall back to running
+        logger.warn("Redis not connected; skipping distributed lock for expiry cron.");
+        return true;
+    }
+
+    try {
+        const result = await redisClient.set(LOCK_KEY, LOCK_VALUE, {
+            NX: true,
+            PX: LOCK_TTL_MS,
+        });
+
+        return result === "OK";
+    } catch (err) {
+        logger.error({
+            message: "Failed to acquire expiry cron lock",
+            error: err,
+        });
+
+        return false;
+    }
+}
+
+async function releaseLock(): Promise<void> {
+    if (!redisClient.isOpen) return;
+
+    try {
+        const script = `
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("del", KEYS[1])
+            else
+                return 0
+            end
+        `;
+
+        await redisClient.eval(script, {
+            keys: [LOCK_KEY],
+            arguments: [LOCK_VALUE],
+        });
+    } catch (err) {
+        logger.error({
+            message: "Failed to release expiry cron lock",
+            error: err,
+        });
+    }
+}
 
 function buildExpiryPayload(medicineName: string, daysLeft: number) {
     return {
@@ -22,15 +75,27 @@ function buildExpiryPayload(medicineName: string, daysLeft: number) {
 export const initExpiryCron = () => {
     // Runs every day at 00:00 (midnight)
     cron.schedule("0 0 * * *", async () => {
+        const acquired = await acquireLock();
+
+        if (!acquired) {
+            logger.info(
+                "Expiry cron lock held by another instance — skipping this scheduled run."
+            );
+            return;
+        }
+
         try {
             logger.info("Running medicine expiry check...");
+
             const today = new Date();
             today.setHours(0, 0, 0, 0);
+
             const alertWindows = [
                 { days: 30, min: 15, max: 30 },
                 { days: 14, min: 8, max: 14 },
                 { days: 7, min: 0, max: 7 },
             ];
+
             for (const window of alertWindows) {
                 const days = window.days;
 
@@ -41,6 +106,7 @@ export const initExpiryCron = () => {
                 const maxDate = new Date(today);
                 maxDate.setDate(today.getDate() + window.max);
                 maxDate.setHours(23, 59, 59, 999);
+
                 const flagColumn = `notified_${days}d`;
 
                 const { data, error } = await supabase
@@ -51,7 +117,9 @@ export const initExpiryCron = () => {
                     .eq(flagColumn, false);
 
                 if (error) {
-                    logger.error(`Error fetching ${days}d expiring medicines`, { error });
+                    logger.error(`Error fetching ${days}d expiring medicines`, {
+                        error,
+                    });
                     continue;
                 }
 
@@ -61,18 +129,28 @@ export const initExpiryCron = () => {
                 for (const medicine of data || []) {
                     try {
                         let delivered = false;
+
                         const expiry = new Date(medicine.expiry_date);
 
                         const daysLeft = Math.max(
                             0,
-                            Math.ceil((expiry.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+                            Math.ceil(
+                                (expiry.getTime() - today.getTime()) /
+                                    (1000 * 60 * 60 * 24)
+                            )
                         );
-                        const payload = buildExpiryPayload(medicine.name, daysLeft);
+
+                        const payload = buildExpiryPayload(
+                            medicine.name,
+                            daysLeft
+                        );
 
                         // --- Web Push ---
                         if (isWebPushConfigured()) {
                             const allSubs = await listPushSubscriptions();
-                            const userSubs = allSubs.filter((s) => s.userId === medicine.user_id);
+                            const userSubs = allSubs.filter(
+                                (s) => s.userId === medicine.user_id
+                            );
 
                             if (userSubs.length > 0) {
                                 const results = await Promise.allSettled(
@@ -84,7 +162,6 @@ export const initExpiryCron = () => {
                                     )
                                 );
 
-                                // Record delivery events for analytics
                                 const fakeAlert = {
                                     id: `expiry-${medicine.id}-${days}d`,
                                     medicineName: medicine.name,
@@ -92,30 +169,43 @@ export const initExpiryCron = () => {
                                     severity: "medium" as const,
                                     source: "expiry-cron",
                                 };
+
                                 const events = results.map((result, i) =>
-                                    buildPushDeliveryEvent(fakeAlert, userSubs[i].endpoint, result)
+                                    buildPushDeliveryEvent(
+                                        fakeAlert,
+                                        userSubs[i].endpoint,
+                                        result
+                                    )
                                 );
+
                                 await recordPushDeliveryEvents(events);
 
-                                // Clean up expired subscriptions (404/410 = unsubscribed)
                                 results.forEach((result, i) => {
                                     if (
                                         result.status === "rejected" &&
                                         [404, 410].includes(
-                                            (result.reason as { statusCode?: number })
-                                                ?.statusCode ?? -1
+                                            (
+                                                result.reason as {
+                                                    statusCode?: number;
+                                                }
+                                            )?.statusCode ?? -1
                                         )
                                     ) {
-                                        removePushSubscription(userSubs[i].endpoint);
+                                        removePushSubscription(
+                                            userSubs[i].endpoint
+                                        );
                                     }
                                 });
 
-                                const sent = results.filter((r) => r.status === "fulfilled").length;
+                                const sent = results.filter(
+                                    (r) => r.status === "fulfilled"
+                                ).length;
+
                                 if (sent > 0) delivered = true;
                             }
                         }
 
-                        // --- SMS via notification_subscribers ---
+                        // --- SMS ---
                         if (medicine.user_id) {
                             const { data: subscriber } = await supabase
                                 .from("notification_subscribers")
@@ -125,16 +215,17 @@ export const initExpiryCron = () => {
 
                             if (subscriber?.phone) {
                                 const smsMessage = `SahiDawa Alert: ${medicine.name} expires in ${daysLeft} day${daysLeft === 1 ? "" : "s"}. Please check your stock.`;
+
                                 const smsSent = await smsService.send(
                                     subscriber.phone,
                                     smsMessage,
                                     subscriber.language ?? "en"
                                 );
+
                                 if (smsSent) delivered = true;
                             }
                         }
 
-                        // Collect delivered IDs for bulk update
                         if (delivered) {
                             deliveredIds.push(medicine.id);
                             notifiedCount++;
@@ -151,7 +242,6 @@ export const initExpiryCron = () => {
                     }
                 }
 
-                // Single bulk update after loop — avoids N+1 DB calls
                 if (deliveredIds.length > 0) {
                     const { error: updateError } = await supabase
                         .from("tracked_medicines")
@@ -171,7 +261,12 @@ export const initExpiryCron = () => {
                 );
             }
         } catch (err) {
-            logger.error("Expiry check cron: unhandled error during scheduled run", { error: err });
+            logger.error(
+                "Expiry check cron: unhandled error during scheduled run",
+                { error: err }
+            );
+        } finally {
+            await releaseLock();
         }
     });
 };


### PR DESCRIPTION
## Summary

Fixes #3395.

The medicine expiry cron previously executed independently on every running API instance. In a horizontally scaled deployment, each scheduler queried the same unnotified rows and sent duplicate SMS and push notifications before the notification flags were updated.

This PR wraps the cron execution with the same Redis distributed lock pattern already used by `alert-broadcaster.ts`.

## Changes

- Added Redis distributed lock to `expiry-check.ts`
- Added `acquireLock()` and `releaseLock()` helpers
- Introduced dedicated lock key:
  - `expiry-check:lock`
- Wrapped the scheduled job so only one API instance performs expiry processing
- Ensured the lock is always released via `finally`

## Result

Only one API instance executes the midnight expiry job, preventing duplicate SMS and push notifications in horizontally scaled deployments.