### PR TITLE
fix(a11y): add ARIA live regions and keyboard focus management to InteractiveOverlays

### DIFF
--- a/apps/web/app/[locale]/components/Chatbot.tsx
+++ b/apps/web/app/[locale]/components/Chatbot.tsx
@@ -8,6 +8,7 @@ import { Link } from "@/i18n/routing";
 import { getChatbotPanelClasses, getChatbotPositionClasses } from "./chatbotPosition";
 import { ChatMarkdown } from "@/app/components/ChatMarkdown";
 import { isAbortError, readChatErrorMessage, readTextResponseStream } from "@/lib/chatStream";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 
 type Message = {
     text: string;
@@ -70,7 +71,29 @@ export default function Chatbot() {
     const [isConfirmingClear, setIsConfirmingClear] = useState(false);
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const chatbotRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
     const activeRequestRef = useRef<AbortController | null>(null);
+
+    // Traps Tab inside the panel while it is open and restores focus to the launcher on close.
+    useFocusTrap(chatbotRef, isOpen);
+
+    // The trap lands on the first control in the header; the message input is where a keyboard
+    // user actually wants to start, so claim focus after the trap has run.
+    useEffect(() => {
+        if (isOpen) {
+            inputRef.current?.focus();
+        }
+    }, [isOpen]);
+
+    const lastMessage = messages[messages.length - 1];
+    const assistantAnnouncement =
+        !isOpen || !lastMessage?.isBot
+            ? ""
+            : lastMessage.isTyping
+              ? tA11y("assistantThinking")
+              : lastMessage.isTranslationKey
+                ? safeT(t, lastMessage.text, lastMessage.text)
+                : lastMessage.text;
 
     const scrollToBottom = () => {
         messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -195,8 +218,27 @@ export default function Chatbot() {
 
     return (
         <div className={getChatbotPositionClasses({ pathname, isOpen })}>
+            {/* Lives outside the panel so it stays in the accessibility tree while the panel is
+                inert, letting screen readers announce replies as they land. */}
+            <p className="sr-only" role="status" aria-live="polite">
+                {assistantAnnouncement}
+            </p>
+
             <div
                 ref={chatbotRef}
+                id="chatbot-panel"
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="chatbot-title"
+                // The panel stays mounted so it can animate, so it must be pulled out of the tab
+                // order and the accessibility tree while it is visually hidden.
+                inert={!isOpen}
+                aria-hidden={!isOpen}
+                onKeyDown={(e) => {
+                    if (e.key === "Escape") {
+                        setIsOpen(false);
+                    }
+                }}
                 className={`${getChatbotPanelClasses({ pathname })} ${
                     isOpen
                         ? "pointer-events-auto scale-100 opacity-100"
@@ -210,7 +252,9 @@ export default function Chatbot() {
                             <Bot size={20} />
                         </div>
                         <div>
-                            <h3 className="text-sm font-bold">{titleLabel}</h3>
+                            <h3 id="chatbot-title" className="text-sm font-bold">
+                                {titleLabel}
+                            </h3>
                             <p className="text-xs text-white/95">{statusLabel}</p>
                         </div>
                     </div>
@@ -285,11 +329,13 @@ export default function Chatbot() {
                 {/* Input Area */}
                 <div className="flex items-center gap-2 border-t border-(--color-border-muted) bg-(--color-surface-page) p-3">
                     <input
+                        ref={inputRef}
                         type="text"
                         value={input}
                         onChange={(e) => setInput(e.target.value)}
                         onKeyDown={(e) => e.key === "Enter" && handleSend()}
                         placeholder={placeholderLabel}
+                        aria-label={placeholderLabel}
                         className="flex-1 rounded-full bg-(--color-surface-muted) px-4 py-3 text-sm text-(--color-text-primary) transition-all placeholder:text-(--color-text-muted) focus:ring-2 focus:ring-green-500/50 focus:outline-none"
                     />
                     <button
@@ -317,6 +363,8 @@ export default function Chatbot() {
                     }}
                     className="relative z-10 flex h-14 w-14 items-center justify-center rounded-full bg-green-600 text-white shadow-[0_8px_20px_rgba(22,163,74,0.3)] transition-all hover:scale-105 hover:shadow-[0_8px_25px_rgba(22,163,74,0.4)] active:scale-95 dark:bg-green-700 dark:hover:bg-green-800"
                     aria-label={isOpen ? tA11y("closeAiChat") : tA11y("openAiChat")}
+                    aria-expanded={isOpen}
+                    aria-controls="chatbot-panel"
                 >
                     {isOpen ? <X size={28} /> : <MessageSquare size={28} />}
                 </button>

--- a/apps/web/app/[locale]/components/CommandPalette.tsx
+++ b/apps/web/app/[locale]/components/CommandPalette.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "@/i18n/routing";
 import { useTranslations } from "next-intl";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 import {
     Search,
     X,
@@ -111,6 +112,10 @@ export default function CommandPalette() {
         cmd.label.toLowerCase().includes(query.toLowerCase())
     );
 
+    const optionId = (cmd: Command) => `command-palette-option-${cmd.id}`;
+    const activeCommand = filtered[activeIndex];
+    const activeOptionId = activeCommand ? optionId(activeCommand) : undefined;
+
     // Open/close with Ctrl+K
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
@@ -126,14 +131,36 @@ export default function CommandPalette() {
         return () => window.removeEventListener("keydown", handleKeyDown);
     }, []);
 
-    // Focus input when opened
+    // Moves focus into the palette (the search input is its first focusable child), keeps Tab
+    // inside it, and restores focus to whatever was focused before it opened.
+    useFocusTrap(containerRef, isOpen);
+
+    // Reset the search when opened
     useEffect(() => {
         if (isOpen) {
-            setTimeout(() => inputRef.current?.focus(), 50);
             setQuery("");
             setActiveIndex(0);
         }
     }, [isOpen]);
+
+    // Keep the background page from scrolling behind the modal
+    useEffect(() => {
+        if (!isOpen) return;
+
+        const previousOverflow = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+
+        return () => {
+            document.body.style.overflow = previousOverflow;
+        };
+    }, [isOpen]);
+
+    // Keep the arrow-key selection visible in the scrollable results list
+    useEffect(() => {
+        if (!isOpen || !activeOptionId) return;
+
+        document.getElementById(activeOptionId)?.scrollIntoView({ block: "nearest" });
+    }, [isOpen, activeOptionId]);
 
     // Close on outside click
     useEffect(() => {
@@ -173,11 +200,18 @@ export default function CommandPalette() {
         <div className="fixed inset-0 z-[9999] flex items-start justify-center bg-black/50 pt-[15vh] backdrop-blur-sm">
             <div
                 ref={containerRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label={t("title")}
                 className="w-full max-w-lg rounded-2xl border border-(--color-border-muted) bg-(--color-surface-page) shadow-2xl"
             >
+                <p className="sr-only" role="status" aria-live="polite">
+                    {t("resultsCount", { count: filtered.length })}
+                </p>
+
                 {/* Search input */}
                 <div className="flex items-center gap-3 border-b border-(--color-border-muted) px-4 py-3">
-                    <Search size={18} className="shrink-0 opacity-50" />
+                    <Search size={18} className="shrink-0 opacity-50" aria-hidden="true" />
                     <input
                         ref={inputRef}
                         type="text"
@@ -188,42 +222,73 @@ export default function CommandPalette() {
                         }}
                         onKeyDown={handleKeyDown}
                         placeholder={t("placeholder")}
+                        aria-label={t("placeholder")}
+                        role="combobox"
+                        aria-expanded={filtered.length > 0}
+                        aria-controls="command-palette-listbox"
+                        aria-activedescendant={activeOptionId}
+                        aria-autocomplete="list"
                         className="flex-1 bg-transparent text-sm text-(--color-text-primary) outline-none placeholder:opacity-50"
                     />
                     <button
+                        type="button"
                         onClick={() => setIsOpen(false)}
+                        aria-label={t("close")}
                         className="shrink-0 opacity-50 hover:opacity-100"
                     >
-                        <X size={16} />
+                        <X size={16} aria-hidden="true" />
                     </button>
                 </div>
 
                 {/* Results */}
-                <div className="max-h-80 overflow-y-auto p-2">
+                <div
+                    id="command-palette-listbox"
+                    role="listbox"
+                    aria-label={t("title")}
+                    className="max-h-80 overflow-y-auto p-2"
+                >
                     {filtered.length === 0 ? (
                         <p className="py-8 text-center text-sm opacity-50">{t("noResults")}</p>
                     ) : (
-                        groups.map((group) => (
-                            <div key={group} className="mb-2">
-                                <p className="mb-1 px-2 text-[10px] font-bold tracking-wider uppercase opacity-40">
+                        groups.map((group, groupIndex) => (
+                            <div
+                                key={group}
+                                role="group"
+                                aria-labelledby={`command-palette-group-${groupIndex}`}
+                                className="mb-2"
+                            >
+                                <p
+                                    id={`command-palette-group-${groupIndex}`}
+                                    className="mb-1 px-2 text-[10px] font-bold tracking-wider uppercase opacity-40"
+                                >
                                     {group}
                                 </p>
                                 {filtered
                                     .filter((c) => c.group === group)
                                     .map((cmd) => {
                                         const globalIndex = filtered.indexOf(cmd);
+                                        const isActive = activeIndex === globalIndex;
                                         return (
                                             <button
                                                 key={cmd.id}
+                                                id={optionId(cmd)}
+                                                type="button"
+                                                role="option"
+                                                aria-selected={isActive}
+                                                // Selection is driven by aria-activedescendant from
+                                                // the input, so options stay out of the tab order.
+                                                tabIndex={-1}
                                                 onClick={() => execute(cmd)}
                                                 onMouseEnter={() => setActiveIndex(globalIndex)}
                                                 className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm font-medium transition-colors ${
-                                                    activeIndex === globalIndex
+                                                    isActive
                                                         ? "bg-emerald-500/10 text-emerald-600"
                                                         : "text-(--color-text-primary) hover:bg-(--color-surface-muted)"
                                                 }`}
                                             >
-                                                <span className="opacity-60">{cmd.icon}</span>
+                                                <span className="opacity-60" aria-hidden="true">
+                                                    {cmd.icon}
+                                                </span>
                                                 {cmd.label}
                                             </button>
                                         );

--- a/apps/web/hooks/useFocusTrap.ts
+++ b/apps/web/hooks/useFocusTrap.ts
@@ -27,10 +27,14 @@ export function useFocusTrap<T extends HTMLElement>(
         const FOCUSABLE_SELECTOR =
             'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable], [tabindex]:not([tabindex="-1"])';
 
-        // Find focusable elements
+        // Find focusable elements. Elements opted out of the tab order (tabindex="-1") are
+        // programmatically focusable but never reachable via Tab, so they must not act as the
+        // trap's boundaries — e.g. aria-activedescendant listbox options.
         const getFocusableElements = (): HTMLElement[] => {
             if (!ref.current) return [];
-            return Array.from(ref.current.querySelectorAll(FOCUSABLE_SELECTOR)) as HTMLElement[];
+            return Array.from(ref.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+                (element) => element.getAttribute("tabindex") !== "-1"
+            );
         };
 
         // Focus the first focusable element initially

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -194,6 +194,7 @@
         "sendMessage": "Send message",
         "openAiChat": "Open AI chat",
         "closeAiChat": "Close AI chat",
+        "assistantThinking": "SahiDawa AI is thinking",
         "mainNavigation": "Main navigation",
         "mobileNavigation": "Mobile navigation",
         "toggleSystemParameters": "Toggle system parameters"
@@ -1021,6 +1022,9 @@
         "placeholder": "Search pages or actions...",
         "noResults": "No results found.",
         "hint": "Press Esc to close",
+        "title": "Command palette",
+        "close": "Close command palette",
+        "resultsCount": "{count, plural, =0 {No results available} one {# result available} other {# results available}}",
         "pages": "Pages",
         "actions": "Actions",
         "open": "Open command palette",

--- a/apps/web/tests/interactive-overlays-a11y.test.tsx
+++ b/apps/web/tests/interactive-overlays-a11y.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import Chatbot from "../app/[locale]/components/Chatbot";
+import CommandPalette from "../app/[locale]/components/CommandPalette";
+
+jest.mock("next-intl", () => ({
+    useLocale: () => "en",
+    useTranslations: () => (key: string, values?: Record<string, unknown>) =>
+        values && "count" in values ? `${key}:${String(values.count)}` : key,
+}));
+
+describe("Chatbot accessibility", () => {
+    it("exposes the panel as a labelled modal dialog", () => {
+        render(<Chatbot />);
+
+        const dialog = screen.getByRole("dialog", { hidden: true });
+        expect(dialog).toHaveAttribute("aria-modal", "true");
+        expect(dialog).toHaveAttribute("aria-labelledby", "chatbot-title");
+        expect(document.getElementById("chatbot-title")).toHaveTextContent("title");
+    });
+
+    it("keeps the closed panel out of the tab order and accessibility tree", () => {
+        render(<Chatbot />);
+
+        // The panel stays mounted so it can animate, so `inert` is what actually hides it.
+        const dialog = screen.getByRole("dialog", { hidden: true });
+        expect(dialog).toHaveAttribute("inert");
+        expect(dialog).toHaveAttribute("aria-hidden", "true");
+
+        const launcher = screen.getByRole("button", { name: "openAiChat" });
+        expect(launcher).toHaveAttribute("aria-expanded", "false");
+        expect(launcher).toHaveAttribute("aria-controls", "chatbot-panel");
+    });
+
+    it("moves focus into the panel on open and restores it to the launcher on close", async () => {
+        render(<Chatbot />);
+
+        const launcher = screen.getByRole("button", { name: "openAiChat" });
+        launcher.focus();
+        fireEvent.click(launcher);
+
+        const dialog = screen.getByRole("dialog");
+        expect(dialog).not.toHaveAttribute("inert");
+        expect(dialog).toHaveAttribute("aria-hidden", "false");
+
+        // Focus lands on the message input, not the first header button.
+        await waitFor(() => {
+            expect(screen.getByRole("textbox", { name: "placeholder" })).toHaveFocus();
+        });
+        expect(dialog).toContainElement(document.activeElement as HTMLElement);
+
+        fireEvent.keyDown(dialog, { key: "Escape" });
+
+        await waitFor(() => expect(launcher).toHaveFocus());
+    });
+
+    it("announces the assistant's latest message in a polite live region", async () => {
+        render(<Chatbot />);
+
+        const status = screen.getByRole("status");
+        expect(status).toHaveAttribute("aria-live", "polite");
+        // Nothing to announce while the chat is closed.
+        expect(status).toBeEmptyDOMElement();
+
+        fireEvent.click(screen.getByRole("button", { name: "openAiChat" }));
+
+        await waitFor(() => expect(status).toHaveTextContent("welcome"));
+    });
+});
+
+describe("CommandPalette accessibility", () => {
+    const openPalette = () => {
+        fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    };
+
+    beforeEach(() => {
+        document.body.style.overflow = "";
+    });
+
+    afterEach(() => {
+        document.body.style.overflow = "";
+    });
+
+    it("renders as a labelled modal dialog and locks background scrolling", () => {
+        render(<CommandPalette />);
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+        openPalette();
+
+        const dialog = screen.getByRole("dialog");
+        expect(dialog).toHaveAttribute("aria-modal", "true");
+        expect(dialog).toHaveAccessibleName("title");
+        expect(document.body.style.overflow).toBe("hidden");
+    });
+
+    it("moves focus to the search input and restores it to the opener on close", async () => {
+        const opener = document.createElement("button");
+        document.body.appendChild(opener);
+        opener.focus();
+
+        render(<CommandPalette />);
+        openPalette();
+
+        const input = screen.getByRole("combobox");
+        await waitFor(() => expect(input).toHaveFocus());
+
+        fireEvent.keyDown(window, { key: "Escape" });
+
+        await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+        await waitFor(() => expect(opener).toHaveFocus());
+        expect(document.body.style.overflow).toBe("");
+
+        opener.remove();
+    });
+
+    it("wires the search input to the results listbox with aria-activedescendant", () => {
+        render(<CommandPalette />);
+        openPalette();
+
+        const input = screen.getByRole("combobox");
+        expect(input).toHaveAttribute("aria-controls", "command-palette-listbox");
+        expect(input).toHaveAttribute("aria-expanded", "true");
+
+        const options = screen.getAllByRole("option");
+        expect(options[0]).toHaveAttribute("aria-selected", "true");
+        expect(input).toHaveAttribute("aria-activedescendant", options[0].id);
+
+        // Options are driven by aria-activedescendant, so they stay out of the tab order and
+        // focus remains on the input as the user arrows through results.
+        expect(options[0]).toHaveAttribute("tabindex", "-1");
+
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+
+        expect(input).toHaveAttribute("aria-activedescendant", options[1].id);
+        expect(options[1]).toHaveAttribute("aria-selected", "true");
+        expect(options[0]).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("announces the number of matching results as the query changes", () => {
+        render(<CommandPalette />);
+        openPalette();
+
+        const status = screen.getByRole("status");
+        expect(status).toHaveAttribute("aria-live", "polite");
+        expect(status).toHaveTextContent("resultsCount:10");
+
+        fireEvent.change(screen.getByRole("combobox"), { target: { value: "zzzz" } });
+
+        expect(status).toHaveTextContent("resultsCount:0");
+        expect(screen.getByText("noResults")).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Closes #3272

> **On assignment:** this task was still unassigned and open to all at the time of writing, so I followed the contributor instructions by posting my proposed approach on the issue rather than asking to be assigned. Opening the PR alongside it so the approach is reviewable against real code. If a maintainer would rather assign this to someone else, say the word and I'll close it.

## Summary

Makes the two overlays rendered by `InteractiveOverlays` — the Chatbot and the Command Palette — usable with a screen reader and a keyboard: both are now real modal dialogs that announce themselves, trap Tab, and hand focus back where it came from.

Rather than pull in Radix or a headless-UI dialog, this reuses the project's existing `useFocusTrap` hook, which already backs `ConfirmationDialog`, `ExpiryModal`, `ExportModal` and `RequestVerificationModal` — so the overlays now behave consistently with the dialogs we already ship, and the PR adds no new dependency.

## Two findings worth calling out

**1. The Chatbot panel never unmounts.** It stays in the DOM at `opacity-0` so it can animate open and closed. `pointer-events-none` hides it from the *mouse* only — which means today the entire **closed** chat panel (its input, the clear/home/close buttons, the whole transcript) is reachable by Tab and readable by a screen reader on every page of the site. This is the concrete form of the "interacting with the hidden background page" problem in the issue. The panel is now `inert` + `aria-hidden` while closed.

**2. `useFocusTrap` had a latent bug.** Its focusable-elements selector matches `button:not([disabled])`, which also matches buttons with `tabindex="-1"`. Those are not Tab-reachable, so when one of them was picked as the trap's *last* boundary, Tab escaped the dialog entirely instead of cycling. The Command Palette's `aria-activedescendant` listbox options are exactly that case, so this had to be fixed for the trap to hold. `tabindex="-1"` elements are now excluded from the boundary calculation. This is strictly a fix — no existing modal uses `tabindex="-1"`, so none of them change behaviour (the existing suites confirm this).

## Changes

**`Chatbot.tsx`**
- Panel exposed as `role="dialog"` / `aria-modal="true"`, labelled by its existing title heading.
- `inert` + `aria-hidden` while closed (see finding 1).
- Tab trapped inside the panel while open; focus lands on the **message input** (the trap alone would land on the header's "clear" button, which isn't where a keyboard user wants to start).
- <kbd>Esc</kbd> closes the panel and focus returns to the launcher button, which now carries `aria-expanded` / `aria-controls`.
- Bot replies announced through a polite live region deliberately placed **outside** the panel — a live region inside an `inert` subtree cannot announce. It holds a steady "is thinking" message while the reply streams and announces the completed reply once, rather than re-announcing on every streamed chunk.

**`CommandPalette.tsx`**
- `role="dialog"` / `aria-modal="true"` with an accessible name.
- The focus trap replaces the existing `setTimeout(() => input.focus(), 50)` hack, and additionally restores focus to whatever was focused before the palette opened.
- Proper combobox/listbox semantics: the input keeps DOM focus and drives selection via `aria-activedescendant`; options are `role="option"` with `aria-selected` and `tabindex="-1"`; arrow-key selection scrolls into view.
- A polite live region announces the number of matching results as the query changes.
- Background scroll locked while open.

**`useFocusTrap.ts`** — the `tabindex="-1"` boundary fix (see finding 2).

**`messages/en.json`** — three new strings (`A11y.assistantThinking`, `CommandPalette.title` / `close` / `resultsCount`). English only is correct here: `i18n/request.ts` deep-merges `en.json` as a fallback beneath every locale, which is why the `A11y` namespace currently exists in `en.json` alone.

`InteractiveOverlays.tsx` itself is unchanged — it's a `dynamic()` wrapper with no interactive markup, so the accessibility work belongs in the two child components. (Note the components live under `app/[locale]/components/`, not `apps/web/components/` as the issue lists.)

## Testing

New suite `apps/web/tests/interactive-overlays-a11y.test.tsx` (8 tests) asserting the acceptance criteria directly rather than incidentally:
- focus moves into each overlay on open and back to the opener on close;
- the closed Chatbot panel is `inert` and out of the accessibility tree;
- the combobox/listbox wiring (`aria-activedescendant`, `aria-selected`, `tabindex`) tracks arrow-key navigation;
- both live regions announce (assistant replies; palette result counts).

- New suite: **8/8 passing**.
- Suites covering the shared hook and the four modals that depend on it: **33/33 passing** — no regression from the `useFocusTrap` change.
- ESLint and Prettier clean; `tsc --noEmit` introduces no new errors.

Manual screen-reader pass still to do (the issue asks for VoiceOver/NVDA confirmation) — happy to record a pass before merge if you'd like.
