### PR TITLE
fix(i18n): translate Hindi comments to English in notifications.ts

### DIFF
--- a/apps/api/src/services/notifications.ts
+++ b/apps/api/src/services/notifications.ts
@@ -185,14 +185,13 @@ export async function listPushSubscriptions() {
     return [...memorySubscriptions.values()];
 }
 
-//  ISE ADD KARO:
 export async function listPushSubscriptionsForUser(userId: string): Promise<StoredSubscription[]> {
     const results: StoredSubscription[] = [];
 
-    // Pehle local memory-cache se matches check karte hain safely
+    // Check local memory-cache matches first (fast path)
     const localMatches = [...memorySubscriptions.values()].filter((sub) => sub.userId === userId);
 
-    // Agar local memory me context store nahi hai ya hum direct db check karna chahte hain
+    // Query Supabase for persisted subscriptions
     try {
         const { data, error } = await supabase
             .from("push_subscriptions")
@@ -201,7 +200,7 @@ export async function listPushSubscriptionsForUser(userId: string): Promise<Stor
             .order("created_at", { ascending: false });
 
         if (error || !data || data.length === 0) {
-            // Safe fallback agar database empty hai but memory me stored subscription ho
+            // DB empty or error — fall back to memory-cache subscriptions
             return localMatches;
         }
 


### PR DESCRIPTION
## Description
Fixes #3694

Production code in `notifications.ts` contained Hindi-language comments and a leftover TODO (`// ISE ADD KARO:`), creating a maintainability barrier for non-Hindi-speaking contributors.

## Change
- `apps/api/src/services/notifications.ts`: Replaced Hindi comments with clear English equivalents
  - `// ISE ADD KARO:` → removed (was an unactioned developer note)
  - `// Pehle local memory-cache se matches check karte hain safely` → `// Check local memory-cache matches first (fast path)`
  - `// Agar local memory me context store nahi hai ya hum direct db check karna chahte hain` → `// Query Supabase for persisted subscriptions`
  - `// Safe fallback agar database empty hai but memory me stored subscription ho` → `// DB empty or error — fall back to memory-cache subscriptions`

## Proof of Testing
- [x] Build passes
- [x] No logic changes — comments only