### PR TITLE
fix: paginated calculations on Live Alerts Log stats panel (#3001)

### DIFF
--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from "express";
+﻿import { Router, Request, Response } from "express";
 import { supabase } from "../db/client";
 import { z } from "zod";
 import { triggerRecallAlert } from "../services/notifications";
@@ -39,11 +39,13 @@ const alertsRouter = Router();
  *
  * Response schema:
  *   {
- *     data:           Alert[],
- *     pageIndex:      number,   // current page (1-based)
- *     pageSize:       number,   // items returned on this page
- *     totalCount:     number,   // total rows in the table
- *     totalPageCount: number,   // ceil(totalCount / limit)
+ *     data:                      Alert[],
+ *     pageIndex:                 number,   // current page (1-based)
+ *     pageSize:                  number,   // items returned on this page
+ *     totalCount:                number,   // total rows matching the filters
+ *     totalPageCount:            number,   // ceil(totalCount / limit)
+ *     totalCriticalCount:        number,   // system-wide count of banned/counterfeit alerts (not just this page)
+ *     totalImpactedRegionsCount: number,   // system-wide count of distinct impacted states (not just this page)
  *   }
  */
 alertsRouter.get("/", alertsReadLimiter, async (req: Request, res: Response) => {
@@ -74,14 +76,35 @@ alertsRouter.get("/", alertsReadLimiter, async (req: Request, res: Response) => 
     }
 
     try {
-        const { data, error, count } = await query
-            .order("created_at", { ascending: false })
-            .range(offset, offset + limit - 1);
+        // Run the paginated page fetch and the system-wide stats aggregation
+        // concurrently — the stats RPC scans the whole (filtered) table, so it
+        // must NOT be derived from the paginated `data` below.
+        const [pageResult, statsResult] = await Promise.all([
+            query.order("created_at", { ascending: false }).range(offset, offset + limit - 1),
+            supabase.rpc("get_alerts_aggregate_stats", {
+                p_brand: brand || null,
+                p_region: region || null,
+                p_batch_number: batchNumber || null,
+            }),
+        ]);
+
+        const { data, error, count } = pageResult;
 
         if (error) {
             res.status(500).json({ error: "Failed to fetch alerts" });
             return;
         }
+
+        if (statsResult.error) {
+            // Don't fail the whole request over the stats panel — log and degrade
+            // gracefully so the alert list itself still loads.
+            logger.error("Failed to fetch alert aggregate stats", { error: statsResult.error });
+        }
+
+        const stats = (statsResult.data ?? {}) as {
+            totalCriticalCount?: number;
+            totalImpactedRegionsCount?: number;
+        };
 
         const totalCount = count ?? 0;
         const totalPageCount = Math.ceil(totalCount / limit);
@@ -92,6 +115,8 @@ alertsRouter.get("/", alertsReadLimiter, async (req: Request, res: Response) => 
             pageSize: (data ?? []).length,
             totalCount,
             totalPageCount,
+            totalCriticalCount: stats.totalCriticalCount ?? 0,
+            totalImpactedRegionsCount: stats.totalImpactedRegionsCount ?? 0,
         });
     } catch (err) {
         logger.error("Unexpected error in GET /api/alerts", { error: err });
@@ -215,7 +240,10 @@ alertsRouter.post("/ingest", requireApiKey, limiter, async (req: ApiKeyRequest, 
                 );
                 await redisClient.del(keys);
             } catch (err) {
-                logger.error({ message: "Failed to invalidate cache for alert batches", error: err });
+                logger.error({
+                    message: "Failed to invalidate cache for alert batches",
+                    error: err,
+                });
             }
         }
 

--- a/apps/api/tests/alertsPagination.test.ts
+++ b/apps/api/tests/alertsPagination.test.ts
@@ -1,4 +1,4 @@
-import request from "supertest";
+﻿import request from "supertest";
 import app from "../src/app";
 
 // jest.mock is hoisted — everything must be self-contained inside the factory
@@ -22,6 +22,10 @@ jest.mock("../src/db/client", () => {
     return {
         supabase: {
             from: jest.fn().mockReturnValue(chain),
+            rpc: jest.fn().mockResolvedValue({
+                data: { totalCriticalCount: 0, totalImpactedRegionsCount: 0 },
+                error: null,
+            }),
         },
     };
 });
@@ -61,6 +65,17 @@ function mockSupabase(alerts: object[], totalCount: number, error: object | null
         data: error ? null : alerts,
         error,
         count: error ? null : totalCount,
+    });
+}
+
+function mockStats(
+    totalCriticalCount: number,
+    totalImpactedRegionsCount: number,
+    error: object | null = null
+) {
+    (supabase.rpc as jest.Mock).mockResolvedValue({
+        data: error ? null : { totalCriticalCount, totalImpactedRegionsCount },
+        error,
     });
 }
 
