### PR TITLE
fix: Replace fail-open validation with fail-closed 503 on RPC error

### DIFF
--- a/apps/api/src/services/reportValidation.service.ts
+++ b/apps/api/src/services/reportValidation.service.ts
@@ -70,14 +70,14 @@ export async function validateReport(
     });
 
     if (error) {
-        logger.error("RPC validate_report_submission failed", { error });
-        // Fail open on database error so legitimate reports aren't blocked entirely
-        return {
-            passed: true,
-            riskScore: 0,
-            reasons: ["Validation failed due to database error (fallback pass)"],
-            isDuplicate: false,
-        };
+        logger.error("RPC validate_report_submission failed — rejecting report to fail closed", {
+            error,
+        });
+        const serviceError = new Error(
+            "Report validation is temporarily unavailable. Please try again later."
+        ) as Error & { statusCode: number };
+        serviceError.statusCode = 503;
+        throw serviceError;
     }
 
     const res = rpcResult as any;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3620 **
- **Summary:**
Fixes "fail-open" vulnerability in report validation — when the `validate_report_submission` RPC fails, the system now rejects the submission with 503 instead of silently passing it through.

## Changes
- **apps/api/src/services/reportValidation.service.ts:72-77**
  - Before: returned `{ passed: true, riskScore: 0 }` on RPC error, bypassing all fraud checks (dedup, burst, sybil, reputation, pharmacy verification)
  - After: throws an error with `statusCode: 503`, which Express 5's error handler converts to a proper `503 Service Unavailable` response

## Impact
- Callers (`reports.ts` POST `/` and `batch.ts` POST `/report`) already have try-catch or async error handling — both will now return 503 instead of silently accepting fraudulent reports during DB outages
- An attacker can no longer exploit transient DB hiccups to submit unlimited counterfeit reports



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3620`)
- [x] I have pulled the latest `main` and resolved any conflicts
