### PR TITLE
fix: resolve nppa seed path reliably

### DIFF
--- a/apps/etl/src/loaders/supabase_loader.py
+++ b/apps/etl/src/loaders/supabase_loader.py
@@ -39,10 +39,25 @@ from src.utils.logger import logger
 
 load_dotenv(Path(__file__).resolve().parents[4] / ".env")
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+NPPA_CEILING_PRICES_CSV = REPO_ROOT / "data" / "seeds" / "nppa_ceiling_prices.csv"
+
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_SERVICE_ROLE_KEY = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
 
 BATCH_SIZE = 100
+
+
+def _resolve_nppa_csv_path(nppa_csv: "Path | str | None" = None) -> Path:
+    """Resolve the NPPA seed CSV independent of the process cwd."""
+    if nppa_csv is None:
+        return NPPA_CEILING_PRICES_CSV
+
+    csv_path = Path(nppa_csv)
+    if csv_path.is_absolute():
+        return csv_path
+
+    return REPO_ROOT / csv_path
 DELAY_SEC = 0.5
 
 # Postgres RPC (supabase/migrations) for atomic Jan Aushadhi price back-fill.
@@ -724,7 +739,7 @@ class SupabaseLoader:
         ----------
         nppa_csv:
             Path to NPPA ceiling price CSV. Defaults to
-            data/seeds/nppa_ceiling_prices.csv relative to this file.
+            data/seeds/nppa_ceiling_prices.csv at the repository root.
         table:
             Target Supabase table (default ``"medicines"``).
         page_size:
@@ -736,13 +751,12 @@ class SupabaseLoader:
         """
         import csv as _csv
 
-        _default_csv = Path(__file__).resolve().parents[4] / "data" / "seeds" / "nppa_ceiling_prices.csv"
-        csv_path = Path(nppa_csv) if nppa_csv else _default_csv
+        csv_path = _resolve_nppa_csv_path(nppa_csv)
 
         if not csv_path.exists():
             logger.error(
                 f"[Loader] merge_jan_aushadhi_price: NPPA CSV not found at {csv_path}. "
-                "Run: cp data/seeds/nppa_ceiling_price.csv data/seeds/nppa_ceiling_prices.csv"
+                "Ensure data/seeds/nppa_ceiling_prices.csv is committed or pass nppa_csv explicitly."
             )
             return {"checked": 0, "updated": 0, "skipped": 0, "failed": 0}
 

--- a/apps/etl/tests/test_loader.py
+++ b/apps/etl/tests/test_loader.py
@@ -8,7 +8,12 @@ import pandas as pd
 # Ensure src.* imports resolve when running pytest from apps/etl/
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from src.loaders.supabase_loader import SupabaseLoader
+from src.loaders.supabase_loader import (
+    NPPA_CEILING_PRICES_CSV,
+    REPO_ROOT,
+    SupabaseLoader,
+    _resolve_nppa_csv_path,
+)
 
 
 class FakeExecuteResponse:
@@ -658,6 +663,23 @@ def make_merge_loader(client, tmp_path):
     loader.failed_rows_dir = tmp_path
     loader.pipeline_name = "ja_backfill"
     return loader
+
+
+def test_resolve_nppa_csv_path_is_cwd_independent(tmp_path, monkeypatch):
+    """Default and relative NPPA paths resolve from the repo root, not cwd."""
+    monkeypatch.chdir(tmp_path)
+
+    assert _resolve_nppa_csv_path() == NPPA_CEILING_PRICES_CSV
+    assert _resolve_nppa_csv_path("data/seeds/nppa_ceiling_prices.csv") == NPPA_CEILING_PRICES_CSV
+    assert _resolve_nppa_csv_path("apps/etl/data/seeds/nppa_ceiling_prices.csv") == (
+        REPO_ROOT / "apps" / "etl" / "data" / "seeds" / "nppa_ceiling_prices.csv"
+    )
+
+
+def test_resolve_nppa_csv_path_preserves_absolute_paths(tmp_path):
+    csv_path = tmp_path / "nppa_ceiling_prices.csv"
+
+    assert _resolve_nppa_csv_path(csv_path) == csv_path
 
 
 def test_ja_backfill_updates_null_jan_aushadhi_price_rows(tmp_path):


### PR DESCRIPTION
## Summary
- add repo-root constants for the NPPA seed CSV and resolve the default path with `pathlib`
- resolve relative `nppa_csv` inputs from the repository root instead of the process cwd
- update the missing-file guidance and add focused tests for default, relative, and absolute NPPA CSV paths

Closes #3114

## Validation
- `git diff --check` passed
- `python -m py_compile apps/etl/src/loaders/supabase_loader.py apps/etl/tests/test_loader.py` passed
- `python -m pytest apps/etl/tests/test_loader.py -q` could not collect locally because this environment imports a `supabase` module without `Client` / `create_client`; no test body ran before that import error