### PR TITLE
refactor(api): move verify schema into @sahidawa/validators

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
     setupFiles: ["<rootDir>/tests/setup.ts"],
     moduleNameMapper: {
         "^@sahidawa/shared$": "<rootDir>/../../packages/shared/src",
+        "^@sahidawa/validators$": "<rootDir>/../../packages/validators/src",
     },
     transform: {
         "^.+\\.tsx?$": [

--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from "express";
-import { z } from "zod";
+import { getVerifySchema } from "@sahidawa/validators";
 import { supabase } from "../db/client";
 import { verifyLimiter } from "../middleware/rateLimit";
 import { optionalAuth } from "../middleware/auth";
@@ -41,28 +41,7 @@ function maskClientIp(ip: string | undefined): string | null {
 
 const router = Router();
 
-const verifySchema = z
-    .object({
-        batchNumber: z
-            .string({ message: "batchNumber is required and must be a string" })
-            .min(3, "batchNumber must be at least 3 characters long"),
-        brandName: z.string().optional(),
-        barcodeId: z.string().optional(),
-        latitude: z
-            .number()
-            .min(-90, "Latitude must be between -90 and 90")
-            .max(90, "Latitude must be between -90 and 90")
-            .optional(),
-        longitude: z
-            .number()
-            .min(-180, "Longitude must be between -180 and 180")
-            .max(180, "Longitude must be between -180 and 180")
-            .optional(),
-    })
-    .refine((data) => data.brandName || data.barcodeId, {
-        message: "Either brandName or barcodeId must be provided",
-        path: ["brandName", "barcodeId"],
-    });
+const verifySchema = getVerifySchema();
 
 /**
  * @openapi

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./reports";
+export * from "./verify";

--- a/packages/validators/src/verify.ts
+++ b/packages/validators/src/verify.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+export interface VerifySchemaMessages {
+    batchNumberRequired?: string;
+    batchNumberMin?: string;
+    latitudeRange?: string;
+    longitudeRange?: string;
+    brandOrBarcodeRequired?: string;
+}
+
+export const getVerifyFields = (messages?: VerifySchemaMessages) => {
+    return {
+        batchNumber: z
+            .string({
+                message:
+                    messages?.batchNumberRequired ?? "batchNumber is required and must be a string",
+            })
+            .min(3, messages?.batchNumberMin ?? "batchNumber must be at least 3 characters long"),
+        brandName: z.string().optional(),
+        barcodeId: z.string().optional(),
+        latitude: z
+            .number()
+            .min(-90, messages?.latitudeRange ?? "Latitude must be between -90 and 90")
+            .max(90, messages?.latitudeRange ?? "Latitude must be between -90 and 90")
+            .optional(),
+        longitude: z
+            .number()
+            .min(-180, messages?.longitudeRange ?? "Longitude must be between -180 and 180")
+            .max(180, messages?.longitudeRange ?? "Longitude must be between -180 and 180")
+            .optional(),
+    };
+};
+
+export const getVerifySchema = (messages?: VerifySchemaMessages) => {
+    return z.object(getVerifyFields(messages)).refine((data) => data.brandName || data.barcodeId, {
+        message:
+            messages?.brandOrBarcodeRequired ?? "Either brandName or barcodeId must be provided",
+        path: ["brandName", "barcodeId"],
+    });
+};


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3674**
- **Summary:**

The `verify` route built its request schema inline with `z.object(...)`. That works until the Next.js side wants the same rules for a form, at which point it can't reach a schema that lives inside an Express route file, and the two slowly drift apart. I moved the verify schema into `@sahidawa/validators` and pointed the route at it.

The schema now lives in `packages/validators/src/verify.ts` and is exported from the package index. `apps/api/src/routes/verify.ts` drops its inline `z.object(...).refine(...)` and calls `getVerifySchema()` instead. The rules are unchanged: same `batchNumber` min-3, same latitude/longitude bounds, same "brandName or barcodeId required" refine, same messages.

One choice worth calling out. I made it a factory, `getVerifySchema(messages?)`, rather than a bare exported schema. The app runs in en/ta/bn, so the frontend will eventually want localized validation messages. The factory takes optional overrides and falls back to the exact strings the API already used, so calling it with no arguments is byte-identical to what was there before.

What I left alone. There are ~17 other route files with inline `z.object(` schemas. Migrating all of them here would touch half the API and be impossible to review, so I scoped this to the `verify` route the issue names. The pattern is in place now and the rest can follow one route per PR.

One extra file, and why it's here. `apps/api/jest.config.js` gets a one-line addition. Its `moduleNameMapper` mapped `@sahidawa/shared` to source but never `@sahidawa/validators`, so once a route imports the package, jest can't resolve it unless the package's `dist` happens to be built first. That already bites `reports.ts` (which imports `@sahidawa/validators` on `main`), and it's exactly what my `verify.ts` import would hit too. Without this line, `verify.test.ts` can't even load in CI. I mapped `@sahidawa/validators` to `packages/validators/src` the same way `@sahidawa/shared` is already done, so it resolves from source under ts-jest and doesn't depend on a build step running first.

## 📸 Proof of Work (Screenshots / Logs)

Backend only, no UI change.

The verify route validates exactly as before. The two 400 cases below run through the moved schema:

```
$ (cd apps/api && npx jest tests/verify.test.ts)
  POST /api/verify
    ✓ should verify a valid batch number
    ✓ should flag suspicious duplicate scan volume
    ✓ should return 404 for an unknown batch number
    ✓ should return 400 when batchNumber field is missing
    ✓ should return 400 when batchNumber is not a string
    ✓ should not return mock data in production even when VERIFY_ENABLE_MOCKS is enabled

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
```

Both the package and the API type-check:

```
$ (cd packages/validators && npx tsc --noEmit)   # exit 0
$ (cd apps/api && npx tsc --noEmit)              # exit 0
```

On the jest mapper specifically. I reproduced the CI condition locally by moving `packages/validators/dist` aside, so the package can only resolve from source:

```
# before the mapper line, with dist hidden
FAIL tests/reports.test.ts
  Cannot find module '@sahidawa/validators' from 'src/routes/reports.ts'

# after the mapper line, dist still hidden
Test Suites: 2 passed, 2 total   (verify.test.ts, reports.test.ts)
```

That matches what CI shows on this branch: the API workspace now reports `Test Suites: 56 passed, 56 total`, where the `@sahidawa/validators` resolution error had previously taken out 18 suites.

The remaining red on this PR is in the **web** workspace, not the API: `Cannot find module '@sahidawa/shared' from 'lib/api.ts'`. That one is pre-existing on `main` and unrelated to this change — `apps/web/jest.config.cjs` has no mapper for `@sahidawa/shared`, and `lib/api.ts` has imported it since before this branch. It reproduces on a PR of mine that only edits a YAML file. I've left it alone rather than widening this PR, and I'm happy to send it separately.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3674`)
- [x] I have pulled the latest `main` and resolved any conflicts
