### PR TITLE
fix(api): exclude soft-deleted pharmacies from admin pharmacy listings

### DIFF
--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -32,6 +32,13 @@ const paginationSchema = z.object({
     limit: z.coerce.number().int().min(1).max(100).default(50),
 });
 
+const pharmacyListSchema = paginationSchema.extend({
+    includeInactive: z
+        .enum(["true", "false"])
+        .default("false")
+        .transform((val) => val === "true"),
+});
+
 interface AdminAuditLog {
     id: string;
     admin_id: string | null;
@@ -292,6 +299,7 @@ export const getPendingPharmacies = async (
                 "id, name, license_id, address, district, state, phone_number, is_verified, status, created_at"
             )
             .eq("status", "pending")
+            .eq("is_active", true)
             .order("created_at", { ascending: false });
 
         if (error) {
@@ -451,7 +459,7 @@ export const getAuditLogs = async (req: AuthenticatedRequest, res: Response): Pr
 
 export const getAllPharmacies = async (req: AuthenticatedRequest, res: Response): Promise<void> => {
     try {
-        const parsed = paginationSchema.safeParse(req.query);
+        const parsed = pharmacyListSchema.safeParse(req.query);
 
         if (!parsed.success) {
             res.status(400).json({
@@ -461,10 +469,10 @@ export const getAllPharmacies = async (req: AuthenticatedRequest, res: Response)
             return;
         }
 
-        const { page, limit } = parsed.data;
+        const { page, limit, includeInactive } = parsed.data;
         const offset = (page - 1) * limit;
 
-        const { data, error, count } = await supabase
+        let query = supabase
             .from("pharmacies")
             .select(
                 "id, name, license_id, address, district, state, phone_number, is_verified, status, created_at, is_active, deleted_at",
@@ -472,6 +480,12 @@ export const getAllPharmacies = async (req: AuthenticatedRequest, res: Response)
             )
             .order("created_at", { ascending: false })
             .range(offset, offset + limit - 1);
+
+        if (!includeInactive) {
+            query = query.eq("is_active", true);
+        }
+
+        const { data, error, count } = await query;
 
         if (error) {
             res.status(500).json({ error: "Failed to fetch pharmacies" });

--- a/apps/api/tests/adminPharmacies.test.ts
+++ b/apps/api/tests/adminPharmacies.test.ts
@@ -49,7 +49,8 @@ describe("Admin pharmacy moderation routes", () => {
             ],
             error: null,
         });
-        const eq = jest.fn().mockReturnValue({ order });
+        const eq = jest.fn();
+        eq.mockReturnValue({ eq, order });
         const select = jest.fn().mockReturnValue({ eq });
 
         (supabase.from as jest.Mock).mockReturnValue({ select });
@@ -62,8 +63,21 @@ describe("Admin pharmacy moderation routes", () => {
         expect(res.body.pharmacies).toHaveLength(1);
         expect(res.body.pharmacies[0].status).toBe("pending");
         expect(supabase.from).toHaveBeenCalledWith("pharmacies");
+    });
+    it("excludes soft-deleted pharmacies from the pending list", async () => {
+        const order = jest.fn().mockResolvedValue({ data: [], error: null });
+        const eq = jest.fn();
+        eq.mockReturnValue({ eq, order });
+        const select = jest.fn().mockReturnValue({ eq });
+        (supabase.from as jest.Mock).mockReturnValue({ select });
+
+        const res = await request(app)
+            .get("/api/v1/admin/pharmacies/pending")
+            .set("Authorization", "Bearer test-token");
+
+        expect(res.status).toBe(200);
         expect(eq).toHaveBeenCalledWith("status", "pending");
-        expect(order).toHaveBeenCalledWith("created_at", { ascending: false });
+        expect(eq).toHaveBeenCalledWith("is_active", true);
     });
 
     it("approves a pharmacy and logs the admin action", async () => {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3409**
- **Summary:** `getAllPharmacies` selected `is_active`/`deleted_at` in its column list but never filtered by them, unlike every RPC function in the codebase (all correctly updated to filter `is_active = true` when soft-delete was introduced in `supabase/migrations/20260622000000_soft_delete_pharmacies.sql`). `getPendingPharmacies` had the same gap — only filtered by `status`, not `is_active`.

Adds `pharmacyListSchema` (extends `paginationSchema` with an `includeInactive` flag, default `false`) so `getAllPharmacies` excludes soft-deleted pharmacies by default while still allowing an admin to explicitly view them via `?includeInactive=true`. Adds `.eq("is_active", true)` to `getPendingPharmacies` unconditionally, since a soft-deleted pharmacy has no business appearing in a pending-review queue.

## 📸 Proof of Work (Screenshots / Logs)

No UI changes — backend-only filtering fix. Added a new regression test, `"excludes soft-deleted pharmacies from the pending list"`, which directly asserts both filters are applied (`expect(eq).toHaveBeenCalledWith("status", "pending")` and `expect(eq).toHaveBeenCalledWith("is_active", true)`) — not just that existing behavior didn't break.

PASS  tests/adminPharmacies.test.ts
Admin pharmacy moderation routes
√ lists pending pharmacies
√ excludes soft-deleted pharmacies from the pending list
√ approves a pharmacy and logs the admin action
√ rejects a pharmacy without marking it verified
√ rejects invalid pharmacy statuses
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total

`npx tsc --noEmit` also compiles clean, aside from one unrelated pre-existing error in `pharmacies.ts`.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] 🔒 `type: security`
- [x] 🧪 `type: testing`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3409`)
- [x] I have pulled the latest `main` and resolved any conflicts