### PR TITLE
perf : Add Redis Cache on ML Image Analysis Proxies

### DIFF
--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -275,37 +275,66 @@ router.post("/extract", uploadRateLimiter, validateUploadSize, (req: Request, re
         );
 
         try {
-            const formData = new FormData();
             const fileBuffer = await fs.promises.readFile(tempFilePath);
-            const blob = new Blob([fileBuffer], {
-                type: file.mimetype,
-            });
-            formData.append("file", blob, file.originalname);
+            const fileHash = crypto.createHash("sha256").update(fileBuffer).digest("hex");
+            const cacheKey = `ocr_extract:${fileHash}`;
 
-            const response = await fetch(targetUrl, {
-                method: "POST",
-                body: formData,
-                signal: AbortSignal.timeout(30_000), // 30 s hard timeout
-            });
+            let data: { text?: string; confidence?: number; filename?: string } | null = null;
 
-            if (!response.ok) {
-                let errorDetail = `ML service returned HTTP ${response.status}`;
-                try {
-                    const body = (await response.json()) as { detail?: string };
-                    if (body.detail) errorDetail = body.detail;
-                } catch {
-                    // Non-JSON body — keep generic message
+            try {
+                if (redisClient.isOpen) {
+                    const cached = await redisClient.get(cacheKey);
+                    if (cached) {
+                        data = JSON.parse(cached);
+                        logger.info(`OCR Cache HIT for image hash ${fileHash}`);
+                    }
                 }
-                logger.error(`ML OCR error: ${errorDetail}`);
-                res.status(response.status).json({ error: errorDetail });
-                return;
+            } catch (cacheErr) {
+                logger.error(`Redis cache check error: ${cacheErr}`);
             }
 
-            const data = (await response.json()) as {
-                text?: string;
-                confidence?: number;
-                filename?: string;
-            };
+            if (!data) {
+                const formData = new FormData();
+                const blob = new Blob([fileBuffer], {
+                    type: file.mimetype,
+                });
+                formData.append("file", blob, file.originalname);
+
+                const response = await fetch(targetUrl, {
+                    method: "POST",
+                    body: formData,
+                    signal: AbortSignal.timeout(30_000), // 30 s hard timeout
+                });
+
+                if (!response.ok) {
+                    let errorDetail = `ML service returned HTTP ${response.status}`;
+                    try {
+                        const body = (await response.json()) as { detail?: string };
+                        if (body.detail) errorDetail = body.detail;
+                    } catch {
+                        // Non-JSON body — keep generic message
+                    }
+                    logger.error(`ML OCR error: ${errorDetail}`);
+                    res.status(response.status).json({ error: errorDetail });
+                    return;
+                }
+
+                data = (await response.json()) as {
+                    text?: string;
+                    confidence?: number;
+                    filename?: string;
+                };
+
+                try {
+                    if (redisClient.isOpen) {
+                        // Cache the ML response for 24 hours (86400 seconds)
+                        await redisClient.set(cacheKey, JSON.stringify(data), { EX: 86400 });
+                        logger.info(`OCR Cache SET for image hash ${fileHash}`);
+                    }
+                } catch (cacheErr) {
+                    logger.error(`Redis cache set error: ${cacheErr}`);
+                }
+            }
             logger.info(`OCR extraction successful for "${file.originalname}"`);
 
             const rawText = data.text || "";

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "clean": "npx rimraf .turbo node_modules apps/*/node_modules apps/*/.next packages/*/node_modules",
         "test": "turbo run test",
         "lint": "npm run lint --workspaces --if-present",
-        "lint:circular": "madge --circular apps/api/src apps/web packages/shared/src packages/types/src packages/validators/src",
+        "lint:circular": "npx madge --circular apps/api/src apps/web packages/shared/src packages/types/src packages/validators/src",
         "test:a11y:voice": "npm run test:a11y:voice -w web",
         "prepare": "node -e \"if(!process.env.CI) { require('child_process').execSync('npx --yes husky', {stdio: 'inherit'}) }\" || true",
         "check:migrations": "node scripts/check-migrations.js",


### PR DESCRIPTION
#3680

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3680 **
- **Summary:**
- read the raw image bytes into a fileBuffer and create a SHA-256 hash from it (const fileHash = crypto.createHash("sha256").update(fileBuffer).digest("hex");). I then query Redis using this hash (ocr_extract:<fileHash>). If a match is found, it  parse the stored data and entirely bypass the if (!data) block, skipping the network fetch to the ML container and instantly proceeding to the next steps.
- When storing the result for the first time, we pass the { EX: 86400 } configuration argument to the redisClient.set() command. This automatically expires the key after exactly 24 hours (86,400 seconds). This acts as a robust mechanism to prevent stale entries from living in your server memory forever while being long enough to efficiently intercept redundant uploads.
- The redisClient.get(cacheKey) call is wrapped in a try/catch block and preceded by a check to redisClient.isOpen. If Redis is offline or throws a connection error, the error is safely caught and logged, leaving the data variable as null. This forces the code to gracefully fall through to the if (!data) block, ensuring the ML container is called seamlessly.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
