### PR TITLE
feat: secure /models/current endpoint with API key middleware

### DIFF
--- a/apps/ml/dependencies.py
+++ b/apps/ml/dependencies.py
@@ -1,0 +1,7 @@
+import os
+from fastapi import Header, HTTPException, status
+
+def verify_api_key(x_api_key: str = Header(...)):
+    expected = os.getenv("ML_API_KEY")
+    if not expected or x_api_key != expected:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid or missing API key")

--- a/apps/ml/routers/health.py
+++ b/apps/ml/routers/health.py
@@ -1,7 +1,8 @@
 import os
 from pathlib import Path
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from routers import asr
+from dependencies import verify_api_key
 from services import medicine_ner
 from services import embedding
 
@@ -20,7 +21,7 @@ except ImportError:
 
 router = APIRouter(tags=["Health"])
 
-@router.get("/models/current")
+@router.get("/models/current", dependencies=[Depends(verify_api_key)])
 def get_current_models():
     # ASR model metadata
     asr_metadata = {

--- a/apps/ml/tests/test_api.py
+++ b/apps/ml/tests/test_api.py
@@ -2,6 +2,7 @@ from fastapi.testclient import TestClient
 from unittest.mock import MagicMock
 import sys
 import os
+os.environ["ML_API_KEY"]="test-secret-123"
 
 # Mock faster_whisper before importing app
 sys.modules["faster_whisper"] = MagicMock()
@@ -32,7 +33,11 @@ def test_health_endpoint():
 
 
 def test_models_current_endpoint():
-    response = client.get("/models/current")
+    response = client.get(
+        "/models/current",
+        headers={"x-api-key":"test-secret-123"}
+
+    )
 
     assert response.status_code == 200
     data = response.json()
@@ -67,7 +72,11 @@ def test_models_current_endpoint():
     assert tflite_model["filename"] == "mobilenetv3_large_int8.tflite"
     assert tflite_model["exists"] is True
 
+def test_models_current_endpoint_no_api_key():
+    response = client.get("/models/current")
 
+    assert response.status_code in (401, 403)
+    
 def test_transcribe_missing_file():
     response = client.post("/asr/transcribe")
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3422**
- **Summary:Added a verify_api_key FastAPI dependency to apps/ml/dependencies.py and applied it to GET /models/current in health.py. No existing API key middleware existed in apps/ml (checked thoroughly, only the Node apps/api service has one, which is unrelated). Updated test_api.py to send x-api-key on the existing test and added a new test asserting 401/403 without the key.**

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3422`)
- [x] I have pulled the latest `main` and resolved any conflicts
