### PR TITLE
fix(ci): build workspace packages before test and lighthouse runs

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: 🏗️ Build Web App
-        run: npm run build --workspace=web
+        run: npx turbo run build --filter=web
         env:
           NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
           NEXT_PUBLIC_SUPABASE_ANON_KEY: dummy-anon-key

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,7 @@
             ]
         },
         "test": {
+            "dependsOn": ["^build"],
             "outputs": ["coverage/**"]
         },
         "dev": {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3732
- **Summary:** Lighthouse CI and the Test Suite were failing on `main` because the internal workspace packages (`@sahidawa/shared`, `@sahidawa/types`, `@sahidawa/validators`) were never compiled to `dist/index.js` before their consumers ran.
  - `turbo.json`: the `test` task had no `dependsOn`, so `turbo run test` started Jest before the packages built → `Cannot find module '@sahidawa/shared' from 'lib/api.ts'`. Added `"dependsOn": ["^build"]` so Turbo compiles upstream packages first.
  - `.github/workflows/lighthouse.yml`: `npm run build --workspace=web` invoked `next build` directly, bypassing Turbo's dependency graph, so the packages were never built and Next.js could not resolve `@sahidawa/validators`. Switched to `npx turbo run build --filter=web`, which builds the deps in dependency order first.
  - Verified with `turbo run test/build --dry-run` (both now depend on `@sahidawa/{shared,types,validators}#build`) and a clean `turbo run build --filter=web` that produces each package's `dist/` before the web build.
  - Scope: `turbo.json` and `.github/workflows/lighthouse.yml` only. `e2e-tests.yml` already builds these packages manually and is unaffected; `pr-quality-check.yml` doesn't run `turbo run test`.



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] 🛠️ `type: devops`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3732`)
- [x] I have pulled the latest `main` and resolved any conflicts
