### PR TITLE
fix(web): revert optimistic UI update on dose log error and display toast warning

### DIFF
--- a/apps/web/app/[locale]/schedule/page.tsx
+++ b/apps/web/app/[locale]/schedule/page.tsx
@@ -19,6 +19,7 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { fetchTodaySummary, logDose, type TodaySchedule } from "@/lib/scheduleApi";
 import { useSession } from "@/src/components/AuthProvider";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 
 function formatTime(time: string): string {
     const [h, m] = time.split(":");
@@ -72,24 +73,34 @@ function DoseButton({
     logDate: string;
     time: string;
     currentStatus: string | undefined;
-    onStatusChange: (time: string, status: "taken" | "skipped") => void;
+    onStatusChange: (time: string, status: "taken" | "skipped" | undefined) => void;
     t: (key: string) => string;
 }) {
     const [loading, setLoading] = useState(false);
     const [actionError, setActionError] = useState<string | null>(null);
 
     const handleAction = async (status: "taken" | "skipped") => {
+        const previousStatus = currentStatus as "taken" | "skipped" | undefined;
         setLoading(true);
         setActionError(null);
+
+        // Optimistically update the UI
+        onStatusChange(time, status);
+
         try {
             await logDose(scheduleId, {
                 log_date: logDate,
                 log_time: time,
                 status,
             });
-            onStatusChange(time, status);
+            toast.success(status === "taken" ? t("doseLoggedSuccess") : t("doseSkippedSuccess"), {
+                id: `dose-${scheduleId}-${time}`,
+            });
         } catch {
+            // Revert optimistic update
+            onStatusChange(time, previousStatus);
             setActionError(t("doseErrorMessage"));
+            toast.error(t("doseErrorMessage"), { id: `dose-${scheduleId}-${time}` });
         } finally {
             setLoading(false);
         }
@@ -184,8 +195,20 @@ export default function SchedulePage() {
         }
     }, [authLoading, fetchData]);
 
-    const handleDoseChange = (scheduleId: string, time: string, status: "taken" | "skipped") => {
-        setDoseStatus((prev) => ({ ...prev, [`${scheduleId}-${time}`]: status }));
+    const handleDoseChange = (
+        scheduleId: string,
+        time: string,
+        status: "taken" | "skipped" | undefined
+    ) => {
+        setDoseStatus((prev) => {
+            const next = { ...prev };
+            if (status === undefined) {
+                delete next[`${scheduleId}-${time}`];
+            } else {
+                next[`${scheduleId}-${time}`] = status;
+            }
+            return next;
+        });
     };
 
     return (

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1587,5 +1587,18 @@
         "savePreferences": "Save Preferences",
         "locationLabel": "Location Services",
         "scanHistoryLabel": "Scan History Storage"
+    },
+    "schedule": {
+        "pageTitle": "Schedule",
+        "pageSubtitle": "Track your daily medicine compliance",
+        "heading": "Daily Schedule",
+        "statusTaken": "Taken",
+        "statusSkipped": "Skipped",
+        "actionTaken": "Taken",
+        "actionTake": "Mark Taken",
+        "actionSkip": "Skip",
+        "doseErrorMessage": "Failed to update dose status. Please try again.",
+        "doseLoggedSuccess": "Dose status updated successfully.",
+        "doseSkippedSuccess": "Dose marked as skipped."
     }
 }

--- a/apps/web/tests/schedule-dose-logging.test.tsx
+++ b/apps/web/tests/schedule-dose-logging.test.tsx
@@ -1,0 +1,153 @@
+/** @jest-environment jsdom */
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import SchedulePage from "../app/[locale]/schedule/page";
+import { fetchTodaySummary, logDose } from "@/lib/scheduleApi";
+import { useSession } from "@/src/components/AuthProvider";
+import { toast } from "sonner";
+
+// Mock next-intl
+jest.mock("next-intl", () => ({
+    useLocale: () => "en",
+    useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
+}));
+
+// Mock routing Link
+jest.mock("@/i18n/routing", () => ({
+    Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+
+// Mock scheduleApi
+jest.mock("@/lib/scheduleApi", () => ({
+    fetchTodaySummary: jest.fn(),
+    logDose: jest.fn(),
+}));
+
+// Mock AuthProvider session hook
+jest.mock("@/src/components/AuthProvider", () => ({
+    useSession: jest.fn(),
+}));
+
+// Mock sonner toast
+jest.mock("sonner", () => ({
+    toast: {
+        success: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+const mockSchedules = [
+    {
+        id: "schedule-1",
+        medicine_name: "Aspirin",
+        dosage: "100mg",
+        doses: [
+            { time: "08:00", status: "none" },
+            { time: "20:00", status: "taken" },
+        ],
+    },
+];
+
+describe("SchedulePage Dose Logging Optimistic UI Updates & Error Reverting", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (useSession as any).mockReturnValue({
+            token: "valid-token",
+            isLoading: false,
+        });
+        (fetchTodaySummary as any).mockResolvedValue({
+            schedules: mockSchedules,
+            date: "2026-07-15",
+        });
+    });
+
+    it("renders daily schedule doses properly", async () => {
+        render(<SchedulePage />);
+
+        await waitFor(() => {
+            expect(screen.getByText("Aspirin")).toBeInTheDocument();
+            expect(screen.getByText("100mg")).toBeInTheDocument();
+        });
+
+        // 08:00 dose is currently untracked ("none") -> shows both "Mark Taken" and "Skip"
+        expect(screen.getByText("schedule.actionTake")).toBeInTheDocument();
+        expect(screen.getByText("schedule.actionSkip")).toBeInTheDocument();
+
+        // 20:00 dose is currently "taken" -> shows only "Taken" button
+        expect(screen.getByText("schedule.actionTaken")).toBeInTheDocument();
+    });
+
+    it("optimistically updates UI and triggers success toast when logDose API succeeds", async () => {
+        (logDose as any).mockResolvedValue({ success: true });
+
+        render(<SchedulePage />);
+
+        // Wait for rendering to complete
+        await waitFor(() => {
+            expect(screen.getByText("Aspirin")).toBeInTheDocument();
+        });
+
+        // Click "Mark Taken" on 08:00 dose
+        const takeButton = screen.getByText("schedule.actionTake");
+        fireEvent.click(takeButton);
+
+        // Optimistic UI check: count of "Taken" buttons increases to 2
+        expect(screen.getAllByText("schedule.actionTaken")).toHaveLength(2);
+
+        // Verify API is called
+        await waitFor(() => {
+            expect(logDose).toHaveBeenCalledWith("schedule-1", {
+                log_date: "2026-07-15",
+                log_time: "08:00",
+                status: "taken",
+            });
+        });
+
+        // Verify success toast triggers
+        expect(toast.success).toHaveBeenCalledWith("schedule.doseLoggedSuccess", {
+            id: "dose-schedule-1-08:00",
+        });
+    });
+
+    it("optimistically updates UI and reverts to original state with toast error when logDose API fails", async () => {
+        (logDose as any).mockRejectedValue(new Error("Network Error"));
+
+        render(<SchedulePage />);
+
+        // Wait for rendering to complete
+        await waitFor(() => {
+            expect(screen.getByText("Aspirin")).toBeInTheDocument();
+        });
+
+        // Click "Mark Taken" on 08:00 dose
+        const takeButton = screen.getByText("schedule.actionTake");
+        fireEvent.click(takeButton);
+
+        // Optimistic UI check: count of "Taken" buttons increases to 2
+        expect(screen.getAllByText("schedule.actionTaken")).toHaveLength(2);
+
+        // Wait for async logDose rejection to complete
+        await waitFor(() => {
+            expect(logDose).toHaveBeenCalled();
+        });
+
+        // UI check: state should revert back to original untracked state (count of "Taken" buttons goes back to 1)
+        await waitFor(() => {
+            expect(screen.getAllByText("schedule.actionTaken")).toHaveLength(1);
+            expect(screen.getByText("schedule.actionTake")).toBeInTheDocument();
+            expect(screen.getByText("schedule.actionSkip")).toBeInTheDocument();
+        });
+
+        // Verify error text is rendered in components under DoseButton
+        expect(screen.getByText("schedule.doseErrorMessage")).toBeInTheDocument();
+
+        // Verify toast.error was triggered
+        expect(toast.error).toHaveBeenCalledWith("schedule.doseErrorMessage", {
+            id: "dose-schedule-1-08:00",
+        });
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes** #3611
- **Summary:**
  - Integrated `toast` alerts from `sonner` when logging medicine dose statuses (taken/skipped).
  - Implemented optimistic UI updates in `DoseButton` to immediately show compliance state transitions.
  - Implemented error recovery to cache and revert to the previous dose status if the database API request fails (e.g., due to session expiry or network issues).
  - Updated parent `handleDoseChange` to clear reverted status entries from local state.
  - Added new descriptive fallback translation keys in `en.json` under the `"schedule"` namespace.
  - Created comprehensive unit tests in `apps/web/tests/schedule-dose-logging.test.tsx`.

## 📸 Proof of Work (Screenshots / Logs)

### Unit tests execution:
```bash
PASS tests/schedule-dose-logging.test.tsx
  SchedulePage Dose Logging Optimistic UI Updates & Error Reverting
    √ renders daily schedule doses properly (94 ms)
    √ optimistically updates UI and triggers success toast when logDose API succeeds (49 ms)
    √ optimistically updates UI and reverts to original state with toast error when logDose API fails (63 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        2.37 s
```

### Build compilation logs:
```bash
▲ Next.js 16.2.9 (Turbopack)
- Environments: .env

  Creating an optimized production build ...
✓ Compiled successfully in 8.5s
  Running TypeScript ...
  Finished TypeScript in 17.0s ...
  Collecting page data using 15 workers ...
✓ Generating static pages using 15 workers (13/13) in 255ms
  Finalizing page optimization ...
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3611`)
- [x] I have pulled the latest `main` and resolved any conflicts