### PR TITLE
fix(api): account for multipart upload overhead

### DIFF
--- a/apps/api/src/middleware/uploadSizeValidator.ts
+++ b/apps/api/src/middleware/uploadSizeValidator.ts
@@ -1,6 +1,14 @@
 import { Request, Response, NextFunction } from "express";
 
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+export const MAX_SCAN_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+// Configure the parser boundary so the public 10 MiB maximum remains
+// inclusive: exactly 10 MiB is accepted, while the next byte is rejected.
+export const MULTER_SCAN_FILE_SIZE_CUTOFF_BYTES = MAX_SCAN_FILE_SIZE_BYTES + 1;
+
+// /scan/submit accepts two 10 MiB files. Its multipart metadata and framing must
+// fit alongside those files within this separate total-request security ceiling.
+export const MAX_SCAN_MULTIPART_BODY_SIZE_BYTES = 25 * 1024 * 1024;
 
 export const validateUploadSize = (req: Request, res: Response, next: NextFunction) => {
     const contentLength = req.headers["content-length"];
@@ -14,10 +22,10 @@ export const validateUploadSize = (req: Request, res: Response, next: NextFuncti
 
     const size = parseInt(contentLength, 10);
 
-    if (isNaN(size) || size > MAX_FILE_SIZE) {
+    if (isNaN(size) || size > MAX_SCAN_MULTIPART_BODY_SIZE_BYTES) {
         res.status(413).json({
-            error: `File size exceeds maximum allowed size of ${MAX_FILE_SIZE / 1024 / 1024}MB`,
-            maxSize: MAX_FILE_SIZE,
+            error: `Request body exceeds maximum allowed size of ${MAX_SCAN_MULTIPART_BODY_SIZE_BYTES / 1024 / 1024}MiB`,
+            maxSize: MAX_SCAN_MULTIPART_BODY_SIZE_BYTES,
             providedSize: size,
         });
         return;

--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -7,7 +7,10 @@ import crypto from "crypto";
 import logger from "../utils/logger";
 import { supabase } from "../db/client";
 import { getMlServiceUrl, MISSING_ML_SERVICE_URL_MESSAGE } from "../config/mlService";
-import { validateUploadSize } from "../middleware/uploadSizeValidator";
+import {
+    MULTER_SCAN_FILE_SIZE_CUTOFF_BYTES,
+    validateUploadSize,
+} from "../middleware/uploadSizeValidator";
 import { uploadRateLimiter } from "../middleware/uploadRateLimit";
 import { scanQueryLimiter } from "../middleware/rateLimit";
 import { redisClient } from "../utils/redis";
@@ -51,7 +54,7 @@ const upload = multer({
             cb(null, uniqueName);
         },
     }),
-    limits: { fileSize: 10 * 1024 * 1024 }, // 10 MB
+    limits: { fileSize: MULTER_SCAN_FILE_SIZE_CUTOFF_BYTES },
     fileFilter(_req, file, cb) {
         if (ALLOWED_MIME_TYPES.has(file.mimetype)) {
             cb(null, true);

--- a/apps/api/tests/uploadSizeValidator.test.ts
+++ b/apps/api/tests/uploadSizeValidator.test.ts
@@ -1,0 +1,186 @@
+import express, { type NextFunction, type Request, type Response } from "express";
+import request from "supertest";
+import app from "../src/app";
+import {
+    MAX_SCAN_FILE_SIZE_BYTES,
+    MAX_SCAN_MULTIPART_BODY_SIZE_BYTES,
+    validateUploadSize,
+} from "../src/middleware/uploadSizeValidator";
+
+function invokeMiddleware(contentLength?: string) {
+    const json = jest.fn();
+    const status = jest.fn(() => ({ json }));
+    const next = jest.fn();
+    const req = {
+        headers: contentLength === undefined ? {} : { "content-length": contentLength },
+    } as Request;
+    const res = { status } as unknown as Response;
+
+    validateUploadSize(req, res, next as NextFunction);
+
+    return { json, next, status };
+}
+
+function createMultipartBody(fileSize: number) {
+    const boundary = "sahidawa-upload-size-test-boundary";
+    const prefix = Buffer.from(
+        `--${boundary}\r\n` +
+            'Content-Disposition: form-data; name="file"; filename="medicine.jpg"\r\n' +
+            "Content-Type: image/jpeg\r\n\r\n"
+    );
+    const suffix = Buffer.from(`\r\n--${boundary}--\r\n`);
+
+    return {
+        body: Buffer.concat([prefix, Buffer.alloc(fileSize), suffix]),
+        contentType: `multipart/form-data; boundary=${boundary}`,
+    };
+}
+
+function createTwoFileSubmitBody() {
+    const boundary = "sahidawa-two-file-submit-test-boundary";
+    const field = (name: string, value: string) =>
+        Buffer.from(
+            `--${boundary}\r\n` +
+                `Content-Disposition: form-data; name="${name}"\r\n\r\n` +
+                `${value}\r\n`
+        );
+    const fileHeader = (name: string, filename: string, contentType: string) =>
+        Buffer.from(
+            `--${boundary}\r\n` +
+                `Content-Disposition: form-data; name="${name}"; filename="${filename}"\r\n` +
+                `Content-Type: ${contentType}\r\n\r\n`
+        );
+
+    return {
+        body: Buffer.concat([
+            field("clientUpdatedAt", "1784139437317"),
+            field("metadata", JSON.stringify({ name: "Paracetamol" })),
+            fileHeader("image", "medicine.jpg", "image/jpeg"),
+            Buffer.alloc(MAX_SCAN_FILE_SIZE_BYTES),
+            Buffer.from("\r\n"),
+            fileHeader("voice", "medicine.webm", "audio/webm"),
+            Buffer.alloc(MAX_SCAN_FILE_SIZE_BYTES),
+            Buffer.from(`\r\n--${boundary}--\r\n`),
+        ]),
+        contentType: `multipart/form-data; boundary=${boundary}`,
+    };
+}
+
+describe("validateUploadSize", () => {
+    it("accepts Content-Length below the multipart request limit", () => {
+        const { next, status } = invokeMiddleware(String(MAX_SCAN_MULTIPART_BODY_SIZE_BYTES - 1));
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(status).not.toHaveBeenCalled();
+    });
+
+    it("accepts Content-Length exactly at the multipart request limit", () => {
+        const { next, status } = invokeMiddleware(String(MAX_SCAN_MULTIPART_BODY_SIZE_BYTES));
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(status).not.toHaveBeenCalled();
+    });
+
+    it("rejects Content-Length above the multipart request limit", () => {
+        const { json, next, status } = invokeMiddleware(
+            String(MAX_SCAN_MULTIPART_BODY_SIZE_BYTES + 1)
+        );
+
+        expect(next).not.toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(413);
+        expect(json).toHaveBeenCalledWith({
+            error: "Request body exceeds maximum allowed size of 25MiB",
+            maxSize: MAX_SCAN_MULTIPART_BODY_SIZE_BYTES,
+            providedSize: MAX_SCAN_MULTIPART_BODY_SIZE_BYTES + 1,
+        });
+    });
+
+    it("preserves invalid Content-Length handling", () => {
+        const { json, next, status } = invokeMiddleware("not-a-number");
+
+        expect(next).not.toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(413);
+        expect(json).toHaveBeenCalledWith(
+            expect.objectContaining({
+                maxSize: MAX_SCAN_MULTIPART_BODY_SIZE_BYTES,
+                providedSize: Number.NaN,
+            })
+        );
+    });
+
+    it("preserves missing Content-Length handling", () => {
+        const { json, next, status } = invokeMiddleware();
+
+        expect(next).not.toHaveBeenCalled();
+        expect(status).toHaveBeenCalledWith(411);
+        expect(json).toHaveBeenCalledWith({ error: "Content-Length header required" });
+    });
+
+    it("accepts a two-file submit body within the 25 MiB request ceiling", async () => {
+        const { body, contentType } = createTwoFileSubmitBody();
+        expect(body.length).toBeGreaterThan(2 * MAX_SCAN_FILE_SIZE_BYTES);
+        expect(body.length).toBeLessThan(MAX_SCAN_MULTIPART_BODY_SIZE_BYTES);
+
+        const middlewareApp = express();
+        middlewareApp.post("/submit", validateUploadSize, (req, res) => {
+            req.on("data", () => undefined);
+            req.on("end", () => res.sendStatus(204));
+        });
+
+        const response = await request(middlewareApp)
+            .post("/submit")
+            .set("Content-Type", contentType)
+            .set("Content-Length", String(body.length))
+            .send(body);
+
+        expect(response.status).toBe(204);
+    });
+});
+
+describe("POST /api/v1/scan/extract upload limits", () => {
+    const realFetch = global.fetch;
+
+    afterEach(() => {
+        global.fetch = realFetch;
+        jest.restoreAllMocks();
+    });
+
+    it("accepts an exactly 10,485,760-byte file despite multipart overhead", async () => {
+        const { body, contentType } = createMultipartBody(MAX_SCAN_FILE_SIZE_BYTES);
+        expect(MAX_SCAN_FILE_SIZE_BYTES).toBe(10_485_760);
+        expect(body.length).toBeGreaterThan(MAX_SCAN_FILE_SIZE_BYTES);
+        expect(body.length).toBeLessThan(MAX_SCAN_MULTIPART_BODY_SIZE_BYTES);
+
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            json: async () => ({ text: "rs 12 mrp", confidence: 0.9 }),
+        }) as never;
+
+        const response = await request(app)
+            .post("/api/v1/scan/extract")
+            .set("Content-Type", contentType)
+            .set("Content-Length", String(body.length))
+            .send(body);
+
+        expect(response.status).toBe(200);
+        expect(global.fetch).toHaveBeenCalledWith(
+            "http://example.com/ocr/extract",
+            expect.objectContaining({ method: "POST" })
+        );
+    });
+
+    it("rejects a 10,485,761-byte file through Multer", async () => {
+        const { body, contentType } = createMultipartBody(MAX_SCAN_FILE_SIZE_BYTES + 1);
+        expect(body.length).toBeLessThan(MAX_SCAN_MULTIPART_BODY_SIZE_BYTES);
+
+        const response = await request(app)
+            .post("/api/v1/scan/extract")
+            .set("Content-Type", contentType)
+            .set("Content-Length", String(body.length))
+            .send(body);
+
+        expect(response.status).toBe(400);
+        expect(response.body).toEqual({ error: "File too large" });
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #3624**
* **Summary:**

  * Fixed a regression where `validateUploadSize` compared the entire multipart request `Content-Length` against the advertised 10 MiB file limit.
  * Introduced a separate multipart request-body safety ceiling while keeping the public per-file limit unchanged.
  * Preserved early rejection of clearly oversized requests without incorrectly rejecting valid uploads at the documented file-size boundary.
  * Reused shared upload-size constants between middleware and scan routes.
  * Added regression tests covering multipart overhead, boundary conditions, and oversized-file handling.

### Files Changed

* `apps/api/src/middleware/uploadSizeValidator.ts`

  * Added separate constants for:

    * public scan file-size limit
    * Multer parser cutoff
    * multipart request-body safety limit
  * Updated validation logic to check request-body size rather than treating request size as file size.
  * Corrected the HTTP 413 error message to describe request-body limits accurately.

* `apps/api/src/routes/scan.ts`

  * Reused the shared scan upload-size constants.
  * Configured Multer so an exact 10 MiB upload remains valid while a file exceeding the limit is rejected.

* `apps/api/tests/uploadSizeValidator.test.ts`

  * Added focused unit and integration coverage for multipart upload boundary conditions.

## 📸 Proof of Work (Screenshots / Logs)

### Validation Results

```text
Focused upload-size test suite: PASSED (8/8)

Additional scan test suites:
- scanCleanup.test.ts: PASSED
- scans.sync.test.ts: PASSED
- 1 pre-existing skipped test unchanged

TypeScript:
- npx.cmd tsc --noEmit -p tsconfig.json
- PASSED

Git:
- git diff --check
- PASSED

Upload cleanup verification:
- Temporary upload directory empty after tests
```

### Regression Verification

```text
10,485,760-byte file:
- Accepted
- Reached mocked OCR service
- HTTP 200

10,485,761-byte file:
- Rejected by Multer
- HTTP 400
- { "error": "File too large" }
```

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3624`)
* [x] I have pulled the latest `main` and resolved any conflicts