### PR TITLE
fix(notifications): add csrf protection to push subscriptions

### DIFF
--- a/apps/web/components/alerts/RecallPushSubscriber.tsx
+++ b/apps/web/components/alerts/RecallPushSubscriber.tsx
@@ -2,17 +2,13 @@
 
 import { useState, useEffect } from "react";
 import { Bell, BellOff } from "lucide-react";
-import { API_BASE } from "@/lib/api";
+import { API_BASE, getCsrfToken } from "@/lib/api";
+import { fetchWithRetry } from "@/lib/apiWithRetry";
 import { LiveMessage } from "@/components/ui/LiveMessage";
 import { useSession } from "@/src/components/AuthProvider";
 
 type SubscribeState =
-    | "idle"
-    | "subscribing"
-    | "subscribed"
-    | "unsupported"
-    | "error"
-    | "unsubscribing";
+    "idle" | "subscribing" | "subscribed" | "unsupported" | "error" | "unsubscribing";
 
 function urlBase64ToUint8Array(value: string) {
     const padding = "=".repeat((4 - (value.length % 4)) % 4);
@@ -36,6 +32,20 @@ async function getVapidPublicKey() {
     }
 
     return data.publicKey;
+}
+
+async function subscriptionMutationFetch(token: string, options: RequestInit): Promise<Response> {
+    const csrfToken = await getCsrfToken();
+    return fetchWithRetry(`${API_BASE}/api/notifications/subscriptions`, {
+        ...options,
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+            ...(options.headers as Record<string, string> | undefined),
+            "x-csrf-token": csrfToken,
+        },
+        credentials: "include",
+    });
 }
 
 export default function RecallPushSubscriber() {
@@ -71,17 +81,16 @@ export default function RecallPushSubscriber() {
             const registration = await navigator.serviceWorker.getRegistration("/sw.js");
             const existing = await registration?.pushManager.getSubscription();
             if (existing) {
-                await existing.unsubscribe();
                 if (token) {
-                    await fetch(`${API_BASE}/api/notifications/subscriptions`, {
+                    const res = await subscriptionMutationFetch(token, {
                         method: "DELETE",
-                        headers: {
-                            "Content-Type": "application/json",
-                            Authorization: `Bearer ${token}`,
-                        },
                         body: JSON.stringify({ endpoint: existing.endpoint }),
                     });
+                    if (!res.ok) {
+                        throw new Error("Unable to disable alerts. Please try again.");
+                    }
                 }
+                await existing.unsubscribe();
             }
             setState("idle");
             setMessage(null);
@@ -122,17 +131,17 @@ export default function RecallPushSubscriber() {
                 return;
             }
 
-            const res = await fetch(`${API_BASE}/api/notifications/subscriptions`, {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${token}`,
-                },
-                body: JSON.stringify(subscription),
-            });
-
-            if (!res.ok) {
-                throw new Error("Failed to save push subscription");
+            try {
+                const res = await subscriptionMutationFetch(token, {
+                    method: "POST",
+                    body: JSON.stringify(subscription),
+                });
+                if (!res.ok) {
+                    throw new Error("Failed to save push subscription");
+                }
+            } catch (error) {
+                await subscription.unsubscribe().catch(() => false);
+                throw error;
             }
 
             setState("subscribed");

--- a/apps/web/tests/RecallPushSubscriber.test.tsx
+++ b/apps/web/tests/RecallPushSubscriber.test.tsx
@@ -1,0 +1,194 @@
+/** @jest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import RecallPushSubscriber from "@/components/alerts/RecallPushSubscriber";
+import { getCsrfToken } from "@/lib/api";
+import { fetchWithRetry } from "@/lib/apiWithRetry";
+import { useSession } from "@/src/components/AuthProvider";
+
+jest.mock("@/lib/api", () => ({
+    API_BASE: "http://localhost:4000",
+    getCsrfToken: jest.fn(),
+}));
+
+jest.mock("@/lib/apiWithRetry", () => ({
+    fetchWithRetry: jest.fn(),
+}));
+
+jest.mock("@/src/components/AuthProvider", () => ({
+    useSession: jest.fn(),
+}));
+
+const mockGetCsrfToken = jest.mocked(getCsrfToken);
+const mockFetchWithRetry = jest.mocked(fetchWithRetry);
+const mockUseSession = jest.mocked(useSession);
+const mockFetch = jest.fn();
+const mockGetRegistration = jest.fn();
+const mockRegister = jest.fn();
+
+function createSubscription() {
+    return {
+        endpoint: "https://push.example/subscription-1",
+        unsubscribe: jest.fn().mockResolvedValue(true),
+        toJSON: () => ({
+            endpoint: "https://push.example/subscription-1",
+            keys: { p256dh: "key", auth: "auth" },
+        }),
+    };
+}
+
+function createRegistration(subscription: ReturnType<typeof createSubscription> | null) {
+    return {
+        pushManager: {
+            getSubscription: jest.fn().mockResolvedValue(subscription),
+            subscribe: jest.fn().mockResolvedValue(subscription),
+        },
+    };
+}
+
+describe("RecallPushSubscriber", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseSession.mockReturnValue({
+            token: "access-token-123",
+            session: null,
+            isLoading: false,
+        });
+        mockGetCsrfToken.mockResolvedValue("csrf-token-123");
+        Object.defineProperty(global, "fetch", { value: mockFetch, writable: true });
+        mockFetch.mockResolvedValue({
+            ok: true,
+            json: async () => ({ configured: true, publicKey: "AQ" }),
+        });
+        Object.defineProperty(global, "Notification", {
+            configurable: true,
+            value: { requestPermission: jest.fn().mockResolvedValue("granted") },
+        });
+        Object.defineProperty(window, "PushManager", { configurable: true, value: class {} });
+        Object.defineProperty(navigator, "serviceWorker", {
+            configurable: true,
+            value: {
+                getRegistration: mockGetRegistration,
+                register: mockRegister,
+            },
+        });
+    });
+
+    it("registers a push subscription with CSRF and Bearer credentials", async () => {
+        const subscription = createSubscription();
+        mockGetRegistration.mockResolvedValue(null);
+        mockRegister.mockResolvedValue(createRegistration(subscription));
+        mockFetchWithRetry.mockResolvedValue({ ok: true, status: 201 } as Response);
+
+        render(<RecallPushSubscriber />);
+        fireEvent.click(screen.getByRole("button", { name: "Enable alerts" }));
+
+        await waitFor(() => expect(screen.getByText("Disable alerts")).toBeInTheDocument());
+        expect(mockGetCsrfToken).toHaveBeenCalledTimes(1);
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+            "http://localhost:4000/api/notifications/subscriptions",
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer access-token-123",
+                    "x-csrf-token": "csrf-token-123",
+                },
+                credentials: "include",
+                body: JSON.stringify(subscription),
+            }
+        );
+        expect(subscription.unsubscribe).not.toHaveBeenCalled();
+    });
+
+    it("removes the server subscription before unsubscribing locally", async () => {
+        const subscription = createSubscription();
+        mockGetRegistration.mockResolvedValue(createRegistration(subscription));
+        mockFetchWithRetry.mockResolvedValue({ ok: true, status: 204 } as Response);
+
+        render(<RecallPushSubscriber />);
+        await waitFor(() => expect(screen.getByText("Disable alerts")).toBeInTheDocument());
+        fireEvent.click(screen.getByRole("button", { name: "Disable alerts" }));
+
+        await waitFor(() => expect(screen.getByText("Enable alerts")).toBeInTheDocument());
+        expect(mockGetCsrfToken).toHaveBeenCalledTimes(1);
+        expect(mockFetchWithRetry).toHaveBeenCalledWith(
+            "http://localhost:4000/api/notifications/subscriptions",
+            {
+                method: "DELETE",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: "Bearer access-token-123",
+                    "x-csrf-token": "csrf-token-123",
+                },
+                credentials: "include",
+                body: JSON.stringify({ endpoint: subscription.endpoint }),
+            }
+        );
+        expect(mockFetchWithRetry.mock.invocationCallOrder[0]).toBeLessThan(
+            subscription.unsubscribe.mock.invocationCallOrder[0]
+        );
+    });
+
+    it("cleans up a new local subscription when server registration fails", async () => {
+        const subscription = createSubscription();
+        mockGetRegistration.mockResolvedValue(null);
+        mockRegister.mockResolvedValue(createRegistration(subscription));
+        mockFetchWithRetry.mockResolvedValue({ ok: false, status: 500 } as Response);
+
+        render(<RecallPushSubscriber />);
+        fireEvent.click(screen.getByRole("button", { name: "Enable alerts" }));
+
+        await waitFor(() =>
+            expect(screen.getByText("Failed to save push subscription")).toBeInTheDocument()
+        );
+        expect(subscription.unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("cleans up a new local subscription when registration throws", async () => {
+        const subscription = createSubscription();
+        mockGetRegistration.mockResolvedValue(null);
+        mockRegister.mockResolvedValue(createRegistration(subscription));
+        mockFetchWithRetry.mockRejectedValue(new Error("Network request failed"));
+
+        render(<RecallPushSubscriber />);
+        fireEvent.click(screen.getByRole("button", { name: "Enable alerts" }));
+
+        await waitFor(() => expect(screen.getByText("Network request failed")).toBeInTheDocument());
+        expect(subscription.unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the local subscription when server removal fails", async () => {
+        const subscription = createSubscription();
+        mockGetRegistration.mockResolvedValue(createRegistration(subscription));
+        mockFetchWithRetry.mockResolvedValue({ ok: false, status: 500 } as Response);
+
+        render(<RecallPushSubscriber />);
+        await waitFor(() => expect(screen.getByText("Disable alerts")).toBeInTheDocument());
+        fireEvent.click(screen.getByRole("button", { name: "Disable alerts" }));
+
+        await waitFor(() =>
+            expect(
+                screen.getByText("Unable to disable alerts. Please try again.")
+            ).toBeInTheDocument()
+        );
+        expect(subscription.unsubscribe).not.toHaveBeenCalled();
+        expect(screen.getByText("Disable alerts")).toBeInTheDocument();
+    });
+
+    it("does not call the subscription API when authentication is unavailable", async () => {
+        const subscription = createSubscription();
+        mockUseSession.mockReturnValue({ token: null, session: null, isLoading: false });
+        mockGetRegistration.mockResolvedValue(null);
+        mockRegister.mockResolvedValue(createRegistration(subscription));
+
+        render(<RecallPushSubscriber />);
+        fireEvent.click(screen.getByRole("button", { name: "Enable alerts" }));
+
+        await waitFor(() =>
+            expect(screen.getByText("Please sign in to enable push alerts.")).toBeInTheDocument()
+        );
+        expect(mockGetCsrfToken).not.toHaveBeenCalled();
+        expect(mockFetchWithRetry).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3724**
- **Summary:**
  - Added CSRF protection to authenticated push-subscription POST and DELETE requests by reusing the existing `getCsrfToken()` and `fetchWithRetry()` utilities.
  - Ensured both mutation requests include `credentials: "include"` and the required `x-csrf-token` header while preserving existing Bearer authentication.
  - Improved subscription consistency by cleaning up newly created browser subscriptions when server registration fails and delaying local unsubscribe until the server successfully removes the subscription.
  - Added focused tests covering CSRF headers, credentials, request ordering, cleanup behavior, and authentication handling.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Validation Performed

- ✅ Focused RecallPushSubscriber tests passed (6/6).
- ✅ ESLint passed for modified files.
- ✅ TypeScript type check passed.
- ✅ Prettier check passed for modified files.
- ✅ `git diff --check` passed.

### Notes

- Repository-wide `lint` reports pre-existing issues in unrelated files.
- Application build could not be completed locally because the installed environment is missing the `@ducanh2912/next-pwa` dependency.
- Browser-level notification flow and end-to-end authenticated API integration were not tested.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] 🧪 `type: testing`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3724`)
- [x] I have pulled the latest `main` and resolved any conflicts