### PR TITLE
Feat :  Wired homepage search into the existing offline queue#3437

### DIFF
--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-// TODO: Add offline queue logic
-
 import { MedicineSafetyPanel } from "@/components/medicine";
 import React, { useEffect, useState } from "react";
+import { useOfflineStatus } from "@/hooks/useOfflineStatus";
+import { usePendingSearchQueue } from "@/hooks/usePendingSearchQueue";
+import { addToSearchQueue } from "@/lib/db/searchQueue";
+import { PendingSearchQueue } from "@/components/SearchBar/PendingSearchQueue";
 import {
     Camera,
     Mic,
@@ -91,6 +93,29 @@ export default function SahiDawaHome() {
     const [loading, setLoading] = useState<boolean>(true);
     const [activeSearchQuery, setActiveSearchQuery] = useState<string>("");
 
+    const { isOffline } = useOfflineStatus();
+    const {
+        pendingSearches,
+        isSyncing,
+        refresh: refreshSearchQueue,
+    } = usePendingSearchQueue((query) => {
+        setActiveSearchQuery(query);
+    });
+
+    const handleSearchSubmit = async (query: string) => {
+        if (!query) {
+            setActiveSearchQuery("");
+            return;
+        }
+
+        if (isOffline) {
+            await addToSearchQueue(query);
+            await refreshSearchQueue();
+        } else {
+            setActiveSearchQuery(query);
+        }
+    };
+
     // 1. Define the predictive query layer
     const prefetchAlertsData = async () => {
         try {
@@ -169,7 +194,8 @@ export default function SahiDawaHome() {
 
                     {/* Search Bar */}
                     <div className="mx-auto w-full max-w-2xl pt-2">
-                        <SearchBar onSearchChange={(query) => setActiveSearchQuery(query)} />
+                        <PendingSearchQueue pending={pendingSearches} isSyncing={isSyncing} />
+                        <SearchBar onSearchChange={handleSearchSubmit} />
                     </div>
 
                     {/* Medicine Safety Panel — shown inline on home page, NO redirect */}

--- a/apps/web/components/SearchBar/PendingSearchQueue.tsx
+++ b/apps/web/components/SearchBar/PendingSearchQueue.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Clock, Search } from "lucide-react";
+import type { QueuedSearch } from "@/lib/db/searchQueue";
+import { useTranslations } from "next-intl";
+
+export function PendingSearchQueue({
+    pending,
+    isSyncing,
+}: {
+    pending: QueuedSearch[];
+    isSyncing?: boolean;
+}) {
+    const t = useTranslations("ScanQueue"); // Reusing ScanQueue translations for stylistic consistency
+
+    if (pending.length === 0) return null;
+
+    return (
+        <section
+            aria-label="Pending Searches"
+            className="mx-auto mb-4 w-full max-w-2xl rounded-2xl border border-blue-500/30 bg-blue-500/10 p-4 text-(--color-text-primary)"
+        >
+            <div className="mb-3 flex items-center justify-between gap-2">
+                <div>
+                    <h2 className="text-sm font-bold text-blue-700 dark:text-blue-300">
+                        Queued Searches
+                    </h2>
+                    <p className="text-xs text-blue-800/80 dark:text-blue-200/80">
+                        Will execute when you are back online
+                    </p>
+                </div>
+                {isSyncing && (
+                    <span className="rounded-full bg-blue-500/20 px-2 py-1 text-xs font-semibold text-blue-800 dark:text-blue-200">
+                        Syncing...
+                    </span>
+                )}
+            </div>
+
+            <ul className="space-y-2">
+                {pending.map((item) => (
+                    <li
+                        key={item.id}
+                        className="flex items-center justify-between gap-3 rounded-xl bg-white/70 px-3 py-2 text-sm dark:bg-black/20"
+                    >
+                        <span className="flex items-center gap-2 truncate font-mono font-medium">
+                            <Search size={14} className="text-blue-500" />
+                            {item.query}
+                        </span>
+                        <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-blue-500/20 px-2 py-0.5 text-xs font-semibold text-blue-800 dark:text-blue-200">
+                            <Clock size={12} />
+                            Pending
+                        </span>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    );
+}

--- a/apps/web/hooks/usePendingSearchQueue.ts
+++ b/apps/web/hooks/usePendingSearchQueue.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { getSearchQueue, type QueuedSearch, clearSearchQueue } from "@/lib/db/searchQueue";
+import { toast } from "sonner";
+
+export function usePendingSearchQueue(onSync?: (query: string) => void) {
+    const [pendingSearches, setPendingSearches] = useState<QueuedSearch[]>([]);
+    const [isSyncing, setIsSyncing] = useState(false);
+
+    const refresh = useCallback(async () => {
+        setPendingSearches(await getSearchQueue());
+    }, []);
+
+    useEffect(() => {
+        void refresh();
+
+        const handleOnline = async () => {
+            setIsSyncing(true);
+            const currentQueue = await getSearchQueue();
+            if (currentQueue.length > 0) {
+                // Sort by most recent first
+                const sorted = currentQueue.sort((a, b) => b.timestamp - a.timestamp);
+                const mostRecent = sorted[0];
+
+                if (onSync) {
+                    onSync(mostRecent.query);
+                }
+
+                toast.success(`Restored queued search: "${mostRecent.query}"`);
+
+                await clearSearchQueue();
+                void refresh();
+            }
+            setIsSyncing(false);
+        };
+
+        window.addEventListener("online", handleOnline);
+
+        return () => {
+            window.removeEventListener("online", handleOnline);
+        };
+    }, [refresh, onSync]);
+
+    return { pendingSearches, isSyncing, refresh };
+}

--- a/apps/web/lib/db/searchQueue.ts
+++ b/apps/web/lib/db/searchQueue.ts
@@ -1,0 +1,53 @@
+import { openDB, IDBPDatabase } from "idb";
+
+export interface QueuedSearch {
+    id: string;
+    query: string;
+    timestamp: number;
+}
+
+const DB_NAME = "sahidawa-offline-search";
+const STORE_NAME = "search-queue";
+
+let dbPromise: Promise<IDBPDatabase<any>> | null = null;
+
+if (typeof window !== "undefined") {
+    dbPromise = openDB(DB_NAME, 1, {
+        upgrade(db) {
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                db.createObjectStore(STORE_NAME, { keyPath: "id" });
+            }
+        },
+    });
+}
+
+export async function addToSearchQueue(query: string): Promise<QueuedSearch> {
+    if (!dbPromise) throw new Error("IndexedDB not available");
+    const db = await dbPromise;
+
+    const item: QueuedSearch = {
+        id: crypto.randomUUID(),
+        query,
+        timestamp: Date.now(),
+    };
+    await db.put(STORE_NAME, item);
+    return item;
+}
+
+export async function getSearchQueue(): Promise<QueuedSearch[]> {
+    if (!dbPromise) return [];
+    const db = await dbPromise;
+    return db.getAll(STORE_NAME);
+}
+
+export async function removeFromSearchQueue(id: string): Promise<void> {
+    if (!dbPromise) return;
+    const db = await dbPromise;
+    await db.delete(STORE_NAME, id);
+}
+
+export async function clearSearchQueue(): Promise<void> {
+    if (!dbPromise) return;
+    const db = await dbPromise;
+    await db.clear(STORE_NAME);
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3437 **
- **Summary:**
- Inside `SearchBar.tsx`, the component correctly handles offline states by gracefully preventing network fetch attempts for suggestions. The submission logic in `page.tsx` now actively checks `isOffline` using SahiDawa's existing `useOfflineStatus` hook. If you are offline, it stops the UI from attempting to mount the `MedicineSafetyPanel` (which would otherwise trigger failing network requests) and instead routes the query to the offline queue.
- Created `lib/db/searchQueue.ts`. This uses the exact same underlying `idb `offline storage primitive (IndexedDB) as `syncQueue.ts` but isolates search data to a sahidawa-offline-search database.
- Additionally, the `<PendingSearchQueue />` component is injected right above the `SearchBar`. It perfectly mimics the existing `<PendingScanQueue />` UI, providing clear, consistent visual feedback (e.g. "Queued Searches — Will execute when you are back online") as soon as an offline search is submitted.
- The new `usePendingSearchQueue` hook actively listens for the window online event (the same pattern used by `usePendingScanQueue`). When connectivity is restored, it flushes the queue, grabs the most recent search attempt, surfaces a success toast notification, and automatically triggers the homepage's `activeSearchQuery` state. This seamlessly opens the `MedicineSafetyPanel` with their results exactly as if they had just searched for it.
- The `handleSearchSubmit` wrapper in `page.tsx` explicitly checks if `(isOffline)`. If `isOffline is false`, it proceeds to call `setActiveSearchQuery(query)` immediately, which is the exact same, untouched code path that existed before this change
## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
