### PR TITLE
fix(web): prevent report image upload id collisions

### DIFF
--- a/apps/web/app/api/upload/route.ts
+++ b/apps/web/app/api/upload/route.ts
@@ -90,11 +90,12 @@ export async function POST(req: NextRequest) {
         const timestamp = Math.round(new Date().getTime() / 1000).toString();
         const folder = "sahidawa/reports";
 
-        // Store each report image at cloud_name/sahidawa/reports/{batch_number}_{timestamp}.
+        // Store each report image with a readable prefix and a collision-resistant suffix.
         // Sanitise the batch number so it cannot inject extra folder paths into the public_id.
         const rawBatchNumber = (formData.get("batch_number") as string | null) ?? "";
         const batchNumber = rawBatchNumber.replace(/[^A-Za-z0-9._-]/g, "") || "report";
-        const publicId = `${batchNumber}_${timestamp}`;
+        const uniqueSuffix = crypto.randomBytes(8).toString("hex");
+        const publicId = `${batchNumber}_${timestamp}_${uniqueSuffix}`;
 
         // correct signature format — sorted params + secret appended at end
         const paramsToSign = `folder=${folder}&public_id=${publicId}&signature_algorithm=sha256&timestamp=${timestamp}${apiSecret}`;

--- a/apps/web/tests/upload-route.test.ts
+++ b/apps/web/tests/upload-route.test.ts
@@ -80,8 +80,8 @@ function buildRequest(
     return req;
 }
 
-function captureCloudinaryFormData(fetchMock: jest.Mock): FormData {
-    const [, init] = fetchMock.mock.calls[0];
+function captureCloudinaryFormData(fetchMock: jest.Mock, callIndex = 0): FormData {
+    const [, init] = fetchMock.mock.calls[callIndex];
     return init.body as FormData;
 }
 
@@ -117,26 +117,44 @@ describe("POST /api/upload", () => {
         jest.restoreAllMocks();
     });
 
-    it("stores the image under sahidawa/reports with a {batch_number}_{timestamp} public_id", async () => {
-        const response = await post(buildRequest({ batch_number: "BATCH123" }));
+    it("generates unique public IDs for concurrent uploads with the same batch number", async () => {
+        const responses = await Promise.all([
+            post(buildRequest({ batch_number: "BATCH123" })),
+            post(buildRequest({ batch_number: "BATCH123" })),
+        ]);
 
-        expect(response.status).toBe(200);
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(responses.map((response) => response.status)).toEqual([200, 200]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
 
-        const sent = captureCloudinaryFormData(fetchMock);
-        const timestamp = sent.get("timestamp") as string;
+        const first = captureCloudinaryFormData(fetchMock, 0);
+        const second = captureCloudinaryFormData(fetchMock, 1);
+        const firstPublicId = first.get("public_id") as string;
+        const secondPublicId = second.get("public_id") as string;
 
-        expect(sent.get("folder")).toBe("sahidawa/reports");
-        expect(sent.get("public_id")).toBe(`BATCH123_${timestamp}`);
+        expect(first.get("folder")).toBe("sahidawa/reports");
+        expect(firstPublicId).toMatch(/^BATCH123_\d+_[a-f0-9]{16}$/);
+        expect(secondPublicId).toMatch(/^BATCH123_\d+_[a-f0-9]{16}$/);
+        expect(firstPublicId).not.toBe(secondPublicId);
     });
 
-    it("falls back to a 'report' prefix when no batch number is supplied", async () => {
-        await post(buildRequest());
+    it("generates unique public IDs with a 'report' prefix when no batch number is supplied", async () => {
+        const responses = await Promise.all([post(buildRequest()), post(buildRequest())]);
 
-        const sent = captureCloudinaryFormData(fetchMock);
-        const timestamp = sent.get("timestamp") as string;
+        const firstPublicId = captureCloudinaryFormData(fetchMock, 0).get("public_id") as string;
+        const secondPublicId = captureCloudinaryFormData(fetchMock, 1).get("public_id") as string;
 
-        expect(sent.get("public_id")).toBe(`report_${timestamp}`);
+        expect(responses.map((response) => response.status)).toEqual([200, 200]);
+        expect(firstPublicId).toMatch(/^report_\d+_[a-f0-9]{16}$/);
+        expect(secondPublicId).toMatch(/^report_\d+_[a-f0-9]{16}$/);
+        expect(firstPublicId).not.toBe(secondPublicId);
+    });
+
+    it("removes unsafe characters from the batch number prefix", async () => {
+        await post(buildRequest({ batch_number: "BATCH / 123?!" }));
+
+        const publicId = captureCloudinaryFormData(fetchMock).get("public_id") as string;
+
+        expect(publicId).toMatch(/^BATCH123_\d+_[a-f0-9]{16}$/);
     });
 
     it("signs the request over the sorted params including public_id", async () => {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3529**
- **Summary:**
  - Adds a cryptographically secure random suffix to Cloudinary report-image `public_id` values.
  - Prevents concurrent uploads from generating identical identifiers and overwriting existing images.
  - Preserves the sanitized batch-number prefix, timestamp, validation logic, Cloudinary signing flow, response shape, and existing upload API.
  - Adds focused tests for concurrency, fallback behavior, sanitization, and signature consistency.

## 📸 Proof of Work (Screenshots / Logs)

> This is a server-side upload identifier collision fix. There are no UI changes.

### Test Results

```text
PASS apps/web/tests/upload-route.test.ts

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
```

### Additional Verification

```text
Prettier check: passed
git diff --check: passed
```

### Behavior Verified

* Concurrent uploads with the same batch number generate different Cloudinary identifiers.
* Concurrent uploads without a batch number generate different `report_*` identifiers.
* Sanitized batch prefixes are preserved.
* The final unique identifier is used consistently in Cloudinary signing and upload requests.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [x] 🔒 `type: security`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3529`)
* [x] I have pulled the latest `main` and resolved any conflicts

## Implementation Details

Cloudinary identifiers previously followed:

```text
<batch_number>_<timestamp>
```

This could lead to collisions when multiple uploads occurred within the same second.

Identifiers now follow:

```text
<sanitized-batch-number>_<timestamp>_<secure-random-suffix>
```

The suffix is generated server-side using:

```ts
crypto.randomBytes(8).toString("hex")
```

This ensures collision-resistant identifiers while keeping IDs readable and traceable.