### PR TITLE
[Bug] Create missing migration for medicine_schedules table

### DIFF
--- a/apps/api/src/db/schema.sql
+++ b/apps/api/src/db/schema.sql
@@ -239,3 +239,23 @@ CREATE TABLE IF NOT EXISTS public.wishlists (
 
 CREATE INDEX IF NOT EXISTS idx_wishlists_user_id ON public.wishlists(user_id);
 CREATE INDEX IF NOT EXISTS idx_wishlists_product_id ON public.wishlists(product_id);
+
+-- 11. Medicine Schedules
+CREATE TABLE IF NOT EXISTS public.medicine_schedules (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    medicine_id UUID REFERENCES public.medicines(id) ON DELETE SET NULL,
+    medicine_name TEXT NOT NULL,
+    dosage TEXT NOT NULL DEFAULT '1 tablet',
+    frequency INTEGER NOT NULL CHECK (frequency > 0),
+    times JSONB NOT NULL DEFAULT '[]'::jsonb,
+    start_date DATE NOT NULL,
+    end_date DATE,
+    notes TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_medicine_schedules_user_id ON public.medicine_schedules(user_id);
+CREATE INDEX IF NOT EXISTS idx_medicine_schedules_active ON public.medicine_schedules(is_active) WHERE is_active = TRUE;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.


## 📋 PR Summary & Link

- **Closes #3101**
- **Summary:**
This PR updates `apps/api/src/db/schema.sql` to include the medicine_schedules table so that the schema definition stays in sync with the existing Supabase migrations.

**Notes**

While working on issue #3101 , I found that the medicine_schedules table has already been implemented in:

`supabase/migrations/20260609000003_create_medicine_schedules.sql`

The migration already:

- Creates the medicine_schedules table
- Adds indexes
- Enables Row Level Security (RLS)


However, `apps/api/src/db/schema.sql` was not updated to reflect this table, leaving the schema definition out of sync with the actual database migrations.

This PR does not introduce a new migration because the table already exists in the project's migration history. It only synchronizes the schema definition with the existing database structure.

## 📸 Proof of Work (Screenshots / Logs)
Change in backend code only. 

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3101 `)
- [x] I have pulled the latest `main` and resolved any conflicts
