### PR TITLE
fix(#3708): gracefully skip python audit instead of failing git push …

### DIFF
--- a/scripts/audit-python.js
+++ b/scripts/audit-python.js
@@ -125,10 +125,11 @@ function parseAndPinRequirements(content) {
 
 function runAudit() {
     if (!checkPipAudit()) {
-        log(c.red, "✖", "pip-audit is not installed.");
-        console.log(`  ${c.bold}Please install pip-audit in your environment:${c.reset}`);
+        log(c.yellow, "⚠", "pip-audit is not installed.");
+        console.log(`  ${c.bold}If you are modifying Python code, please install it:${c.reset}`);
         console.log(`  pip install pip-audit\n`);
-        process.exit(1);
+        log(c.yellow, "⚠", "Skipping Python audit gracefully so frontend developers are not blocked.");
+        process.exit(0);
     }
 
     let failed = false;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3708**
- **Summary:** Modified `scripts/audit-python.js` to gracefully skip the Python dependency audit if `pip-audit` is not installed in the environment. Instead of exiting with an error code (`1`) which breaks the husky pre-push hook, it now prints a yellow warning and exits successfully (`0`). This unblocks frontend developers who do not have Python tools configured.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

No UI changes. Verified the script output when `pip-audit` is missing:


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [x] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3708`)
- [x] I have pulled the latest `main` and resolved any conflicts