### PR TITLE
fix: move cron startup into job scheduler

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -16,8 +16,6 @@ import medicineSchedulesRouter from "./routes/medicineSchedules";
 
 import abhaRoutes from "./routes/abha";
 import trackingRouter from "./routes/tracking";
-import { initExpiryCron } from "./cron/expiry-check";
-import { initDistrictAlertSyncCron } from "./cron/districtAlertSync";
 // ── Environment Configuration ──────────────────────────────────────────────
 const rootEnvPath = path.resolve(__dirname, "../../../.env");
 dotenv.config({ path: rootEnvPath });
@@ -92,8 +90,6 @@ app.use(requestIdMiddleware);
 app.use(httpsRedirect);
 
 app.use(compression());
-initExpiryCron();
-initDistrictAlertSyncCron();
 // ── Global Middleware Configuration ───────────────────────────────────────
 app.use(cookieParser());
 

--- a/apps/api/src/cron/districtAlertSync.ts
+++ b/apps/api/src/cron/districtAlertSync.ts
@@ -131,9 +131,9 @@ export async function syncDistrictAlertTallies(): Promise<void> {
     }
 }
 
-export const initDistrictAlertSyncCron = (): void => {
+export const initDistrictAlertSyncCron = (): { stop: () => void } => {
     // Runs every 6 hours
-    cron.schedule("0 */6 * * *", async () => {
+    const task = cron.schedule("0 */6 * * *", async () => {
         try {
             await syncDistrictAlertTallies();
         } catch (err) {
@@ -144,4 +144,5 @@ export const initDistrictAlertSyncCron = (): void => {
         }
     });
     logger.info("District alert tally sync cron initialized (every 6 hours)");
+    return task;
 };

--- a/apps/api/src/cron/expiry-check.ts
+++ b/apps/api/src/cron/expiry-check.ts
@@ -72,9 +72,9 @@ function buildExpiryPayload(medicineName: string, daysLeft: number) {
     };
 }
 
-export const initExpiryCron = () => {
+export const initExpiryCron = (): { stop: () => void } => {
     // Runs every day at 00:00 (midnight)
-    cron.schedule("0 0 * * *", async () => {
+    return cron.schedule("0 0 * * *", async () => {
         const acquired = await acquireLock();
 
         if (!acquired) {

--- a/apps/api/src/services/jobScheduler.service.ts
+++ b/apps/api/src/services/jobScheduler.service.ts
@@ -1,6 +1,8 @@
 import logger from "../utils/logger";
 import { startAlertBroadcaster } from "../cron/alert-broadcaster";
 import { startTempCleanupJob } from "../cron/tempCleanup";
+import { initExpiryCron } from "../cron/expiry-check";
+import { initDistrictAlertSyncCron } from "../cron/districtAlertSync";
 
 interface StoppableJob {
     stop: () => void;
@@ -10,8 +12,15 @@ class JobScheduler {
     private jobs: StoppableJob[] = [];
 
     public start(): void {
+        if (this.jobs.length > 0) {
+            logger.warn("Background jobs are already running.");
+            return;
+        }
+
         this.jobs.push(startAlertBroadcaster());
         this.jobs.push(startTempCleanupJob());
+        this.jobs.push(initExpiryCron());
+        this.jobs.push(initDistrictAlertSyncCron());
         logger.info("All background jobs have been started.");
     }
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3470**
- **Summary:**
  - Removes expiry and district-alert cron startup side effects from `apps/api/src/app.ts`.
  - Starts those cron jobs from `jobScheduler.start()` so they run only after the API startup path finishes Redis/cache initialization.
  - Registers the cron tasks with the scheduler so shutdown can stop them consistently.
  - Adds a guard to avoid starting duplicate background jobs if `jobScheduler.start()` is called more than once.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

Local tests were skipped as requested. Verified branch scope with `git diff --stat upstream/main...HEAD`:

```text
apps/api/src/app.ts                           | 4 ----
apps/api/src/cron/districtAlertSync.ts        | 5 +++--
apps/api/src/cron/expiry-check.ts             | 6 +++---
apps/api/src/services/jobScheduler.service.ts | 9 +++++++++
4 files changed, 15 insertions(+), 9 deletions(-)
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
