### PR TITLE
fix: validate maximum length for state input

### DIFF
--- a/apps/api/src/routes/eligibility.ts
+++ b/apps/api/src/routes/eligibility.ts
@@ -12,7 +12,13 @@ const eligibilitySchema = z.object({
     age: z.number().int().min(0, "Age cannot be negative").optional().default(30),
     annual_income: z.number().min(0, "Income cannot be negative").optional().default(150000),
     family_size: z.number().int().min(1, "Family size must be at least 1").optional().default(4),
-    state: z.string().trim().optional().default(""),
+    state: z
+        .string()
+        .trim()
+        .max(80, "State name is too long")
+        .regex(/^[a-zA-Z\s'&-]*$/, "State name contains invalid characters")
+        .optional()
+        .default(""),
     has_bpl_card: z.boolean().optional().default(false),
     has_abha_id: z.boolean().optional().default(false),
 });


### PR DESCRIPTION
## Related Issue

Closes #3447

---

## Description

Fixed an issue where the Scheme Eligibility API accepted the `state` field without enforcing a maximum length.

Previously, excessively long state values could be used to generate oversized Redis cache keys and trigger unnecessary database queries, potentially affecting performance and resource usage.

This fix adds maximum length validation to the `state` field in the Zod schema, ensuring invalid input is rejected before it reaches the cache or database layer. Optionally, the validation also restricts the input to valid state-name characters.

---

## Changes Made

- Added a maximum length validation (`.max(80)`) for the `state` field in the Zod schema.
- Ensured oversized state values are rejected with a **400 Bad Request** response.
- Improved input validation before Redis cache key generation and database queries.
- Preserved existing behavior for valid state names.

---

## Steps to Test

1. Start the API server.
2. Send a request with a valid state name (e.g., `"Maharashtra"`).
3. Verify the request is processed successfully.
4. Send a request with a state value longer than 80 characters.
5. Verify the API responds with **400 Bad Request** and an appropriate validation message.
6. Confirm valid requests continue to function normally.

---

## Expected Result

- Valid state names are accepted.
- State values longer than 80 characters are rejected.
- The API returns **400 Bad Request** for oversized input.
- Redis cache keys and database queries are protected from excessively long input.

---

## Files Changed

- `apps/api/src/routes/eligibility.ts`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update