### PR TITLE
fix(#3425): secure rate limit metrics cron route

### DIFF
--- a/apps/web/app/api/cron/rate-limit-metrics/route.ts
+++ b/apps/web/app/api/cron/rate-limit-metrics/route.ts
@@ -9,7 +9,7 @@ function isAuthorizedCronRequest(req: NextRequest): boolean {
     const cronSecret = process.env.CRON_SECRET;
 
     if (!cronSecret) {
-        return process.env.NODE_ENV !== "production";
+        return false;
     }
 
     return req.headers.get("authorization") === `Bearer ${cronSecret}`;

--- a/apps/web/tests/rate-limit-metrics-cron-route.test.ts
+++ b/apps/web/tests/rate-limit-metrics-cron-route.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment node
+ */
+
+const mockCreateRateLimitRedisClient = jest.fn();
+const mockCollectRateLimitMetrics = jest.fn();
+const mockPersistRateLimitMetrics = jest.fn();
+
+jest.mock("@/lib/rateLimitMetrics", () => ({
+    createRateLimitRedisClient: mockCreateRateLimitRedisClient,
+    collectRateLimitMetrics: mockCollectRateLimitMetrics,
+    persistRateLimitMetrics: mockPersistRateLimitMetrics,
+}));
+
+import { NextRequest } from "next/server";
+import { GET } from "../app/api/cron/rate-limit-metrics/route";
+
+describe("GET /api/cron/rate-limit-metrics", () => {
+    const originalCronSecret = process.env.CRON_SECRET;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        process.env.CRON_SECRET = "test-cron-secret";
+    });
+
+    afterEach(() => {
+        if (originalCronSecret === undefined) {
+            delete process.env.CRON_SECRET;
+        } else {
+            process.env.CRON_SECRET = originalCronSecret;
+        }
+    });
+
+    it("returns 401 when the authorization header is missing", async () => {
+        const response = await GET(new NextRequest("http://localhost/api/cron/rate-limit-metrics"));
+
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+        expect(mockCreateRateLimitRedisClient).not.toHaveBeenCalled();
+        expect(mockCollectRateLimitMetrics).not.toHaveBeenCalled();
+        expect(mockPersistRateLimitMetrics).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when the bearer token is incorrect", async () => {
+        const response = await GET(
+            new NextRequest("http://localhost/api/cron/rate-limit-metrics", {
+                headers: {
+                    authorization: "Bearer wrong-secret",
+                },
+            })
+        );
+
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+        expect(mockCreateRateLimitRedisClient).not.toHaveBeenCalled();
+        expect(mockCollectRateLimitMetrics).not.toHaveBeenCalled();
+        expect(mockPersistRateLimitMetrics).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when CRON_SECRET is unset", async () => {
+        delete process.env.CRON_SECRET;
+
+        const response = await GET(
+            new NextRequest("http://localhost/api/cron/rate-limit-metrics", {
+                headers: {
+                    authorization: "Bearer test-cron-secret",
+                },
+            })
+        );
+
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+        expect(mockCreateRateLimitRedisClient).not.toHaveBeenCalled();
+        expect(mockCollectRateLimitMetrics).not.toHaveBeenCalled();
+        expect(mockPersistRateLimitMetrics).not.toHaveBeenCalled();
+    });
+
+    it("allows the existing cron logic to run when the bearer token is correct", async () => {
+        const redis = {};
+        const snapshot = {
+            snapshotId: "snapshot-1",
+            capturedAt: "2026-07-10T00:00:00.000Z",
+            rows: [{ ip_address: "127.0.0.1" }],
+            totalRejections: 3,
+            otpMetrics: {
+                totalHits: 1,
+                blocked: 1,
+            },
+            scannedKeys: 2,
+            truncated: false,
+        };
+
+        mockCreateRateLimitRedisClient.mockReturnValue(redis);
+        mockCollectRateLimitMetrics.mockResolvedValue(snapshot);
+        mockPersistRateLimitMetrics.mockResolvedValue(undefined);
+
+        const response = await GET(
+            new NextRequest("http://localhost/api/cron/rate-limit-metrics", {
+                headers: {
+                    authorization: "Bearer test-cron-secret",
+                },
+            })
+        );
+
+        await expect(response.json()).resolves.toEqual({
+            ok: true,
+            snapshotId: snapshot.snapshotId,
+            capturedAt: snapshot.capturedAt,
+            persisted: snapshot.rows.length,
+            totalRejections: snapshot.totalRejections,
+            otpMetrics: snapshot.otpMetrics,
+            scannedKeys: snapshot.scannedKeys,
+            truncated: snapshot.truncated,
+        });
+        expect(response.status).toBe(200);
+        expect(mockCreateRateLimitRedisClient).toHaveBeenCalledTimes(1);
+        expect(mockCollectRateLimitMetrics).toHaveBeenCalledWith(redis);
+        expect(mockPersistRateLimitMetrics).toHaveBeenCalledWith(snapshot);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #3425**
* **Summary:**

  * Secured the Vercel cron route at `apps/web/app/api/cron/rate-limit-metrics/route.ts`.
  * Removed the non-production authorization bypass by requiring `CRON_SECRET` to be present for all environments.
  * Ensured requests are authorized only when the `Authorization` header exactly matches `Bearer ${process.env.CRON_SECRET}`.
  * Added focused tests covering:

    * Missing authorization header (`401`)
    * Invalid bearer token (`401`)
    * Missing `CRON_SECRET` (`401`)
    * Valid bearer token allowing the existing cron logic to execute
  * Verified that unauthorized requests do not reach the rate-limit metrics collection logic.

## 📸 Proof of Work (Screenshots / Logs)

```text
> npm.cmd test -- --runTestsByPath tests/rate-limit-metrics-cron-route.test.ts

PASS tests/rate-limit-metrics-cron-route.test.ts

GET /api/cron/rate-limit-metrics
√ returns 401 when the authorization header is missing
√ returns 401 when the bearer token is incorrect
√ returns 401 when CRON_SECRET is unset
√ allows the existing cron logic to run when the bearer token is correct

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
```

## 🏷️ PR Type

* [ ] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [x] 🧪 `type: testing`
* [x] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3425`)
* [x] I have pulled the latest `main` and resolved any conflicts