### PR TITLE
Feature: Wire Twilio SMS to counterfeit report confirmation flow

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -12,6 +12,8 @@ import {
 import { triggerRecallAlert } from "../services/notifications";
 import logger from "../utils/logger";
 import { validateOutboundUrl } from "../utils/security/urlValidator";
+import { smsService } from "../services/sms-service";
+import { formatPhoneNumber } from "../utils/phone";
 
 const reportsRouter = Router();
 const DEFAULT_ADMIN_REPORTS_LIMIT = 20;
@@ -44,6 +46,7 @@ const createReportSchema = getBaseReportSchema()
             .max(180, "Longitude must be between -180 and 180")
             .optional(),
         medicineId: uuidSchema.optional(),
+        phone: z.string().optional(),
     })
     .superRefine((data, ctx) => {
         const validDistricts =
@@ -91,6 +94,7 @@ reportsRouter.post(
 
         const data = parsed.data;
         const district = data.district ?? data.city;
+        const phone = data.phone ? formatPhoneNumber(data.phone) : null;
 
         try {
             const ipAddress = anonymizeIp(req.ip);
@@ -137,6 +141,7 @@ reportsRouter.post(
                         duplicate_group_id: validation.duplicateGroupId ?? null,
                         status: "pending",
                         scanned_barcode: data.scannedBarcode ?? null,
+                        reporter_phone: phone,
                         medicine_id: data.medicineId ?? null,
                     },
                     { onConflict: "report_hash", ignoreDuplicates: true }
@@ -194,6 +199,16 @@ reportsRouter.post(
             }
 
             res.status(statusCode).json(response);
+
+            if (phone) {
+                const message = `Your counterfeit report for ${data.medicineName} has been submitted successfully. Reference ID: ${report.id}. - SahiDawa`;
+                smsService.send(phone, message, "en").catch((err) => {
+                    logger.error("Failed to send confirmation SMS", {
+                        error: err,
+                        reportId: report.id,
+                    });
+                });
+            }
         } catch (err) {
             next(err);
         }

--- a/supabase/migrations/20260709000000_add_reporter_phone_to_reports.sql
+++ b/supabase/migrations/20260709000000_add_reporter_phone_to_reports.sql
@@ -1,0 +1,6 @@
+-- Add reporter_phone column to counterfeit_reports for SMS confirmation
+ALTER TABLE counterfeit_reports
+  ADD COLUMN IF NOT EXISTS reporter_phone VARCHAR(20);
+
+CREATE INDEX IF NOT EXISTS idx_counterfeit_reports_phone
+  ON counterfeit_reports(reporter_phone);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3138 **
- **Summary:**

### Changes
1. apps/api/src/routes/reports.ts
- Added imports: smsService from sms-service.ts and formatPhoneNumber from utils/phone.ts
- Added phone field to the createReportSchema as an optional string
- Formats phone to E.164 via formatPhoneNumber early in the handler; null if invalid/absent
- Stores reporter_phone in the counterfeit_reports upsert payload
- Sends confirmation SMS after a successful response via smsService.send() with .catch() for graceful failure handling,  the response is never blocked or failed due to SMS issues
2. supabase/migrations/20260709000000_add_reporter_phone_to_reports.sql
- Adds reporter_phone VARCHAR(20) column to counterfeit_reports with an index

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3138 `)
- [x] I have pulled the latest `main` and resolved any conflicts
