### PR TITLE
refactor(api): introduce DISCORD_APP_ALERTS_WEBHOOK_URL for app-level alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,11 @@ GOOGLE_APPLICATION_CREDENTIALS=apps/ml/google-credentials.json
 
 # --- Caching (Redis/Upstash) ---
 REDIS_URL=your_redis_url
+# --- Discord Alerts (Application-Level) ---
+# Used for backend application failure alerts (e.g. Redis cache errors).
+# Separate from PG_CRON_MONITOR_WEBHOOK_URL, which is dedicated to
+# database cron job monitoring only (see apps/api/src/cron/pgCronMonitor.ts).
+DISCORD_APP_ALERTS_WEBHOOK_URL=your_discord_webhook_url
 
 # --- Web Push Notifications ---
 # Generate with: npx web-push generate-vapid-keys

--- a/apps/api/src/services/cache.service.ts
+++ b/apps/api/src/services/cache.service.ts
@@ -316,7 +316,7 @@ let lastDiscordAlertTime = 0;
 const DISCORD_ALERT_DEBOUNCE_MS = 15 * 60 * 1000; // 15 minutes
 
 async function sendCacheAlertDiscord(): Promise<void> {
-    const WEBHOOK_URL = process.env.PG_CRON_MONITOR_WEBHOOK_URL;
+    const WEBHOOK_URL = process.env.DISCORD_APP_ALERTS_WEBHOOK_URL;
     if (!WEBHOOK_URL) return;
 
     const now = Date.now();

--- a/apps/api/src/services/cache.test.ts
+++ b/apps/api/src/services/cache.test.ts
@@ -152,7 +152,7 @@ describe("cache.service", () => {
 
         beforeEach(() => {
             mockFetch.mockClear();
-            process.env.PG_CRON_MONITOR_WEBHOOK_URL = "http://mock-webhook";
+            process.env.DISCORD_APP_ALERTS_WEBHOOK_URL = "http://mock-webhook";
         });
 
         it("should return live stats and save snapshot on success", async () => {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #3604**
- **Summary:** `PG_CRON_MONITOR_WEBHOOK_URL` was being reused in `apps/api/src/services/cache.service.ts` to send app-level Redis-failure alerts to Discord, despite that variable being intended exclusively for `pgCronMonitor.ts`'s database cron job monitoring. Introduced `DISCORD_APP_ALERTS_WEBHOOK_URL` as a separate, correctly-scoped variable and repointed `cache.service.ts` (and its test mock) to it. `apps/api/src/cron/pgCronMonitor.ts` is untouched — confirmed via `git status` before committing. Note: the issue references `apps/api/.env.example`, but the repo's actual env template lives at the repo root (`.env.example`) — added the new variable there instead, with a comment explaining the distinction from `PG_CRON_MONITOR_WEBHOOK_URL`. Repo-wide search confirmed `cache.service.ts` and `pgCronMonitor.ts` are the only two files referencing this variable — no other app-level alerting scripts needed updating.

## 📸 Proof of Work (Screenshots / Logs)

<img width="1372" height="771" alt="image" src="https://github.com/user-attachments/assets/cec98012-339b-41e0-b2ca-4f3095d616f1" />

Backend-only change, verified via targeted test run:

    npx jest cache.test.ts

    PASS  src/services/cache.test.ts
    Tests:       13 passed, 13 total

Specifically covers `"should fire discord alert and return default
stats if all fail and no snapshot"`, which exercises the renamed env
var end-to-end. Also confirmed `npx tsc --noEmit` passes clean.

## 🏷️ PR Type
- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [x] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #3604`)
- [x] I have pulled the latest `main` and resolved any conflicts