### PR TITLE
fix(#3569): downgrade @zxing/library override from 0.23.0 to 0.21.3 t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "turbo": "^2.10.2"
     },
     "overrides": {
-        "@zxing/library": "0.23.0",
+        "@zxing/library": "0.21.3",
         "postcss": "^8.5.15",
         "form-data": "^4.0.6",
         "protobufjs": "^7.6.3",


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.
> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.
## 📋 PR Summary & Link
- **Closes #3569**
- **Summary:** Downgraded the `@zxing/library` override in root `package.json` from `0.23.0` to `0.21.3`. Version `0.23.0` requires Node.js >= 24.0.0 but the project targets Node 22 (per `.nvmrc` and `engines` field), causing an `EBADENGINE` warning on every `npm install`. Version `0.21.3` is fully compatible with Node >= 10.4.0, resolving the conflict.
## 📸 Proof of Work (Screenshots / Logs)
**Before fix** — running `npm install` on Node 22 produced:
npm warn EBADENGINE Unsupported engine { package: '@zxing/library@0.23.0', required: { node: '>= 24.0.0' }, current: { node: 'v22.22.2', npm: '10.9.7' } }



**After fix** — `@zxing/library@0.21.3` engine requirement: `{ node: '>= 10.4.0' }` ✅ Compatible with Node 22
## 🏷️ PR Type
- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`
## ✅ Checklist
- [x] My PR has a linked issue (`Closes #3569`)
- [x] I have pulled the latest `main` and resolved any conflicts