### PR TITLE
fix(api): apply CSRF middleware consistently across environments

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -98,14 +98,28 @@ app.use(cors(createCorsOptions()));
 // csrf-csrf is recognized by CodeQL as a valid CSRF defense unlike custom header checks.
 const ANON_SESSION_COOKIE = "csrf_anon_id";
 
+// Decided once at startup so it stays stable even if a test mutates NODE_ENV.
+const SKIP_CSRF_VALIDATION = process.env.NODE_ENV === "test";
+
+// Ephemeral fallback secret for local dev when CSRF_SECRET is unset (see getSecret).
+let devCsrfSecret: string | undefined;
+
 const { doubleCsrfProtection, generateCsrfToken: generateToken } = doubleCsrf({
     getSecret: () => {
         const secret = process.env.CSRF_SECRET;
-        if (!secret) {
-            logger.error("CSRF_SECRET environment variable is not set");
-            throw new Error("CSRF_SECRET environment variable is required");
+        if (secret) return secret;
+        // Production never reaches here: startup exits when CSRF_SECRET is missing
+        // outside dev/test. Now that the middleware runs in development too, mint a
+        // random per-process secret so local dev works without extra setup instead
+        // of 500-ing every request. Generated (not hardcoded) so it is never a
+        // predictable credential; it simply won't survive a restart.
+        if (!devCsrfSecret) {
+            devCsrfSecret = crypto.randomBytes(32).toString("hex");
+            logger.warn(
+                "CSRF_SECRET is not set — using an ephemeral per-process dev secret. Set CSRF_SECRET (see .env.example) outside local development."
+            );
         }
-        return secret;
+        return devCsrfSecret;
     },
     getSessionIdentifier: (req: Request) => {
         if (req.cookies?.access_token) {
@@ -122,13 +136,17 @@ const { doubleCsrfProtection, generateCsrfToken: generateToken } = doubleCsrf({
         path: "/",
     },
     size: 64,
+    // Let the automated test suites bypass token validation without stripping the
+    // middleware from the app. The supertest suites don't run the token handshake.
+    // Captured once at load (like the previous env gate) so tests that flip
+    // NODE_ENV mid-run to exercise prod branches don't suddenly hit CSRF.
+    skipCsrfProtection: () => SKIP_CSRF_VALIDATION,
 });
 
-// Skip CSRF in test and development environments to support cross-port local testing
-const isTestOrDev = process.env.NODE_ENV === "test" || process.env.NODE_ENV === "development";
-if (!isTestOrDev) {
-    app.use(doubleCsrfProtection);
-}
+// Registered in every environment so CodeQL sees CSRF middleware on every route
+// (resolves Alert 136) and development mirrors production, surfacing CSRF
+// integration issues locally instead of only after deploy.
+app.use(doubleCsrfProtection);
 
 // ── CSRF token endpoint — frontend fetches this once on load ───────────────
 app.get("/api/csrf-token", (req: Request, res: Response) => {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -116,7 +116,7 @@ const { doubleCsrfProtection, generateCsrfToken: generateToken } = doubleCsrf({
         if (!devCsrfSecret) {
             devCsrfSecret = crypto.randomBytes(32).toString("hex");
             logger.warn(
-                "CSRF_SECRET is not set — using an ephemeral per-process dev secret. Set CSRF_SECRET (see .env.example) outside local development."
+                "CSRF_SECRET is not set — using an ephemeral per-process dev secret. Set the CSRF_SECRET environment variable outside local development."
             );
         }
         return devCsrfSecret;

--- a/apps/api/tests/csrfProtection.test.ts
+++ b/apps/api/tests/csrfProtection.test.ts
@@ -1,0 +1,86 @@
+import request from "supertest";
+import type { Express } from "express";
+
+// Enforcement coverage for #3552.
+//
+// The fix mounts doubleCsrfProtection in every environment and only skips token
+// validation when NODE_ENV === "test". The rest of the suite runs under "test",
+// where the skip is active, so nothing there proves the middleware actually
+// blocks a forged request. These tests load a fresh app instance with
+// NODE_ENV=development (skip inactive, http-safe cookie) and assert the real
+// double-submit behaviour: a state-changing request with no token is rejected,
+// and the same request carrying a token minted by /api/csrf-token is accepted.
+//
+// The probe targets a path with no route so the assertion is about the global
+// CSRF middleware itself, not any single route's auth or body validation.
+
+// Booting the app under a non-test env would otherwise construct the real BullMQ
+// sms queue, whose ioredis connection retries 127.0.0.1:6379 forever and keeps
+// jest from exiting. Stub it with the same no-op shape the source uses under
+// test so the app still wires the real CSRF middleware — just without the socket.
+jest.mock("../src/queues/smsQueue", () => ({
+    smsQueue: { add: async () => {}, on: () => {} },
+}));
+
+const PROBE = "/api/__csrf_probe__";
+
+describe("CSRF protection enforcement (#3552)", () => {
+    const OLD_ENV = process.env.NODE_ENV;
+    let app: Express;
+    // Intervals the app's module graph registers at load time, captured so they
+    // can be cleared after the suite (see beforeAll).
+    const bootTimers: NodeJS.Timeout[] = [];
+
+    beforeAll(() => {
+        // Load the app under development so SKIP_CSRF_VALIDATION is false and the
+        // middleware actually validates. This file imports the app lazily (here,
+        // not at top level) precisely so this env is set before the module loads.
+        process.env.NODE_ENV = "development";
+
+        // Under NODE_ENV != "test", requiring the app boots db/client.ts, which
+        // starts a 30s Supabase probe via setInterval that is never unref'd — it
+        // would keep the event loop (and jest) alive after the suite finishes.
+        // Capture every interval the load registers so afterAll can clear them;
+        // these tests drive the in-memory app directly and need no background probe.
+        const realSetInterval = global.setInterval;
+        global.setInterval = ((...args: Parameters<typeof setInterval>) => {
+            const timer = realSetInterval(...args);
+            bootTimers.push(timer);
+            return timer;
+        }) as typeof global.setInterval;
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            app = require("../src/app").default as Express;
+        } finally {
+            global.setInterval = realSetInterval;
+        }
+    });
+
+    afterAll(() => {
+        bootTimers.forEach((timer) => clearInterval(timer));
+        process.env.NODE_ENV = OLD_ENV;
+    });
+
+    it("rejects a state-changing POST that carries no CSRF token", async () => {
+        const res = await request(app).post(PROBE).send({ hello: "world" });
+        expect(res.status).toBe(403);
+    });
+
+    it("accepts the same POST once a token from /api/csrf-token accompanies it", async () => {
+        // request.agent keeps the cookie jar (anon id + csrf cookie) across calls.
+        const agent = request.agent(app);
+
+        const tokenRes = await agent.get("/api/csrf-token");
+        expect(tokenRes.status).toBe(200);
+        const token = tokenRes.body.csrfToken as string;
+        expect(typeof token).toBe("string");
+        expect(token.length).toBeGreaterThan(0);
+
+        const res = await agent.post(PROBE).set("x-csrf-token", token).send({ hello: "world" });
+
+        // Valid token → the CSRF middleware lets the request through; the probe
+        // path has no route, so it 404s. The point is it is NOT rejected as 403.
+        expect(res.status).not.toBe(403);
+        expect(res.status).toBe(404);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3552**
- **Summary:**

The old code only mounted `doubleCsrfProtection` when `NODE_ENV` was neither `test` nor `development`. That left route paths with no CSRF middleware on them at all, which is what CodeQL flagged in Alert 136, and it meant dev ran with protection switched off.

The middleware is now mounted unconditionally. What used to be an environment check around `app.use()` became a `skipCsrfProtection` callback on the `doubleCsrf()` config, and that callback only returns true for `NODE_ENV === "test"`. So the middleware is always in the chain, which is what the CodeQL query looks for, and development validates tokens the same way production does.

Two things in here that reviewers should look at closely.

Dev needs a secret now. Since the middleware actually runs in development, `getSecret()` gets called there, and it used to throw when `CSRF_SECRET` was unset. Rather than make every dev request 500, it now mints a random 32-byte secret once per process and logs a warning. It comes from `crypto.randomBytes`, not a hardcoded string, so it is never a predictable credential, and it does not survive a restart. Production cannot reach that branch: `app.ts` already calls `process.exit(1)` at startup if `CSRF_SECRET` is missing outside dev and test.

The test skip is captured at module load, not per request. Some existing suites flip `NODE_ENV` mid-run to exercise production branches. If the skip were evaluated per request, those suites would start failing CSRF checks for reasons that have nothing to do with what they are testing. Reading it once at load keeps the same timing the old env gate had.

No frontend changes were needed. `apps/web/lib/api.ts` already fetches `/api/csrf-token`, sends `x-csrf-token`, and refreshes the token on a 403.

## 📸 Proof of Work (Screenshots / Logs)

I booted the API with `NODE_ENV=development` and sent real requests, first on `main` and then on this branch.

Before, on `main` @ `bd718cf1`. A forged cross-site POST carrying no CSRF token is accepted and passes straight through to the route's own validation:

```
### BEFORE (main @ bd718cf1, NODE_ENV=development) — forged POST, no CSRF token:
   -> HTTP 400   (not 403 => CSRF middleware absent, request accepted)
```

After, on this branch. The forged request is rejected, the real double-submit flow gets through, and a tampered token is rejected:

```
### 1. Forged POST — no CSRF token (attacker's cross-site request)
   -> HTTP 403

### 2. Legit flow — fetch token from /api/csrf-token, then POST with it
   token: b78904ff3a97b74547e9010582993ed7...
   -> HTTP 400  (NOT 403 — CSRF passed; 400 is the route's own body validation)

### 3. Tampered token
   -> HTTP 403
```

`apps/api/tests/csrfProtection.test.ts` locks this in. It loads a fresh app under `NODE_ENV=development` so the skip is inactive, then asserts both directions of the double-submit check. It aims at a path with no route behind it, so what gets asserted is the global middleware and not some individual route's auth or body validation:

```
$ npx jest tests/csrfProtection.test.ts
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```

On regressions: the full API suite comes out the same on this branch as on `main`. 536 passing, and the 7 failures across 5 suites (`requestId`, `adminReportStatus`, `map`, `cache.service`, `abha.service`) reproduce identically on `main` @ `bd718cf1` whether this branch is checked out or not. They are pre-existing and I have not touched them.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3552`)
- [x] I have pulled the latest `main` and resolved any conflicts