@@ -221,6 +236,52 @@ describe("GET /api/v1/alerts — pagination", () => {
 
         expect(res.status).toBe(500);
         expect(res.body).toHaveProperty("error");
+    });
+
+    it("returns system-wide totalCriticalCount/totalImpactedRegionsCount from the stats RPC, not just the current page", async () => {
+        // Only 10 rows are returned for this page, but the stats RPC reflects
+        // the full (unpaginated) table — the whole point of the fix for #3001.
+        mockSupabase(buildAlerts(10), 250);
+        mockStats(42, 17);
+
+        const res = await request(app).get("/api/v1/alerts?page=1&limit=10");
+
+        expect(res.status).toBe(200);
+        expect(supabase.rpc).toHaveBeenCalledWith("get_alerts_aggregate_stats", {
+            p_brand: null,
+            p_region: null,
+            p_batch_number: null,
+        });
+        expect(res.body.totalCriticalCount).toBe(42);
+        expect(res.body.totalImpactedRegionsCount).toBe(17);
+    });
+
+    it("passes brand/region/batch filters through to the stats RPC", async () => {
+        mockSupabase(buildAlerts(5), 5);
+        mockStats(3, 2);
+
+        const res = await request(app).get(
+            "/api/v1/alerts?page=1&limit=10&brand=Paracetamol&region=Punjab&batch_number=B123"
+        );
+
+        expect(res.status).toBe(200);
+        expect(supabase.rpc).toHaveBeenCalledWith("get_alerts_aggregate_stats", {
+            p_brand: "Paracetamol",
+            p_region: "Punjab",
+            p_batch_number: "B123",
+        });
+    });
+
+    it("degrades gracefully to zero counts when the stats RPC fails, without failing the whole request", async () => {
+        mockSupabase(buildAlerts(10), 35);
+        mockStats(0, 0, { message: "RPC failed" });
+
+        const res = await request(app).get("/api/v1/alerts?page=1&limit=10");
+
+        expect(res.status).toBe(200);
+        expect(res.body.data).toHaveLength(10);
+        expect(res.body.totalCriticalCount).toBe(0);
+        expect(res.body.totalImpactedRegionsCount).toBe(0);
     });
 });
 

--- a/apps/web/app/[locale]/alerts/page.tsx
+++ b/apps/web/app/[locale]/alerts/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 import React, { useEffect, useState } from "react";
 import { PageHeader } from "../components/PageHeader";
 import {
@@ -76,6 +76,8 @@ export default function FullAlertsLogPage() {
         fetchNextPage,
         hasNextPage,
         totalCount,
+        totalCriticalCount,
+        totalImpactedRegionsCount,
         snoozeAlert,
         refetch,
     } = useAlerts({ debouncedBrandSearch, debouncedRegionSearch });
@@ -94,17 +96,6 @@ export default function FullAlertsLogPage() {
             }
         },
     });
