### PR TITLE
feat(ml): add POST /triage/clear endpoint for session reset

### DIFF
--- a/apps/ml/routers/triage.py
+++ b/apps/ml/routers/triage.py
@@ -7,7 +7,7 @@ import uuid
 
 
 from starlette.concurrency import run_in_threadpool
-from services.triage_graph import run_triage_flow
+from services.triage_graph import run_triage_flow, clear_session
 from utils.rate_limiter import RateLimiter  
 
 router = APIRouter(prefix="/triage", tags=["Triage"])
@@ -60,6 +60,23 @@ class TriageResponse(BaseModel):
         ...,
         description="Session ID for this triage conversation. Pass this back in "
         "subsequent requests to preserve context across turns.",
+    )
+
+
+class ClearSessionRequest(BaseModel):
+    session_id: str = Field(
+        ...,
+        min_length=1,
+        description="The session ID whose persisted triage state should be deleted.",
+    )
+
+
+class ClearSessionResponse(BaseModel):
+    session_id: str = Field(..., description="The session ID that was requested to clear.")
+    cleared: bool = Field(
+        ...,
+        description="True if a stored session was found and removed; False if there "
+        "was nothing to clear (unknown or already-expired session).",
     )
 
 
@@ -119,3 +136,34 @@ async def triage_chat(payload: TriageRequest):
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Triage service temporarily unavailable. Please try again."
             )
+
+
+# The limiter keys on request path + IP, so /clear gets its own quota bucket
+# and doesn't eat into a client's /chat allowance.
+@router.post(
+    "/clear",
+    response_model=ClearSessionResponse,
+    dependencies=[Depends(triage_limiter)],
+)
+async def triage_clear(payload: ClearSessionRequest):
+    """Deletes a triage session's persisted state from Redis so the user can
+    start fresh without waiting for the 30-minute TTL to expire.
+
+    Clearing an unknown or already-expired session is not an error; the
+    response simply reports cleared=False.
+    """
+    try:
+        cleared = await run_in_threadpool(clear_session, payload.session_id)
+    except Exception as e:
+        logging.error(f"Error clearing triage session '{payload.session_id}': {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not clear the triage session. Please try again.",
+        )
+
+    logging.info(
+        "Clear requested for triage session '%s' (existed=%s)",
+        payload.session_id,
+        cleared,
+    )
+    return ClearSessionResponse(session_id=payload.session_id, cleared=cleared)

--- a/apps/ml/services/triage_graph.py
+++ b/apps/ml/services/triage_graph.py
@@ -64,6 +64,32 @@ async def _save_session_state(session_id: str, state: Dict[str, Any]) -> None:
     except Exception:
         logging.exception("Failed to save triage session '%s' to Redis.", session_id)
 
+
+async def _clear_session_state(session_id: str) -> bool:
+    """Delete a session's persisted triage state from Redis.
+
+    Returns True if a stored session was removed, False if there was nothing
+    to clear (unknown/expired session_id) or the delete failed.
+    """
+    try:
+        removed = await redis_client.delete(_session_key(session_id))
+    except Exception:
+        logging.exception("Failed to clear triage session '%s' from Redis.", session_id)
+        return False
+
+    return bool(removed)
+
+
+def clear_session(session_id: str) -> bool:
+    """Synchronous wrapper around _clear_session_state for the API layer.
+
+    Mirrors how run_triage_flow drives the async session helpers via
+    asyncio.run, so callers running in a threadpool don't need their own
+    event loop plumbing.
+    """
+    return asyncio.run(_clear_session_state(session_id))
+
+
 # Check if LangChain and LangGraph are available
 try:
     from langchain_google_genai import ChatGoogleGenerativeAI

--- a/apps/ml/tests/test_triage_session_persistence.py
+++ b/apps/ml/tests/test_triage_session_persistence.py
@@ -24,6 +24,13 @@ class FakeRedis:
         self.store[key] = value
         return True
 
+    async def delete(self, *keys):
+        removed = 0
+        for key in keys:
+            if self.store.pop(key, None) is not None:
+                removed += 1
+        return removed
+
 
 # ---------------------------------------------------------------------------
 # services.triage_graph — unit-level tests
@@ -75,6 +82,69 @@ def test_load_session_state_redis_error_returns_none(monkeypatch):
 
     # Should not raise — gracefully falls back to a fresh session.
     assert asyncio.run(triage_graph._load_session_state("session-x")) is None
+
+
+def test_clear_session_state_removes_stored_session(monkeypatch):
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(triage_graph, "redis_client", fake_redis)
+
+    asyncio.run(
+        triage_graph._save_session_state(
+            "session-to-clear",
+            {
+                "language": "Tamil",
+                "emergency_detected": False,
+                "collected_info": {"onset": "today"},
+                "retrieved_medicines": [],
+            },
+        )
+    )
+    assert asyncio.run(triage_graph._load_session_state("session-to-clear")) is not None
+
+    removed = asyncio.run(triage_graph._clear_session_state("session-to-clear"))
+
+    assert removed is True
+    # The state should be gone, so a subsequent load starts fresh.
+    assert asyncio.run(triage_graph._load_session_state("session-to-clear")) is None
+
+
+def test_clear_session_state_unknown_session_is_noop(monkeypatch):
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(triage_graph, "redis_client", fake_redis)
+
+    # Clearing a session that was never stored (or already expired) is harmless.
+    assert asyncio.run(triage_graph._clear_session_state("never-existed")) is False
+
+
+def test_clear_session_state_redis_error_returns_false(monkeypatch):
+    class BrokenRedis:
+        async def delete(self, *keys):
+            raise ConnectionError("redis unavailable")
+
+    monkeypatch.setattr(triage_graph, "redis_client", BrokenRedis())
+
+    # A Redis failure must not surface as an exception to the caller.
+    assert asyncio.run(triage_graph._clear_session_state("session-y")) is False
+
+
+def test_clear_session_wrapper_runs_async_helper(monkeypatch):
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(triage_graph, "redis_client", fake_redis)
+
+    asyncio.run(
+        triage_graph._save_session_state(
+            "wrapper-session",
+            {
+                "language": "English",
+                "emergency_detected": False,
+                "collected_info": {},
+                "retrieved_medicines": [],
+            },
+        )
+    )
+
+    assert triage_graph.clear_session("wrapper-session") is True
+    assert triage_graph.clear_session("wrapper-session") is False
 
 
 def test_run_triage_flow_reuses_persisted_state(monkeypatch):
