### PR TITLE
feat(stats): replace hardcoded SafetyStatsBanner values with cached DB count queries

### DIFF
--- a/apps/web/app/api/stats/route.ts
+++ b/apps/web/app/api/stats/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+export const revalidate = 3600; // Cache for 1 hour
+
+export async function GET() {
+    try {
+        const [bannedRes, recalledRes, counterfeitRes, nsqRes, scansRes, pharmaciesRes] =
+            await Promise.all([
+                supabase
+                    .from("drug_alerts")
+                    .select("*", { count: "exact", head: true })
+                    .eq("alert_type", "banned"),
+                supabase
+                    .from("drug_alerts")
+                    .select("*", { count: "exact", head: true })
+                    .eq("alert_type", "recalled"),
+                supabase
+                    .from("drug_alerts")
+                    .select("*", { count: "exact", head: true })
+                    .eq("alert_type", "counterfeit"),
+                supabase
+                    .from("drug_alerts")
+                    .select("*", { count: "exact", head: true })
+                    .eq("alert_type", "nsq"),
+                supabase.from("scan_history").select("*", { count: "exact", head: true }),
+                supabase
+                    .from("pharmacies")
+                    .select("*", { count: "exact", head: true })
+                    .eq("is_verified", true),
+            ]);
+
+        // Check for any errors
+        if (bannedRes.error) throw bannedRes.error;
+        if (recalledRes.error) throw recalledRes.error;
+        if (counterfeitRes.error) throw counterfeitRes.error;
+        if (nsqRes.error) throw nsqRes.error;
+        if (scansRes.error) throw scansRes.error;
+        if (pharmaciesRes.error) throw pharmaciesRes.error;
+
+        return NextResponse.json({
+            banned: bannedRes.count ?? 0,
+            recalled: recalledRes.count ?? 0,
+            counterfeit: counterfeitRes.count ?? 0,
+            nsq: nsqRes.count ?? 0,
+            totalScans: scansRes.count ?? 0,
+            verifiedPharmacies: pharmaciesRes.count ?? 0,
+        });
+    } catch (error) {
+        console.error("Error fetching stats:", error);
+        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    }
+}

