### PR TITLE
fix(#3571): remove duplicate /reports route without /api prefix

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -279,7 +279,6 @@ app.get("/health", async (_req: Request, res: Response) => {
 
 // ── Feature API Modules ────────────────────────────────────────────────────
 app.use("/api/reports", reportsRouter);
-app.use("/reports", reportsRouter);
 app.use("/api/pharmacies", pharmaciesRouter);
 app.use("/api/verify/batch", batchRouter);
 app.use("/api/verify", verifyRouter);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.
> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.
## 📋 PR Summary & Link
- **Closes #3571**
- **Summary:** Removed the duplicate `app.use("/reports", reportsRouter)` line from `apps/api/src/app.ts`. The reports router was unintentionally registered at two paths — `/api/reports` and `/reports`. Every other route follows the `/api/...` convention, so this duplicate was inconsistent and could bypass middleware or gateway rules scoped to `/api/*`.
## 📸 Proof of Work (Screenshots / Logs)
Only `apps/api/src/app.ts` was changed. One line removed:
```diff
- app.use("/reports", reportsRouter);
The reports endpoint remains correctly accessible at /api/reports.

🏷️ PR Type
 🐛 type: bug
 ✨ type: feature
 📖 type: docs
 🧪 type: testing
 🔒 type: security
 ⚡ type: performance
 🎨 type: design
 ♻️ type: refactor
 🛠️ type: devops
 ♿ type: accessibility
✅ Checklist
 My PR has a linked issue (Closes #3571)
 I have pulled the latest main and resolved any conflicts