-
-    const criticalCount = allAlerts.filter(
-        (alert) =>
-            alert.cdsco_approval_status === "banned" ||
-            alert.is_counterfeit_alert ||
-            alert.alert_type === "Banned"
-    ).length;
-
-    const uniqueRegionsCount = Array.from(
-        new Set(allAlerts.map((alert) => alert.state).filter(Boolean))
-    ).length;
 
     const toggleExpand = (id: string) => {
         setExpandedAlertId((prev) => (prev === id ? null : id));
@@ -267,7 +258,7 @@ export default function FullAlertsLogPage() {
                         </div>
                         <div className="mt-4 flex items-baseline gap-2">
                             <span className="text-3xl font-black tracking-tight text-(--color-text-primary)">
-                                {loading ? "..." : criticalCount}
+                                {loading ? "..." : totalCriticalCount}
                             </span>
                         </div>
                     </div>
@@ -283,7 +274,7 @@ export default function FullAlertsLogPage() {
                         </div>
                         <div className="mt-4 flex items-baseline gap-2">
                             <span className="text-3xl font-black tracking-tight text-(--color-text-primary)">
-                                {loading ? "..." : uniqueRegionsCount}
+                                {loading ? "..." : totalImpactedRegionsCount}
                             </span>
                         </div>
                     </div>

--- a/apps/web/hooks/useAlerts.ts
+++ b/apps/web/hooks/useAlerts.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+﻿import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { API_BASE, getCsrfToken } from "@/lib/api";
 import { toast } from "sonner";
 import { Alert } from "@/app/[locale]/alerts/page";
@@ -91,6 +91,11 @@ export function useAlerts({ debouncedBrandSearch, debouncedRegionSearch }: UseAl
 
     const allAlerts = data?.pages.flatMap((page) => page.data || []) || [];
     const totalCount = data?.pages[0]?.totalCount || 0;
+    // These are system-wide aggregates computed server-side over the full
+    // filtered table — NOT derived from `allAlerts`, which only holds the
+    // pages fetched so far. See issue #3001.
+    const totalCriticalCount = data?.pages[0]?.totalCriticalCount || 0;
+    const totalImpactedRegionsCount = data?.pages[0]?.totalImpactedRegionsCount || 0;
 
     return {
         allAlerts,
@@ -100,6 +105,8 @@ export function useAlerts({ debouncedBrandSearch, debouncedRegionSearch }: UseAl
         fetchNextPage,
         hasNextPage,
         totalCount,
+        totalCriticalCount,
+        totalImpactedRegionsCount,
         snoozeAlert,
         refetch,
     };

--- a/supabase/migrations/20260713120000_add_alerts_aggregate_stats_rpc.sql
+++ b/supabase/migrations/20260713120000_add_alerts_aggregate_stats_rpc.sql
@@ -1,0 +1,50 @@
+﻿-- =============================================================================
+-- Fix #3001: Paginated Calculations on Live Alerts Log Stats Panel
+--
+-- The "Critical / Banned" and "Impacted Areas" stats cards on the Alerts page
+-- were being derived client-side from the paginated `allAlerts` array, so they
+-- only reflected whatever page(s) had been loaded so far instead of the full
+-- system-wide totals.
+--
+-- This RPC computes both totals in a single fast aggregate query over the
+-- *entire* (unpaginated) drug_alerts table, honoring the same active-alert
+-- and filter conditions as GET /api/v1/alerts, so the API can return correct
+-- system-wide counts alongside the paginated page of results.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_alerts_aggregate_stats(
+    p_brand TEXT DEFAULT NULL,
+    p_region TEXT DEFAULT NULL,
+    p_batch_number TEXT DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_critical_count INT;
+    v_impacted_regions_count INT;
+BEGIN
+    SELECT
+        COUNT(*) FILTER (
+            WHERE m.cdsco_approval_status = 'banned'
+               OR m.is_counterfeit_alert IS TRUE
+               OR da.alert_type ILIKE 'banned'
+        ),
+        COUNT(DISTINCT da.state)
+    INTO v_critical_count, v_impacted_regions_count
+    FROM public.drug_alerts da
+    LEFT JOIN public.medicines m ON m.id = da.medicine_id
+    WHERE (da.snoozed_until IS NULL OR da.snoozed_until <= NOW())
+      AND (p_brand IS NULL OR da.reported_brand_name ILIKE '%' || p_brand || '%')
+      AND (p_region IS NULL OR da.state ILIKE '%' || p_region || '%')
+      AND (p_batch_number IS NULL OR da.batch_number = p_batch_number);
+
+    RETURN jsonb_build_object(
+        'totalCriticalCount', COALESCE(v_critical_count, 0),
+        'totalImpactedRegionsCount', COALESCE(v_impacted_regions_count, 0)
+    );
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_alerts_aggregate_stats IS
+    'Returns system-wide (unpaginated) critical-alert and impacted-region counts for the Alerts page stats panel. See issue #3001.';


### PR DESCRIPTION
Fixes #3001

## Problem
The "Critical / Banned" and "Impacted Areas" stats cards were computed
client-side over the paginated `allAlerts` array, so they only reflected
whatever page(s) had loaded so far instead of system-wide totals.

## Fix
- New Postgres RPC `get_alerts_aggregate_stats` computes both totals in a
  single aggregate query over the full (unpaginated, filtered) table.
- `GET /api/v1/alerts` now runs this RPC in parallel with the paginated
  page fetch and returns `totalCriticalCount` / `totalImpactedRegionsCount`
  in the response metadata. Degrades gracefully to 0 if the RPC fails.
- `useAlerts` + the alerts page now read these values directly from the
  API instead of deriving them from `allAlerts`.

## Testing
- Added 3 new test cases covering: correct system-wide totals returned
  even with a small page, filters passed through to the RPC, and graceful
  degradation on RPC failure.
- All 19 tests in `alertsPagination.test.ts` pass.
- `tsc --noEmit` clean on both `apps/api` and `apps/web`.