### PR TITLE
fix: clear CSRF token cache and retry on 403

### DIFF
--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -37,6 +37,11 @@ async function fetchWithCsrf<T>(
 
     let res = await doFetch(await getCsrfToken());
 
+    if (res.status === 403) {
+        const freshToken = await refreshCsrfToken();
+        res = await doFetch(freshToken);
+    }
+
     if (!res.ok && !(ignore404 && res.status === 404)) {
         const body = (await res.json().catch(() => ({}))) as {
             error?: { message?: string } | string;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3718**
- **Summary:**
### Root Cause
fetchWithCsrf in `apps/web/lib/api.ts:38` calls `doFetch(await getCsrfToken())` and, if the response is not OK, immediately throws — with no check for a 403 CSRF mismatch and no retry mechanism. The stale token remains cached in csrf.ts until a manual page refresh.
### Fix
Added a 403 handler in fetchWithCsrf (apps/web/lib/api.ts:40-43) that:
1. Calls refreshCsrfToken() which clears the stale csrfTokenCache and fetches a fresh token from GET `/api/csrf-token`
2. Retries the original request exactly once with the new token
If the retry also returns 403 (e.g., genuinely unauthorized, not a CSRF issue), it falls through to the existing error handling and throws as before. This follows the standard SPA CSRF retry pattern used in frameworks like Angular and Next.js.
Changes
- `apps/web/lib/api.ts` — Added 403 detection and automatic retry with a refreshed CSRF token in `fetchWithCsrf` (lines 40-43)



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3718`)
- [x] I have pulled the latest `main` and resolved any conflicts
