### PR TITLE
fix(etl): handle dictionary RPC count responses

### DIFF
--- a/apps/etl/src/loaders/supabase_loader.py
+++ b/apps/etl/src/loaders/supabase_loader.py
@@ -928,16 +928,27 @@ class SupabaseLoader:
         """Read the integer row count returned by the bulk RPC.
 
         PostgREST returns a scalar function result as the raw value, but tolerate
-        a single-element list too. Returns ``None`` when the shape is unrecognized
-        so the caller can decide how to account for it rather than guessing here.
+        a single-element list containing either the count or a single-key mapping
+        to it. Returns ``None`` when the shape is unrecognized so the caller can
+        decide how to account for it rather than guessing here.
         """
         data = getattr(response, "data", None)
         if isinstance(data, bool):  # bool is an int subclass — exclude it
             return None
         if isinstance(data, int):
             return data
-        if isinstance(data, list) and len(data) == 1 and isinstance(data[0], int):
-            return data[0]
+        if isinstance(data, list) and len(data) == 1:
+            item = data[0]
+            if isinstance(item, bool):
+                return None
+            if isinstance(item, int):
+                return item
+            if isinstance(item, dict) and len(item) == 1:
+                value = next(iter(item.values()))
+                if isinstance(value, bool):
+                    return None
+                if isinstance(value, int):
+                    return value
         return None
 
     def _update_ja_price_rows_one_by_one(

--- a/apps/etl/tests/test_loader.py
+++ b/apps/etl/tests/test_loader.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pandas as pd
 
@@ -735,7 +736,57 @@ def test_ja_backfill_counts_short_rpc_result_as_failed(tmp_path):
     assert client.update_calls == []  # no row-by-row fallback was triggered
 
 
-def test_ja_backfill_assumes_full_batch_on_unrecognized_rpc_shape(tmp_path):
+def test_coerce_rpc_updated_count():
+    valid_cases = [
+        (45, 45),
+        ([45], 45),
+        ([{"bulk_update_jan_aushadhi_price": 45}], 45),
+        ([{"value": 45}], 45),
+    ]
+    invalid_cases = [
+        True,
+        [True],
+        [{"value": True}],
+        [{}],
+        [{"value": "45"}],
+        [{"value": 45, "other": 1}],
+        [],
+        [1, 2],
+        None,
+    ]
+
+    for data, expected in valid_cases:
+        response = SimpleNamespace(data=data)
+        assert SupabaseLoader._coerce_rpc_updated_count(response) == expected
+
+    for data in invalid_cases:
+        response = SimpleNamespace(data=data)
+        assert SupabaseLoader._coerce_rpc_updated_count(response) is None
+
+
+def test_ja_backfill_does_not_warn_for_single_key_rpc_count(tmp_path, monkeypatch):
+    medicines = [
+        {"id": "m1", "generic_name": "Paracetamol", "jan_aushadhi_price": None},
+    ]
+    client = MergeFakeSupabaseClient(medicines=medicines)
+    client.rpc_override_set = True
+    client.rpc_data_override = [{"bulk_update_jan_aushadhi_price": 1}]
+    loader = make_merge_loader(client, tmp_path)
+    error_messages = []
+    monkeypatch.setattr(
+        "src.loaders.supabase_loader.logger.error",
+        lambda message: error_messages.append(message),
+    )
+
+    batch = [{"id": "m1", "jan_aushadhi_price": 18.50}]
+    updated, failed = loader._upsert_ja_price_update_batches(batch, "medicines")
+
+    assert updated == 1
+    assert failed == 0
+    assert not any("unrecognized count shape" in message for message in error_messages)
+
+
+def test_ja_backfill_assumes_full_batch_on_unrecognized_rpc_shape(tmp_path, monkeypatch):
     """An unrecognized RPC count shape is assumed to be a full success (the RPC
     committed without raising) rather than miscounted as failed."""
     medicines = [
@@ -745,6 +796,11 @@ def test_ja_backfill_assumes_full_batch_on_unrecognized_rpc_shape(tmp_path):
     client.rpc_override_set = True
     client.rpc_data_override = {"unexpected": "shape"}
     loader = make_merge_loader(client, tmp_path)
+    error_messages = []
+    monkeypatch.setattr(
+        "src.loaders.supabase_loader.logger.error",
+        lambda message: error_messages.append(message),
+    )
 
     batch = [{"id": "m1", "jan_aushadhi_price": 18.50}]
     updated, failed = loader._upsert_ja_price_update_batches(batch, "medicines")
@@ -752,6 +808,7 @@ def test_ja_backfill_assumes_full_batch_on_unrecognized_rpc_shape(tmp_path):
     assert updated == 1
     assert failed == 0
     assert client.update_calls == []
+    assert any("unrecognized count shape" in message for message in error_messages)
 
 
 def test_ja_backfill_retries_transient_batch_rpc_before_fallback(tmp_path, monkeypatch):


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #3486**
* **Summary:**

  * Updated `_coerce_rpc_updated_count` in `apps/etl/src/loaders/supabase_loader.py` to support RPC responses returned as a single-item list containing a single-key dictionary, such as:

    ```python
    [{"bulk_update_jan_aushadhi_price": 45}]
    [{"value": 45}]
    ```
  * Preserved support for bare integers and single-item integer lists.
  * Explicitly rejects boolean values, including nested boolean values, since `bool` is a subclass of `int`.
  * Continues returning `None` for unsupported or ambiguous shapes (empty dictionaries, multi-key dictionaries, non-integer values, empty lists, multi-item lists, etc.).
  * Prevents false-positive `unrecognized count shape` warnings for valid dictionary RPC responses while preserving existing warning behavior for genuinely unsupported responses.
  * Added focused test coverage for valid and invalid coercion paths and warning behavior.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Validation

```text
git diff --check
✓ Passed
```

```text
.\.venv\Scripts\python.exe -m pytest apps/etl/tests/test_loader.py
```

Result:

```text
ImportError: cannot import name 'Client' from 'supabase'
```

Environment:

```text
Python 3.14.3
pytest 9.1.1
```

* Test collection failed before execution due to an existing Supabase dependency/environment issue.
* Zero tests were executed.
* The implementation was manually reviewed against all required valid, invalid, and warning-path scenarios.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3486`)
* [x] I have pulled the latest `main` and resolved any conflicts