### PR TITLE
fix: use native vaccine date input

### DIFF
--- a/apps/web/components/vaccine/DateInitializer.tsx
+++ b/apps/web/components/vaccine/DateInitializer.tsx
@@ -3,58 +3,11 @@
 import { VaccineProfile } from "@/lib/vaccineData";
 import { Calendar } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { useState, useEffect } from "react";
 
 interface DateInitializerProps {
     vaccine: VaccineProfile;
     value: string; // ISO format: yyyy-mm-dd
     onChange: (date: string) => void;
-}
-
-/** Convert ISO yyyy-mm-dd → dd/mm/yyyy for display */
-function isoToDmy(iso: string): string {
-    if (!iso) return "";
-    const [y, m, d] = iso.split("-");
-    if (!y || !m || !d) return "";
-    return `${d}/${m}/${y}`;
-}
-
-/**
- * Checks whether day/month/year form a real calendar date
- * (rejects things like 31/02/2026, 00/12/2026, month 13, etc.)
- */
-function isValidCalendarDate(day: number, month: number, year: number): boolean {
-    if (!Number.isInteger(day) || !Number.isInteger(month) || !Number.isInteger(year)) {
-        return false;
-    }
-    if (year < 1000 || year > 9999) return false;
-    if (month < 1 || month > 12) return false;
-    if (day < 1 || day > 31) return false;
-
-    // Date's constructor rolls over out-of-range values (e.g. Feb 31 → Mar 3).
-    // Building the date and reading the components back out catches that rollover.
-    const date = new Date(year, month - 1, day);
-    return (
-        date.getFullYear() === year &&
-        date.getMonth() === month - 1 &&
-        date.getDate() === day
-    );
-}
-
-/** Convert dd/mm/yyyy → ISO yyyy-mm-dd for storage, or null if the date isn't real */
-function dmyToIso(dmy: string): string | null {
-    const parts = dmy.split("/");
-    if (parts.length !== 3) return null;
-    const [dStr, mStr, yStr] = parts;
-    if (!dStr || !mStr || !yStr || yStr.length !== 4) return null;
-
-    const day = Number(dStr);
-    const month = Number(mStr);
-    const year = Number(yStr);
-
-    if (!isValidCalendarDate(day, month, year)) return null;
-
-    return `${yStr}-${mStr.padStart(2, "0")}-${dStr.padStart(2, "0")}`;
 }
 
 /** Parse ISO date string without UTC offset to avoid off-by-one day bugs */
