### PR TITLE
feat(cache): Implement stale-value fallback and Discord alerting on R…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,3 +59,7 @@ SARVAM_API_KEY=your_sarvam_api_key
 OPENAI_API_KEY=your_openai_api_key
 GEMINI_API_KEY=your_gemini_api_key
 CSRF_SECRET=generate-a-strong-random-secret-here
+
+# --- Monitoring / Alerts ---
+PG_CRON_MONITOR_WEBHOOK_URL=your_discord_webhook_url
+

--- a/apps/api/src/services/cache.service.ts
+++ b/apps/api/src/services/cache.service.ts
@@ -312,6 +312,48 @@ export async function flushInteractionCache(): Promise<number> {
     }
 }
 
+let lastDiscordAlertTime = 0;
+const DISCORD_ALERT_DEBOUNCE_MS = 15 * 60 * 1000; // 15 minutes
+
+async function sendCacheAlertDiscord(): Promise<void> {
+    const WEBHOOK_URL = process.env.PG_CRON_MONITOR_WEBHOOK_URL;
+    if (!WEBHOOK_URL) return;
+
+    const now = Date.now();
+    if (now - lastDiscordAlertTime < DISCORD_ALERT_DEBOUNCE_MS) return;
+
+    try {
+        const payload = {
+            embeds: [
+                {
+                    title: `🚨 Redis Cache Stats Failure`,
+                    color: 16711680,
+                    description:
+                        "All Redis stat fetches failed or Redis is unreachable. Returning stale/zero data.",
+                    timestamp: new Date().toISOString(),
+                },
+            ],
+        };
+
+        const response = await fetch(WEBHOOK_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+        });
+
+        if (response.ok) {
+            lastDiscordAlertTime = now;
+            logger.info("Discord alert sent successfully for Redis cache stats failure.");
+        } else {
+            logger.error(
+                `Failed to send Discord alert for cache stats. Status: ${response.status}`
+            );
+        }
+    } catch (err) {
+        logger.error("Error sending Discord alert for cache stats", err);
+    }
+}
+
 /**
  * Returns cache performance stats: hit/miss counts, tier breakdown, top drugs.
  */
