### PR TITLE
feat(map): add aria-labels to Leaflet map markers

### DIFF
--- a/apps/web/app/[locale]/map/PharmacyMap.tsx
+++ b/apps/web/app/[locale]/map/PharmacyMap.tsx
@@ -312,9 +312,24 @@ export default function PharmacyMap({
                 popupAnchor: [0, -36],
             });
 
+            const ashaLabel = worker.district
+                ? `ASHA Worker: ${worker.name}, ${worker.district}`
+                : `ASHA Worker: ${worker.name}`;
+
             const marker = L.marker([worker.coordinates.lat, worker.coordinates.lng], {
                 icon: customIcon,
+                keyboard: true,
+                title: ashaLabel,
             }).addTo(ashaLayerGroup.current);
+
+            // Expose the marker to assistive tech: the pin opens a popup on
+            // click/Enter, so role="button" + an accessible name lets screen
+            // readers announce it as actionable instead of an unlabelled graphic.
+            const ashaEl = marker.getElement();
+            if (ashaEl) {
+                ashaEl.setAttribute("role", "button");
+                ashaEl.setAttribute("aria-label", ashaLabel);
+            }
 
             const popupContent = `
         <div style="
@@ -493,9 +508,27 @@ export default function PharmacyMap({
                 });
             }
 
+            const pharmacyKind = isVerified
+                ? "Verified pharmacy"
+                : isGovt
+                  ? "Government pharmacy"
+                  : "Pharmacy";
+            const pharmacyLabel = `${pharmacyKind}: ${pharmacy.name}`;
+
             const marker = L.marker([pharmacy.coordinates.lat, pharmacy.coordinates.lng], {
                 icon: customMarker,
+                keyboard: true,
+                title: pharmacyLabel,
             }).addTo(layerGroup.current);
+
+            // Announce the pin to screen readers with the pharmacy name and its
+            // verification status, mirroring what a sighted user sees from the
+            // marker colour/badge. role="button" because the pin opens a popup.
+            const pharmacyEl = marker.getElement();
+            if (pharmacyEl) {
+                pharmacyEl.setAttribute("role", "button");
+                pharmacyEl.setAttribute("aria-label", pharmacyLabel);
+            }
 
             // Store reference for programmatic access
             markersRef.current.set(pharmacy.id, marker);
@@ -727,7 +760,15 @@ export default function PharmacyMap({
         userMarker.current = L.marker([userLocation.lat, userLocation.lng], {
             icon: userIcon,
             zIndexOffset: 1000,
+            keyboard: true,
+            title: "Your location",
         }).addTo(map.current);
+
+        const userEl = userMarker.current.getElement();
+        if (userEl) {
+            userEl.setAttribute("role", "img");
+            userEl.setAttribute("aria-label", "Your location");
+        }
 
         map.current.flyTo([userLocation.lat, userLocation.lng], 14, {
             duration: 1,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3116**
- **Summary:**
  Every Leaflet marker on the map was an unlabeled `<div>`, so a screen reader announced all of them the same way and gave no idea which pin was which. This adds an `aria-label` to the three marker types in `PharmacyMap.tsx`:

  - Pharmacies: `"Verified pharmacy: Apollo Pharmacy"` / `"Government pharmacy: ..."` / `"Pharmacy: ..."`, depending on the flags already on the record.
  - ASHA workers: `"ASHA Worker: <name>, <district>"`.
  - The user's own location pin: `"Your location"`.

  Pharmacy and ASHA pins also get `role="button"` and `keyboard: true`, because clicking them opens a popup, so they should be reachable by Tab and Enter. The location pin isn't interactive, so it gets `role="img"` instead. I set a matching `title` too, which gives the hover tooltip for free.

  Attributes are applied with `setAttribute` on `marker.getElement()` right after `addTo`, not by building the label into the icon HTML. Pharmacy names come from Overpass, so some of them contain quotes and apostrophes, and `setAttribute` keeps that safe without needing to escape anything.

  One thing worth flagging: the labels are English. The popup content in this same file is hardcoded English too, so I kept the two consistent rather than half-translating the map. Happy to move both through `next-intl` in a follow-up if you'd like that as a separate issue.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

This is an attribute-only change, so the map looks exactly the same as before. To make the change actually visible I ran the map locally, pulled the real markup back out of the DOM, and drew it on top of the screenshot. The highlighted pin (red outline) is the one being described:

![sahidawa-map-aria-labels-proof.png](https://github.com/user-attachments/assets/3a93a6b9-e2ec-40fa-b4db-a32a15c7c58a)

The map itself, unchanged, with 205 live pharmacies loaded from Overpass around Delhi:

![sahidawa-map-aria-labels.png](https://github.com/user-attachments/assets/24f424a9-22c6-434d-a1ce-fc4bfd55f6bf)

Counted straight from the rendered page: **205 markers, 205 with an `aria-label`**, none missed. Rendered markup for a pharmacy pin:

```html
<div class="leaflet-marker-icon ..." tabindex="0" role="button"
     title="Pharmacy: R. K. Health Care"
     aria-label="Pharmacy: R. K. Health Care">
```

Checks run:

```bash
npx prettier --check 'apps/web/app/[locale]/map/PharmacyMap.tsx'   # passes
npx tsc --noEmit                                                   # no errors in PharmacyMap.tsx
```

The repo has some pre-existing TS errors in files I didn't touch. I left those alone.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [x] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3116`)
- [x] I have pulled the latest `main` and resolved any conflicts
