### PR TITLE
fix: handle corrupted offline scan history

### DIFF
--- a/apps/web/lib/offlineCache.ts
+++ b/apps/web/lib/offlineCache.ts
@@ -21,5 +21,17 @@ export const getVerificationResults = (): ScanResult[] => {
     if (typeof window === "undefined") return [];
 
     const data = localStorage.getItem(CACHE_KEY);
-    return data ? JSON.parse(data) : [];
+    if (!data) return [];
+
+    try {
+        const parsed = JSON.parse(data);
+        if (!Array.isArray(parsed)) {
+            throw new Error("Cached scan history is not an array");
+        }
+        return parsed;
+    } catch (err) {
+        console.warn("[offlineCache] Corrupted scan history detected, clearing cache:", err);
+        localStorage.removeItem(CACHE_KEY);
+        return [];
+    }
 };


### PR DESCRIPTION
## Related Issue

Closes #3445

---

## Description

Fixed an issue where the Offline page could crash if the saved scan history in `localStorage` contained invalid or corrupted JSON.

Previously, the application directly called `JSON.parse()` on the stored value. If the data was malformed, a parsing exception was thrown, preventing the Offline page from loading.

This fix wraps the parsing logic in a `try/catch` block. If parsing fails, the corrupted `localStorage` entry is removed and an empty scan history is returned, allowing the page to continue functioning normally.

---

## Changes Made

- Wrapped `JSON.parse()` in a `try/catch` block.
- Removed corrupted scan history from `localStorage` when parsing fails.
- Returned an empty scan history as a safe fallback.
- Prevented the Offline page from crashing due to malformed cached data.

---

## Steps to Test

1. Open the application.
2. In the browser DevTools console, save an invalid value:
   ```javascript
   localStorage.setItem("scanHistory", "{invalid-json");
   ```
3. Open the **Offline** page.
4. Verify the page loads successfully without crashing.
5. Confirm the recent scans list is empty.
6. Check that the corrupted `localStorage` entry has been removed.
7. Add valid scan history and verify it still loads correctly.

---

## Expected Result

- The Offline page loads successfully even when stored scan history is corrupted.
- Invalid cached data is ignored and removed.
- An empty recent scans list is shown when recovery is needed.
- Valid cached scan history continues to load normally.

---

## Files Changed

- `apps/web/lib/offlineCache.ts`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update