### PR TITLE
[GSSoC'26] fix: wrap scan history insert in try/catch to prevent crash on connection failure

### DIFF
--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -324,20 +324,24 @@ router.post(
             const origin = req.headers.origin ?? null;
 
             setImmediate(async () => {
-                const { error: insertError } = await supabase.from("scan_history").insert([
-                    {
-                        batch_number: data.batch_number,
-                        medicine_id: data.id,
-                        barcode_id: data.barcode_id,
-                        client_ip: clientIp,
-                        origin,
-                        user_agent: userAgent,
-                        latitude: latitude ?? null,
-                        longitude: longitude ?? null,
-                    },
-                ]);
-                if (insertError) {
-                    logger.error("Failed to record scan history", { error: insertError });
+                try {
+                    const { error: insertError } = await supabase.from("scan_history").insert([
+                        {
+                            batch_number: data.batch_number,
+                            medicine_id: data.id,
+                            barcode_id: data.barcode_id,
+                            client_ip: clientIp,
+                            origin,
+                            user_agent: userAgent,
+                            latitude: latitude ?? null,
+                            longitude: longitude ?? null,
+                        },
+                    ]);
+                    if (insertError) {
+                        logger.error("Failed to record scan history", { error: insertError });
+                    }
+                } catch (err) {
+                    logger.error("Scan history insert threw unexpectedly", { error: err });
                 }
             });
 


### PR DESCRIPTION
## Description

- Wrapped `setImmediate` callback in try/catch to catch thrown errors from Supabase insert
- Prevents unhandled promise rejection from crashing the server on transient Supabase failures

## Files Changed

- `apps/api/src/routes/verify.ts`: Wrap async scan history insert in try/catch

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

N/A — no test suite available. Changes are a try/catch wrapper around existing logic.

Result: Verified by code review.

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #3665