### PR TITLE
fix(etl): implement dynamic pagination bounds calculation for cdsco s…

### DIFF
--- a/apps/etl/src/scrapers/cdsco.py
+++ b/apps/etl/src/scrapers/cdsco.py
@@ -14,6 +14,7 @@ PIPELINE ROLE:
 import os
 import sys
 import time
+import math
 import threading
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -124,15 +125,44 @@ class CDSCOScraper:
             logger.info(f"[CDSCO] Reference CSV already exists at {REFERENCE_CSV} — skipping fetch.")
             return REFERENCE_CSV
 
-        logger.info("[CDSCO] Fetching data from portal using parallel threads...")
+        logger.info("[CDSCO] Initializing probe query to determine catalog ceiling dynamically...")
         
-        page_size = 100
-        max_pages = 500  
-        max_workers = 10 
-
+        page_size = 100 
+        max_workers = 10
         all_records_map = {}
-        tasks = [(page_num, (page_num - 1) * page_size, page_size) for page_num in range(1, max_pages + 1)]
+       
+        # Step 1: Probe query to Page 1 to fetch total records metadata
+        try:
+            paginated_url = f"{CDSCO_URL}&iDisplayStart=0&iDisplayLength={page_size}"
+            self.rate_limiter.wait()
+            probe_response = self.session.get(paginated_url, timeout=30)
+            
+            if probe_response.status_code != 200:
+                raise RuntimeError(f"Probe request failed with status code {probe_response.status_code}")
+                
+            probe_data = probe_response.json()
+            
+            # Extract total records from metadata fields (fallback to 0 if not present)
+            total_records = probe_data.get("iTotalDisplayRecords") or probe_data.get("iTotalRecords") or 0
+            
+            if total_records == 0:
+                raise ValueError("Could not extract a valid total record count from CDSCO API metadata metadata fields.")
 
+            # Step 2: Dynamically calculate exact max pages needed
+            max_pages = math.ceil(total_records / page_size)
+            logger.info(f"[CDSCO] Catalog Metadata Detected — Total Records: {total_records}, Dynamic Ceiling: {max_pages} pages.")
+            
+            # Store first page records to avoid duplicate network overhead
+            all_records_map[1] = probe_data.get("aaData", [])
+            
+        except Exception as probe_err:
+            logger.critical(f"[CDSCO] Failed to initiate probe or calculate dynamic pagination bounds: {probe_err}")
+            raise probe_err
+
+        # Step 3: Schedule remaining pages from page 2 onwards
+        logger.info(f"[CDSCO] Fetching remaining {max_pages - 1} pages using parallel threads...")
+        tasks = [(page_num, (page_num - 1) * page_size, page_size) for page_num in range(2, max_pages + 1)]
+        
         try:
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 future_to_page = {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #3485**
* **Summary:**

This PR removes the hardcoded pagination limit from the CDSCO reference data scraper by introducing a lightweight probe request that dynamically determines the total number of available records. The scraper now calculates the required number of pages at runtime and schedules only the necessary requests, eliminating unnecessary network calls while ensuring complete dataset retrieval.

### Changes Made

* Added an initial probe request to fetch pagination metadata from the CDSCO API.
* Dynamically computed the pagination ceiling using `iTotalDisplayRecords` / `iTotalRecords`.
* Replaced the hardcoded `max_pages = 500` with a runtime-calculated value.
* Cached the first page response from the probe request to avoid duplicate network requests.
* Updated thread scheduling to process only the remaining pages.
* Added logging for detected record count and calculated pagination ceiling.
* Preserved the existing parallel fetching logic and output format.

## 📸 Proof of Work (Screenshots / Logs)

### Validation Performed

* ✅ Verified the scraper calculates the page limit dynamically.
* ✅ Confirmed only the required pages are scheduled.
* ✅ Verified the first-page probe response is reused instead of making a duplicate request.
* ✅ Confirmed existing parallel scraping behavior remains unchanged.

*(Attach execution logs or screenshots here.)*

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3485`)
* [x] I have pulled the latest `main` and resolved any conflicts.
