### PR TITLE
fix(health): do not degrade overallStatus when ML is not configured

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -238,10 +238,10 @@ app.get("/health", async (_req: Request, res: Response) => {
         }
 
         // Overall status
+        // ML service is optional — "not-configured" does not degrade overallStatus.
         const overallStatus =
             redisStatus === "connected" &&
-            mlStatus !== "not-configured" &&
-            mlStatus !== "unreachable"
+            (mlUrl === null || mlStatus === "healthy")
                 ? "healthy"
                 : "degraded";
 


### PR DESCRIPTION
## Description
Fixes #3692

ML service is optional per project docs. The `/health` endpoint was incorrectly reporting `overallStatus: "degraded"` when `ML_SERVICE_URL` was unset (`mlStatus: "not-configured"`), causing false monitoring alerts.

## Change
- `apps/api/src/app.ts`: Changed overallStatus check from `mlStatus !== "not-configured" && mlStatus !== "unreachable"` to `(mlUrl === null || mlStatus === "healthy")`
  - ML **not configured** → no effect on overallStatus (was: degraded)
  - ML **configured and healthy** → healthy
  - ML **configured but unreachable** → degraded (unchanged)

## Proof of Testing
- [x] Build passes
- [x] Logic verified: when `mlUrl === null`, overallStatus depends only on Redis status