### PR TITLE
Feat : Added Rate Limiting/Semaphore to ETL CDSCO ThreadPoolExecutor#3440

### DIFF
--- a/apps/etl/src/scrapers/cdsco.py
+++ b/apps/etl/src/scrapers/cdsco.py
@@ -14,6 +14,7 @@ PIPELINE ROLE:
 import os
 import sys
 import time
+import threading
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -35,6 +36,29 @@ SEEDS_DIR = Path(__file__).resolve().parents[4] / "data" / "seeds"
 REFERENCE_CSV = SEEDS_DIR / "cdsco_reference.csv"
 
 
+# ── Rate Limiter ───────────────────────────────────────────────────────────────
+
+class RateLimiter:
+    """Thread-safe rate limiter to enforce max N requests per period."""
+    def __init__(self, max_requests: int, period: float):
+        self.max_requests = max_requests
+        self.period = period
+        self.requests = []
+        self.lock = threading.Lock()
+
+    def wait(self):
+        while True:
+            with self.lock:
+                now = time.time()
+                # Remove requests older than the period
+                self.requests = [t for t in self.requests if now - t < self.period]
+                if len(self.requests) < self.max_requests:
+                    self.requests.append(now)
+                    return
+                # Calculate time to wait until the oldest request in the window expires
+                sleep_time = self.period - (now - self.requests[0])
+            time.sleep(sleep_time)
+
 # ── Scraper ────────────────────────────────────────────────────────────────────
 
 class CDSCOScraper:
@@ -48,12 +72,14 @@ class CDSCOScraper:
         retries = Retry(
             total=5,
             backoff_factor=1,
-            status_forcelist=[500, 502, 503, 504],
+            status_forcelist=[429, 500, 502, 503, 504],
             allowed_methods=["GET"]
         )
         adapter = HTTPAdapter(max_retries=retries)
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
+        # Limit to 5 requests per second to avoid being blocked by CDSCO
+        self.rate_limiter = RateLimiter(max_requests=5, period=1.0)
 
     def _fetch_single_page(self, page_num: int, display_start: int, page_size: int) -> list:
         paginated_url = f"{CDSCO_URL}&iDisplayStart={display_start}&iDisplayLength={page_size}"
@@ -62,6 +88,7 @@ class CDSCOScraper:
         page_response = None
         for attempt in range(1, 4):
             try:
+                self.rate_limiter.wait()
                 page_response = self.session.get(paginated_url, timeout=30)
                 if page_response.status_code == 200:
                     break


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3440 **
- **Summary:**
- Implemented a thread-safe sliding window rate-limiter using `threading.Lock()` that restricts the scraper to a maximum of 5 requests per second across all threads. This enforces a strict delay between request batches.
- Instantiated the rate limiter in `CDSCOScraper.__init__` and placed `self.rate_limiter.wait()` right before `self.session.get()` inside the `_fetch_single_page `function.
- Updated the Retry configuration in the `HTTPAdapter` to include the `429 (Too Many Requests)` status code in its `status_forcelist`. Because `backoff_factor=1` is already present, urllib3 will natively apply an exponential backoff curve and also respect any Retry-After headers if the server sends them.
## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
