### PR TITLE
fix(a11y): add ARIA live regions and keyboard focus management to InteractiveOverlays

### DIFF
--- a/apps/web/app/[locale]/components/Chatbot.tsx
+++ b/apps/web/app/[locale]/components/Chatbot.tsx
@@ -8,6 +8,7 @@ import { Link } from "@/i18n/routing";
 import { getChatbotPanelClasses, getChatbotPositionClasses } from "./chatbotPosition";
 import { ChatMarkdown } from "@/app/components/ChatMarkdown";
 import { isAbortError, readChatErrorMessage, readTextResponseStream } from "@/lib/chatStream";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 
 type Message = {
     text: string;
@@ -121,6 +122,7 @@ export default function Chatbot() {
             activeRequestRef.current?.abort();
         };
     }, []);
+    useFocusTrap(chatbotRef, isOpen);
 
     // Securely check route-based visibility after hook declarations to satisfy React Rules of Hooks
     if (pathname && pathname.includes("/health")) {
@@ -195,8 +197,16 @@ export default function Chatbot() {
 
     return (
         <div className={getChatbotPositionClasses({ pathname, isOpen })}>
+            <div aria-live="polite" className="sr-only">
+                {isOpen ? `${titleLabel} ${statusLabel}` : ""}
+            </div>
             <div
                 ref={chatbotRef}
+                role="dialog"
+                aria-modal={isOpen}
+                aria-hidden={!isOpen}
+                aria-label={titleLabel}
+                inert={!isOpen}
                 className={`${getChatbotPanelClasses({ pathname })} ${
                     isOpen
                         ? "pointer-events-auto scale-100 opacity-100"

--- a/apps/web/app/[locale]/components/CommandPalette.tsx
+++ b/apps/web/app/[locale]/components/CommandPalette.tsx
@@ -16,6 +16,7 @@ import {
     FileText,
     User,
 } from "lucide-react";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 
 interface Command {
     id: string;
@@ -145,6 +146,7 @@ export default function CommandPalette() {
         if (isOpen) document.addEventListener("mousedown", handleClickOutside);
         return () => document.removeEventListener("mousedown", handleClickOutside);
     }, [isOpen]);
+    useFocusTrap(containerRef, isOpen);
 
     // Arrow key navigation
     const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -173,6 +175,9 @@ export default function CommandPalette() {
         <div className="fixed inset-0 z-[9999] flex items-start justify-center bg-black/50 pt-[15vh] backdrop-blur-sm">
             <div
                 ref={containerRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label={t("placeholder")}
                 className="w-full max-w-lg rounded-2xl border border-(--color-border-muted) bg-(--color-surface-page) shadow-2xl"
             >
                 {/* Search input */}


### PR DESCRIPTION
Closes #3272

## What this does
Adds keyboard focus management and dialog semantics to the Chatbot and CommandPalette overlays extracted in `InteractiveOverlays.tsx`, so keyboard and screen reader users aren't left interacting with the hidden background page while an overlay is open.

## Approach
The repo already had a fully-implemented `useFocusTrap` hook (with its own test suite) that wasn't wired into either overlay yet. Rather than reimplementing focus-trapping from scratch, this PR wires it in and adds the missing dialog semantics on top:

**Chatbot.tsx**
- Wired in the existing `useFocusTrap(chatbotRef, isOpen)` hook
- Added `role="dialog"`, `aria-modal`, `aria-hidden`, and `aria-label` to the panel
- Added `inert={!isOpen}` — since this panel stays mounted and only fades via CSS transitions (rather than unmounting), `inert` is needed to remove it from the tab order and screen reader tree while closed; `aria-hidden` alone isn't sufficient for a keyboard-only user
- Added a visually-hidden `aria-live="polite"` region that announces when the assistant opens

**CommandPalette.tsx**
- Wired in `useFocusTrap(containerRef, isOpen)`
- Added `role="dialog"`, `aria-modal="true"`, and `aria-label`
- No separate live region needed here since this component fully unmounts on close (`if (!isOpen) return null`), so its `role="dialog"` and label are picked up naturally when it mounts

## Testing
- Manually verified keyboard-only navigation: Tab/Shift+Tab stay contained within both overlays while open, wrapping correctly at the first/last focusable element
- Verified closing each overlay returns focus appropriately (Chatbot: back to the trigger bubble via the hook's built-in focus restoration, which already has test coverage in `useFocusTrap.test.tsx`)
- Confirmed no visual regressions — the added attributes are behavioral only
- Ran `npm run lint` and `npx tsc --noEmit` — no new errors introduced (pre-existing `@sahidawa/*` workspace build and jest tsconfig deprecation issues were confirmed present on clean `main` via `git stash`, unrelated to this change)