### PR TITLE
Fix: WhatsApp OTP Verification Never Sent for Dual-Channel Subscribers

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -413,15 +413,22 @@ router.post(
             }
 
             if (!isOwner && otp) {
+                const sends: Promise<unknown>[] = [];
                 if (channels.includes("sms")) {
-                    await smsService
-                        .sendOtp(formattedPhone, otp, language)
-                        .catch((e) => logger.error("SMS failed", e));
-                } else if (channels.includes("whatsapp")) {
-                    await whatsappService
-                        .sendOtp(formattedPhone, otp, language)
-                        .catch((e) => logger.error("WhatsApp failed", e));
+                    sends.push(
+                        smsService
+                            .sendOtp(formattedPhone, otp, language)
+                            .catch((e) => logger.error("SMS failed", e))
+                    );
                 }
+                if (channels.includes("whatsapp")) {
+                    sends.push(
+                        whatsappService
+                            .sendOtp(formattedPhone, otp, language)
+                            .catch((e) => logger.error("WhatsApp failed", e))
+                    );
+                }
+                await Promise.allSettled(sends);
             }
 
             res.status(201).json({ success: true, subscriber: result });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3517**
- **Summary:**
When a non-owner registers for notifications with both "sms" and
"whatsapp" channels, the WhatsApp OTP was silently skipped because
it was guarded by an `else if` clause. This left the WhatsApp
channel unverified in "pending" status.

Changed `else if` to `if` and used `Promise.allSettled` so that
OTPs are sent concurrently through all selected channels.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3517`)
- [x] I have pulled the latest `main` and resolved any conflicts
