### PR TITLE
fix(sw): preserve binary map tiles by caching via blob() instead of text()

### DIFF
--- a/apps/web/worker/index.js
+++ b/apps/web/worker/index.js
@@ -242,7 +242,11 @@ async function cacheFirstWithExpiry(request, cacheName, maxAgeMs) {
         if (networkResponse && networkResponse.ok) {
             const headers = new Headers(networkResponse.headers);
             headers.set("sw-cached-at", new Date().toISOString());
-            const cloned = new Response(await networkResponse.clone().text(), {
+            // Use blob() (not text()) so binary bodies — map tiles, PNG icons —
+            // are preserved byte-for-byte. text() decodes as UTF-8, replacing
+            // invalid byte sequences with U+FFFD, which corrupts the cached
+            // image and leaves offline reloads blank even with a cache hit.
+            const cloned = new Response(await networkResponse.clone().blob(), {
                 status: networkResponse.status,
                 statusText: networkResponse.statusText,
                 headers,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #** 3690
- **Summary:** The map-tile route matcher, dedicated `TILES_CACHE` namespace, and Cache-First strategy this issue asks for were already present in `apps/web/worker/index.js`. The blocker to the acceptance criteria was a binary-corruption bug in the shared `cacheFirstWithExpiry` helper: it rebuilt the response-to-cache with `new Response(await res.clone().text(), …)`. `text()` decodes the body as UTF-8, so binary content (OSM PNG tiles, PNG app icons) had invalid byte sequences replaced with U+FFFD and could not be re-encoded to the original bytes — a cache entry was written but the cached image was corrupt, so offline reloads still showed blank/broken tiles on a cache hit.
  - Fix: cache via `res.clone().blob()` instead of `.text()`, preserving the body byte-for-byte — the same byte-safe approach the sibling `staleWhileRevalidate` already uses. The `sw-cached-at` expiry-header logic is unchanged.
  - This also fixes the app icons cached through the same helper.
  - Scope: `apps/web/worker/index.js` only (single function).


## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3690`)
- [x] I have pulled the latest `main` and resolved any conflicts
