### PR TITLE
ci(deploy): add automated Vercel deploy pipeline for apps/web

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -6,10 +6,23 @@ on:
   pull_request:
     branches: [main]
 
-# Org and project IDs are read from the environment by `vercel pull`.
+# Credentials are read from the environment by the Vercel CLI. Passing the token
+# this way rather than as a --token flag keeps it out of command-line arguments,
+# which the CLI docs recommend for CI: https://vercel.com/docs/cli/global-options
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+# Only the checkout needs repository access.
+permissions:
+  contents: read
+
+# A newer commit makes an in-flight preview obsolete, so drop it. Production
+# deploys are left to finish rather than cancelled halfway.
+concurrency:
+  group: deploy-web-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   deploy:
@@ -44,10 +57,10 @@ jobs:
           fi
 
       - name: Pull Vercel environment
-        run: vercel pull --yes --environment=${{ steps.target.outputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ steps.target.outputs.environment }}
 
       - name: Build project
-        run: vercel build ${{ steps.target.outputs.environment == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build ${{ steps.target.outputs.environment == 'production' && '--prod' || '' }}
 
       - name: Deploy to Vercel
-        run: vercel deploy --prebuilt ${{ steps.target.outputs.environment == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt ${{ steps.target.outputs.environment == 'production' && '--prod' || '' }}

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,53 @@
+name: Deploy Web (Vercel)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Org and project IDs are read from the environment by `vercel pull`.
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  deploy:
+    name: Deploy apps/web
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Pushes to main deploy production. PRs deploy a preview, but only from
+    # branches in this repo — fork PRs cannot read the deployment secrets, so
+    # skip them here instead of failing on a missing token.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Resolve deployment target
+        id: target
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "environment=production" >> "$GITHUB_OUTPUT"
+          else
+            echo "environment=preview" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=${{ steps.target.outputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project
+        run: vercel build ${{ steps.target.outputs.environment == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel
+        run: vercel deploy --prebuilt ${{ steps.target.outputs.environment == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ Thumbs.db
 coverage/
 .nyc_output/
 
+# Vercel CLI output (`vercel pull` writes project.json with org/project IDs here)
+.vercel/
+
 # Temporary files
 .tmp/
 .cache/


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3687**
- **Summary:**

Adds `.github/workflows/deploy-web.yml`, a GitHub Actions pipeline that deploys `apps/web` to Vercel: a preview on every PR to `main`, and production on push to `main`. It drives the Vercel CLI directly (`vercel pull`, `vercel build`, `vercel deploy --prebuilt`) instead of a third-party action, so there's no extra action to trust and the steps line up with Vercel's own documented CI flow.

How it picks prod vs preview: one small step reads `github.ref` and sets `environment=production` on `refs/heads/main`, otherwise `preview`. That single output feeds `vercel pull --environment=...` and the `--prod` flag on both build and deploy, so the environment it pulls, the build, and the deploy can't end up disagreeing with each other.

Two things to flag.

Fork PRs are skipped on purpose. A `pull_request` from a fork can't read repo secrets, so the token would be empty and the job would fail in a confusing way. The `if:` guard runs the job only for pushes and for PRs whose head repo is this repo. Fork contributors don't get an auto-preview, which is the right trade rather than a permanently red check.

It needs three secrets. The workflow reads `VERCEL_TOKEN`, `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` from GitHub Secrets, all three through `env:`. Those have to be added in the repo settings before a run does anything real. I can't set those from a fork, so the "successfully triggers a build" criterion is something that'll show up in the Actions logs once the secrets exist.

A note on how the token is passed, because Vercel's own docs disagree with each other here. Their GitHub Actions guide shows `--token=...` inline on each command, but the CLI reference is explicit that the environment variable is the right call for CI: "Using the `VERCEL_TOKEN` environment variable is recommended for CI/CD pipelines because it avoids exposing the token in command-line arguments, which can be visible in process lists and logs." ([global options](https://vercel.com/docs/cli/global-options)). I went with the env var. GitHub masks secrets in log output either way, but keeping it out of argv is free, so there's no reason not to.

Two other things while I was in here. The workflow declares `permissions: contents: read`, since the checkout is the only thing that needs repo access and workflows otherwise inherit a much broader default token. And a `concurrency` group drops an in-flight preview when a newer commit supersedes it, while letting production deploys run to completion rather than cancelling one halfway.

Also added `.vercel/` to `.gitignore`, since `vercel pull` writes a `project.json` with the org and project IDs into that folder and it shouldn't be committed.

## 📸 Proof of Work (Screenshots / Logs)

CI config change, no UI.

The workflow is valid YAML and parses to the expected steps:

```
$ node -e "const y=require('js-yaml');const d=y.load(require('fs').readFileSync('.github/workflows/deploy-web.yml','utf8'));console.log(d.jobs.deploy.steps.map(s=>s.name).join(' | '))"
Checkout | Setup Node.js | Install Vercel CLI | Resolve deployment target | Pull Vercel environment | Build project | Deploy to Vercel
```

`node-version-file` points at the repo's `.nvmrc` (node 22), and the action versions (`checkout@v7`, `setup-node@v7`) are the current majors and match the other workflows here.

The new `Deploy apps/web` job reports `skipping` on this PR, which is the fork guard doing exactly what it's meant to do rather than failing on an empty token.

I can't run the deploy end-to-end from a fork without the three secrets set on this repo. That last mile is yours to confirm in the PR's Actions logs once the secrets are in place.

On the red checks: this PR adds one YAML file and one `.gitignore` line, and touches no application code at all, so the failures are all pre-existing on `main`. `Build & Test` dies on `Cannot find module '@sahidawa/validators' from 'src/routes/reports.ts'` and `Cannot find module '@sahidawa/shared' from 'lib/api.ts'` — the workspace jest configs don't map those packages to source, so they only resolve when `dist` is already built. `quality-check` and Lighthouse are likewise red on an untouched tree. Worth using this PR as the control when reading the same failures on other branches.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [x] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3687`)
- [x] I have pulled the latest `main` and resolved any conflicts