--- a/apps/web/components/SafetyStatsBanner.tsx
+++ b/apps/web/components/SafetyStatsBanner.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useState, useEffect } from "react";
-import { supabase } from "@/lib/supabase";
 import { Link } from "@/i18n/routing";
 import {
     Ban,
@@ -200,29 +199,23 @@ export default function SafetyStatsBanner() {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
-        async function fetchAlerts() {
-            const { data, error } = await supabase.from("drug_alerts").select("alert_type");
-
-            if (!error && data) {
-                let b = 0,
-                    r = 0,
-                    c = 0,
-                    n = 0;
-                data.forEach((alert) => {
-                    const type = alert.alert_type?.toLowerCase();
-                    if (type === "banned") b++;
-                    else if (type === "recalled") r++;
-                    else if (type === "counterfeit") c++;
-                    else if (type === "nsq") n++;
-                });
-                setBanned(b);
-                setRecalled(r);
-                setCounterfeit(c);
-                setNsq(n);
+        async function fetchStats() {
+            try {
+                const res = await fetch("/api/stats");
+                if (res.ok) {
+                    const data = await res.json();
+                    setBanned(data.banned ?? 0);
+                    setRecalled(data.recalled ?? 0);
+                    setCounterfeit(data.counterfeit ?? 0);
+                    setNsq(data.nsq ?? 0);
+                }
+            } catch (error) {
+                console.error("Failed to fetch safety stats:", error);
+            } finally {
+                setLoading(false);
             }
-            setLoading(false);
         }
-        fetchAlerts();
+        fetchStats();
     }, []);
 
     // const now = new Date();

--- a/apps/web/tests/stats-route.test.ts
+++ b/apps/web/tests/stats-route.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { GET } from "../app/api/stats/route";
+
+// Setup mocks for supabase
+const mockEq = jest.fn();
+const mockSelect = jest.fn();
+const mockFrom = jest.fn();
+
+jest.mock("@/lib/supabase", () => ({
+    supabase: {
+        from: (table: string) => mockFrom(table),
+    },
+}));
+
+describe("GET /api/stats", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("returns correct count statistics when supabase queries succeed", async () => {
+        // Setup mock implementations for the chain
+        mockFrom.mockImplementation((table: string) => {
+            if (table === "drug_alerts") {
+                return {
+                    select: jest.fn().mockImplementation(() => {
+                        return {
+                            eq: jest.fn().mockImplementation((col: string, val: string) => {
+                                let countVal = 0;
+                                if (val === "banned") countVal = 10;
+                                else if (val === "recalled") countVal = 15;
+                                else if (val === "counterfeit") countVal = 5;
+                                else if (val === "nsq") countVal = 20;
+
+                                return Promise.resolve({
+                                    count: countVal,
+                                    error: null,
+                                });
+                            }),
+                        };
+                    }),
+                };
+            }
+            if (table === "scan_history") {
+                return {
+                    select: jest.fn().mockImplementation(() => {
+                        return Promise.resolve({
+                            count: 100,
+                            error: null,
+                        });
+                    }),
+                };
+            }
+            if (table === "pharmacies") {
+                return {
+                    select: jest.fn().mockImplementation(() => {
+                        return {
+                            eq: jest.fn().mockImplementation((col: string, val: boolean) => {
+                                return Promise.resolve({
+                                    count: 50,
+                                    error: null,
+                                });
+                            }),
+                        };
+                    }),
+                };
+            }
+            return {};
+        });
+
+        const response = await GET();
+        expect(response.status).toBe(200);
+
+        const data = await response.json();
+        expect(data).toEqual({
+            banned: 10,
+            recalled: 15,
+            counterfeit: 5,
+            nsq: 20,
+            totalScans: 100,
+            verifiedPharmacies: 50,
+        });
+    });
+
+    it("returns 500 error response if any supabase query fails", async () => {
+        mockFrom.mockImplementation((table: string) => {
+            if (table === "drug_alerts") {
+                return {
+                    select: jest.fn().mockImplementation(() => {
+                        return {
+                            eq: jest.fn().mockImplementation((col: string, val: string) => {
+                                if (val === "banned") {
+                                    return Promise.resolve({
+                                        count: null,
+                                        error: new Error("Database query failed"),
+                                    });
+                                }
+                                return Promise.resolve({ count: 0, error: null });
+                            }),
+                        };
+                    }),
+                };
+            }
+            if (table === "scan_history") {
+                return {
+                    select: jest.fn().mockImplementation(() => {
+                        return Promise.resolve({
+                            count: 0,
+                            error: null,
+                        });
+                    }),
+                };
+            }
+            if (table === "pharmacies") {
+                return {
+                    select: jest.fn().mockImplementation(() => {
+                        return {
+                            eq: jest.fn().mockImplementation((col: string, val: boolean) => {
+                                return Promise.resolve({
+                                    count: 0,
+                                    error: null,
+                                });
+                            }),
+                        };
+                    }),
+                };
+            }
+            return {};
+        });
+
+        // Suppress console.error output in tests for expected errors
+        const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+        const response = await GET();
+        expect(response.status).toBe(500);
+
+        const data = await response.json();
+        expect(data).toEqual({ error: "Internal Server Error" });
+
+        consoleErrorSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3128**
- **Summary:**
  - Added a cached `/api/stats` endpoint to return live database statistics using efficient Supabase `COUNT` queries (`head: true`).
  - Configured `revalidate = 3600` to cache the response for one hour.
  - Updated `SafetyStatsBanner` to fetch statistics from the new API instead of querying Supabase directly on the client.
  - Added unit tests covering successful responses and error handling for the stats endpoint.

## 📸 Proof of Work (Screenshots / Logs)

- Attached screenshots of the updated `SafetyStatsBanner`.
- Verification completed:
  - ✅ `npx tsc --noEmit`
  - ✅ `npm run test -- tests/stats-route.test.ts`
  - ✅ Code formatted with Prettier

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3128`)
- [x] I have pulled the latest `main` and resolved any conflicts