@@ -208,3 +278,76 @@ def test_triage_chat_reuses_supplied_session_id(mock_run_triage):
 
     _, kwargs = mock_run_triage.call_args
     assert kwargs["session_id"] == "existing-session-123"
+
+
+@patch("routers.triage.clear_session")
+def test_triage_clear_removes_existing_session(mock_clear):
+    mock_clear.return_value = True
+
+    response = client.post("/triage/clear", json={"session_id": "existing-session-123"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"session_id": "existing-session-123", "cleared": True}
+    mock_clear.assert_called_once_with("existing-session-123")
+
+
+@patch("routers.triage.clear_session")
+def test_triage_clear_unknown_session_reports_not_cleared(mock_clear):
+    mock_clear.return_value = False
+
+    response = client.post("/triage/clear", json={"session_id": "never-existed"})
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"session_id": "never-existed", "cleared": False}
+
+
+def test_triage_clear_requires_session_id():
+    # Missing session_id fails request validation before touching Redis.
+    response = client.post("/triage/clear", json={})
+    assert response.status_code == 422
+
+    # An empty session_id is likewise rejected by the min_length constraint.
+    response = client.post("/triage/clear", json={"session_id": ""})
+    assert response.status_code == 422
+
+
+def test_triage_clear_is_rate_limited():
+    """/clear sits behind the same per-IP limiter as /chat (5 req/60s)."""
+    from utils.database import get_redis
+
+    class OverLimitPipeline:
+        async def incr(self, key):
+            pass
+
+        async def ttl(self, key):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        async def execute(self):
+            # Simulate a client already past the 5-requests-per-window limit.
+            return [6, 30]
+
+    class OverLimitRedis:
+        def pipeline(self, transaction=True):
+            return OverLimitPipeline()
+
+        async def expire(self, key, seconds):
+            return True
+
+    async def over_limit_redis():
+        return OverLimitRedis()
+
+    app.dependency_overrides[get_redis] = over_limit_redis
+    try:
+        response = client.post("/triage/clear", json={"session_id": "abc"})
+    finally:
+        app.dependency_overrides.pop(get_redis, None)
+
+    assert response.status_code == 429


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3304**
- **Summary:**
  There was no way to end a triage session. The state sat in Redis until it expired on its own, so a user starting a fresh conversation could still be carrying the previous one's context, and there was nothing the frontend could call on "start over".

  This adds `POST /triage/clear`. It takes a `session_id`, deletes that session's state from Redis, and reports whether a session was actually there:

  ```json
  { "session_id": "abc123", "cleared": true }
  ```

  `cleared: false` means there was nothing stored under that ID. The endpoint is idempotent, so clearing twice, or clearing an ID that never existed, is a normal 200 and not an error. That felt right for a "reset" button, which shouldn't fail just because the user pressed it twice.

  The Redis delete goes through `_clear_session_state`, which sits next to the existing load/save helpers and follows the same convention they do: a Redis outage is swallowed and returns `False` rather than 500ing the caller.

  I put the rate limiter on it as well:

  ```python
  dependencies=[Depends(triage_limiter)]
  ```

  `/chat` already had one and `/clear` writes to Redis on every call, so leaving it open would have been an easy way to hammer the instance. The limiter keys on request path plus IP, so `/clear` gets its own bucket and doesn't eat into a client's `/chat` allowance.

  **One thing to confirm before merge:** the router is mounted at `/triage`, not `/api/v1/triage`, so the real path is `POST /triage/clear`. The issue writes it as `/api/v1/triage/clear`. I matched the router that's actually there rather than move the prefix, since changing it would break the existing `/triage/chat` callers. Say the word if you'd rather I add the `/api/v1` prefix across the router and I'll do it in this PR.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

No UI in this one, it's the ML service only. Test coverage, 8 new cases on top of the 8 that were already there:

```bash
cd apps/ml && python -m pytest tests/test_triage_session_persistence.py -q
```

```
................                                                         [100%]
16 passed in 1.51s
```

The new cases cover the clear endpoint end to end: clearing a session that exists, clearing one that doesn't (`cleared: false`), a missing `session_id` giving 422, a Redis failure being handled instead of crashing, and the rate limiter returning 429 once the quota is used up.

The rate-limit test drives it through a fake Redis that reports the client already over the limit, then asserts the endpoint answers 429 rather than touching session state.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3304`)
- [x] I have pulled the latest `main` and resolved any conflicts
