### PR TITLE
refactor(#3418): add multi-channel ETL alert dispatcher

### DIFF
--- a/apps/etl/run_all.py
+++ b/apps/etl/run_all.py
@@ -34,10 +34,7 @@ import argparse
 import asyncio
 import sys
 from pathlib import Path
-import os
-import sys
 import requests
-from src.utils.logger import logger
 
 # Allow running as `python run_all.py` from apps/etl/
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -47,6 +44,7 @@ from src.scrapers.commercial_medicine import CommercialMedicineScraper, Commerci
 from src.scrapers.cdsco import CDSCOScraper
 from src.validators.cdsco_validator import CDSCOValidator
 from src.loaders.supabase_loader import SupabaseLoader
+from src.utils.alert_dispatcher import dispatch_alerts, format_slack_summary
 from src.utils.logger import logger
 import pandas as pd
 
@@ -239,55 +237,6 @@ async def run(
     _summary(stats)
     return stats
 
-# ── NEW NOTIFICATION HELPERS ──────────────────────────────────────────────────
-def send_slack_notification(summary_text: str):
-    """
-    Configurable webhook ke through notification dispatch karta hai.
-    """
-    webhook_url = os.getenv("SLACK_WEBHOOK_URL")
-    if not webhook_url:
-        logger.warning("[Notifier] SLACK_WEBHOOK_URL nahi mila. Notification skip ho rahi hai.")
-        return
-
-    payload = {"text": summary_text}
-    try:
-        response = requests.post(
-            webhook_url, 
-            json=payload,
-            headers={"Content-Type": "application/json"},
-            timeout=10
-        )
-        if response.status_code not in (200, 204):
-            logger.error(f"[Notifier] Webhook returned status {response.status_code}: {response.text}")
-        else:
-            logger.info("[Notifier] ETL summary notification successfully send ho gayi.")
-    except Exception as e:
-        logger.error(f"[Notifier] Webhook notification bhejte waqt error aaya: {e}")
-
-
-def format_slack_summary(pipeline_name: str, stats: dict, status_type: str = "COMPLETED") -> str:
-    """
-    ETL stats ko clear markdown notification message me format karta hai.
-    """
-    emoji = "⚠️" if stats.get("failed", 0) > 0 else "✅"
-    if status_type == "CRASHED":
-        emoji = "🚨"
-
-    msg = (
-        f"{emoji} *SahiDawa ETL Run Summary* [{pipeline_name.upper()}]\n"
-        f"• *Status:* {status_type}\n"
-        f"• *Total Rows Processed:* {stats.get('total', 0)}\n"
-        f"• *Successfully Loaded:* {stats.get('inserted', 0)}\n"
-        f"• *Failed Rows:* {stats.get('failed', 0)}\n"
-        f"• *Success Rate:* {stats.get('success_rate', 100.0)}%\n"
-    )
-    
-    if stats.get("error_counts"):
-        msg += f"• *Error Summary:* `{stats['error_counts']}`\n"
-        
-    return msg
-
-
 def _banner(title: str) -> None:
     line = "=" * 60
     logger.info(f"\n{line}\n  {title}\n{line}")
@@ -354,7 +303,7 @@ if __name__ == "__main__":
         if isinstance(result, dict) and result.get("failed", 0) > 0:
             status = "RETRY_PARTIAL_FAILURE" if args.retry_failed else "PARTIAL_FAILURE"
             summary_msg = format_slack_summary(PIPELINE_NAME, result, status_type=status)
-            send_slack_notification(summary_msg)
+            dispatch_alerts(summary_msg)
 
         if result is False:
             sys.exit(1)
@@ -370,5 +319,5 @@ if __name__ == "__main__":
         summary_msg = format_slack_summary(PIPELINE_NAME, crash_stats, status_type="CRASHED")
         summary_msg += f"\n*Fatal Exception details:* `{str(fatal_error)[:200]}`"
         
-        send_slack_notification(summary_msg)
+        dispatch_alerts(summary_msg)
         sys.exit(1)

--- a/apps/etl/src/utils/alert_dispatcher.py
+++ b/apps/etl/src/utils/alert_dispatcher.py
@@ -1,0 +1,93 @@
+import os
+from typing import Callable
+
+import requests
+
+from src.utils.logger import logger
+
+REQUEST_TIMEOUT_SECONDS = 10
+
+
+def format_slack_summary(pipeline_name: str, stats: dict, status_type: str = "COMPLETED") -> str:
+    """Format ETL stats using the existing Slack markdown summary."""
+    emoji = "⚠️" if stats.get("failed", 0) > 0 else "✅"
+    if status_type == "CRASHED":
+        emoji = "🚨"
+
+    msg = (
+        f"{emoji} *SahiDawa ETL Run Summary* [{pipeline_name.upper()}]\n"
+        f"• *Status:* {status_type}\n"
+        f"• *Total Rows Processed:* {stats.get('total', 0)}\n"
+        f"• *Successfully Loaded:* {stats.get('inserted', 0)}\n"
+        f"• *Failed Rows:* {stats.get('failed', 0)}\n"
+        f"• *Success Rate:* {stats.get('success_rate', 100.0)}%\n"
+    )
+
+    if stats.get("error_counts"):
+        msg += f"• *Error Summary:* `{stats['error_counts']}`\n"
+
+    return msg
+
+
+def format_discord_summary(summary_text: str) -> dict[str, str]:
+    """Format an ETL summary for a Discord webhook."""
+    return {"content": summary_text}
+
+
+def send_slack_notification(webhook_url: str, summary_text: str) -> bool:
+    """Send an ETL summary to Slack without raising into the pipeline."""
+    payload = {"text": summary_text}
+    try:
+        response = requests.post(
+            webhook_url,
+            json=payload,
+            headers={"Content-Type": "application/json"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+
+        logger.info("[Notifier] ETL summary notification successfully send ho gayi.")
+        return True
+    except Exception as exc:
+        logger.error("[Notifier] Slack webhook notification bhejte waqt error aaya: %s", exc)
+        return False
+
+
+def send_discord_notification(webhook_url: str, summary_text: str) -> bool:
+    """Send an ETL summary to Discord without raising into the pipeline."""
+    try:
+        response = requests.post(
+            webhook_url,
+            json=format_discord_summary(summary_text),
+            headers={"Content-Type": "application/json"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+
+        logger.info("[Notifier] Discord ETL summary notification sent successfully.")
+        return True
+    except Exception as exc:
+        logger.error("[Notifier] Discord webhook notification failed: %s", exc)
+        return False
+
+
+def _configured_channels() -> list[tuple[str, str, Callable[[str, str], bool]]]:
+    channels: list[tuple[str, str, Callable[[str, str], bool]]] = []
+    slack_webhook_url = os.getenv("SLACK_WEBHOOK_URL")
+    discord_webhook_url = os.getenv("DISCORD_WEBHOOK_URL")
+
+    if slack_webhook_url:
+        channels.append(("Slack", slack_webhook_url, send_slack_notification))
+    if discord_webhook_url:
+        channels.append(("Discord", discord_webhook_url, send_discord_notification))
+
+    return channels
+
+
+def dispatch_alerts(summary_text: str) -> None:
+    """Dispatch an ETL summary to every configured alert channel."""
+    for channel_name, webhook_url, send_notification in _configured_channels():
+        try:
+            send_notification(webhook_url, summary_text)
+        except Exception:
+            logger.exception("[Notifier] Failed to dispatch %s ETL alert", channel_name)

--- a/apps/etl/tests/test_alert_dispatcher.py
+++ b/apps/etl/tests/test_alert_dispatcher.py
@@ -1,0 +1,173 @@
+import sys
+from pathlib import Path
+
+import requests
+
+# Ensure src.* imports resolve when running pytest from the repo root or apps/etl/.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.utils import alert_dispatcher
+
+
+class FakeResponse:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} error")
+
+
+def clear_alert_env(monkeypatch):
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    monkeypatch.delenv("DISCORD_WEBHOOK_URL", raising=False)
+
+
+def test_dispatch_alerts_no_channels_configured(monkeypatch):
+    clear_alert_env(monkeypatch)
+    post_calls = []
+
+    monkeypatch.setattr(
+        alert_dispatcher.requests,
+        "post",
+        lambda *args, **kwargs: post_calls.append((args, kwargs)),
+    )
+
+    alert_dispatcher.dispatch_alerts("summary")
+
+    assert post_calls == []
+
+
+def test_dispatch_alerts_slack_only(monkeypatch):
+    clear_alert_env(monkeypatch)
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.example/test")
+    post_calls = []
+
+    def fake_post(*args, **kwargs):
+        post_calls.append((args, kwargs))
+        return FakeResponse()
+
+    monkeypatch.setattr(alert_dispatcher.requests, "post", fake_post)
+
+    alert_dispatcher.dispatch_alerts("etl summary")
+
+    assert len(post_calls) == 1
+    args, kwargs = post_calls[0]
+    assert args == ("https://hooks.slack.example/test",)
+    assert kwargs["json"] == {"text": "etl summary"}
+    assert kwargs["headers"] == {"Content-Type": "application/json"}
+    assert kwargs["timeout"] == alert_dispatcher.REQUEST_TIMEOUT_SECONDS
+
+
+def test_dispatch_alerts_discord_only(monkeypatch):
+    clear_alert_env(monkeypatch)
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.example/webhook")
+    post_calls = []
+
+    def fake_post(*args, **kwargs):
+        post_calls.append((args, kwargs))
+        return FakeResponse(204)
+
+    monkeypatch.setattr(alert_dispatcher.requests, "post", fake_post)
+
+    alert_dispatcher.dispatch_alerts("etl summary")
+
+    assert len(post_calls) == 1
+    args, kwargs = post_calls[0]
+    assert args == ("https://discord.example/webhook",)
+    assert kwargs["json"] == {"content": "etl summary"}
+    assert kwargs["headers"] == {"Content-Type": "application/json"}
+    assert kwargs["timeout"] == alert_dispatcher.REQUEST_TIMEOUT_SECONDS
+
+
+def test_dispatch_alerts_both_channels(monkeypatch):
+    clear_alert_env(monkeypatch)
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.example/test")
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.example/webhook")
+    post_calls = []
+
+    def fake_post(*args, **kwargs):
+        post_calls.append((args, kwargs))
+        return FakeResponse()
+
+    monkeypatch.setattr(alert_dispatcher.requests, "post", fake_post)
+
+    alert_dispatcher.dispatch_alerts("etl summary")
+
+    assert {call[0][0] for call in post_calls} == {
+        "https://hooks.slack.example/test",
+        "https://discord.example/webhook",
+    }
+
+
+def test_slack_failure_does_not_block_discord(monkeypatch):
+    clear_alert_env(monkeypatch)
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.example/test")
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.example/webhook")
+    post_calls = []
+
+    def fake_post(url, **kwargs):
+        post_calls.append((url, kwargs))
+        if "slack" in url:
+            raise requests.RequestException("slack unavailable")
+        return FakeResponse()
+
+    monkeypatch.setattr(alert_dispatcher.requests, "post", fake_post)
+
+    alert_dispatcher.dispatch_alerts("etl summary")
+
+    assert {call[0] for call in post_calls} == {
+        "https://hooks.slack.example/test",
+        "https://discord.example/webhook",
+    }
+
+
+def test_discord_failure_does_not_raise(monkeypatch):
+    clear_alert_env(monkeypatch)
+    monkeypatch.setenv("DISCORD_WEBHOOK_URL", "https://discord.example/webhook")
+
+    def fake_post(*_args, **_kwargs):
+        raise requests.RequestException("discord unavailable")
+
+    monkeypatch.setattr(alert_dispatcher.requests, "post", fake_post)
+
+    alert_dispatcher.dispatch_alerts("etl summary")
+
+
+def test_format_slack_summary_includes_existing_summary_fields():
+    message = alert_dispatcher.format_slack_summary(
+        "janaushadhi",
+        {
+            "total": 10,
+            "inserted": 8,
+            "failed": 2,
+            "success_rate": 80.0,
+            "error_counts": {"ValidationError": 2},
+        },
+        status_type="PARTIAL_FAILURE",
+    )
+
+    assert message.startswith("⚠️ *SahiDawa ETL Run Summary*")
+    assert "• *Status:* PARTIAL_FAILURE" in message
+    assert "*SahiDawa ETL Run Summary* [JANAUSHADHI]" in message
+    assert "*Status:* PARTIAL_FAILURE" in message
+    assert "*Total Rows Processed:* 10" in message
+    assert "*Successfully Loaded:* 8" in message
+    assert "*Failed Rows:* 2" in message
+    assert "*Success Rate:* 80.0%" in message
+    assert "*Error Summary:* `{'ValidationError': 2}`" in message
+
+
+def test_format_slack_summary_uses_success_and_crashed_symbols():
+    success_message = alert_dispatcher.format_slack_summary(
+        "janaushadhi",
+        {"total": 1, "inserted": 1, "failed": 0},
+    )
+    crashed_message = alert_dispatcher.format_slack_summary(
+        "janaushadhi",
+        {"total": 0, "inserted": 0, "failed": 1},
+        status_type="CRASHED",
+    )
+
+    assert success_message.startswith("✅ *SahiDawa ETL Run Summary*")
+    assert crashed_message.startswith("🚨 *SahiDawa ETL Run Summary*")


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #3418**
* **Summary:**

  * Added a new ETL alert dispatcher module at `apps/etl/src/utils/alert_dispatcher.py`.
  * Moved Slack notification formatting and delivery logic out of `apps/etl/run_all.py`.
  * Added support for dynamic multi-channel dispatch using environment variables:

    * `SLACK_WEBHOOK_URL`
    * `DISCORD_WEBHOOK_URL`
  * Implemented independent per-channel error handling so webhook failures do not interrupt ETL execution.
  * Updated `run_all.py` to use the centralized dispatcher instead of hardcoded Slack notifications.
  * Added tests covering Slack-only, Discord-only, dual-channel dispatch, missing configuration, webhook failures, and summary formatting behavior.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Validation Performed

```text
git diff --check
✔ Passed

Python syntax compilation
✔ Passed for:
- apps/etl/run_all.py
- apps/etl/src/utils/alert_dispatcher.py
- apps/etl/tests/test_alert_dispatcher.py
```

### Notes

```text
Pytest execution could not be completed locally because the available
Python environment does not have the existing `requests` dependency
installed. Focused unit tests were added and verified through static
validation and syntax compilation.
```

## 🏷️ PR Type

* [ ] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [x] ♻️ `type: refactor`
* [x] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #123`)
* [x] I have pulled the latest `main` and resolved any conflicts