### PR TITLE
[GSSoC'26] fix: redact authorization header from webhook unauthorized-attempt logs

### DIFF
--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -31,7 +31,7 @@ router.post(
         if (!isValid) {
             logger.warn("Unauthorized webhook attempt on /api/webhooks/supabase/health-schemes", {
                 ip: req.ip,
-                headers: req.headers,
+                headers: { ...req.headers, authorization: undefined },
             });
             res.status(401).json({ error: "Unauthorized" });
             return;
@@ -103,7 +103,7 @@ router.post(
         if (!isValid) {
             logger.warn("Unauthorized webhook attempt on /api/webhooks/supabase/medicines", {
                 ip: req.ip,
-                headers: req.headers,
+                headers: { ...req.headers, authorization: undefined },
             });
             res.status(401).json({ error: "Unauthorized" });
             return;


### PR DESCRIPTION
## Description

- Redact `authorization` header from webhook unauthorized-attempt log entries to prevent leaking the `SUPABASE_WEBHOOK_SECRET` bearer token
- Previously `req.headers` was logged directly, exposing the full `Authorization: Bearer <secret>` header to log storage
- Fix affects two handlers: `/api/webhooks/supabase/health-schemes` and `/api/webhooks/supabase/medicines`
- Other webhook handlers (pharmacies, reports, users) already only log `req.ip` and were not affected

## Files Changed

- `apps/api/src/routes/webhooks.ts`: Redact `authorization` from logged headers in two unauthorized webhook handlers

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

N/A — no test suite available. Change is a spread-and-override on the headers object.

Result: Verified by code review.

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #3667