### PR TITLE
fix: parse cached Overpass data from Redis

### DIFF
--- a/apps/web/app/api/overpass/route.ts
+++ b/apps/web/app/api/overpass/route.ts
@@ -51,16 +51,32 @@ export async function POST(req: NextRequest) {
         try {
             const cached = await redis.get(cacheKey);
             if (cached) {
-                return NextResponse.json(cached, {
-                    headers: { "X-Cache": "HIT" },
-                });
+                try {
+                    const parsed =
+                        typeof cached === "string" ? JSON.parse(cached) : cached;
+
+                    if (parsed && Array.isArray(parsed.elements)) {
+                        return NextResponse.json(parsed, {
+                            headers: { "X-Cache": "HIT" },
+                        });
+                    }
+
+                    console.warn(
+                        "[overpass] Cached value missing valid elements array, ignoring cache"
+                    );
+                } catch (parseErr) {
+                    console.warn(
+                        "[overpass] Failed to parse cached Redis value, ignoring cache:",
+                        parseErr
+                    );
+                }
             }
         } catch (redisErr) {
             // Redis unavailable — log and fall through to upstream fetch
             console.warn("[overpass] Redis GET failed:", redisErr);
         }
 
-        // Cache miss: query all mirrors in parallel
+        // Cache miss (or invalid cache): query all mirrors in parallel
         const controllers: AbortController[] = [];
         const fetchPromises = OVERPASS_MIRRORS.map(async (mirror) => {
             const controller = new AbortController();


### PR DESCRIPTION
## Related Issue

Closes #3446

---

## Description

Fixed an issue where cached Overpass API responses retrieved from Redis were returned directly as strings instead of being parsed into JSON objects.

Previously, the API stored map data using `JSON.stringify()`, but on cache hits it returned the cached string without calling `JSON.parse()`. This could cause the frontend to receive a string instead of the expected JSON object, leading to map loading failures.

This fix parses cached Redis responses before returning them. If parsing fails due to invalid or corrupted cache data, the cache is ignored and fresh data is fetched from the Overpass API.

---

## Changes Made

- Parsed cached Redis responses using `JSON.parse()`.
- Added error handling for invalid or corrupted cached data.
- Fallback to fetching fresh data when cache parsing fails.
- Preserved existing caching behavior for valid responses.

---

## Steps to Test

1. Start the application.
2. Make a request to the Overpass API endpoint.
3. Verify the first request fetches data from the Overpass API and stores it in Redis.
4. Make the same request again.
5. Verify the response is served from the cache as a valid JSON object.
6. Simulate invalid cached data in Redis.
7. Verify the application ignores the bad cache, fetches fresh data, and returns a valid response.

---

## Expected Result

- Cached responses are returned as valid JSON objects.
- Invalid or corrupted cache entries do not break the API.
- Fresh data is fetched when cache parsing fails.
- Map loading works correctly on both cache misses and cache hits.

---

## Files Changed

- `apps/web/app/api/overpass/route.ts`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update