### PR TITLE
refactor(web): migrate privacy consent to React Context, remove page reload

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -20,6 +20,7 @@ import { TracingInitializer } from "@/components/TracingInitializer";
 import { InteractiveOverlays } from "./components/InteractiveOverlays";
 import { ReactQueryProvider } from "./components/ReactQueryProvider";
 import PrivacyConsentBanner from "@/components/PrivacyConsentBanner";
+import { PrivacyConsentProvider } from "@/components/PrivacyConsentProvider";
 
 export async function generateMetadata({
     params,
@@ -90,22 +91,26 @@ export default async function LocaleLayout({
                         <ReactQueryProvider>
                             <NextIntlClientProvider messages={messages}>
                                 <NuqsAdapter>
-                                    <AuthProvider>
-                                        <a
-                                            href="#main-content"
-                                            className="sr-only absolute top-4 left-4 z-60 rounded-full bg-emerald-600 px-4 py-2 text-sm font-bold text-white shadow-lg focus:not-sr-only focus-visible:ring-[3px] focus-visible:ring-emerald-600 focus-visible:ring-offset-2 focus-visible:outline-[3px] focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
-                                        >
-                                            {t("skip_to_main_content")}
-                                        </a>
-                                        <OfflineBanner />
-                                        <Navbar />
-                                        <main id="main-content" className="flex grow flex-col">
-                                            <OfflineErrorBoundary>{children}</OfflineErrorBoundary>
-                                        </main>
-                                        <Footer />
-                                        <InteractiveOverlays />
-                                        <PrivacyConsentBanner />
-                                    </AuthProvider>
+                                    <PrivacyConsentProvider>
+                                        <AuthProvider>
+                                            <a
+                                                href="#main-content"
+                                                className="sr-only absolute top-4 left-4 z-60 rounded-full bg-emerald-600 px-4 py-2 text-sm font-bold text-white shadow-lg focus:not-sr-only focus-visible:ring-[3px] focus-visible:ring-emerald-600 focus-visible:ring-offset-2 focus-visible:outline-[3px] focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+                                            >
+                                                {t("skip_to_main_content")}
+                                            </a>
+                                            <OfflineBanner />
+                                            <Navbar />
+                                            <main id="main-content" className="flex grow flex-col">
+                                                <OfflineErrorBoundary>
+                                                    {children}
+                                                </OfflineErrorBoundary>
+                                            </main>
+                                            <Footer />
+                                            <InteractiveOverlays />
+                                            <PrivacyConsentBanner />
+                                        </AuthProvider>
+                                    </PrivacyConsentProvider>
                                 </NuqsAdapter>
                             </NextIntlClientProvider>
                         </ReactQueryProvider>

--- a/apps/web/components/PrivacyConsentBanner.tsx
+++ b/apps/web/components/PrivacyConsentBanner.tsx
@@ -1,36 +1,14 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { useTranslations } from "next-intl";
+import { usePrivacyConsent } from "@/components/PrivacyConsentProvider";
 
 export default function PrivacyConsentBanner() {
     const t = useTranslations("PrivacyConsent");
-    const [isVisible, setIsVisible] = useState(false);
+    const { hasRespondedToConsent, acceptAll, denyAll } = usePrivacyConsent();
 
-    useEffect(() => {
-        // Check agar user ne pehle se consent de rakha hai
-        const locationConsent = localStorage.getItem("consent_location");
-        const scanConsent = localStorage.getItem("consent_scan_history");
-
-        if (!locationConsent || !scanConsent) {
-            setIsVisible(true);
-        }
-    }, []);
-
-    const handleAcceptAll = () => {
-        localStorage.setItem("consent_location", "granted");
-        localStorage.setItem("consent_scan_history", "granted");
-        setIsVisible(false);
-        window.location.reload(); // Refresh to trigger maps/hooks immediately
-    };
-
-    const handleDenyAll = () => {
-        localStorage.setItem("consent_location", "denied");
-        localStorage.setItem("consent_scan_history", "denied");
-        setIsVisible(false);
-    };
-
-    if (!isVisible) return null;
+    if (hasRespondedToConsent) return null;
 
     return (
         <div
@@ -53,13 +31,13 @@ export default function PrivacyConsentBanner() {
                 </div>
                 <div className="flex w-full items-center justify-end gap-3 md:w-auto">
                     <button
-                        onClick={handleDenyAll}
+                        onClick={denyAll}
                         className="hover:bg-accent rounded-md border px-4 py-2 text-sm font-medium transition-colors"
                     >
                         {t("denyAll")}
                     </button>
                     <button
-                        onClick={handleAcceptAll}
+                        onClick={acceptAll}
                         className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm font-medium transition-colors"
                     >
                         {t("acceptAll")}

--- a/apps/web/components/PrivacyConsentProvider.tsx
+++ b/apps/web/components/PrivacyConsentProvider.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+type ConsentValue = "granted" | "denied" | null;
+
+interface PrivacyConsentContextValue {
+    locationConsent: ConsentValue;
+    scanHistoryConsent: ConsentValue;
+    hasRespondedToConsent: boolean;
+    acceptAll: () => void;
+    denyAll: () => void;
+}
+
+const PrivacyConsentContext = createContext<PrivacyConsentContextValue | undefined>(undefined);
+
+export function PrivacyConsentProvider({ children }: { children: React.ReactNode }) {
+    const [locationConsent, setLocationConsent] = useState<ConsentValue>(null);
+    const [scanHistoryConsent, setScanHistoryConsent] = useState<ConsentValue>(null);
+    const [hasHydrated, setHasHydrated] = useState(false);
+
+    useEffect(() => {
+        // Read once on mount — localStorage isn't available during SSR.
+        setLocationConsent(localStorage.getItem("consent_location") as ConsentValue);
+        setScanHistoryConsent(localStorage.getItem("consent_scan_history") as ConsentValue);
+        setHasHydrated(true);
+    }, []);
+
+    const acceptAll = () => {
+        localStorage.setItem("consent_location", "granted");
+        localStorage.setItem("consent_scan_history", "granted");
+        setLocationConsent("granted");
+        setScanHistoryConsent("granted");
+    };
+
+    const denyAll = () => {
+        localStorage.setItem("consent_location", "denied");
+        localStorage.setItem("consent_scan_history", "denied");
+        setLocationConsent("denied");
+        setScanHistoryConsent("denied");
+    };
+
+    // Only meaningful after hydration — avoids a flash of the banner
+    // before we've had a chance to read existing localStorage values.
+    const hasRespondedToConsent =
+        hasHydrated && locationConsent !== null && scanHistoryConsent !== null;
+
+    return (
+        <PrivacyConsentContext.Provider
+            value={{
+                locationConsent,
+                scanHistoryConsent,
+                hasRespondedToConsent,
+                acceptAll,
+                denyAll,
+            }}
+        >
+            {children}
+        </PrivacyConsentContext.Provider>
+    );
+}
+
+export function usePrivacyConsent() {
+    const ctx = useContext(PrivacyConsentContext);
+    if (!ctx) {
+        throw new Error("usePrivacyConsent must be used within a PrivacyConsentProvider");
+    }
+    return ctx;
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #3601**
- **Summary:** `PrivacyConsentBanner` previously called `window.location.reload()` after writing consent to `localStorage`, forcing a full page reload to propagate the decision — breaking the SPA experience. Introduced `PrivacyConsentProvider` (React Context, matching this codebase's existing provider convention alongside `AuthProvider`/`ReactQueryProvider`/etc.), which owns `locationConsent`/`scanHistoryConsent` state, hydrates from `localStorage` on mount, and exposes `acceptAll()`/`denyAll()` via a `usePrivacyConsent()` hook. `PrivacyConsentBanner` now consumes this hook instead of managing its own local state — `window.location.reload()` is removed entirely. Note: a repo-wide search confirmed no existing hooks/components currently read `consent_location`/`consent_scan_history` besides the banner itself, so there are no "dependent hooks" to migrate today — this PR makes consent state reactively available via context for any future consumer, satisfying the acceptance criteria's intent. Scope limited to the three files the issue names; no geolocation-gating logic was added, since none existed to migrate.

## 📸 Proof of Work (Screenshots / Logs)
Manually verified in-browser:
1. Cleared `consent_location`/`consent_scan_history` from Local Storage, reloaded — banner appeared correctly.
2. Cleared the Network panel, then clicked **Accept All** — Network panel remained completely empty (no `Doc`/navigation request fired), confirming `window.location.reload()` is gone.
3. Local Storage updated correctly to `consent_location: granted`, `consent_scan_history: granted` immediately on click, no reload needed.
4. Manually refreshed afterward — banner correctly stayed hidden, confirming persistence still works via the same `localStorage` keys.
5. `npx tsc --noEmit` passes clean on all three touched files.

<img width="1920" height="971" alt="image" src="https://github.com/user-attachments/assets/fad94295-23d1-4f9d-9920-1ec6ab41c61e" />


## 🏷️ PR Type
- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #3601`)
- [x] I have pulled the latest `main` and resolved any conflicts