### PR TITLE
perf(ml): remove redundant event loops from triage flow

### DIFF
--- a/apps/ml/routers/triage.py
+++ b/apps/ml/routers/triage.py
@@ -6,7 +6,6 @@ import asyncio
 import uuid
 
 
-from starlette.concurrency import run_in_threadpool
 from services.triage_graph import run_triage_flow, clear_session
 from utils.rate_limiter import RateLimiter  
 
@@ -117,8 +116,8 @@ async def triage_chat(payload: TriageRequest):
                 f"Invoking triage flow for chat of length {len(messages_list)} "
                 f"(session_id={session_id})"
             )
-            result = await run_in_threadpool(
-                run_triage_flow, messages_list, locale=payload.locale, session_id=session_id
+            result = await run_triage_flow(
+                messages_list, locale=payload.locale, session_id=session_id
             )
             return TriageResponse(
                 response=result.get("response", ""),
@@ -153,7 +152,7 @@ async def triage_clear(payload: ClearSessionRequest):
     response simply reports cleared=False.
     """
     try:
-        cleared = await run_in_threadpool(clear_session, payload.session_id)
+        cleared = await clear_session(payload.session_id)
     except Exception as e:
         logging.error(f"Error clearing triage session '{payload.session_id}': {e}")
         raise HTTPException(

--- a/apps/ml/services/triage_graph.py
+++ b/apps/ml/services/triage_graph.py
@@ -1,6 +1,5 @@
 import os
 import json
-import asyncio
 import logging
 from typing import List, Dict, Any, Optional, TypedDict
 from pydantic import BaseModel, Field
@@ -80,14 +79,9 @@ async def _clear_session_state(session_id: str) -> bool:
     return bool(removed)
 
 
-def clear_session(session_id: str) -> bool:
-    """Synchronous wrapper around _clear_session_state for the API layer.
-
-    Mirrors how run_triage_flow drives the async session helpers via
-    asyncio.run, so callers running in a threadpool don't need their own
-    event loop plumbing.
-    """
-    return asyncio.run(_clear_session_state(session_id))
+async def clear_session(session_id: str) -> bool:
+    """Clear persisted session state from the API's existing event loop."""
+    return await _clear_session_state(session_id)
 
 
 # Check if LangChain and LangGraph are available
@@ -510,7 +504,7 @@ def build_triage_graph():
 # Instantiated compiled graph
 triage_app = build_triage_graph() if LANGGRAPH_AVAILABLE else None
 
-def run_triage_flow(
+async def run_triage_flow(
     messages: List[Dict[str, str]],
     locale: str = "en",
     session_id: Optional[str] = None,
@@ -537,7 +531,7 @@ def run_triage_flow(
     persisted_state = None
     if session_id:
         try:
-            persisted_state = asyncio.run(_load_session_state(session_id))
+            persisted_state = await _load_session_state(session_id)
         except Exception:
             logging.exception("Unexpected error loading session '%s'; starting fresh.", session_id)
             persisted_state = None
@@ -560,11 +554,11 @@ def run_triage_flow(
         initial_state["messages"] = messages  # always use this request's messages
 
     try:
-        final_state = triage_app.invoke(initial_state)
+        final_state = await triage_app.ainvoke(initial_state)
 
         if session_id:
             try:
-                asyncio.run(_save_session_state(session_id, final_state))
+                await _save_session_state(session_id, final_state)
             except Exception:
                 logging.exception("Unexpected error saving session '%s'.", session_id)
 

--- a/apps/ml/tests/test_triage_graph.py
+++ b/apps/ml/tests/test_triage_graph.py
@@ -1,12 +1,12 @@
 from fastapi.testclient import TestClient
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, patch
 import pytest
 
 from main import app
 
 client = TestClient(app)
 
-@patch("routers.triage.run_triage_flow")
+@patch("routers.triage.run_triage_flow", new_callable=AsyncMock)
 def test_triage_chat_endpoint_success(mock_run_triage):
     # Mock triage result
     mock_run_triage.return_value = {
@@ -34,3 +34,4 @@ def test_triage_chat_endpoint_success(mock_run_triage):
     assert data["emergency"] is False
     assert data["language"] == "English"
     assert "onset" in data["details"]
+    mock_run_triage.assert_awaited_once()

--- a/apps/ml/tests/test_triage_session_persistence.py
+++ b/apps/ml/tests/test_triage_session_persistence.py
@@ -11,6 +11,11 @@ import services.triage_graph as triage_graph
 client = TestClient(app)
 
 
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
 class FakeRedis:
     """Minimal in-memory stand-in for the async Redis client used in tests."""
 
@@ -127,47 +132,45 @@ def test_clear_session_state_redis_error_returns_false(monkeypatch):
     assert asyncio.run(triage_graph._clear_session_state("session-y")) is False
 
 
-def test_clear_session_wrapper_runs_async_helper(monkeypatch):
+@pytest.mark.anyio
+async def test_clear_session_runs_async_helper(monkeypatch):
     fake_redis = FakeRedis()
     monkeypatch.setattr(triage_graph, "redis_client", fake_redis)
 
-    asyncio.run(
-        triage_graph._save_session_state(
-            "wrapper-session",
-            {
-                "language": "English",
-                "emergency_detected": False,
-                "collected_info": {},
-                "retrieved_medicines": [],
-            },
-        )
+    await triage_graph._save_session_state(
+        "wrapper-session",
+        {
+            "language": "English",
+            "emergency_detected": False,
+            "collected_info": {},
+            "retrieved_medicines": [],
+        },
     )
 
-    assert triage_graph.clear_session("wrapper-session") is True
-    assert triage_graph.clear_session("wrapper-session") is False
+    assert await triage_graph.clear_session("wrapper-session") is True
+    assert await triage_graph.clear_session("wrapper-session") is False
 
 
-def test_run_triage_flow_reuses_persisted_state(monkeypatch):
+@pytest.mark.anyio
+async def test_run_triage_flow_reuses_persisted_state(monkeypatch):
     fake_redis = FakeRedis()
     monkeypatch.setattr(triage_graph, "redis_client", fake_redis)
     monkeypatch.setattr(triage_graph, "LANGGRAPH_AVAILABLE", True)
 
     # Pre-populate a session with prior collected_info, as if turn 1 already ran.
-    asyncio.run(
-        triage_graph._save_session_state(
-            "session-continue",
-            {
-                "language": "English",
-                "emergency_detected": False,
-                "collected_info": {"onset": "yesterday", "severity": "unknown"},
-                "retrieved_medicines": [],
-            },
-        )
+    await triage_graph._save_session_state(
+        "session-continue",
+        {
+            "language": "English",
+            "emergency_detected": False,
+            "collected_info": {"onset": "yesterday", "severity": "unknown"},
+            "retrieved_medicines": [],
+        },
     )
 
     captured_initial_state = {}
 
-    def fake_invoke(initial_state):
+    async def fake_invoke(initial_state):
         captured_initial_state.update(initial_state)
         return {
             "response": "Got it, thanks.",
@@ -180,11 +183,11 @@ def test_run_triage_flow_reuses_persisted_state(monkeypatch):
         }
 
     fake_app = MagicMock()
-    fake_app.invoke.side_effect = fake_invoke
+    fake_app.ainvoke.side_effect = fake_invoke
     monkeypatch.setattr(triage_graph, "triage_app", fake_app)
 
     new_messages = [{"role": "user", "content": "it's also severe now"}]
-    result = triage_graph.run_triage_flow(new_messages, session_id="session-continue")
+    result = await triage_graph.run_triage_flow(new_messages, session_id="session-continue")
 
     # Prior turn's collected_info should have been rehydrated into the graph's
     # starting state instead of being lost.
@@ -194,14 +197,15 @@ def test_run_triage_flow_reuses_persisted_state(monkeypatch):
     assert result["response"] == "Got it, thanks."
 
 
-def test_run_triage_flow_missing_session_starts_fresh(monkeypatch):
+@pytest.mark.anyio
+async def test_run_triage_flow_missing_session_starts_fresh(monkeypatch):
     fake_redis = FakeRedis()
     monkeypatch.setattr(triage_graph, "redis_client", fake_redis)
     monkeypatch.setattr(triage_graph, "LANGGRAPH_AVAILABLE", True)
 
     captured_initial_state = {}
 
-    def fake_invoke(initial_state):
+    async def fake_invoke(initial_state):
         captured_initial_state.update(initial_state)
         return {
             "response": "Hello, how can I help?",
@@ -214,10 +218,10 @@ def test_run_triage_flow_missing_session_starts_fresh(monkeypatch):
         }
 
     fake_app = MagicMock()
-    fake_app.invoke.side_effect = fake_invoke
+    fake_app.ainvoke.side_effect = fake_invoke
     monkeypatch.setattr(triage_graph, "triage_app", fake_app)
 
-    result = triage_graph.run_triage_flow(
+    result = await triage_graph.run_triage_flow(
         [{"role": "user", "content": "hi"}], session_id="brand-new-or-expired-session"
     )
 
@@ -226,11 +230,48 @@ def test_run_triage_flow_missing_session_starts_fresh(monkeypatch):
     assert result["response"] == "Hello, how can I help?"
 
 
+@pytest.mark.anyio
+async def test_run_triage_flow_without_session_skips_persistence(monkeypatch):
+    monkeypatch.setattr(triage_graph, "LANGGRAPH_AVAILABLE", True)
+    load_session = AsyncMock()
+    save_session = AsyncMock()
+    monkeypatch.setattr(triage_graph, "_load_session_state", load_session)
+    monkeypatch.setattr(triage_graph, "_save_session_state", save_session)
+
+    final_state = {
+        "response": "How can I help?",
+        "emergency_detected": False,
+        "language": "English",
+        "final_summary": "",
+        "recommendations": [],
+        "disclaimer": "",
+        "collected_info": {},
+    }
+    fake_app = MagicMock()
+    fake_app.ainvoke = AsyncMock(return_value=final_state)
+    monkeypatch.setattr(triage_graph, "triage_app", fake_app)
+
+    result = await triage_graph.run_triage_flow([{"role": "user", "content": "hi"}])
+
+    load_session.assert_not_awaited()
+    save_session.assert_not_awaited()
+    fake_app.ainvoke.assert_awaited_once()
+    assert result == {
+        "response": "How can I help?",
+        "emergency": False,
+        "language": "English",
+        "summary": "",
+        "recommendations": [],
+        "disclaimer": "",
+        "details": {},
+    }
+
+
 # ---------------------------------------------------------------------------
 # routers.triage — endpoint-level tests
 # ---------------------------------------------------------------------------
 
-@patch("routers.triage.run_triage_flow")
+@patch("routers.triage.run_triage_flow", new_callable=AsyncMock)
 def test_triage_chat_generates_session_id_when_omitted(mock_run_triage):
     mock_run_triage.return_value = {
         "response": "How long have you had this pain?",
@@ -252,9 +293,10 @@ def test_triage_chat_generates_session_id_when_omitted(mock_run_triage):
     # The generated session_id should have been forwarded to run_triage_flow.
     _, kwargs = mock_run_triage.call_args
     assert kwargs["session_id"] == data["session_id"]
+    mock_run_triage.assert_awaited_once()
 
 
-@patch("routers.triage.run_triage_flow")
+@patch("routers.triage.run_triage_flow", new_callable=AsyncMock)
 def test_triage_chat_reuses_supplied_session_id(mock_run_triage):
     mock_run_triage.return_value = {
         "response": "Thanks, noted.",
@@ -278,9 +320,10 @@ def test_triage_chat_reuses_supplied_session_id(mock_run_triage):
 
     _, kwargs = mock_run_triage.call_args
     assert kwargs["session_id"] == "existing-session-123"
+    mock_run_triage.assert_awaited_once()
 
 
-@patch("routers.triage.clear_session")
+@patch("routers.triage.clear_session", new_callable=AsyncMock)
 def test_triage_clear_removes_existing_session(mock_clear):
     mock_clear.return_value = True
 
@@ -289,10 +332,10 @@ def test_triage_clear_removes_existing_session(mock_clear):
     assert response.status_code == 200
     data = response.json()
     assert data == {"session_id": "existing-session-123", "cleared": True}
-    mock_clear.assert_called_once_with("existing-session-123")
+    mock_clear.assert_awaited_once_with("existing-session-123")
 
 
-@patch("routers.triage.clear_session")
+@patch("routers.triage.clear_session", new_callable=AsyncMock)
 def test_triage_clear_unknown_session_reports_not_cleared(mock_clear):
     mock_clear.return_value = False
 
@@ -301,6 +344,7 @@ def test_triage_clear_unknown_session_reports_not_cleared(mock_clear):
     assert response.status_code == 200
     data = response.json()
     assert data == {"session_id": "never-existed", "cleared": False}
+    mock_clear.assert_awaited_once_with("never-existed")
 
 
 def test_triage_clear_requires_session_id():


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #3487**
* **Summary:**

  * Refactored `run_triage_flow(...)` to be fully asynchronous.
  * Removed redundant `asyncio.run(...)` calls used for Redis session persistence.
  * Replaced synchronous graph execution with `await triage_app.ainvoke(...)`.
  * Removed `run_in_threadpool(...)` usage from the `/triage/chat` endpoint.
  * Converted `clear_session(...)` and `/triage/clear` handling to async.
  * Updated affected tests to use `AsyncMock` and async test execution via AnyIO.
  * Added coverage for session persistence, missing-session behavior, async invocation, and no-session execution paths.

## 📸 Proof of Work (Screenshots / Logs)

### Test Results

```text
python -m pytest apps/ml/tests/test_triage_graph.py apps/ml/tests/test_triage_session_persistence.py -v

18 passed
```

```text
python -m pytest apps/ml/tests -v

137 passed, 4 skipped, 2 warnings
```

### Additional Validation

```text
git diff --check
✓ Passed
```

```text
Confirmed no asyncio.run() remains in the production triage request path.
Confirmed no run_in_threadpool remains in apps/ml/routers/triage.py.
Confirmed all run_triage_flow(...) production callers await the async implementation.
```

## 🏷️ PR Type

* [ ] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [x] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [x] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3487`)
* [x] I have pulled the latest `main` and resolved any conflicts