### PR TITLE
feat(api): monitor pg_cron cleanup job failures

### DIFF
--- a/apps/api/src/cron/pgCronMonitor.ts
+++ b/apps/api/src/cron/pgCronMonitor.ts
@@ -1,0 +1,137 @@
+import logger from "../utils/logger";
+import { serviceRoleSupabase } from "../db/client";
+
+// Polling interval in ms (default to 1 hour if not specified)
+const CHECK_INTERVAL_MS = process.env.PG_CRON_MONITOR_INTERVAL_MS
+    ? parseInt(process.env.PG_CRON_MONITOR_INTERVAL_MS, 10)
+    : process.env.NODE_ENV === "test"
+      ? 1000
+      : 60 * 60 * 1000;
+
+const WEBHOOK_URL = process.env.PG_CRON_MONITOR_WEBHOOK_URL;
+
+let intervalId: NodeJS.Timeout | null = null;
+let lastChecked: Date;
+
+export async function checkFailedPgCronJobs(): Promise<void> {
+    const jobName = "cleanup_scan_history";
+
+    try {
+        const { data, error } = await serviceRoleSupabase.rpc("get_failed_pg_cron_jobs", {
+            p_job_name: jobName,
+            p_since_time: lastChecked.toISOString(),
+        });
+
+        // Always update lastChecked to now, regardless of failure, so we don't spam the same alerts.
+        const currentTime = new Date();
+
+        if (error) {
+            logger.error({ message: "Failed to fetch pg_cron job statuses from Supabase", error });
+            return;
+        }
+
+        if (data && data.length > 0) {
+            logger.warn(`Found ${data.length} failed execution(s) for pg_cron job '${jobName}'`);
+
+            for (const failure of data) {
+                await sendDiscordAlert(jobName, failure);
+            }
+        }
+
+        lastChecked = currentTime;
+    } catch (err) {
+        logger.error({ message: "Error in checkFailedPgCronJobs execution", error: err });
+    }
+}
+
+async function sendDiscordAlert(jobName: string, failure: any): Promise<void> {
+    if (!WEBHOOK_URL) {
+        logger.warn("PG_CRON_MONITOR_WEBHOOK_URL is not set. Skipping Discord alert.");
+        return;
+    }
+
+    try {
+        const payload = {
+            embeds: [
+                {
+                    title: `🚨 pg_cron Job Failed: ${jobName}`,
+                    color: 16711680, // Red
+                    fields: [
+                        { name: "Job ID", value: String(failure.jobid), inline: true },
+                        { name: "Run ID", value: String(failure.runid), inline: true },
+                        {
+                            name: "Start Time",
+                            value: failure.start_time
+                                ? new Date(failure.start_time).toLocaleString()
+                                : "Unknown",
+                            inline: false,
+                        },
+                        {
+                            name: "End Time",
+                            value: failure.end_time
+                                ? new Date(failure.end_time).toLocaleString()
+                                : "Unknown",
+                            inline: false,
+                        },
+                        {
+                            name: "Error Message",
+                            value: failure.return_message || "No error message provided",
+                            inline: false,
+                        },
+                        {
+                            name: "Command",
+                            value: `\`\`\`sql\n${failure.command}\n\`\`\``,
+                            inline: false,
+                        },
+                    ],
+                    timestamp: new Date().toISOString(),
+                },
+            ],
+        };
+
+        const response = await fetch(WEBHOOK_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+            logger.error(`Failed to send Discord alert for ${jobName}. Status: ${response.status}`);
+        } else {
+            logger.info(`Discord alert sent successfully for failed ${jobName} job.`);
+        }
+    } catch (err) {
+        logger.error({ message: `Error sending Discord alert for ${jobName}`, error: err });
+    }
+}
+
+export function startPgCronMonitor(): { stop: () => void } {
+    if (intervalId) {
+        logger.warn("pg_cron monitor job is already running.");
+        return { stop: stopPgCronMonitor };
+    }
+
+    logger.info(`Starting pg_cron monitor loop (interval: ${CHECK_INTERVAL_MS}ms)`);
+
+    // Initialize lastChecked to 1 hour ago for the initial run to catch any misses while server was restarting
+    lastChecked = new Date(Date.now() - CHECK_INTERVAL_MS);
+
+    // Run an initial check shortly after boot
+    setTimeout(() => {
+        void checkFailedPgCronJobs();
+    }, 5000);
+
+    intervalId = setInterval(() => {
+        void checkFailedPgCronJobs();
+    }, CHECK_INTERVAL_MS);
+
+    return { stop: stopPgCronMonitor };
+}
+
+export function stopPgCronMonitor(): void {
+    if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+        logger.info("Stopped pg_cron monitor loop");
+    }
+}

