### PR TITLE
fix(api): unify graceful shutdown for SIGTERM/SIGINT and crash paths

### DIFF
--- a/apps/api/src/gracefulShutdown.ts
+++ b/apps/api/src/gracefulShutdown.ts
@@ -2,8 +2,9 @@ import type { Server } from "http";
 import { supabase } from "./db/client";
 import logger from "./utils/logger";
 import { redisClient } from "./utils/redis";
+import { jobScheduler } from "./services/jobScheduler.service";
 
-type ShutdownReason = "uncaughtException" | "unhandledRejection";
+type ShutdownReason = "uncaughtException" | "unhandledRejection" | "SIGTERM" | "SIGINT";
 
 type ShutdownOptions = {
     exitProcess?: (code: number) => never | void;
@@ -72,7 +73,7 @@ export function createGracefulShutdown(server: Server, options: ShutdownOptions 
     const timeoutMs = options.timeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
     let isShuttingDown = false;
 
-    return async (reason: ShutdownReason, error: unknown): Promise<void> => {
+    return async (reason: ShutdownReason, error?: unknown): Promise<void> => {
         if (isShuttingDown) {
             logger.warn("Graceful shutdown already in progress", { reason });
             return;
@@ -81,7 +82,7 @@ export function createGracefulShutdown(server: Server, options: ShutdownOptions 
         isShuttingDown = true;
         logger.error(`${reason} detected. Starting graceful shutdown.`, {
             reason,
-            error: getErrorDetails(error),
+            ...(error !== undefined ? { error: getErrorDetails(error) } : {}),
         });
 
         const timeout = setTimeout(() => {
@@ -94,6 +95,9 @@ export function createGracefulShutdown(server: Server, options: ShutdownOptions 
         timeout.unref();
 
         try {
+            jobScheduler.shutdown();
+            logger.info("Background jobs stopped during graceful shutdown", { reason });
+
             await closeServer(server);
             logger.info("HTTP server closed during graceful shutdown", { reason });
 
@@ -106,7 +110,7 @@ export function createGracefulShutdown(server: Server, options: ShutdownOptions 
             });
         } finally {
             clearTimeout(timeout);
-            exitProcess(1);
+            exitProcess(error !== undefined ? 1 : 0);
         }
     };
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -84,6 +84,11 @@ if (process.env.NODE_ENV !== "test") {
         process.exit(0);
     };
 
-    process.on("SIGTERM", shutdown);
-    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", () => {
+        void gracefulShutdown("SIGTERM");
+    });
+
+    process.on("SIGINT", () => {
+        void gracefulShutdown("SIGINT");
+    });
 }


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3635**
- **Summary:** Fixes an inconsistency where SIGTERM/SIGINT exited the process immediately without closing the HTTP server or releasing Supabase/Redis connections, while the crash-path handler (uncaughtException/unhandledRejection) never stopped background cron jobs. Both paths now go through the same `createGracefulShutdown` sequence: stop jobs → close server → release DB/Redis → exit with the appropriate code.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

Manual verification — SIGINT now triggers the full graceful shutdown sequence:
SIGINT detected. Starting graceful shutdown.
Background jobs stopped during graceful shutdown
HTTP server closed during graceful shutdown
Database resources released during graceful shutdown

Exit code: `0`

Full test suite: 55/55 suites passed, 552/553 tests passed (1 pre-existing skip), no regressions.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts