### PR TITLE
fix(api): prevent auth cache key collisions by hashing entire JWT wit…

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from "express";
+import crypto from "crypto";
 import { SupabaseClient, User } from "@supabase/supabase-js";
 import { supabase, dbConfig } from "../db/client";
 import logger from "../utils/logger";
@@ -118,7 +119,7 @@ export const createAuthMiddleware =
             return;
         }
 
-        const cacheKey = `auth:user:${token.slice(-16)}`;
+        const cacheKey = `auth:user:${crypto.createHash("sha256").update(token).digest("hex")}`;
         try {
             if (redisClient.isOpen) {
                 const cached = await redisClient.get(cacheKey);
@@ -230,7 +231,7 @@ export const createOptionalAuthMiddleware =
             return next();
         }
 
-        const cacheKey = `auth:user:${token.slice(-16)}`;
+        const cacheKey = `auth:user:${crypto.createHash("sha256").update(token).digest("hex")}`;
         try {
             if (redisClient.isOpen) {
                 const cached = await redisClient.get(cacheKey);


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3704 
- **Summary:** Fixed the Auth Cache Key Collision vulnerability in `apps/api/src/middleware/auth.ts`. Previously, Redis cache keys for authenticated sessions were generated using only the last 16 characters of the JWT token (`token.slice(-16)`), creating a collision risk that could allow token impersonation. Updated both `createAuthMiddleware` and `createOptionalAuthMiddleware` to import `crypto` and generate cache keys by hashing the entire JWT token using SHA-256 (`crypto.createHash('sha256').update(token).digest('hex')`).

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

**Backend Verification & Pre-push Audit Logs:**
```text
> sahidawa-india@1.0.0 audit:all
> npm run audit:node && npm run audit:python

> sahidawa-india@1.0.0 audit:node
> npm audit -w sahidawa-api -w web --audit-level=high

found 0 vulnerabilities

✔ Python security audit passed.
[fix/auth-cache-key-collision cd6b73af] fix(api): prevent auth cache key collisions by hashing entire JWT with SHA-256
 1 file changed, 3 insertions(+), 2 deletions(-)
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3704 `) *(Make sure to fill in the issue number above)*
- [x] I have pulled the latest `main` and resolved any conflicts