### PR TITLE
fix(#3573): replace req: any with proper Request types in API route h…

### DIFF
--- a/apps/api/src/routes/abha.ts
+++ b/apps/api/src/routes/abha.ts
@@ -277,7 +277,7 @@ router.get(
     "/health-records",
     limiter,
     requireAuth,
-    async (req: any, res: Response): Promise<void> => {
+    async (req: AuthenticatedRequest, res: Response): Promise<void> => {
         try {
             const userId = req.user?.id;
             if (!userId) {

--- a/apps/api/src/routes/compare.ts
+++ b/apps/api/src/routes/compare.ts
@@ -1,4 +1,4 @@
-import { Router, Response, NextFunction } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import crypto from "crypto";
 import axios from "axios";
@@ -26,7 +26,7 @@ router.post(
     "/",
     requireAuth,
     limiter,
-    async (req: any, res: Response, next: NextFunction): Promise<void> => {
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         try {
             const parsed = compareRequestSchema.safeParse(req.body);
             if (!parsed.success) {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3573**
- **Summary:** Refactored Express route handlers in `compare.ts` and `abha.ts` to use proper TypeScript types (`Request` and `AuthenticatedRequest`) instead of the generic `any` type for the `req` parameter. This restores type safety for these API endpoints.

## 📸 Proof of Work (Screenshots / Logs)

Replaced `any` with strongly-typed `Request` and `AuthenticatedRequest` interfaces in:
- `apps/api/src/routes/compare.ts`
- `apps/api/src/routes/abha.ts`

No UI changes made.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3573`)
- [x] I have pulled the latest `main` and resolved any conflicts