### PR TITLE
Feat : Implement Graceful CSRF Token Refresh via Axios/Fetch Interceptor

### DIFF
--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,15 +1,10 @@
 import { fetchWithRetry } from "./apiWithRetry";
 import { createSWRCache } from "./cacheUtils";
 
-import type {
-  VerifiedPharmacy,
-  LasaMatch,
-  LasaMatchType,
-} from "@sahidawa/types";
+import type { VerifiedPharmacy, LasaMatch, LasaMatchType } from "@sahidawa/types";
 export type { VerifiedPharmacy, LasaMatch, LasaMatchType };
 
 import { PHARMACY_SEARCH_RADIUS_DEFAULT_KM } from "@sahidawa/shared";
-
 
 const DEFAULT_API_ORIGIN = "http://localhost:4000";
 const configuredApiUrl = (process.env.NEXT_PUBLIC_API_URL ?? DEFAULT_API_ORIGIN).trim();
@@ -19,6 +14,18 @@ const fuzzyMatchCache = createSWRCache<FuzzyMatch[]>(60_000); // 60s TTL
 const verifyBrandCache = createSWRCache<VerifyResult>(300_000); // 5min TTL
 
 let csrfTokenCache: string | null = null;
+let isRefreshingCsrf = false;
+let refreshSubscribers: { resolve: (token: string) => void; reject: (err: any) => void }[] = [];
+
+function onCsrfRefreshed(token: string) {
+    refreshSubscribers.forEach(({ resolve }) => resolve(token));
+    refreshSubscribers = [];
+}
+
+function onCsrfRefreshFailed(err: any) {
+    refreshSubscribers.forEach(({ reject }) => reject(err));
+    refreshSubscribers = [];
+}
 
 export async function getCsrfToken(): Promise<string> {
     if (csrfTokenCache) return csrfTokenCache;
@@ -26,19 +33,35 @@ export async function getCsrfToken(): Promise<string> {
 }
 
 export async function refreshCsrfToken(): Promise<string> {
+    if (isRefreshingCsrf) {
+        return new Promise((resolve, reject) => {
+            refreshSubscribers.push({ resolve, reject });
+        });
+    }
+
+    isRefreshingCsrf = true;
     csrfTokenCache = null;
-    const res = await fetch(`${API_BASE}/api/csrf-token`, {
-        credentials: "include",
-    });
-    if (!res.ok) {
-        throw new Error(`Failed to fetch CSRF token: ${res.status} ${res.statusText}`);
+
+    try {
+        const res = await fetch(`${API_BASE}/api/csrf-token`, {
+            credentials: "include",
+        });
+        if (!res.ok) {
+            throw new Error(`Failed to fetch CSRF token: ${res.status} ${res.statusText}`);
+        }
+        const data = await res.json();
+        if (!data.csrfToken) {
+            throw new Error("CSRF token not found in response body");
+        }
+        csrfTokenCache = data.csrfToken;
+        onCsrfRefreshed(data.csrfToken);
+        return data.csrfToken;
+    } catch (error) {
+        onCsrfRefreshFailed(error);
+        throw error;
+    } finally {
+        isRefreshingCsrf = false;
     }
-    const data = await res.json();
-    if (!data.csrfToken) {
-        throw new Error("CSRF token not found in response body");
-    }
-    csrfTokenCache = data.csrfToken;
-    return csrfTokenCache!;
 }
 
 async function fetchWithCsrf<T>(
@@ -62,14 +85,12 @@ async function fetchWithCsrf<T>(
 
     let res = await doFetch(await getCsrfToken());
 
-    if (res.status === 403) {
-        const freshToken = await refreshCsrfToken();
-        res = await doFetch(freshToken);
-    }
-
     if (!res.ok && !(ignore404 && res.status === 404)) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? "Server error occurred. Please retry.");
+        const body = (await res.json().catch(() => ({}))) as {
+            error?: { message?: string } | string;
+        };
+        const errorMessage = typeof body.error === "object" ? body.error.message : body.error;
+        throw new Error(errorMessage ?? "Server error occurred. Please retry.");
     }
 
     return res.json() as Promise<T>;

--- a/apps/web/lib/apiWithRetry.ts
+++ b/apps/web/lib/apiWithRetry.ts
@@ -99,6 +99,44 @@ export async function fetchWithRetry(
             }
 
             if (!response.ok) {
+                // Check for CSRF error globally
+                if (response.status === 403) {
+                    const clonedResponse = response.clone();
+                    const bodyText = await clonedResponse.text().catch(() => "");
+                    const isCsrfError =
+                        bodyText.toLowerCase().includes("csrf") ||
+                        bodyText.toLowerCase().includes("token");
+
+                    if (isCsrfError) {
+                        try {
+                            const { refreshCsrfToken } = await import("./api");
+                            const newToken = await refreshCsrfToken();
+
+                            const newOptions = { ...fetchOptions };
+                            if (newOptions.headers) {
+                                const headers = new Headers(newOptions.headers);
+                                headers.set("x-csrf-token", newToken);
+                                newOptions.headers = headers;
+                            } else {
+                                newOptions.headers = { "x-csrf-token": newToken };
+                            }
+
+                            const retryResponse = await fetch(url, {
+                                ...newOptions,
+                                credentials: newOptions.credentials ?? "include",
+                                signal: controller.signal,
+                            });
+
+                            if (retryResponse.ok || !config.shouldRetry(retryResponse, attempt)) {
+                                return retryResponse;
+                            }
+                        } catch (csrfError) {
+                            // If token refresh fails, don't loop, continue with original error response
+                            console.warn("[API CSRF Interceptor] Token refresh failed:", csrfError);
+                        }
+                    }
+                }
+
                 if (attempt <= config.maxRetries && config.shouldRetry(response, attempt)) {
                     const delay = getBackoffDelay(attempt, config);
                     await sleep(delay);


### PR DESCRIPTION
#3603

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3603**
- **Summary:**
- modified the fetchWithRetry wrapper—which handles all API calls globally—to intercept 403 Forbidden responses. It then inspects the error response body to detect if it's specifically a CSRF failure (e.g. EBADCSRFTOKEN or a token error).
- Upon retrieving the fresh token, the interceptor automatically updates the x-csrf-token header and safely retries the original failed API call, recovering silently without disrupting the user.
-  If the token refresh endpoint itself fails (e.g. the user's entire session is actually gone/expired on the server), the queue immediately rejects. The interceptor catches this and aborts the retry loop, passing the original 403 error downstream for normal error handling (e.g., kicking the user to the login page) to prevent an infinite loop

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
