### PR TITLE
fix(#3575): remove unused and deprecated @supabase/auth-helpers-nextj…

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,6 @@
         "@sahidawa/shared": "*",
         "@sahidawa/types": "*",
         "@sahidawa/validators": "*",
-        "@supabase/auth-helpers-nextjs": "^0.15.0",
         "@supabase/ssr": "^0.12.0",
         "@supabase/supabase-js": "^2.110.0",
         "@tanstack/react-query": "^5.101.2",


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.
> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.
## 📋 PR Summary & Link
- **Closes #3575**
- **Summary:** Removed the unused and deprecated `@supabase/auth-helpers-nextjs` dependency from `apps/web/package.json`. The codebase had already fully migrated to `@supabase/ssr`, so this was dead weight that was causing an `EBADENGINE`/`deprecated` warning during every `npm install`.
## 📸 Proof of Work (Screenshots / Logs)
Only `apps/web/package.json` was changed. One line removed:
```diff
- "@supabase/auth-helpers-nextjs": "^0.15.0",
This resolves the following npm install warning: npm warn deprecated @supabase/auth-helpers-nextjs@0.15.0: Package no longer supported.

🏷️ PR Type
 🐛 type: bug
 ✨ type: feature
 📖 type: docs
 🧪 type: testing
 🔒 type: security
 ⚡ type: performance
 🎨 type: design
 ♻️ type: refactor
 🛠️ type: devops
 ♿ type: accessibility
✅ Checklist
 My PR has a linked issue (Closes #3575)
 I have pulled the latest main and resolved any conflicts