### PR TITLE
fix: add crisp neutral outline ring to Back to Top button for light mode visibility

### DIFF
--- a/apps/web/app/[locale]/components/BackToTopButton.tsx
+++ b/apps/web/app/[locale]/components/BackToTopButton.tsx
@@ -171,8 +171,8 @@ export default function BackToTopButton() {
                     background: "linear-gradient(180deg, #22C55E 0%, #16A34A 100%)",
                     /* Spec shadow: 0 8px 24px rgba(34,197,94,0.25) */
                     boxShadow: isScrollingBack
-                        ? "0 4px 12px rgba(34,197,94,0.18)"
-                        : "0 8px 24px rgba(34,197,94,0.25), 0 2px 8px rgba(0,0,0,0.10)",
+                        ? "0 4px 12px rgba(34,197,94,0.18), 0 0 0 1px rgba(0,0,0,0.08)"
+                        : "0 8px 24px rgba(34,197,94,0.25), 0 2px 8px rgba(0,0,0,0.10), 0 0 0 1px rgba(0,0,0,0.08)",
                 }}
             >
                 {/* Scroll progress ring */}


### PR DESCRIPTION
Closes #3051

## What this does
Improves the Back to Top button's visibility in light mode by adding a subtle, neutral (`rgba(0,0,0,0.08)`) 1px outline ring to its box-shadow, layered underneath the existing green glow.

## Why
The button already uses a solid saturated green gradient (`#22C55E` → `#16A34A`) with a white icon — not a theme-dependent color that fails in light mode. However, its shadow was purely green-tinted (`rgba(34,197,94,...)`), which gives the button soft, blurry edges. A green glow around a green button can visually melt into a bright/light background at the edges, which matches the reported symptom.

Adding a thin neutral dark ring gives the button a crisp, defined edge that reads clearly against any background — light or dark — without changing its color scheme or the existing design language.

## Testing
- Verified in browser: scrolled past the 300px show-threshold in both light and dark mode
- Light mode: button now has a clear, crisp edge against the light page background
- Dark mode: outline is subtle enough that the button's appearance is visually unchanged from before
- No other styling, animation, or behavior was touched