### PR TITLE
fix(#3565): force serialize-javascript to ^7.0.7 to resolve high-seve…

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "form-data": "^4.0.6",
         "protobufjs": "^7.6.3",
         "js-yaml": "^4.1.2",
-        "serialize-javascript": "^7.0.5",
+        "serialize-javascript": "^7.0.7",
         "node-cron": {
             "uuid": "^9.0.1"
         }


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3565**
- **Summary:** Added an override in `package.json` to force the `serialize-javascript` dependency to resolve to `^7.0.7`, patching a high-severity Remote Code Execution (RCE) and Denial of Service (DoS) vulnerability originating from `@ducanh2912/next-pwa`. Updated `package-lock.json` to lock in the safe version. 

*(Note: This is a clean recreation of the previously closed PR #3566 to resolve the merge conflicts.)*

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

No UI changes were made. Verified that the `serialize-javascript` dependency is successfully forced to `^7.0.7` in the updated `package-lock.json` lockfile, mitigating the vulnerability.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [x] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3565`)
- [x] I have pulled the latest `main` and resolved any conflicts