### PR TITLE
[GSSoC'26] fix: allow 127.0.0.1 for ML service URL in development environment

### DIFF
--- a/apps/api/src/config/mlService.ts
+++ b/apps/api/src/config/mlService.ts
@@ -24,7 +24,7 @@ const BLOCKED_HOSTNAME_PATTERNS = [
  * private, loopback, or link-local hostname.
  */
 function isAllowedHostname(hostname: string): boolean {
-    if (process.env.NODE_ENV !== "production" && /^localhost$/i.test(hostname)) {
+    if (process.env.NODE_ENV !== "production" && /^(localhost|127\.0\.0\.1)$/i.test(hostname)) {
         return true;
     }
     return !BLOCKED_HOSTNAME_PATTERNS.some((pattern) => pattern.test(hostname));


### PR DESCRIPTION
## Description

- Extended `isAllowedHostname` to also allow `127.0.0.1` in non-production environments
- Previously only `localhost` was allowed in dev, but `127.0.0.1` (functionally equivalent) was blocked by the `BLOCKED_HOSTNAME_PATTERNS` list
- Fixes confusion for developers using `127.0.0.1` in Docker, WSL2, or headless environments

## Files Changed

- `apps/api/src/config/mlService.ts`: Allow `127.0.0.1` in development alongside `localhost`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

N/A — no test suite available. Change is a single regex update.

Result: Verified by code review.

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #3666