### PR TITLE
Perf : Promise.all failure cascade in getCacheStats blocks Redis metrics

### DIFF
--- a/apps/api/src/services/cache.service.ts
+++ b/apps/api/src/services/cache.service.ts
@@ -328,15 +328,33 @@ export async function getCacheStats(): Promise<{
         };
     }
     try {
-        const [rawHits, rawMisses, hotHitsStr, warmHitsStr, coldHitsStr, rawTopDrugs] =
-            await Promise.all([
-                redisClient.get("stats:hits"),
-                redisClient.get("stats:misses"),
-                redisClient.get("stats:tier:hot"),
-                redisClient.get("stats:tier:warm"),
-                redisClient.get("stats:tier:cold"),
-                redisClient.zRangeWithScores("stats:top_drugs", 0, 9, { REV: true }),
-            ]);
+        const results = await Promise.allSettled([
+            redisClient.get("stats:hits"),
+            redisClient.get("stats:misses"),
+            redisClient.get("stats:tier:hot"),
+            redisClient.get("stats:tier:warm"),
+            redisClient.get("stats:tier:cold"),
+            redisClient.zRangeWithScores("stats:top_drugs", 0, 9, { REV: true }),
+        ]);
+
+        const extractValue = <T>(
+            result: PromiseSettledResult<T>,
+            name: string,
+            defaultVal: T
+        ): T => {
+            if (result.status === "fulfilled") {
+                return result.value;
+            }
+            logger.warn(`Failed to fetch cache stat for ${name}`, result.reason);
+            return defaultVal;
+        };
+
+        const rawHits = extractValue(results[0], "stats:hits", null);
+        const rawMisses = extractValue(results[1], "stats:misses", null);
+        const hotHitsStr = extractValue(results[2], "stats:tier:hot", null);
+        const warmHitsStr = extractValue(results[3], "stats:tier:warm", null);
+        const coldHitsStr = extractValue(results[4], "stats:tier:cold", null);
+        const rawTopDrugs = extractValue(results[5], "stats:top_drugs", []);
 
         const hits = parseInt(rawHits ?? "0", 10);
         const misses = parseInt(rawMisses ?? "0", 10);


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3545**
- **Summary:**
- The Redis calls no longer fail the entire operation if one lookup drops.
- Checked status and handled rejections: Added a generic extractValue helper that inspects the promise status (fulfilled vs rejected).
- Graceful defaults & logging: If a promise rejects, it now safely logs a warning and returns an appropriate default (null which coerces to 0 for hit counts, or [] for the top drugs list).
- Resilient calculations: The hit rate formula remains unchanged, but because it relies on the safe defaults (hits = 0 if failed, etc.), it naturally handles partial failures (e.g. if hits fails but misses succeeds, hit rate safely calculates to 0% rather than throwing an exception).

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
