### PR TITLE
test(ml): provide mock GEMINI_API_KEY for pytest in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,10 @@ jobs:
               env:
                   WHISPER_MODEL_SIZE: base
                   PYTHONPATH: ${{ github.workspace }}
+                  # Dummy key so code paths that expect GEMINI_API_KEY (triage
+                  # LLM via get_llm, embeddings via embed_query) don't fail in
+                  # CI. Tests mock the LLM, so no real API call is ever made.
+                  GEMINI_API_KEY: mock_api_key_for_testing
 
     test-docker-builds:
         name: 🐳 Test Docker Builds

--- a/apps/ml/tests/conftest.py
+++ b/apps/ml/tests/conftest.py
@@ -7,6 +7,13 @@ import numpy as np
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Guarantee a GEMINI_API_KEY before the app modules load, so any code path
+# that expects the variable (triage get_llm, embedding embed_query) works in
+# environments without the real secret (CI, fresh local checkouts). Tests mock
+# the LLM, so the placeholder value is never used for a real API call.
+os.environ.setdefault("GEMINI_API_KEY", "mock_api_key_for_testing")
+
 from routers import asr
 
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3158**
- **Summary:**
  The ML test job runs without a `GEMINI_API_KEY`, and anything that reaches `get_llm()` blows up before the test can mock it. This gives pytest a placeholder key in two places:

  - `.github/workflows/test.yml` sets `GEMINI_API_KEY: mock_api_key_for_testing` on the ML test step, next to the `WHISPER_MODEL_SIZE` and `PYTHONPATH` that are already there.
  - `apps/ml/tests/conftest.py` does `os.environ.setdefault(...)` before the app modules import, so a fresh local checkout behaves the same way as CI without anyone having to export anything first.

  `setdefault` and not a plain assignment, so if you do have a real key in your environment it stays untouched and nothing here overwrites it.

  No real API call is ever made. The tests mock the LLM. The key just has to be a non-empty string so the client will construct.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

No UI, this is CI config plus a test fixture.

The failure is in `ChatGoogleGenerativeAI`, which validates the key at construction time. `get_llm()` in `services/triage_graph.py` reads `os.getenv("GEMINI_API_KEY")` and hands the result straight to the constructor, so with no key set it gets `None` and raises before any test mock can intervene. Reproduced locally with the key unset:

```
ValidationError: 1 validation error for ChatGoogleGenerativeAI
  Value error, API key required for Gemini Developer API. Provide api_key
  parameter or set GOOGLE_API_KEY/GEMINI_API_KEY environment variable.
```

With the placeholder key in place, same call, no error:

```
constructed OK -> ChatGoogleGenerativeAI
```

`services/embedding.py` is fine either way, `embed_query` checks the key itself and returns `None` when it's missing. `get_llm` was the one that didn't.

Full ML suite passes on this branch with no `GEMINI_API_KEY` exported.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3158`)
- [x] I have pulled the latest `main` and resolved any conflicts