@@ -63,7 +16,7 @@ function parseIsoLocal(iso: string): Date | null {
     if (parts.length !== 3) return null;
     const [y, m, d] = parts.map(Number);
     if (!y || !m || !d) return null;
-    return new Date(y, m - 1, d); // Local timezone — no UTC shift
+    return new Date(y, m - 1, d); // Local timezone, no UTC shift
 }
 
 function formatLocalDate(date: Date): string {
@@ -75,98 +28,32 @@ function formatLocalDate(date: Date): string {
 
 export function DateInitializer({ vaccine, value, onChange }: DateInitializerProps) {
     const t = useTranslations("vaccineHub");
-
-    // Display state in dd/mm/yyyy; synced from ISO `value` prop
-    const [displayValue, setDisplayValue] = useState(isoToDmy(value));
-    const [hasInvalidDate, setHasInvalidDate] = useState(false);
-
-    useEffect(() => {
-        setDisplayValue(isoToDmy(value));
-        setHasInvalidDate(false);
-    }, [value]);
-
-    const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        let raw = e.target.value;
-
-        // Auto-insert slashes as user types (e.g. "12" → "12/")
-        const digits = raw.replace(/\D/g, "");
-        if (digits.length <= 2) {
-            raw = digits;
-        } else if (digits.length <= 4) {
-            raw = `${digits.slice(0, 2)}/${digits.slice(2)}`;
-        } else {
-            raw = `${digits.slice(0, 2)}/${digits.slice(2, 4)}/${digits.slice(4, 8)}`;
-        }
-
-        setDisplayValue(raw);
-
-        if (raw === "") {
-            setHasInvalidDate(false);
-            onChange("");
-            return;
-        }
-
-        // Only validate/propagate once a full dd/mm/yyyy has been entered
-        if (raw.length === 10) {
-            const iso = dmyToIso(raw);
-            if (iso) {
-                setHasInvalidDate(false);
-                onChange(iso);
-            } else {
-                // Impossible date (e.g. 31/02/2026, 00/12/2026) — don't save it
-                setHasInvalidDate(true);
-            }
-        } else {
-            setHasInvalidDate(false);
-        }
-    };
-
     const parsedDate = value ? parseIsoLocal(value) : null;
-
     const todayIso = formatLocalDate(new Date());
+    const inputDescriptionId = "date-initializer-hint";
+    const labelText = vaccine.is_relative_to_birth ? t("childBirthDate") : t("milestoneBaseDate");
 
     return (
         <div className="space-y-2">
             <label className="flex items-center gap-2 text-xs font-bold tracking-wider text-emerald-800 uppercase">
                 <Calendar size={14} aria-hidden="true" />
-                {vaccine.is_relative_to_birth ? t("childBirthDate") : t("milestoneBaseDate")}
+                {labelText}
             </label>
 
             <div className="relative">
-                {/* Visible dd/mm/yyyy text input */}
-                <input
-                    type="text"
-                    inputMode="numeric"
-                    placeholder="dd/mm/yyyy"
-                    value={displayValue}
-                    onChange={handleTextChange}
-                    maxLength={10}
-                    aria-invalid={hasInvalidDate}
-                    aria-describedby={hasInvalidDate ? "date-initializer-error" : undefined}
-                    className={`w-full rounded-lg border bg-white px-4 py-3 font-medium text-(--color-text-primary) shadow-sm transition-all outline-none hover:bg-(--color-surface-muted) focus:ring-2 focus:ring-offset-2 dark:bg-slate-800 dark:text-white dark:hover:bg-slate-700 ${
-                        hasInvalidDate
-                            ? "border-red-400 focus:ring-red-500 dark:border-red-500"
-                            : "border-slate-200 focus:ring-emerald-500 dark:border-slate-700"
-                    }`}
-                    aria-label={
-                        vaccine.is_relative_to_birth
-                            ? "Enter child's birth date (dd/mm/yyyy)"
-                            : "Enter first dose date (dd/mm/yyyy)"
-                    }
-                />
-
-                {/* Hidden native date picker — triggered by the calendar icon */}
                 <input
                     type="date"
                     value={value}
                     max={todayIso}
-                    onChange={(e) => {
-                        setHasInvalidDate(false);
-                        onChange(e.target.value);
-                    }}
-                    className="absolute inset-0 w-full cursor-pointer opacity-0"
-                    tabIndex={-1}
-                    aria-hidden="true"
+                    onChange={(e) => onChange(e.target.value)}
+                    aria-label={
+                        vaccine.is_relative_to_birth
+                            ? "Select child's birth date"
+                            : "Select first dose date"
+                    }
+                    aria-describedby={inputDescriptionId}
+                    title={vaccine.is_relative_to_birth ? "Select child's birth date" : "Select first dose date"}
+                    className="w-full cursor-pointer rounded-lg border border-slate-200 bg-white px-4 py-3 pr-11 font-medium text-(--color-text-primary) shadow-sm transition-all outline-none hover:bg-(--color-surface-muted) focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 dark:border-slate-700 dark:bg-slate-800 dark:text-white dark:hover:bg-slate-700"
                 />
 
                 <Calendar
@@ -176,15 +63,13 @@ export function DateInitializer({ vaccine, value, onChange }: DateInitializerPro
                 />
             </div>
 
-            {hasInvalidDate && (
-                <p id="date-initializer-error" role="alert" className="text-xs text-red-600 dark:text-red-400">
-                    Please enter a valid date.
-                </p>
-            )}
+            <p id={inputDescriptionId} className="text-xs text-(--color-text-muted)">
+                Use the native date picker. If your browser shows a plain field, enter the date as yyyy-mm-dd.
+            </p>
 
-            {!hasInvalidDate && parsedDate && (
+            {parsedDate && (
                 <p className="text-xs text-(--color-text-muted)">
-                    📅{" "}
+                    Date selected:{" "}
                     {parsedDate.toLocaleDateString("en-IN", {
                         weekday: "long",
                         year: "numeric",

--- a/apps/web/tests/vaccine-hub.test.tsx
+++ b/apps/web/tests/vaccine-hub.test.tsx
@@ -213,8 +213,9 @@ describe("VaccineHubPage Integration Tests", () => {
 
         // Verify date input appears
         await waitFor(() => {
-            const dateInput = screen.getByLabelText(/birth date/i);
+            const dateInput = screen.getByLabelText(/birth date/i) as HTMLInputElement;
             expect(dateInput).toBeInTheDocument();
+            expect(dateInput).toHaveAttribute("type", "date");
         });
     });
 
@@ -234,7 +235,7 @@ describe("VaccineHubPage Integration Tests", () => {
 
         // Enter date
         const dateInput = screen.getByLabelText(/birth date/i) as HTMLInputElement;
-        await user.type(dateInput, "01012024");
+        fireEvent.change(dateInput, { target: { value: "2024-01-01" } });
 
         // Verify doses are calculated
         await waitFor(() => {
@@ -242,7 +243,7 @@ describe("VaccineHubPage Integration Tests", () => {
         });
     });
 
-    it("rejects an impossible typed date like 31/02/2026 and does not use it for the schedule", async () => {
+    it("uses one accessible native date input instead of a hidden overlay picker", async () => {
         render(<VaccineHubPage />);
 
         // Select vaccine
@@ -256,27 +257,14 @@ describe("VaccineHubPage Integration Tests", () => {
         const polioOption = screen.getAllByText(/Poliomyelitis/i)[0];
         await user.click(polioOption);
 
-        // Type an impossible date: 31/02/2026 (February never has 31 days)
         const dateInput = screen.getByLabelText(/birth date/i) as HTMLInputElement;
-        await user.type(dateInput, "31022026");
 
-        // The raw typed text is still shown to the user...
-        await waitFor(() => {
-            expect(dateInput.value).toBe("31/02/2026");
-        });
-
-        // ...but an inline validation error appears...
-        expect(screen.getByText("Please enter a valid date.")).toBeInTheDocument();
-        expect(dateInput).toHaveAttribute("aria-invalid", "true");
-
-        // ...and it must never be silently normalized (e.g. rolled over to March)
-        // or used to compute a dose schedule.
-        expect(screen.queryByText(/31 Feb 2026/)).not.toBeInTheDocument();
-        expect(screen.queryByText(/3 Mar 2026/)).not.toBeInTheDocument();
-        expect(localStorage.getItem("vaccine-hub-initial-date")).toBeNull();
+        expect(dateInput).toHaveAttribute("type", "date");
+        expect(dateInput).not.toHaveAttribute("aria-hidden", "true");
+        expect(document.querySelector('input[type="date"].opacity-0')).not.toBeInTheDocument();
     });
 
-    it("clears the invalid-date error once a real date is typed", async () => {
+    it("clears the selected date when the native input is cleared", async () => {
         render(<VaccineHubPage />);
 
         const selector = screen.getByRole("button", { name: /Select a vaccine/i });
@@ -291,17 +279,17 @@ describe("VaccineHubPage Integration Tests", () => {
 
         const dateInput = screen.getByLabelText(/birth date/i) as HTMLInputElement;
 
-        // First, an impossible date
-        await user.type(dateInput, "31022026");
-        expect(screen.getByText("Please enter a valid date.")).toBeInTheDocument();
-
-        // Clear and type a real one
-        await user.clear(dateInput);
-        await user.type(dateInput, "28022026");
+        fireEvent.change(dateInput, { target: { value: "2026-02-28" } });
 
         await waitFor(() => {
-            expect(screen.queryByText("Please enter a valid date.")).not.toBeInTheDocument();
             expect(screen.getByText(/28 Feb 2026/)).toBeInTheDocument();
+        });
+
+        fireEvent.change(dateInput, { target: { value: "" } });
+
+        await waitFor(() => {
+            expect(screen.queryByText(/28 Feb 2026/)).not.toBeInTheDocument();
+            expect(localStorage.getItem("vaccine-hub-initial-date")).toBeNull();
         });
     });
 
@@ -361,7 +349,7 @@ describe("VaccineHubPage Integration Tests", () => {
         await user.click(polioOption);
 
         const dateInput = screen.getByLabelText(/birth date/i) as HTMLInputElement;
-        await user.type(dateInput, "01012024");
+        fireEvent.change(dateInput, { target: { value: "2024-01-01" } });
 
         // Unmount and remount
         unmount();
@@ -392,7 +380,7 @@ describe("VaccineHubPage Integration Tests", () => {
         await user.click(polioOption);
 
         const dateInput = screen.getByLabelText(/birth date/i) as HTMLInputElement;
-        await user.type(dateInput, "01012024");
+        fireEvent.change(dateInput, { target: { value: "2024-01-01" } });
 
         expect(localStorage.getItem("vaccine-hub-initial-date")).toBe("2024-01-01");
 


### PR DESCRIPTION
## Summary
- Replace the dual text input + hidden native date picker in `DateInitializer` with a single styled native `input type=date`
- Preserve the existing ISO `yyyy-mm-dd` value/onChange contract used by the vaccine hub state and localStorage
- Keep an accessible label, helper text, max-date guard, and localized selected-date display
- Update vaccine hub tests to interact with native date input values and assert that no hidden opacity date overlay remains

Fixes #3547

## Validation
- Focused test passed: `jest --config apps/web/jest.config.cjs apps/web/tests/vaccine-hub.test.tsx --runInBand` (16 passed)
- Targeted ESLint passed for changed files: `eslint apps/web/components/vaccine/DateInitializer.tsx apps/web/tests/vaccine-hub.test.tsx`
- `git diff --check` passed

## Notes
- A fresh `npm install` in the clean checkout timed out before creating local Jest binaries, so validation used the already-installed local workspace Jest/ESLint binaries from the existing `sahidawa-india` checkout against this clean branch.
- Full `npm run lint --workspace web` is currently blocked by unrelated existing errors in `apps/web/components/map/MapView.tsx` and `apps/web/jest.env.cjs`.
- Full `npm run build --workspace web` is currently blocked in this clean checkout by unresolved local workspace packages (`@sahidawa/shared`, `@sahidawa/validators`) after the timed-out install.