--- a/apps/api/src/services/jobScheduler.service.ts
+++ b/apps/api/src/services/jobScheduler.service.ts
@@ -3,6 +3,7 @@ import { startAlertBroadcaster } from "../cron/alert-broadcaster";
 import { startTempCleanupJob } from "../cron/tempCleanup";
 import { initExpiryCron } from "../cron/expiry-check";
 import { initDistrictAlertSyncCron } from "../cron/districtAlertSync";
+import { startPgCronMonitor } from "../cron/pgCronMonitor";
 
 interface StoppableJob {
     stop: () => void;
@@ -21,6 +22,7 @@ class JobScheduler {
         this.jobs.push(startTempCleanupJob());
         this.jobs.push(initExpiryCron());
         this.jobs.push(initDistrictAlertSyncCron());
+        this.jobs.push(startPgCronMonitor());
         logger.info("All background jobs have been started.");
     }
 

--- a/supabase/migrations/20260711000000_create_pg_cron_monitor_rpc.sql
+++ b/supabase/migrations/20260711000000_create_pg_cron_monitor_rpc.sql
@@ -1,0 +1,32 @@
+-- RPC to fetch failed pg_cron jobs, allowing the API service_role to access cron.job_run_details
+CREATE OR REPLACE FUNCTION get_failed_pg_cron_jobs(p_job_name text, p_since_time timestamptz)
+RETURNS TABLE (
+    jobid bigint,
+    runid bigint,
+    command text,
+    status text,
+    return_message text,
+    start_time timestamptz,
+    end_time timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        cjd.jobid,
+        cjd.runid,
+        cjd.command,
+        cjd.status,
+        cjd.return_message,
+        cjd.start_time,
+        cjd.end_time
+    FROM cron.job_run_details cjd
+    JOIN cron.job cj ON cjd.jobid = cj.jobid
+    WHERE cj.jobname = p_job_name
+      AND cjd.status = 'failed'
+      AND cjd.start_time > p_since_time
+    ORDER BY cjd.start_time DESC;
+END;
+$$;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #3303**

* **Summary:**

  * Added monitoring for the `cleanup_scan_history` pg_cron job.
  * Added a PostgreSQL RPC to query failed executions from `cron.job_run_details`.
  * Implemented a periodic monitoring job under `apps/api/src/cron/` to detect failed executions.
  * Integrated the monitoring job with the existing background job scheduler.
  * Sends a Discord webhook notification whenever a `cleanup_scan_history` execution fails.

## 📸 Proof of Work (Screenshots / Logs)

Backend-only change (no UI changes).

**Validation performed:**

* Verified the monitoring job is registered with the existing scheduler.
* Confirmed the PR only contains the files required for Issue #3303.
* Attempted to run the project's test suite. Existing unrelated frontend test failures were encountered in the repository and are not related to this backend monitoring implementation.

> *Attach terminal output or GitHub Actions logs if available.*

## 🏷️ PR Type

* [ ] 🐛 `type: bug`
* [x] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3303`)
* [x] I have pulled the latest `main` and resolved any conflicts.
