### PR TITLE
feat(web): preserve offline search history

### DIFF
--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -97,6 +97,9 @@ export default function SahiDawaHome() {
     const {
         pendingSearches,
         isSyncing,
+        isLoading: isSearchQueueLoading,
+        executingId,
+        execute: executeQueuedSearch,
         refresh: refreshSearchQueue,
     } = usePendingSearchQueue((query) => {
         setActiveSearchQuery(query);
@@ -194,7 +197,13 @@ export default function SahiDawaHome() {
 
                     {/* Search Bar */}
                     <div className="mx-auto w-full max-w-2xl pt-2">
-                        <PendingSearchQueue pending={pendingSearches} isSyncing={isSyncing} />
+                        <PendingSearchQueue
+                            pending={pendingSearches}
+                            isSyncing={isSyncing}
+                            isLoading={isSearchQueueLoading}
+                            executingId={executingId}
+                            onExecute={executeQueuedSearch}
+                        />
                         <SearchBar onSearchChange={handleSearchSubmit} />
                     </div>
 

--- a/apps/web/components/SearchBar/PendingSearchQueue.tsx
+++ b/apps/web/components/SearchBar/PendingSearchQueue.tsx
@@ -2,19 +2,20 @@
 
 import { Clock, Search } from "lucide-react";
 import type { QueuedSearch } from "@/lib/db/searchQueue";
-import { useTranslations } from "next-intl";
 
 export function PendingSearchQueue({
     pending,
     isSyncing,
+    isLoading,
+    executingId,
+    onExecute,
 }: {
     pending: QueuedSearch[];
     isSyncing?: boolean;
+    isLoading?: boolean;
+    executingId?: string | null;
+    onExecute: (item: QueuedSearch) => void | Promise<unknown>;
 }) {
-    const t = useTranslations("ScanQueue"); // Reusing ScanQueue translations for stylistic consistency
-
-    if (pending.length === 0) return null;
-
     return (
         <section
             aria-label="Pending Searches"
@@ -36,23 +37,39 @@ export function PendingSearchQueue({
                 )}
             </div>
 
-            <ul className="space-y-2">
-                {pending.map((item) => (
-                    <li
-                        key={item.id}
-                        className="flex items-center justify-between gap-3 rounded-xl bg-white/70 px-3 py-2 text-sm dark:bg-black/20"
-                    >
-                        <span className="flex items-center gap-2 truncate font-mono font-medium">
-                            <Search size={14} className="text-blue-500" />
-                            {item.query}
-                        </span>
-                        <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-blue-500/20 px-2 py-0.5 text-xs font-semibold text-blue-800 dark:text-blue-200">
-                            <Clock size={12} />
-                            Pending
-                        </span>
-                    </li>
-                ))}
-            </ul>
+            {isLoading ? (
+                <p className="text-sm text-blue-800/80 dark:text-blue-200/80">
+                    Loading saved searches...
+                </p>
+            ) : pending.length === 0 ? (
+                <p className="text-sm text-blue-800/80 dark:text-blue-200/80">
+                    No saved offline searches
+                </p>
+            ) : (
+                <ul className="space-y-2">
+                    {pending.map((item) => (
+                        <li
+                            key={item.id}
+                            className="flex items-center justify-between gap-3 rounded-xl bg-white/70 px-3 py-2 text-sm dark:bg-black/20"
+                        >
+                            <button
+                                type="button"
+                                onClick={() => void onExecute(item)}
+                                disabled={executingId != null}
+                                aria-label={`Run saved search for ${item.query}`}
+                                className="flex min-w-0 cursor-pointer items-center gap-2 truncate rounded-md font-mono font-medium focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:cursor-wait disabled:opacity-60"
+                            >
+                                <Search size={14} className="shrink-0 text-blue-500" />
+                                <span className="truncate">{item.query}</span>
+                            </button>
+                            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-blue-500/20 px-2 py-0.5 text-xs font-semibold text-blue-800 dark:text-blue-200">
+                                <Clock size={12} />
+                                {executingId === item.id ? "Running..." : "Pending"}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+            )}
         </section>
     );
 }

--- a/apps/web/hooks/usePendingSearchQueue.ts
+++ b/apps/web/hooks/usePendingSearchQueue.ts
@@ -1,38 +1,99 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { getSearchQueue, type QueuedSearch, clearSearchQueue } from "@/lib/db/searchQueue";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getSearchQueue, type QueuedSearch, removeFromSearchQueue } from "@/lib/db/searchQueue";
 import { toast } from "sonner";
 
-export function usePendingSearchQueue(onSync?: (query: string) => void) {
+export function usePendingSearchQueue(onSync?: (query: string) => void | Promise<void>) {
     const [pendingSearches, setPendingSearches] = useState<QueuedSearch[]>([]);
     const [isSyncing, setIsSyncing] = useState(false);
-
-    const refresh = useCallback(async () => {
-        setPendingSearches(await getSearchQueue());
-    }, []);
+    const [isLoading, setIsLoading] = useState(true);
+    const [executingId, setExecutingId] = useState<string | null>(null);
+    const inFlightRef = useRef<string | null>(null);
+    const processingOnlineRef = useRef(false);
+    const onSyncRef = useRef(onSync);
 
     useEffect(() => {
-        void refresh();
+        onSyncRef.current = onSync;
+    }, [onSync]);
+
+    const refresh = useCallback(async () => {
+        try {
+            setPendingSearches(await getSearchQueue());
+        } catch (error) {
+            toast.error("Could not load saved searches");
+            throw error;
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    const execute = useCallback(
+        async (item: QueuedSearch) => {
+            const sync = onSyncRef.current;
+            if (!sync || inFlightRef.current !== null) return false;
+
+            inFlightRef.current = item.id;
+            setExecutingId(item.id);
+            try {
+                await sync(item.query);
+            } catch {
+                toast.error(`Could not run saved search: "${item.query}"`);
+                return false;
+            }
+
+            try {
+                await removeFromSearchQueue(item.id);
+            } catch {
+                toast.error(`Could not remove saved search: "${item.query}"`);
+                return false;
+            }
+
+            setPendingSearches((current) => current.filter(({ id }) => id !== item.id));
+            void refresh().catch(() => undefined);
+            return true;
+        },
+        [refresh]
+    );
+
+    const executeWithLockRelease = useCallback(
+        async (item: QueuedSearch) => {
+            try {
+                return await execute(item);
+            } finally {
+                if (inFlightRef.current === item.id) {
+                    inFlightRef.current = null;
+                    setExecutingId(null);
+                }
+            }
+        },
+        [execute]
+    );
+
+    useEffect(() => {
+        void refresh().catch(() => undefined);
 
         const handleOnline = async () => {
+            if (processingOnlineRef.current || inFlightRef.current) return;
+            processingOnlineRef.current = true;
             setIsSyncing(true);
-            const currentQueue = await getSearchQueue();
-            if (currentQueue.length > 0) {
-                // Sort by most recent first
-                const sorted = currentQueue.sort((a, b) => b.timestamp - a.timestamp);
-                const mostRecent = sorted[0];
-
-                if (onSync) {
-                    onSync(mostRecent.query);
+            try {
+                const currentQueue = await getSearchQueue();
+                if (currentQueue.length > 0) {
+                    const mostRecent = [...currentQueue].sort(
+                        (a, b) => b.timestamp - a.timestamp
+                    )[0];
+                    const succeeded = await executeWithLockRelease(mostRecent);
+                    if (succeeded) {
+                        toast.success(`Restored queued search: "${mostRecent.query}"`);
+                    }
                 }
-
-                toast.success(`Restored queued search: "${mostRecent.query}"`);
-
-                await clearSearchQueue();
-                void refresh();
+            } catch {
+                toast.error("Could not process saved searches");
+            } finally {
+                processingOnlineRef.current = false;
+                setIsSyncing(false);
             }
-            setIsSyncing(false);
         };
 
         window.addEventListener("online", handleOnline);
@@ -40,7 +101,14 @@ export function usePendingSearchQueue(onSync?: (query: string) => void) {
         return () => {
             window.removeEventListener("online", handleOnline);
         };
-    }, [refresh, onSync]);
+    }, [executeWithLockRelease, refresh]);
 
-    return { pendingSearches, isSyncing, refresh };
+    return {
+        pendingSearches,
+        isSyncing,
+        isLoading,
+        executingId,
+        execute: executeWithLockRelease,
+        refresh,
+    };
 }

--- a/apps/web/tests/PendingSearchQueue.test.tsx
+++ b/apps/web/tests/PendingSearchQueue.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { PendingSearchQueue } from "@/components/SearchBar/PendingSearchQueue";
+
+const entries = [
+    { id: "one", query: "paracetamol", timestamp: 1 },
+    { id: "two", query: "paracetamol", timestamp: 2 },
+];
+
+describe("PendingSearchQueue", () => {
+    it("renders an empty state", () => {
+        render(<PendingSearchQueue pending={[]} onExecute={jest.fn()} />);
+        expect(screen.getByText("No saved offline searches")).toBeInTheDocument();
+    });
+
+    it("disables every duplicate-query action while one item is running", () => {
+        const onExecute = jest.fn();
+
+        render(<PendingSearchQueue pending={entries} executingId="one" onExecute={onExecute} />);
+
+        const buttons = screen.getAllByRole("button", { name: "Run saved search for paracetamol" });
+
+        expect(buttons[0]).toBeDisabled();
+        expect(buttons[1]).toBeDisabled();
+
+        fireEvent.click(buttons[1]);
+
+        expect(onExecute).not.toHaveBeenCalled();
+        expect(screen.getByText("Running...")).toBeInTheDocument();
+        expect(screen.getByText("Pending")).toBeInTheDocument();
+    });
+
+    it("executes the selected saved search", () => {
+        const onExecute = jest.fn();
+
+        render(<PendingSearchQueue pending={entries} onExecute={onExecute} />);
+
+        fireEvent.click(
+            screen.getAllByRole("button", {
+                name: "Run saved search for paracetamol",
+            })[1]
+        );
+
+        expect(onExecute).toHaveBeenCalledTimes(1);
+        expect(onExecute).toHaveBeenCalledWith(entries[1]);
+    });
+});

--- a/apps/web/tests/searchQueue.test.ts
+++ b/apps/web/tests/searchQueue.test.ts
@@ -1,0 +1,31 @@
+import { openDB } from "idb";
+
+jest.mock("idb", () => ({ openDB: jest.fn() }));
+
+describe("search queue storage", () => {
+    const records = new Map<string, unknown>();
+
+    beforeEach(() => {
+        records.clear();
+        (openDB as jest.Mock).mockResolvedValue({
+            put: async (_store: string, item: { id: string }) => records.set(item.id, item),
+            getAll: async () => [...records.values()],
+            delete: async (_store: string, id: string) => records.delete(id),
+            clear: async () => records.clear(),
+        });
+    });
+
+    it("removes only the selected ID, including when queries are duplicated", async () => {
+        const { addToSearchQueue, getSearchQueue, removeFromSearchQueue } =
+            await import("@/lib/db/searchQueue");
+        const first = await addToSearchQueue("paracetamol");
+        const duplicate = await addToSearchQueue("paracetamol");
+        const third = await addToSearchQueue("ibuprofen");
+
+        await removeFromSearchQueue(duplicate.id);
+        expect((await getSearchQueue()).map(({ id }) => id)).toEqual([first.id, third.id]);
+
+        await removeFromSearchQueue("missing-id");
+        expect((await getSearchQueue()).map(({ id }) => id)).toEqual([first.id, third.id]);
+    });
+});

--- a/apps/web/tests/usePendingSearchQueue.test.tsx
+++ b/apps/web/tests/usePendingSearchQueue.test.tsx
@@ -1,0 +1,110 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { usePendingSearchQueue } from "@/hooks/usePendingSearchQueue";
+import { getSearchQueue, removeFromSearchQueue } from "@/lib/db/searchQueue";
+import { toast } from "sonner";
+
+jest.mock("@/lib/db/searchQueue", () => ({
+    getSearchQueue: jest.fn(),
+    removeFromSearchQueue: jest.fn(),
+}));
+jest.mock("sonner", () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+
+const entries = [
+    { id: "old", query: "same", timestamp: 1 },
+    { id: "new", query: "same", timestamp: 2 },
+    { id: "third", query: "other", timestamp: 0 },
+];
+
+describe("usePendingSearchQueue", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (getSearchQueue as jest.Mock).mockResolvedValue(entries);
+        (removeFromSearchQueue as jest.Mock).mockResolvedValue(undefined);
+    });
+
+    it("executes and removes only the most recent entry on repeated online events", async () => {
+        let resolveExecution!: () => void;
+        const onSync = jest.fn(() => new Promise<void>((resolve) => (resolveExecution = resolve)));
+        const { result } = renderHook(() => usePendingSearchQueue(onSync));
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        act(() => {
+            window.dispatchEvent(new Event("online"));
+            window.dispatchEvent(new Event("online"));
+        });
+        await waitFor(() => expect(onSync).toHaveBeenCalledWith("same"));
+        expect(onSync).toHaveBeenCalledTimes(1);
+
+        await act(async () => resolveExecution());
+        await waitFor(() => expect(removeFromSearchQueue).toHaveBeenCalledWith("new"));
+        expect(getSearchQueue).toHaveBeenCalledTimes(3);
+    });
+
+    it("keeps an entry when automatic execution fails", async () => {
+        const onSync = jest.fn().mockRejectedValue(new Error("failed"));
+        renderHook(() => usePendingSearchQueue(onSync));
+        await act(async () => window.dispatchEvent(new Event("online")));
+        await waitFor(() => expect(onSync).toHaveBeenCalled());
+        expect(removeFromSearchQueue).not.toHaveBeenCalled();
+    });
+
+    it("allows only one queued item to execute at a time", async () => {
+        let resolveExecution!: () => void;
+        const onSync = jest.fn(() => new Promise<void>((resolve) => (resolveExecution = resolve)));
+        const { result } = renderHook(() => usePendingSearchQueue(onSync));
+        await waitFor(() => expect(result.current.pendingSearches).toEqual(entries));
+
+        let firstExecution!: Promise<boolean>;
+        let secondResult!: boolean;
+        act(() => {
+            firstExecution = result.current.execute(entries[0]);
+        });
+        await waitFor(() => expect(result.current.executingId).toBe("old"));
+        await act(async () => {
+            secondResult = await result.current.execute(entries[2]);
+        });
+
+        expect(secondResult).toBe(false);
+        expect(onSync).toHaveBeenCalledTimes(1);
+        expect(onSync).toHaveBeenCalledWith("same");
+        await act(async () => resolveExecution());
+        await expect(firstExecution).resolves.toBe(true);
+        expect(removeFromSearchQueue).toHaveBeenCalledWith("old");
+    });
+
+    it("returns success after deletion when the subsequent refresh fails", async () => {
+        (getSearchQueue as jest.Mock)
+            .mockResolvedValueOnce(entries)
+            .mockRejectedValueOnce(new Error("refresh failed"));
+        const onSync = jest.fn().mockResolvedValue(undefined);
+        const { result } = renderHook(() => usePendingSearchQueue(onSync));
+        await waitFor(() => expect(result.current.pendingSearches).toEqual(entries));
+
+        let succeeded!: boolean;
+        await act(async () => {
+            succeeded = await result.current.execute(entries[1]);
+        });
+
+        expect(succeeded).toBe(true);
+        expect(removeFromSearchQueue).toHaveBeenCalledWith("new");
+        expect(result.current.pendingSearches.map(({ id }) => id)).toEqual(["old", "third"]);
+        expect(toast.error).toHaveBeenCalledWith("Could not load saved searches");
+        expect(toast.error).not.toHaveBeenCalledWith(expect.stringContaining("Could not run"));
+    });
+
+    it("does not reload the queue when an inline callback changes identity", async () => {
+        const { rerender } = renderHook(
+            ({ version }) => {
+                const onSync = jest.fn(() => version);
+                return usePendingSearchQueue(onSync);
+            },
+            { initialProps: { version: 1 } }
+        );
+        await waitFor(() => expect(getSearchQueue).toHaveBeenCalledTimes(1));
+
+        rerender({ version: 2 });
+
+        await act(async () => Promise.resolve());
+        expect(getSearchQueue).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

* **Closes #3494**
* **Summary:**

  * Preserve offline search history instead of clearing the entire queue after reconnect.
  * Automatically execute only the most recent queued search and remove only that specific entry after successful execution.
  * Keep remaining offline searches persisted in IndexedDB.
  * Add an interactive offline-search history UI that allows users to manually execute saved searches.
  * Preserve queue entries when execution fails.
  * Prevent duplicate execution caused by repeated online events or concurrent interactions.
  * Support duplicate query strings independently through UUID-backed queue entries.

### Files Updated

* `apps/web/hooks/usePendingSearchQueue.ts`
* `apps/web/components/SearchBar/PendingSearchQueue.tsx`
* `apps/web/app/[locale]/page.tsx`
* `apps/web/tests/searchQueue.test.ts`
* `apps/web/tests/usePendingSearchQueue.test.tsx`
* `apps/web/tests/PendingSearchQueue.test.tsx`

## 📸 Proof of Work (Screenshots / Logs)

### Testing

```text
Targeted ESLint: passed
Focused Jest: 3 suites, 9 tests passed
git diff --cached --check: passed
```

### Covered Scenarios

* Deletes only the executed queue entry by ID.
* Preserves duplicate queries as separate entries.
* Restores only the most recent queued search on reconnect.
* Prevents repeated online events from executing the same search multiple times.
* Preserves entries when execution fails.
* Allows only one queued search execution at a time.
* Keeps refresh failures separate from execution success.
* Renders saved offline searches and supports manual execution.
* Prevents callback identity changes from repeatedly reloading the queue.

## 🏷️ PR Type

* [x] ✨ `type: feature`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3494`)
* [x] I have pulled the latest `main` and resolved any conflicts