### PR TITLE
Fix/medicine cache network first

### DIFF
--- a/apps/web/worker/index.js
+++ b/apps/web/worker/index.js
@@ -154,8 +154,8 @@ self.addEventListener("fetch", (event) => {
     }
 
     // -------------------------------------------------------------------------
-    // Strategy 2 — Medicine-lookup API routes: Network-first with cache fallback
-    // (verify, scan, LASA — users must always see the latest safety status)
+    // Strategy 2 — Medicine-lookup API routes: Stale-While-Revalidate
+    // (verify, scan, LASA — show cached result immediately, update in background)
     // -------------------------------------------------------------------------
     if (
         url.pathname.startsWith("/api/medicines/") ||
@@ -163,7 +163,7 @@ self.addEventListener("fetch", (event) => {
         url.pathname.startsWith("/api/v1/scan/") ||
         url.pathname.startsWith("/api/v1/lasa/")
     ) {
-        event.respondWith(networkFirstWithCache(request, MEDICINE_CACHE_NAME));
+        event.respondWith(staleWhileRevalidate(request, MEDICINE_CACHE_NAME));
         return;
     }
 

--- a/apps/web/worker/index.js
+++ b/apps/web/worker/index.js
@@ -154,8 +154,8 @@ self.addEventListener("fetch", (event) => {
     }
 
     // -------------------------------------------------------------------------
-    // Strategy 2 — Medicine-lookup API routes: Stale-While-Revalidate
-    // (verify, scan, LASA — show cached result immediately, update in background)
+    // Strategy 2 — Medicine-lookup API routes: Network-first with cache fallback
+    // (verify, scan, LASA — users must always see the latest safety status)
     // -------------------------------------------------------------------------
     if (
         url.pathname.startsWith("/api/medicines/") ||
@@ -163,7 +163,7 @@ self.addEventListener("fetch", (event) => {
         url.pathname.startsWith("/api/v1/scan/") ||
         url.pathname.startsWith("/api/v1/lasa/")
     ) {
-        event.respondWith(staleWhileRevalidate(request, MEDICINE_CACHE_NAME));
+        event.respondWith(networkFirstWithCache(request, MEDICINE_CACHE_NAME));
         return;
     }
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3719**
- **Summary:**
Changed medicine-lookup API routes (/api/verify, /api/medicines/, /api/v1/scan/, /api/v1/lasa/) from staleWhileRevalidate to networkFirstWithCache (worker/index.js:166), matching the correct behavior already used by alert & other API routes. Users always get the freshest safety status from the network, with cache as an offline fallback.



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3719`)
- [x] I have pulled the latest `main` and resolved any conflicts