@@ -322,17 +364,21 @@ export async function getCacheStats(): Promise<{
     tierBreakdown: { hot: number; warm: number; cold: number };
     topDrugs: { name: string; count: number }[];
 }> {
+    const defaultStats = {
+        hits: 0,
+        misses: 0,
+        hitRate: 0,
+        tierBreakdown: { hot: 0, warm: 0, cold: 0 },
+        topDrugs: [],
+    };
+
     if (!redisClient.isOpen) {
-        return {
-            hits: 0,
-            misses: 0,
-            hitRate: 0,
-            tierBreakdown: { hot: 0, warm: 0, cold: 0 },
-            topDrugs: [],
-        };
+        sendCacheAlertDiscord().catch(() => {});
+        return defaultStats;
     }
     try {
         const results = await Promise.allSettled([
+            redisClient.get("stats:snapshot:last_known"),
             redisClient.get("stats:hits"),
             redisClient.get("stats:misses"),
             redisClient.get("stats:tier:hot"),
@@ -340,6 +386,32 @@ export async function getCacheStats(): Promise<{
             redisClient.get("stats:tier:cold"),
             redisClient.zRangeWithScores("stats:top_drugs", 0, 9, { REV: true }),
         ]);
+
+        const snapshotResult = results[0];
+        let snapshot: any = null;
+
+        if (snapshotResult.status === "fulfilled" && snapshotResult.value) {
+            try {
+                snapshot = JSON.parse(snapshotResult.value);
+            } catch (e) {
+                // Ignore parse errors
+            }
+        }
+
+        const allFailed =
+            results[1].status === "rejected" &&
+            results[2].status === "rejected" &&
+            results[3].status === "rejected" &&
+            results[4].status === "rejected" &&
+            results[5].status === "rejected" &&
+            results[6].status === "rejected";
+
+        if (allFailed) {
+            sendCacheAlertDiscord().catch(() => {});
+            return snapshot || defaultStats;
+        }
+
+        let anyFailed = false;
 
         const extractValue = <T>(
             result: PromiseSettledResult<T>,
@@ -349,16 +421,22 @@ export async function getCacheStats(): Promise<{
             if (result.status === "fulfilled") {
                 return result.value;
             }
+            anyFailed = true;
             logger.warn(`Failed to fetch cache stat for ${name}`, result.reason);
             return defaultVal;
         };
 
-        const rawHits = extractValue(results[0], "stats:hits", null);
-        const rawMisses = extractValue(results[1], "stats:misses", null);
-        const hotHitsStr = extractValue(results[2], "stats:tier:hot", null);
-        const warmHitsStr = extractValue(results[3], "stats:tier:warm", null);
-        const coldHitsStr = extractValue(results[4], "stats:tier:cold", null);
-        const rawTopDrugs = extractValue(results[5], "stats:top_drugs", []);
+        const rawHits = extractValue(results[1], "stats:hits", null);
+        const rawMisses = extractValue(results[2], "stats:misses", null);
+        const hotHitsStr = extractValue(results[3], "stats:tier:hot", null);
+        const warmHitsStr = extractValue(results[4], "stats:tier:warm", null);
+        const coldHitsStr = extractValue(results[5], "stats:tier:cold", null);
+        const rawTopDrugs = extractValue(results[6], "stats:top_drugs", []);
+
+        if (anyFailed && snapshot) {
+            logger.warn("Partial cache stat fetch failure. Returning stale snapshot.");
+            return snapshot;
+        }
 
         const hits = parseInt(rawHits ?? "0", 10);
         const misses = parseInt(rawMisses ?? "0", 10);
@@ -374,22 +452,27 @@ export async function getCacheStats(): Promise<{
             count: item.score,
         }));
 
-        return {
+        const finalStats = {
             hits,
             misses,
             hitRate,
             tierBreakdown: { hot: hotHits, warm: warmHits, cold: coldHits },
             topDrugs,
         };
+
+        if (!anyFailed) {
+            redisClient
+                .set("stats:snapshot:last_known", JSON.stringify(finalStats), {
+                    EX: 300, // 5 minutes
+                })
+                .catch((err: any) => logger.warn("Failed to write cache stats snapshot", err));
+        }
+
+        return finalStats;
     } catch (err) {
         logger.error("Error fetching cache stats", err);
-        return {
-            hits: 0,
-            misses: 0,
-            hitRate: 0,
-            tierBreakdown: { hot: 0, warm: 0, cold: 0 },
-            topDrugs: [],
-        };
+        sendCacheAlertDiscord().catch(() => {});
+        return defaultStats;
     }
 }
 

--- a/apps/api/src/services/cache.test.ts
+++ b/apps/api/src/services/cache.test.ts
@@ -1,4 +1,9 @@
-import { getCachedDrug, incrementHitCount, incrementMissCount } from "./cache.service";
+import {
+    getCachedDrug,
+    incrementHitCount,
+    incrementMissCount,
+    getCacheStats,
+} from "./cache.service";
 
 import { redisClient } from "../utils/redis";
 
@@ -7,9 +12,10 @@ jest.mock("../utils/redis", () => ({
     redisClient: {
         isOpen: true,
         get: jest.fn(),
-        set: jest.fn(),
+        set: jest.fn().mockResolvedValue("OK"),
         incr: jest.fn(),
         zIncrBy: jest.fn(),
+        zRangeWithScores: jest.fn(),
     },
 }));
 
@@ -137,6 +143,91 @@ describe("cache.service", () => {
             const result = await incrementMissCount();
 
             expect(result).toBe(0);
+        });
+    });
+
+    describe("getCacheStats", () => {
+        const mockFetch = jest.fn();
+        global.fetch = mockFetch;
+
+        beforeEach(() => {
+            mockFetch.mockClear();
+            process.env.PG_CRON_MONITOR_WEBHOOK_URL = "http://mock-webhook";
+        });
+
+        it("should return live stats and save snapshot on success", async () => {
+            (redisClient.get as jest.Mock).mockImplementation((key) => {
+                if (key === "stats:snapshot:last_known") return Promise.resolve(null);
+                if (key === "stats:hits") return Promise.resolve("10");
+                if (key === "stats:misses") return Promise.resolve("5");
+                if (key === "stats:tier:hot") return Promise.resolve("2");
+                if (key === "stats:tier:warm") return Promise.resolve("3");
+                if (key === "stats:tier:cold") return Promise.resolve("5");
+                return Promise.resolve(null);
+            });
+            (redisClient.zRangeWithScores as jest.Mock).mockResolvedValue([
+                { value: "Dolo", score: 10 },
+            ]);
+
+            const stats = await getCacheStats();
+
+            expect(stats.hits).toBe(10);
+            expect(stats.misses).toBe(5);
+            expect(stats.hitRate).toBe(67);
+            expect(redisClient.set).toHaveBeenCalledWith(
+                "stats:snapshot:last_known",
+                expect.any(String),
+                { EX: 300 }
+            );
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it("should return snapshot if live stats partially fail", async () => {
+            const staleSnapshot = {
+                hits: 100,
+                misses: 50,
+                hitRate: 67,
+                tierBreakdown: { hot: 10, warm: 20, cold: 30 },
+                topDrugs: [{ name: "Crocin", count: 100 }],
+            };
+
+            (redisClient.get as jest.Mock).mockImplementation((key) => {
+                if (key === "stats:snapshot:last_known")
+                    return Promise.resolve(JSON.stringify(staleSnapshot));
+                if (key === "stats:hits") return Promise.resolve("10");
+                if (key === "stats:misses") return Promise.reject(new Error("Redis error"));
+                return Promise.resolve("0");
+            });
+            (redisClient.zRangeWithScores as jest.Mock).mockResolvedValue([]);
+
+            const stats = await getCacheStats();
+
+            expect(stats).toEqual(staleSnapshot);
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it("should fire discord alert and return default stats if all fail and no snapshot", async () => {
+            // Fast forward time to avoid debounce
+            jest.spyOn(Date, "now").mockImplementation(() => 9999999999999);
+            mockFetch.mockResolvedValue({ ok: true });
+
+            (redisClient.get as jest.Mock).mockRejectedValue(new Error("Redis is down completely"));
+            (redisClient.zRangeWithScores as jest.Mock).mockRejectedValue(
+                new Error("Redis is down completely")
+            );
+
+            const stats = await getCacheStats();
+
+            expect(stats.hits).toBe(0);
+            expect(stats.misses).toBe(0);
+            expect(mockFetch).toHaveBeenCalledWith(
+                "http://mock-webhook",
+                expect.objectContaining({
+                    method: "POST",
+                })
+            );
+
+            jest.restoreAllMocks();
         });
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3579 **
- **Summary:**
-  Successfully fetched cache statistics are now aggregated and written to a short-lived (5-minute TTL) Redis key: stats:snapshot:last_known
- getCacheStats() now polls the live stats alongside the stale snapshot via Promise.allSettled.
-  If any single live stat fetch fails, the function will seamlessly return the stale snapshot to ensure continuity in the UI.
**Discord Alerting**:
- Implemented the sendCacheAlertDiscord helper function following the existing webhook pattern.
- If all stat fetches fail (indicative of a complete node failure), the webhook triggers an alert.
- A 15-minute global debounce (lastDiscordAlertTime) has been added to prevent webhook spam during sustained outages.
 Environment Configuration
- Added the PG_CRON_MONITOR_WEBHOOK_URL definition to .env.example beneath a new # --- Monitoring / Alerts --- header.
**Comprehensive Unit Testing**
- Updated the cache.test.ts suite with three new robust cases:
- Success path: Validates live stats return correct integers and successfully fire redisClient.set to save the snapshot.
- Partial failure path: Mocks an error for one live stat fetch and confirms the snapshot is appropriately returned without alerting.
- Complete failure path: Mocks an entirely down Redis fetch, verifies that the webhook POST is initiated via global fetch(), and returns default 0 values as a last resort fallback.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
