### PR TITLE
fix(api): guarantee temp-uploads cleanup via response lifecycle hooks

### DIFF
--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -229,10 +229,14 @@ router.post("/extract", uploadRateLimiter, validateUploadSize, (req: Request, re
             }
         };
 
+        // Guarantees cleanup on every response outcome — success, thrown error,
+        // or the client disconnecting before a response is ever sent.
+        res.on("finish", cleanupTempFile);
+        res.on("close", cleanupTempFile);
+
         if (multerErr) {
             const msg = multerErr instanceof Error ? multerErr.message : "File upload error";
             logger.warn(`File upload rejected: ${msg}`);
-            cleanupTempFile();
             res.status(400).json({ error: msg });
             return;
         }
@@ -253,8 +257,6 @@ router.post("/extract", uploadRateLimiter, validateUploadSize, (req: Request, re
         const mlServiceUrl = getMlServiceUrl();
         if (!mlServiceUrl) {
             logger.error(MISSING_ML_SERVICE_URL_MESSAGE, { route: "/api/v1/scan/extract" });
-
-            cleanupTempFile();
 
             res.status(500).json({
                 error: "OCR service is not configured.",
@@ -614,8 +616,6 @@ router.post("/extract", uploadRateLimiter, validateUploadSize, (req: Request, re
                 error: "OCR service is currently unavailable. Please verify manually.",
                 details: msg,
             });
-        } finally {
-            cleanupTempFile();
         }
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link
- **Closes #3481**
- **Summary:** `/api/v1/scan/extract` in `apps/api/src/routes/scan.ts` relied on a `finally` block plus scattered manual `cleanupTempFile()` calls to delete uploaded files from `temp-uploads`, which could leave leaked files behind on certain interruption paths. This PR moves cleanup onto Express's response-lifecycle events (`res.on("finish")` and `res.on("close")`) so every uploaded file under `temp-uploads` is guaranteed to be unlinked on request completion, rejection, or client disconnect — matching the acceptance criteria in the issue. Change is scoped entirely to the `/extract` route handler; no other routes touched.

## 📸 Proof of Work (Screenshots / Logs)
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/d6f9ed26-bd17-4961-9bd5-b50f7e6d3d1f" />

<img width="1463" height="110" alt="image" src="https://github.com/user-attachments/assets/f5803d48-77ce-4053-a957-85e3f4618785" />


This is a backend-only change with no UI, so verified via server logs instead of screenshots:
2026-07-12 16:36:09 error: POST /api/v1/scan/extract 500 - 32.442 ms
2026-07-12 16:36:09 info: Cleaned up temp file: C:\Users\anany\sahidawa-india\apps\api\temp-uploads\0e9a7504-5b13-4bdd-89c5-bdd6f77225b0-1783854369669.jpg

Confirmed `apps/api/temp-uploads/` was empty before and after each test request (via `dir apps\api\temp-uploads`), across multiple requests hitting the early-return branches that previously relied on manual cleanup calls.

`npm test` is currently blocked in `apps/api` by a pre-existing, unrelated `ts-jest` config issue (`Preset ts-jest not found relative to rootDir`) — unrelated to this change, verified manually as described above instead.

## 🏷️ PR Type
- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #3481`)
- [x] I have pulled the latest `main` and resolved any conflicts