### PR TITLE
feat(eligibility): add offline static fallback for state health schemes

### DIFF
--- a/apps/api/src/routes/eligibility.ts
+++ b/apps/api/src/routes/eligibility.ts
@@ -1,10 +1,8 @@
 import { Router, Request, Response } from "express";
+import { z } from "zod";
 import logger from "../utils/logger";
 import { anonSupabase } from "../db/supabase";
-
-const router = Router();
-
-import { z } from "zod";
+import { dbConfig } from "../db/client";
 import { redisClient } from "../utils/redis";
 import { eligibilityLimiter } from "../middleware/rateLimit";
 import {
@@ -15,6 +13,92 @@ import {
     PmjayUpstreamError,
     PmjayNetworkError,
 } from "../services/governmentEligibility";
+
+const router = Router();
+
+// Static offline fallback — served when Supabase is unreachable.
+interface StaticScheme {
+    scheme_name: string;
+    description: string;
+    coverage: string;
+    how_to_apply: string;
+    link: string;
+}
+
+const OFFLINE_STATE_SCHEMES: Record<string, StaticScheme[]> = {
+    maharashtra: [
+        {
+            scheme_name: "Mahatma Jyotiba Phule Jan Arogya Yojana (MJPJAY)",
+            description:
+                "State-funded cashless health insurance scheme for Below Poverty Line and other vulnerable families in Maharashtra, covering major surgeries and critical illnesses.",
+            coverage:
+                "Cashless treatment up to ₹1.5 Lakh per family per year (₹2.5 Lakh for defined critical illnesses) at empaneled hospitals.",
+            how_to_apply:
+                "Visit any empaneled network hospital with your Aadhar card, yellow/orange/antyodaya ration card. The hospital facilitates enrolment on the spot.",
+            link: "https://www.jeevandayee.gov.in/",
+        },
+    ],
+    delhi: [
+        {
+            scheme_name: "Delhi Arogya Kosh (DAK)",
+            description:
+                "Financial assistance scheme by the Delhi Government for BPL families requiring treatment for serious illnesses at empaneled government hospitals in Delhi.",
+            coverage:
+                "Up to ₹5 Lakh per annum for serious illnesses at Delhi government hospitals.",
+            how_to_apply:
+                "Apply through the CMO (Chief Medical Officer) at any empaneled government hospital in Delhi with a BPL ration card and income certificate.",
+            link: "https://health.delhi.gov.in/",
+        },
+    ],
+    kerala: [
+        {
+            scheme_name: "Karunya Arogya Suraksha Padhathi (KASP)",
+            description:
+                "Kerala's flagship health insurance program replacing Rashtriya Swasthya Bima Yojana (RSBY), providing cashless in-patient care to BPL and vulnerable families.",
+            coverage:
+                "Cashless secondary and tertiary care up to ₹5 Lakh per family per year at empaneled government and private hospitals.",
+            how_to_apply:
+                "Enrol through your nearest Akshaya Centre or Primary Health Centre (PHC) with your Aadhaar card and BPL/priority household ration card.",
+            link: "https://kasp.kerala.gov.in/",
+        },
+    ],
+    karnataka: [
+        {
+            scheme_name: "Ayushman Bharat - Arogya Karnataka (AB-ArK)",
+            description:
+                "Karnataka's integrated health protection scheme combining Ayushman Bharat PM-JAY with state-specific top-ups, covering all residents regardless of income.",
+            coverage:
+                "Universal coverage up to ₹5 Lakh for BPL families; general (APL) families covered for secondary care up to ₹1.5 Lakh per year.",
+            how_to_apply:
+                "Visit any empaneled government or private hospital with your Aadhaar card. For APL families, a SSLC certificate or voter ID may be required.",
+            link: "https://arogyakarnataka.gov.in/",
+        },
+    ],
+    "uttar pradesh": [
+        {
+            scheme_name: "Ayushman Bharat - Mukhyamantri Jan Arogya Yojana (AB-MJAY UP)",
+            description:
+                "Uttar Pradesh's state-extended version of Ayushman Bharat PM-JAY, expanding coverage to additional families not covered under the central scheme.",
+            coverage:
+                "Cashless hospitalization up to ₹5 Lakh per family per year at empaneled hospitals across Uttar Pradesh.",
+            how_to_apply:
+                "Check eligibility at the PM-JAY portal or your nearest Common Service Center (CSC) / government hospital with your Aadhaar card and ration card.",
+            link: "https://shasya.sects.up.gov.in/",
+        },
+    ],
+    "tamil nadu": [
+        {
+            scheme_name: "Chief Minister's Comprehensive Health Insurance Scheme (CMCHIS)",
+            description:
+                "Tamil Nadu's flagship health insurance scheme providing free cashless medical treatment for serious and life-threatening illnesses to BPL and low-income families.",
+            coverage:
+                "Cashless treatment up to ₹5 Lakh per family per year (₹4 Lakh base + ₹1 Lakh top-up) for 1,027+ procedures at empaneled hospitals.",
+            how_to_apply:
+                "Register at your nearest Government Hospital or Primary Health Centre with your Aadhaar card and family ration card (any colour).",
+            link: "https://www.cmchistn.com/",
+        },
+    ],
+};
 
 const eligibilitySchema = z.object({
     age: z.number().int().min(0, "Age cannot be negative").optional().default(30),
@@ -89,15 +173,7 @@ router.post("/", eligibilityLimiter, async (req: Request, res: Response): Promis
         const income = Number(annual_income);
         const userState = (state || "").trim();
 
-        // Author note: we first attempt a real government API call
-        // (PM-JAY / ESIC). Those integrations are not official yet, so
-        // fetchGovernmentEligibility() will simply return null until the
-        // required env vars (PMJAY_API_KEY, PMJAY_BASE_URL, ESIC_API_KEY,
-        // ESIC_BASE_URL) are configured with real, approved credentials.
-        // Nothing below this block changes: if the government call fails,
-        // isn't configured, or times out, we silently continue with the
-        // existing Redis/Supabase + rule-based logic, so this is safe to
-        // ship without breaking anything today.
+        // Try PM-JAY government API if credentials are configured.
         const isPmjayConfigured = !!(process.env.PMJAY_BASE_URL && process.env.PMJAY_API_KEY);
         if (isPmjayConfigured) {
             try {
@@ -168,7 +244,6 @@ router.post("/", eligibilityLimiter, async (req: Request, res: Response): Promis
         const eligibleSchemes = [];
 
         // 1. Ayushman Bharat - PM-JAY (National Scheme)
-        // Eligibility: BPL Card OR Annual Income <= 2,50,000 OR ABHA ID (rural integration)
         if (has_bpl_card || income <= 250000 || has_abha_id) {
             eligibleSchemes.push({
                 name: "Ayushman Bharat - PM-JAY",
@@ -201,25 +276,48 @@ router.post("/", eligibilityLimiter, async (req: Request, res: Response): Promis
             }
 
             if (!data) {
-                const { data: dbData, error } = await anonSupabase
-                    .from("health_schemes")
-                    .select("*")
-                    .ilike("state_name", `%${userState}%`);
-
-                if (error) {
-                    logger.error("Failed to query health_schemes", { error });
-                }
-
-                data = dbData as any[] | null;
-
-                if (data && redisClient.isOpen) {
+                // Use static fallback if Supabase is offline, otherwise query DB.
+                if (dbConfig.isSupabaseOffline) {
+                    logger.warn(
+                        "Supabase is offline — using static offline fallback for state health schemes",
+                        { state: userState }
+                    );
+                    data = OFFLINE_STATE_SCHEMES[userState.toLowerCase()] ?? null;
+                } else {
                     try {
-                        await redisClient.setEx(cacheKey, 604800, JSON.stringify(data));
-                    } catch (err) {
-                        logger.warn({
-                            message: "Redis set error in eligibility",
-                            error: String(err),
-                        });
+                        const { data: dbData, error } = await anonSupabase
+                            .from("health_schemes")
+                            .select("*")
+                            .ilike("state_name", `%${userState}%`);
+
+                        if (error) {
+                            // DB error — fall back to static data.
+                            logger.error(
+                                "Failed to query health_schemes — falling back to offline static data",
+                                { error }
+                            );
+                            data = OFFLINE_STATE_SCHEMES[userState.toLowerCase()] ?? null;
+                        } else {
+                            data = dbData as any[] | null;
+
+                            if (data && redisClient.isOpen) {
+                                try {
+                                    await redisClient.setEx(cacheKey, 604800, JSON.stringify(data));
+                                } catch (err) {
+                                    logger.warn({
+                                        message: "Redis set error in eligibility",
+                                        error: String(err),
+                                    });
+                                }
+                            }
+                        }
+                    } catch (dbErr) {
+                        // Unexpected DB exception — fall back to static data.
+                        logger.error(
+                            "Unexpected error querying health_schemes — falling back to offline static data",
+                            { error: String(dbErr) }
+                        );
+                        data = OFFLINE_STATE_SCHEMES[userState.toLowerCase()] ?? null;
                     }
                 }
             }
@@ -238,24 +336,20 @@ router.post("/", eligibilityLimiter, async (req: Request, res: Response): Promis
             }
         }
 
-        if (!foundStateScheme) {
-            // General state insurance schemes fallback for other states
-            if (income <= 300000 || has_bpl_card) {
-                eligibleSchemes.push({
-                    name: "State Government Health Insurance (SGHIS)",
-                    description:
-                        "Cashless state-sponsored healthcare scheme integrated with Central National Health Authority guidelines.",
-                    coverage:
-                        "Cashless hospitalization benefits up to ₹3 Lakh to ₹5 Lakh per family per year at empaneled government/private hospitals.",
-                    how_to_apply:
-                        "Visit your local Block Development Office (BDO) or Chief Medical Officer's (CMO) helpdesk with Aadhaar card, income details, and BPL card.",
-                    link: "https://nha.gov.in/",
-                });
-            }
+        if (!foundStateScheme && (income <= 300000 || has_bpl_card)) {
+            eligibleSchemes.push({
+                name: "State Government Health Insurance (SGHIS)",
+                description:
+                    "Cashless state-sponsored healthcare scheme integrated with Central National Health Authority guidelines.",
+                coverage:
+                    "Cashless hospitalization benefits up to ₹3 Lakh to ₹5 Lakh per family per year at empaneled government/private hospitals.",
+                how_to_apply:
+                    "Visit your local Block Development Office (BDO) or Chief Medical Officer's (CMO) helpdesk with Aadhaar card, income details, and BPL card.",
+                link: "https://nha.gov.in/",
+            });
         }
 
-        // 3. PM Jan Aushadhi Scheme (Generic Medicines Support)
-        // Eligible for everyone (universal)
+        // 3. PM Jan Aushadhi Scheme (universal)
         eligibleSchemes.push({
             name: "Pradhan Mantri Bhartiya Janaushadhi Pariyojana (PMBJP)",
             description:
@@ -267,7 +361,7 @@ router.post("/", eligibilityLimiter, async (req: Request, res: Response): Promis
             link: "http://janaushadhi.gov.in/",
         });
 
-        // 4. Senior Citizen Health Insurance Scheme (SCHIS)
+        // 4. Senior Citizen Health Coverage
         if (age >= 60 && (income <= 300000 || has_bpl_card)) {
             eligibleSchemes.push({
                 name: "Rashtriya Vayoshri Yojana & Senior Citizen Health Coverage",

--- a/apps/api/tests/eligibility.test.ts
+++ b/apps/api/tests/eligibility.test.ts
@@ -1,31 +1,70 @@
 import request from "supertest";
 import app from "../src/app";
+import { dbConfig } from "../src/db/client";
 
-jest.mock("../src/db/supabase", () => {
-    return {
-        anonSupabase: {
-            from: jest.fn().mockReturnThis(),
-            select: jest.fn().mockReturnThis(),
-            ilike: jest.fn((field, value) => {
-                if (value.toLowerCase().includes("maharashtra")) {
-                    return Promise.resolve({
-                        data: [
-                            {
-                                scheme_name: "Mahatma Jyotirao Phule Jan Arogya Yojana (MJPJAY)",
-                                description: "Cashless health insurance scheme.",
-                                coverage: "Up to 5 Lakh.",
-                                how_to_apply: "Visit a network hospital.",
-                                link: "https://www.jeevandayee.gov.in/",
-                            },
-                        ],
-                        error: null,
-                    });
-                }
-                return Promise.resolve({ data: [], error: null });
-            }),
-        },
-    };
-});
+jest.mock("../src/db/client", () => ({
+    dbConfig: {
+        isSupabaseOffline: false,
+        offlineSince: null,
+        setOffline: jest.fn(),
+        setOnline: jest.fn(),
+    },
+    pool: {
+        acquire: jest.fn().mockResolvedValue(undefined),
+        release: jest.fn(),
+        stats: { active: 0, queued: 0, max: 20 },
+    },
+    supabase: {},
+    serviceRoleSupabase: {},
+}));
+
+jest.mock("../src/db/supabase", () => ({
+    anonSupabase: {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        ilike: jest.fn((_, value) =>
+            Promise.resolve(
+                value.toLowerCase().includes("maharashtra")
+                    ? {
+                          data: [
+                              {
+                                  scheme_name: "Mahatma Jyotirao Phule Jan Arogya Yojana (MJPJAY)",
+                                  description: "Cashless health insurance scheme.",
+                                  coverage: "Up to 5 Lakh.",
+                                  how_to_apply: "Visit a network hospital.",
+                                  link: "https://www.jeevandayee.gov.in/",
+                              },
+                          ],
+                          error: null,
+                      }
+                    : { data: [], error: null }
+            )
+        ),
+    },
+}));
+
+// Helpers
+const post = (body: object) => request(app).post("/api/v1/scheme-eligibility").send(body);
+const hasScheme = (schemes: any[], ...keywords: string[]) =>
+    schemes.some((s) => keywords.some((k) => s.name.includes(k)));
+const defaultPayload = {
+    age: 45,
+    annual_income: 80000,
+    family_size: 5,
+    state: "Maharashtra",
+    has_bpl_card: true,
+    has_abha_id: false,
+};
+
+function mockFetchResponse(status: number, data: any) {
+    return Promise.resolve({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? "OK" : "Error",
+        json: () =>
+            typeof data === "string" ? Promise.reject(new Error(data)) : Promise.resolve(data),
+    } as any);
+}
 
 describe("POST /api/v1/scheme-eligibility", () => {
     const originalEnv = process.env;
@@ -36,22 +75,20 @@ describe("POST /api/v1/scheme-eligibility", () => {
         global.fetch = jest.fn();
         mockFetch = global.fetch as jest.Mock;
     });
-
     beforeEach(() => {
         mockFetch.mockReset();
         process.env = { ...originalEnv };
         delete process.env.PMJAY_BASE_URL;
         delete process.env.PMJAY_API_KEY;
     });
-
     afterAll(() => {
         process.env = originalEnv;
         global.fetch = originalFetch;
     });
 
     describe("Fallback (Unconfigured)", () => {
-        it("should evaluate scheme eligibility based on BPL card status and state", async () => {
-            const res = await request(app).post("/api/v1/scheme-eligibility").send({
+        it("should return PM-JAY and MJPJAY for eligible Maharashtra user", async () => {
+            const res = await post({
                 age: 45,
                 annual_income: 80000,
                 family_size: 5,
@@ -59,25 +96,15 @@ describe("POST /api/v1/scheme-eligibility", () => {
                 has_bpl_card: true,
                 has_abha_id: false,
             });
-
             expect(res.status).toBe(200);
-            expect(res.body.eligible_schemes).toBeDefined();
-
-            // Assert PMJAY is in the list of eligible schemes
-            const hasPMJAY = res.body.eligible_schemes.some(
-                (s: any) => s.name.includes("PM-JAY") || s.name.includes("Ayushman Bharat")
+            expect(hasScheme(res.body.eligible_schemes, "PM-JAY", "Ayushman Bharat")).toBe(true);
+            expect(hasScheme(res.body.eligible_schemes, "MJPJAY", "Mahatma Jyotirao Phule")).toBe(
+                true
             );
-            expect(hasPMJAY).toBe(true);
-
-            // Assert MJPJAY is in the list of eligible schemes for Maharashtra
-            const hasMJPJAY = res.body.eligible_schemes.some(
-                (s: any) => s.name.includes("MJPJAY") || s.name.includes("Mahatma Jyotirao Phule")
-            );
-            expect(hasMJPJAY).toBe(true);
         });
 
-        it("should evaluate scheme eligibility for higher income households", async () => {
-            const res = await request(app).post("/api/v1/scheme-eligibility").send({
+        it("should not return PM-JAY for high-income user without BPL/ABHA", async () => {
+            const res = await post({
                 age: 30,
                 annual_income: 600000,
                 family_size: 4,
@@ -85,13 +112,8 @@ describe("POST /api/v1/scheme-eligibility", () => {
                 has_bpl_card: false,
                 has_abha_id: false,
             });
-
             expect(res.status).toBe(200);
-            // High income and no BPL card/ABHA card should not qualify for PM-JAY
-            const hasPMJAY = res.body.eligible_schemes.some(
-                (s: any) => s.name.includes("PM-JAY") || s.name.includes("Ayushman Bharat")
-            );
-            expect(hasPMJAY).toBe(false);
+            expect(hasScheme(res.body.eligible_schemes, "PM-JAY", "Ayushman Bharat")).toBe(false);
         });
     });
 
@@ -99,23 +121,8 @@ describe("POST /api/v1/scheme-eligibility", () => {
         beforeEach(() => {
             process.env.PMJAY_BASE_URL = "https://api.pmjay.gov.in";
             process.env.PMJAY_API_KEY = "mock-api-key";
-            // Set timeout low for tests so they run fast
             process.env.GOVT_API_TIMEOUT = "100";
         });
-
-        function mockFetchResponse(status: number, data: any) {
-            return Promise.resolve({
-                ok: status >= 200 && status < 300,
-                status,
-                statusText: status === 200 ? "OK" : "Error",
-                json: () => {
-                    if (typeof data === "string") {
-                        return Promise.reject(new Error(data));
-                    }
-                    return Promise.resolve(data);
-                },
-            } as any);
-        }
 
         it("should return eligible schemes from API on success", async () => {
             mockFetch.mockResolvedValueOnce(
@@ -131,16 +138,7 @@ describe("POST /api/v1/scheme-eligibility", () => {
                     ],
                 })
             );
-
-            const res = await request(app).post("/api/v1/scheme-eligibility").send({
-                age: 45,
-                annual_income: 80000,
-                family_size: 5,
-                state: "Maharashtra",
-                has_bpl_card: true,
-                has_abha_id: false,
-            });
-
+            const res = await post(defaultPayload);
             expect(res.status).toBe(200);
             expect(res.body.eligible_schemes).toHaveLength(1);
             expect(res.body.eligible_schemes[0].name).toBe("API Ayushman Bharat - PM-JAY");
@@ -149,112 +147,194 @@ describe("POST /api/v1/scheme-eligibility", () => {
 
         it("should return 401 on authentication failures", async () => {
             mockFetch.mockResolvedValueOnce(mockFetchResponse(401, {}));
-
-            const res = await request(app).post("/api/v1/scheme-eligibility").send({
-                age: 45,
-                annual_income: 80000,
-                family_size: 5,
-                state: "Maharashtra",
-                has_bpl_card: true,
-                has_abha_id: false,
-            });
-
+            const res = await post(defaultPayload);
             expect(res.status).toBe(401);
             expect(res.body.error).toContain("Authentication failed");
         });
 
         it("should return 504 on request timeout", async () => {
             const abortError = new DOMException("The user aborted a request.", "AbortError");
-            // Fails on initial try and all 2 retries (total 3 attempts)
             mockFetch
                 .mockRejectedValueOnce(abortError)
                 .mockRejectedValueOnce(abortError)
                 .mockRejectedValueOnce(abortError);
-
-            const res = await request(app).post("/api/v1/scheme-eligibility").send({
-                age: 45,
-                annual_income: 80000,
-                family_size: 5,
-                state: "Maharashtra",
-                has_bpl_card: true,
-                has_abha_id: false,
-            });
-
+            const res = await post(defaultPayload);
             expect(res.status).toBe(504);
             expect(res.body.error).toContain("timed out");
         });
 
         it("should return 502 on invalid JSON response", async () => {
             mockFetch.mockResolvedValueOnce(mockFetchResponse(200, "Invalid JSON string"));
-
-            const res = await request(app).post("/api/v1/scheme-eligibility").send({
-                age: 45,
-                annual_income: 80000,
-                family_size: 5,
-                state: "Maharashtra",
-                has_bpl_card: true,
-                has_abha_id: false,
-            });
-
+            const res = await post(defaultPayload);
             expect(res.status).toBe(502);
             expect(res.body.error).toContain("Invalid response format");
         });
 
         it("should return 502 on mismatching schema (missing scheme_name)", async () => {
             mockFetch.mockResolvedValueOnce(
-                mockFetchResponse(200, {
-                    schemes: [
-                        {
-                            // scheme_name is missing
-                            description: "No name",
-                        },
-                    ],
-                })
+                mockFetchResponse(200, { schemes: [{ description: "No name" }] })
             );
-
-            const res = await request(app).post("/api/v1/scheme-eligibility").send({
-                age: 45,
-                annual_income: 80000,
-                family_size: 5,
-                state: "Maharashtra",
-                has_bpl_card: true,
-                has_abha_id: false,
-            });
-
+            const res = await post(defaultPayload);
             expect(res.status).toBe(502);
             expect(res.body.error).toContain("Invalid response format");
         });
 
         it("should return 502 on persistent upstream server failure", async () => {
             mockFetch.mockResolvedValue(mockFetchResponse(500, {}));
-
-            const res = await request(app).post("/api/v1/scheme-eligibility").send({
-                age: 45,
-                annual_income: 80000,
-                family_size: 5,
-                state: "Maharashtra",
-                has_bpl_card: true,
-                has_abha_id: false,
-            });
-
+            const res = await post(defaultPayload);
             expect(res.status).toBe(502);
             expect(res.body.error).toContain("upstream error");
         });
 
         it("should return 502 on network exceptions", async () => {
             mockFetch.mockRejectedValue(new Error("Connection refused"));
+            const res = await post(defaultPayload);
+            expect(res.status).toBe(502);
+            expect(res.body.error).toContain("Network communication error");
+        });
+    });
 
-            const res = await request(app).post("/api/v1/scheme-eligibility").send({
-                age: 45,
-                annual_income: 80000,
-                family_size: 5,
+    describe("Offline Database Fallback", () => {
+        beforeEach(() => {
+            (dbConfig as any).isSupabaseOffline = true;
+        });
+        afterEach(() => {
+            (dbConfig as any).isSupabaseOffline = false;
+        });
+
+        it.each([
+            [
+                "Maharashtra",
+                {
+                    age: 35,
+                    annual_income: 100000,
+                    family_size: 4,
+                    state: "Maharashtra",
+                    has_bpl_card: true,
+                    has_abha_id: false,
+                },
+                ["MJPJAY", "Mahatma Jyotiba Phule"],
+            ],
+            [
+                "Delhi",
+                {
+                    age: 40,
+                    annual_income: 120000,
+                    family_size: 3,
+                    state: "Delhi",
+                    has_bpl_card: true,
+                    has_abha_id: false,
+                },
+                ["Delhi Arogya Kosh", "DAK"],
+            ],
+            [
+                "Kerala",
+                {
+                    age: 50,
+                    annual_income: 90000,
+                    family_size: 5,
+                    state: "Kerala",
+                    has_bpl_card: true,
+                    has_abha_id: false,
+                },
+                ["Karunya", "KASP"],
+            ],
+            [
+                "Karnataka",
+                {
+                    age: 28,
+                    annual_income: 150000,
+                    family_size: 4,
+                    state: "Karnataka",
+                    has_bpl_card: false,
+                    has_abha_id: true,
+                },
+                ["Arogya Karnataka", "AB-ArK"],
+            ],
+            [
+                "Uttar Pradesh",
+                {
+                    age: 45,
+                    annual_income: 80000,
+                    family_size: 6,
+                    state: "Uttar Pradesh",
+                    has_bpl_card: true,
+                    has_abha_id: false,
+                },
+                ["Mukhyamantri Jan Arogya", "AB-MJAY UP"],
+            ],
+            [
+                "Tamil Nadu",
+                {
+                    age: 55,
+                    annual_income: 70000,
+                    family_size: 4,
+                    state: "Tamil Nadu",
+                    has_bpl_card: true,
+                    has_abha_id: false,
+                },
+                ["Chief Minister", "CMCHIS"],
+            ],
+        ])(
+            "should return correct scheme for %s when DB is offline",
+            async (_, payload, keywords) => {
+                const res = await post(payload as object);
+                expect(res.status).toBe(200);
+                expect(hasScheme(res.body.eligible_schemes, ...keywords)).toBe(true);
+            }
+        );
+
+        it("should return national schemes alongside offline state scheme", async () => {
+            const res = await post({
+                age: 35,
+                annual_income: 150000,
+                family_size: 4,
+                state: "Maharashtra",
+                has_bpl_card: true,
+                has_abha_id: false,
+            });
+            expect(res.status).toBe(200);
+            expect(hasScheme(res.body.eligible_schemes, "PM-JAY", "Ayushman Bharat")).toBe(true);
+            expect(hasScheme(res.body.eligible_schemes, "MJPJAY", "Mahatma Jyotiba Phule")).toBe(
+                true
+            );
+        });
+
+        it("should not crash for an unknown state when DB is offline", async () => {
+            const res = await post({
+                age: 35,
+                annual_income: 100000,
+                family_size: 3,
+                state: "Meghalaya",
+                has_bpl_card: true,
+                has_abha_id: false,
+            });
+            expect(res.status).toBe(200);
+            expect(Array.isArray(res.body.eligible_schemes)).toBe(true);
+        });
+
+        it("should fall back to static data when DB query returns an error", async () => {
+            (dbConfig as any).isSupabaseOffline = false;
+            const supabaseMock = require("../src/db/supabase");
+            const originalIlike = supabaseMock.anonSupabase.ilike;
+            supabaseMock.anonSupabase.ilike = jest
+                .fn()
+                .mockResolvedValue({ data: null, error: { message: "DB connection failed" } });
+
+            const res = await post({
+                age: 35,
+                annual_income: 100000,
+                family_size: 4,
                 state: "Maharashtra",
                 has_bpl_card: true,
                 has_abha_id: false,
             });
 
-            expect(res.status).toBe(502);
-            expect(res.body.error).toContain("Network communication error");
+            supabaseMock.anonSupabase.ilike = originalIlike;
+            expect(res.status).toBe(200);
+            expect(hasScheme(res.body.eligible_schemes, "MJPJAY", "Mahatma Jyotiba Phule")).toBe(
+                true
+            );
         });
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #2826**
- **Summary:** Implements a 3-layer offline static fallback for state-specific health schemes in `eligibility.ts`. When Supabase is offline (`dbConfig.isSupabaseOffline`), a DB query errors out, or an unexpected exception occurs, the route now serves curated static scheme data for 6 states (Maharashtra, Delhi, Kerala, Karnataka, Uttar Pradesh, Tamil Nadu) instead of silently returning nothing. Added 9 offline-mode tests using `it.each` for all 6 states plus edge cases.

## 📸 Proof of Work (Screenshots / Logs)
<img width="681" height="137" alt="image" src="https://github.com/user-attachments/assets/a90d2ea3-2c79-4044-985e-a1eca122e535" />

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #2826`)
- [x] I have pulled the latest `main` and resolved any conflicts

