### PR TITLE
refactor(types): centralize Medicine types into @sahidawa/types

### DIFF
--- a/apps/web/app/[locale]/expiry-tracker/components/types.ts
+++ b/apps/web/app/[locale]/expiry-tracker/components/types.ts
@@ -1,12 +1,7 @@
 import type React from "react";
+import type { TrackedMedicine } from "@sahidawa/types";
 
-export interface Medicine {
-    id: string;
-    name: string;
-    expiryDate: string;
-    batchNumber?: string;
-    notes?: string;
-}
+export type { TrackedMedicine as Medicine };
 
 export type FilterStatus = "all" | "expired" | "expiringSoon" | "safe";
 export type SortOption = "expirySoonest" | "expiryLatest" | "alpha";

--- a/apps/web/hooks/useMedicineTracker.ts
+++ b/apps/web/hooks/useMedicineTracker.ts
@@ -13,17 +13,11 @@ import {
     checkAndTriggerLocalNotifications as checkAndTriggerNotificationsHelper,
     cancelNotificationsForMedicine,
 } from "@/lib/expiry-notifications";
+import type { TrackedMedicine, TrackedMedicine as Medicine } from "@sahidawa/types";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export interface Medicine {
-    id: string;
-    name: string;
-    expiryDate: string;
-    batchNumber?: string;
-    notes?: string;
-    snoozedUntil?: string;
-}
+export type { TrackedMedicine, TrackedMedicine as Medicine };
 
 export interface AddMedicineFields {
     name: string;

--- a/apps/web/src/components/ComparisonGrid.tsx
+++ b/apps/web/src/components/ComparisonGrid.tsx
@@ -1,18 +1,8 @@
 import { AlertTriangle, Download, FileSpreadsheet } from "lucide-react";
 import { exportComparisonToCSV, exportComparisonToPDF } from "@/src/lib/comparisonExport";
+import type { Medicine } from "@sahidawa/types";
 
-export interface Medicine {
-    id: string;
-    brand_name: string | null;
-    generic_name: string;
-    composition: string | null;
-    manufacturer: string;
-    mrp?: number | null;
-    jan_aushadhi_price?: number | null;
-    expiry_date?: string | null;
-    medicine_type?: "brand" | "generic";
-    cdsco_approval_status: string;
-}
+export type { Medicine };
 
 export interface ComparisonGridLabels {
     emptyComparison: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./pharmacy.types";
 export * from "./lasa.types";
 export * from "./abha.types";
+export * from "./medicine.types";

--- a/packages/types/src/medicine.types.ts
+++ b/packages/types/src/medicine.types.ts
@@ -1,0 +1,52 @@
+/**
+ * Medicine-related shared types.
+ *
+ * SahiDawa has two distinct "medicine" entities that were previously declared
+ * inline in multiple frontend files. They are kept separate on purpose because
+ * they map to two different Supabase tables with different shapes:
+ *
+ *  - `Medicine`       → `public.medicines` (CDSCO master catalog)
+ *  - `TrackedMedicine` → `public.expiry_tracker_items` (per-user expiry tracking)
+ */
+
+/**
+ * A projection of a row from the `public.medicines` table (CDSCO master
+ * catalog). Field names mirror the Supabase schema. The fields that are
+ * nullable in the database (`barcode_id`, `batch_number`, `manufacturing_date`,
+ * `expiry_date`, `composition`) and the audit columns (`is_counterfeit_alert`,
+ * `created_at`, `updated_at`) are optional here because different frontend
+ * surfaces select different subsets of columns. `medicine_type` is a UI-only
+ * hint not stored in the database, and `mrp` / `jan_aushadhi_price` are optional
+ * because some projection sites omit them.
+ */
+export interface Medicine {
+    id: string;
+    brand_name: string;
+    generic_name: string;
+    manufacturer: string;
+    cdsco_approval_status: string;
+    barcode_id?: string | null;
+    composition?: string | null;
+    batch_number?: string | null;
+    manufacturing_date?: string | null;
+    expiry_date?: string | null;
+    is_counterfeit_alert?: boolean;
+    created_at?: string;
+    updated_at?: string;
+    mrp?: number | null;
+    jan_aushadhi_price?: number | null;
+    medicine_type?: "brand" | "generic";
+}
+
+/**
+ * A row from the `public.expiry_tracker_items` table (per-user expiry tracking).
+ * The frontend models this with camelCase UI fields (e.g. `expiryDate`).
+ */
+export interface TrackedMedicine {
+    id: string;
+    name: string;
+    expiryDate: string;
+    batchNumber?: string;
+    notes?: string;
+    snoozedUntil?: string;
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3673**
- **Summary:**

  Centralizes the duplicated `Medicine` interface definitions out of the Next.js frontend and into the shared `@sahidawa/types` workspace package, making them the single source of truth across the monorepo.

  The issue assumed a single `Medicine` interface, but the codebase actually has **two distinct entities** that were each declared inline in multiple frontend files:

  - **Catalog** → `public.medicines` (CDSCO master catalog)
  - **Tracker** → `public.expiry_tracker_items` (per-user expiry tracking)

  Forcing a single type would have broken the expiry tracker (it reads `.name` / `.expiryDate` / `.notes` / `.snoozedUntil`, not catalog fields). Both shapes are therefore centralized as separate, schema-faithful types: `Medicine` (catalog) and `TrackedMedicine` (tracker).

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> This is a type-only refactor with no UI/runtime behavior change, so no screenshots are required. Proof of correctness is provided via build + test logs below.

**Type check / build (`npm run build -w @sahidawa/types` then `npm run build -w web`):**
```
> @sahidawa/types@1.0.0 build
> tsc -p tsconfig.json
✓ compiled cleanly to dist/

> web@0.1.0 build
> next build
✓ Compiled successfully
✓ Finished TypeScript
✓ Generating static pages (50/50 routes)
```
(The only build error is a runtime `fetch` to the placeholder `example.supabase.co` during static export — a missing Supabase env secret, unrelated to this change.)

**Tests (Jest — ComparisonGrid / compare-pricing / compare-interactions):**
```
Test Suites: 3 passed, 3 total
Tests:       28 passed, 28 total
```

**Lint (ESLint, web workspace):** no errors in the changed files.

**Circular dependency check:** `madge --circular` → *No circular dependency found!*

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3673`)
- [x] I have pulled the latest `main` and resolved any conflicts

---

### Files changed (5)

| File | Change |
|------|--------|
| medicine.types.ts | **New** — canonical `Medicine` (catalog) + `TrackedMedicine` (tracker) interfaces |
| index.ts | Re-exports `./medicine.types` (follows existing per-domain pattern) |
| ComparisonGrid.tsx | Removes local `Medicine`; imports + re-exports from `@sahidawa/types` |
| useMedicineTracker.ts | Removes local `Medicine`; imports `TrackedMedicine`, re-exports `Medicine` alias |
| types.ts | Removes local `Medicine`; re-exports `TrackedMedicine as Medicine` |

### Notes for reviewers
- **Two types, not one:** catalog `Medicine` + tracker `TrackedMedicine`. A single merged type would break the tracker.
- **`Medicine` is a projection**, not the full DB row — nullable/audit columns are optional because UI surfaces select different column subsets; `medicine_type` is a UI-only hint not stored in the DB.
- **useMedicineTracker.ts preserves the `Medicine` alias** so existing consumers (useExpiryIO.ts, `expiry-tracker/page.tsx`) need no changes — keeping the diff to exactly the issue's scope.
- **Build order:** `@sahidawa/types` must be built before `web` resolves it (turbo build ordering; see PR #3748).
- **Out of scope:** `admin/dashboard/page.tsx` still has a local catalog `Medicine`. It is the same entity and could be centralized in a follow-up for full DRY, but was left untouched to stay within this issue's 3-file scope.