### PR TITLE
fix(web): distinguish compare search failures

### DIFF
--- a/apps/web/app/[locale]/compare/page.tsx
+++ b/apps/web/app/[locale]/compare/page.tsx
@@ -159,7 +159,7 @@ async function searchMedicines(query: string): Promise<Medicine[]> {
 
     if (error) {
         console.error(error.message);
-        return [];
+        throw error;
     }
     return ((data ?? []) as Record<string, unknown>[]).map((row) => mapMedicineRow(row));
 }

--- a/apps/web/src/components/MedicineSearchSelect.tsx
+++ b/apps/web/src/components/MedicineSearchSelect.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { Clock, Loader2, Search, X } from "lucide-react";
 import type { Medicine } from "./ComparisonGrid";
 
 // ─── constants ────────────────────────────────────────────────────────────────
 const HISTORY_KEY = "sahidawa_search_history";
 const MAX_HISTORY = 5;
+const SEARCH_ERROR_MESSAGE = "Search failed. Please try again.";
 
 // ─── types ────────────────────────────────────────────────────────────────────
 interface HistoryEntry {
@@ -85,42 +86,77 @@ export default function MedicineSearchSelect({
     const [query, setQuery] = useState("");
     const [results, setResults] = useState<Medicine[]>([]);
     const [loading, setLoading] = useState(false);
+    const [searchError, setSearchError] = useState<string | null>(null);
     const [history, setHistory] = useState<HistoryEntry[]>([]);
     const [activeIndex, setActiveIndex] = useState(-1);
-    const latestQueryRef = useRef("");
+    const requestIdRef = useRef(0);
 
     // Load history once on mount
     useEffect(() => {
         setHistory(loadHistory());
     }, []);
 
-    // Debounced search
-    useEffect(() => {
-        if (!open) return;
-        const q = query.trim();
-        if (q.length < 2) {
+    const runSearch = useCallback(
+        async (normalizedQuery: string, requestId: number) => {
+            setLoading(true);
+            setSearchError(null);
             setResults([]);
             setActiveIndex(-1);
+
+            try {
+                const nextResults = await onSearch(normalizedQuery);
+                if (requestIdRef.current !== requestId) return;
+
+                setResults(nextResults);
+                setSearchError(null);
+                setActiveIndex(nextResults.length ? 0 : -1);
+                // Only persist successful searches that returned results.
+                if (nextResults.length > 0) {
+                    setHistory((previous) => pushToHistory(normalizedQuery, previous));
+                }
+            } catch {
+                if (requestIdRef.current !== requestId) return;
+
+                setResults([]);
+                setActiveIndex(-1);
+                setSearchError(SEARCH_ERROR_MESSAGE);
+            } finally {
+                if (requestIdRef.current === requestId) {
+                    setLoading(false);
+                }
+            }
+        },
+        [onSearch]
+    );
+
+    // Debounced search. Incrementing the request id immediately invalidates any
+    // in-flight request before the next debounce timer starts.
+    useEffect(() => {
+        const requestId = ++requestIdRef.current;
+        const q = query.trim();
+
+        setLoading(false);
+        setSearchError(null);
+        setResults([]);
+        setActiveIndex(-1);
+
+        if (!open) return;
+        if (q.length < 2) {
             return;
         }
-        latestQueryRef.current = q;
-        const t = setTimeout(async () => {
-            setLoading(true);
-            try {
-                const res = await onSearch(q);
-                if (latestQueryRef.current !== q) return;
-                setResults(res);
-                setActiveIndex(res.length ? 0 : -1);
-                // Only persist to history when we actually got results back
-                if (res.length > 0) {
-                    setHistory((prev) => pushToHistory(q, prev));
-                }
-            } finally {
-                setLoading(false);
-            }
+
+        const t = setTimeout(() => {
+            void runSearch(q, requestId);
         }, 300);
         return () => clearTimeout(t);
-    }, [query, open, onSearch]);
+    }, [query, open, runSearch]);
+
+    useEffect(
+        () => () => {
+            requestIdRef.current += 1;
+        },
+        []
+    );
 
     // Close dropdown on outside click
     useEffect(() => {
@@ -147,8 +183,17 @@ export default function MedicineSearchSelect({
     function handleClearQuery() {
         setQuery("");
         setResults([]);
+        setSearchError(null);
         setActiveIndex(-1);
         inputRef.current?.focus();
+    }
+
+    function handleRetry() {
+        const normalizedQuery = query.trim();
+        if (normalizedQuery.length < 2) return;
+
+        const requestId = ++requestIdRef.current;
+        void runSearch(normalizedQuery, requestId);
     }
 
     const showHistory = !value && history.length > 0;
@@ -174,6 +219,7 @@ export default function MedicineSearchSelect({
                         type="button"
                         onClick={() => {
                             onChange(null);
+                            setSearchError(null);
                             setOpen(true);
                             inputRef.current?.focus();
                         }}
@@ -204,6 +250,7 @@ export default function MedicineSearchSelect({
                             value={query}
                             onChange={(e) => {
                                 setQuery(e.target.value);
+                                setSearchError(null);
                                 setOpen(true);
                             }}
                             onFocus={() => {
@@ -224,6 +271,7 @@ export default function MedicineSearchSelect({
 
                                     setQuery("");
                                     setResults([]);
+                                    setSearchError(null);
                                     setActiveIndex(-1);
                                     setOpen(false);
                                     e.currentTarget.blur();
@@ -338,11 +386,29 @@ export default function MedicineSearchSelect({
                             Enter at least 2 characters
                         </li>
                     )}
-                    {!loading && query.trim().length >= 2 && results.length === 0 && (
-                        <li className="px-3 py-2 text-sm text-slate-500 dark:text-slate-400">
-                            No results
+                    {!loading && searchError && (
+                        <li
+                            role="alert"
+                            className="flex items-center justify-between gap-3 px-3 py-2 text-sm text-rose-700 dark:text-rose-400"
+                        >
+                            <span>{searchError}</span>
+                            <button
+                                type="button"
+                                onClick={handleRetry}
+                                className="shrink-0 rounded-md border border-rose-300 px-2.5 py-1 font-medium hover:bg-rose-50 focus:ring-2 focus:ring-rose-500 focus:ring-offset-1 focus:outline-none dark:border-rose-700 dark:hover:bg-rose-950/40 dark:focus:ring-offset-slate-900"
+                            >
+                                Retry
+                            </button>
                         </li>
                     )}
+                    {!loading &&
+                        !searchError &&
+                        query.trim().length >= 2 &&
+                        results.length === 0 && (
+                            <li className="px-3 py-2 text-sm text-slate-500 dark:text-slate-400">
+                                No results
+                            </li>
+                        )}
                     {!loading &&
                         results.map((m, index) => (
                             <li
@@ -362,6 +428,7 @@ export default function MedicineSearchSelect({
                                     onClick={() => {
                                         onChange(m);
                                         setQuery("");
+                                        setSearchError(null);
                                         setOpen(false);
                                         setActiveIndex(-1);
                                     }}

--- a/apps/web/tests/MedicineSearchSelect.test.tsx
+++ b/apps/web/tests/MedicineSearchSelect.test.tsx
@@ -74,6 +74,7 @@ describe("MedicineSearchSelect", () => {
         expect(screen.getByText(/crocin/i)).toBeInTheDocument();
 
         expect(screen.getByText(/gsk/i)).toBeInTheDocument();
+        expect(screen.queryByText(/search failed/i)).not.toBeInTheDocument();
     });
 
     test("clear button calls onChange with null", async () => {
@@ -150,6 +151,120 @@ describe("MedicineSearchSelect", () => {
         });
 
         expect(screen.getByText(/no results/i)).toBeInTheDocument();
+        expect(screen.queryByText(/search failed/i)).not.toBeInTheDocument();
+    });
+
+    test("shows an error instead of no results when search rejects", async () => {
+        const user = userEvent.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+        const onSearch = jest.fn().mockRejectedValue(new Error("Supabase unavailable"));
+
+        render(<MedicineSearchSelect {...defaultProps} onSearch={onSearch} />);
+
+        await user.type(screen.getByRole("combobox"), "cro");
+        await act(async () => {
+            jest.advanceTimersByTime(300);
+        });
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+            "Search failed. Please try again."
+        );
+        expect(screen.queryByText(/no results/i)).not.toBeInTheDocument();
+        expect(localStorage.getItem("sahidawa_search_history")).toBeNull();
+    });
+
+    test("retries the same query and clears the previous error after success", async () => {
+        const user = userEvent.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+        const onSearch = jest
+            .fn()
+            .mockRejectedValueOnce(new Error("Temporary failure"))
+            .mockResolvedValueOnce([mockMedicine]);
+
+        render(<MedicineSearchSelect {...defaultProps} onSearch={onSearch} />);
+
+        await user.type(screen.getByRole("combobox"), "  cro  ");
+        await act(async () => {
+            jest.advanceTimersByTime(300);
+        });
+        expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: /retry/i }));
+
+        await waitFor(() => expect(onSearch).toHaveBeenCalledTimes(2));
+        expect(onSearch).toHaveBeenNthCalledWith(1, "cro");
+        expect(onSearch).toHaveBeenNthCalledWith(2, "cro");
+        expect(await screen.findByText(/crocin/i)).toBeInTheDocument();
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    test("clears a failed search error when a new query succeeds", async () => {
+        const user = userEvent.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+        const onSearch = jest
+            .fn()
+            .mockRejectedValueOnce(new Error("Temporary failure"))
+            .mockResolvedValueOnce([mockMedicine]);
+
+        render(<MedicineSearchSelect {...defaultProps} onSearch={onSearch} />);
+
+        const input = screen.getByRole("combobox");
+        await user.type(input, "old");
+        await act(async () => {
+            jest.advanceTimersByTime(300);
+        });
+        expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+        await user.clear(input);
+        await user.type(input, "cro");
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+        await act(async () => {
+            jest.advanceTimersByTime(300);
+        });
+        expect(await screen.findByText(/crocin/i)).toBeInTheDocument();
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    test("ignores an older search failure after a newer query succeeds", async () => {
+        const user = userEvent.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+        let rejectOlderSearch: ((reason?: unknown) => void) | undefined;
+        const olderSearch = new Promise<never>((_resolve, reject) => {
+            rejectOlderSearch = reject;
+        });
+        const onSearch = jest
+            .fn()
+            .mockReturnValueOnce(olderSearch)
+            .mockResolvedValueOnce([mockMedicine]);
+
+        render(<MedicineSearchSelect {...defaultProps} onSearch={onSearch} />);
+
+        const input = screen.getByRole("combobox");
+        await user.type(input, "old");
+        await act(async () => {
+            jest.advanceTimersByTime(300);
+        });
+        expect(onSearch).toHaveBeenCalledWith("old");
+
+        await user.clear(input);
+        await user.type(input, "cro");
+        await act(async () => {
+            jest.advanceTimersByTime(300);
+        });
+        expect(await screen.findByText(/crocin/i)).toBeInTheDocument();
+
+        await act(async () => {
+            rejectOlderSearch?.(new Error("Late failure"));
+            await olderSearch.catch(() => undefined);
+        });
+
+        expect(screen.getByText(/crocin/i)).toBeInTheDocument();
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
 
     test("renders search history when history exists", async () => {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3622**
- **Summary:** Propagates Supabase comparison-search failures and adds a distinct, accessible error state with retry support to the medicine search combobox.

### Root cause

The compare page converted Supabase errors into an empty array, so the combobox could not distinguish a failed request from a successful search with zero matches. Rejected search callbacks also had no handled UI path.

### Changes

- Throw Supabase search errors after logging diagnostic details.
- Display `Search failed. Please try again.` in an announced error state.
- Add a keyboard-accessible Retry button that repeats the current normalized query.
- Invalidate stale requests on query changes, retries, and unmount.
- Preserve `No results` for successful empty searches and save history only after successful non-empty searches.
- Add focused tests for matches, empty results, rejection, retry, new-query recovery, stale failures, and failed-history exclusion.

## 📸 Proof of Work (Screenshots / Logs)

Automated validation:

- `npm.cmd run test -- --runInBand tests/MedicineSearchSelect.test.tsx` — passed, 14/14 tests.
- `npx.cmd eslint "app/[locale]/compare/page.tsx" src/components/MedicineSearchSelect.tsx tests/MedicineSearchSelect.test.tsx` — passed.
- `npm.cmd run build -w @sahidawa/shared -w @sahidawa/types -w @sahidawa/validators` — passed.
- `npx.cmd tsc --noEmit -p tsconfig.json` — passed after building internal workspaces.
- `git diff --check` — passed.
- Pre-push `npm run audit:all` — passed; Node reported zero vulnerabilities and unchanged Python dependency files were skipped as designed.

The local installation contains TypeScript 6.0.3 despite the repository declaring ^5.6.2. The focused Jest run therefore used a temporary `ignoreDeprecations: "6.0"` compatibility value in `tsconfig.test.json`; that file was restored and is not part of this PR.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3622`)
- [ ] I have pulled the latest `main` and resolved any conflicts
- [x] I reviewed and tested the AI-assisted implementation before submission.
