### PR TITLE
fix(ui): handle clipboard write promise rejection in shareComparison

### DIFF
--- a/apps/web/src/components/ComparisonGrid.tsx
+++ b/apps/web/src/components/ComparisonGrid.tsx
@@ -198,14 +198,18 @@ function getDirectComparison(medicine1: Medicine | null, medicine2: Medicine | n
     };
 }
 
-function shareComparison(medicine1: Medicine | null, medicine2: Medicine | null) {
+async function shareComparison(medicine1: Medicine | null, medicine2: Medicine | null) {
     if (!medicine1 || !medicine2) return;
 
     const url =
         `${window.location.origin}${window.location.pathname}` +
         `?m1=${medicine1.id}&m2=${medicine2.id}`;
 
-    navigator.clipboard.writeText(url);
+    try {
+        await navigator.clipboard.writeText(url);
+    } catch {
+        // Clipboard write failed — non-critical UX feature, fail silently
+    }
 }
 
 function handleExportCSV(


### PR DESCRIPTION
## Description
Fixes #3693

`navigator.clipboard.writeText()` returns a `Promise` that rejects in non-HTTPS contexts or when clipboard permission is denied. The unhandled rejection caused runtime errors (`unhandledrejection` event).

## Change
- `apps/web/src/components/ComparisonGrid.tsx`: Made `shareComparison` async, awaited the clipboard promise, and wrapped in try-catch

## Proof of Testing
- [x] Build passes
- [x] Logic verified: React onClick accepts `() => Promise<void>`