### PR TITLE
fix(scripts): avoid clear-text logging of GEMINI_API_KEY in check_models

### DIFF
--- a/scripts/check_models.py
+++ b/scripts/check_models.py
@@ -14,7 +14,7 @@ if not API_KEY:
 # URL that could be echoed back in an error message or CI log.
 url = "https://generativelanguage.googleapis.com/v1beta/models"
 
-response = requests.get(url, headers={"x-goog-api-key": API_KEY})
+response = requests.get(url, headers={"x-goog-api-key": API_KEY}, timeout=30)
 
 if response.status_code == 200:
     models = response.json().get("models", [])

--- a/scripts/check_models.py
+++ b/scripts/check_models.py
@@ -10,9 +10,11 @@ API_KEY = os.getenv("GEMINI_API_KEY")
 if not API_KEY:
     raise ValueError("GEMINI_API_KEY not found in .env")
 
-url = f"https://generativelanguage.googleapis.com/v1beta/models?key={API_KEY}"
+# Send the key in a header instead of the query string so it never lands in a
+# URL that could be echoed back in an error message or CI log.
+url = "https://generativelanguage.googleapis.com/v1beta/models"
 
-response = requests.get(url)
+response = requests.get(url, headers={"x-goog-api-key": API_KEY})
 
 if response.status_code == 200:
     models = response.json().get("models", [])
@@ -23,4 +25,6 @@ if response.status_code == 200:
         if "generateContent" in model.get("supportedGenerationMethods", []):
             print(f"- {model['name'].replace('models/', '')}")
 else:
-    print("Error:", response.text)
+    # Never print the raw response body — an auth failure can echo the API key
+    # back in clear text. The HTTP status line alone is enough to debug with.
+    print(f"Error: request failed with status {response.status_code} {response.reason}")


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3551**
- **Summary:**

`scripts/check_models.py` put the Gemini key in the query string, then printed `response.text` verbatim on any non-200. Google's error bodies echo the request back, so an auth failure could print the key into a terminal or a CI log.

Two changes. The key moves out of the URL and into the `x-goog-api-key` header, so it can no longer end up in a URL that gets echoed back inside an error body. That header is not a workaround, it is how Google's own `google-genai` client authenticates (`_api_client.py` sets `headers['x-goog-api-key']`). And the error branch stops printing the response body. It prints the status code and reason instead, which is what you need to tell a bad key apart from a network problem or a rate limit.

I also added `timeout=30` to the request. `requests.get` with no timeout blocks forever if the endpoint hangs, which would leave a CI job stuck until the runner kills it. That has nothing to do with the key leak, but it was a one-word fix on the line I was already editing.

## 📸 Proof of Work (Screenshots / Logs)

Ran the script against the live Google endpoint with a deliberately bad key, which is the exact failure path the CodeQL alert is about:

```
$ GEMINI_API_KEY=bogus-test-key python3 scripts/check_models.py
Error: request failed with status 400 Bad Request
```

The key is not in the output. The old code would have printed Google's full JSON error body at this point, and that body is the string that can contain the key.

Compiles clean:

```
$ python3 -m py_compile scripts/check_models.py
(no output)
```

The 200 path is unchanged, so listing models still behaves as it did before.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3551`)
- [x] I have pulled the latest `main` and resolved any conflicts

---

One thing I noticed while working on this, left alone because it is outside the scope of the issue: `apps/ml/services/embedding.py:31` still passes the key as `?key={api_key}` in the URL. Same bug class. Happy to file a separate issue for it if you want it tracked.
