### PR TITLE
fix(devops): remove redundant pip cache from ETL workflow

### DIFF
--- a/.github/workflows/etl-cron.yml
+++ b/.github/workflows/etl-cron.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-          cache: 'pip' # Caches dependencies to speed up future runs
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3501**

- **Summary:**
  - Removed the redundant `cache: 'pip'` configuration from `actions/setup-python@v5` in `.github/workflows/etl-cron.yml`.
  - The ETL workflow already uses `astral-sh/setup-uv@v5` together with `uv sync`, which manages dependency caching natively.
  - This removes an unnecessary cache restore/save step, reducing CI overhead and keeping the workflow aligned with the current dependency management approach.


Configuration-only change.

## 🏷️ PR Type

- [x] 🛠️ `type: devops`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3501`)
- [x] I have pulled the latest `main` and resolved any conflicts