### PR TITLE
feat: implement automated sensitive data redaction in logger and remove manual header sanitization in webhooks

### DIFF
--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -31,7 +31,7 @@ router.post(
         if (!isValid) {
             logger.warn("Unauthorized webhook attempt on /api/webhooks/supabase/health-schemes", {
                 ip: req.ip,
-                headers: { ...req.headers, authorization: undefined },
+                headers: req.headers,
             });
             res.status(401).json({ error: "Unauthorized" });
             return;
@@ -103,7 +103,7 @@ router.post(
         if (!isValid) {
             logger.warn("Unauthorized webhook attempt on /api/webhooks/supabase/medicines", {
                 ip: req.ip,
-                headers: { ...req.headers, authorization: undefined },
+                headers: req.headers,
             });
             res.status(401).json({ error: "Unauthorized" });
             return;

--- a/apps/api/src/utils/logger.ts
+++ b/apps/api/src/utils/logger.ts
@@ -22,6 +22,54 @@ const injectRequestId = winston.format((info) => {
     return info;
 });
 
+const SENSITIVE_KEYS = new Set([
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "password",
+    "token",
+    "secret",
+]);
+
+function redactObj(obj: any, seen: WeakSet<any> = new WeakSet()): any {
+    if (obj === null || typeof obj !== "object") {
+        return obj;
+    }
+
+    if (seen.has(obj)) {
+        return "[CIRCULAR]";
+    }
+    seen.add(obj);
+
+    if (Array.isArray(obj)) {
+        return obj.map((item) => redactObj(item, seen));
+    }
+
+    const redacted: any = {};
+    for (const key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+            if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+                redacted[key] = "[REDACTED]";
+            } else {
+                redacted[key] = redactObj(obj[key], seen);
+            }
+        }
+    }
+
+    // Copy symbol keys (like LEVEL, MESSAGE, SPLAT used by winston)
+    const symbols = Object.getOwnPropertySymbols(obj);
+    for (const sym of symbols) {
+        redacted[sym] = obj[sym];
+    }
+
+    return redacted;
+}
+
+const redactSensitiveData = winston.format((info) => {
+    return redactObj(info);
+});
+
 const logFormat = printf(({ level, message, timestamp, stack, requestId }) => {
     const reqIdTag = requestId ? ` [${requestId}]` : "";
     if (stack) {
@@ -53,6 +101,7 @@ const logger = winston.createLogger({
         errors({ stack: true }),
         timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
         injectRequestId(),
+        redactSensitiveData(),
         process.env.NODE_ENV === "production" ? json() : combine(colorize(), logFormat)
     ),
     transports: [new winston.transports.Console(), errorTransport, combinedTransport],


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #3672** 
* **Summary:**

  * Added a global Winston log redaction format to automatically sanitize sensitive metadata before logs are written.
  * Implemented recursive redaction for sensitive keys (`authorization`, `cookie`, `set-cookie`, `x-api-key`, `password`, `token`, and `secret`) with case-insensitive matching.
  * Added circular reference handling using a `WeakSet` to safely prevent infinite recursion.
  * Integrated the custom redaction format into the main Winston logger pipeline.
  * Removed manual `authorization: undefined` redactions from the webhook routes, relying on the centralized logger instead.

## 📸 Proof of Work (Screenshots / Logs)

> **Backend Change – Validation Results**

Verified using a scratch test script (`scratch/test_logger.ts`):

* ✅ Flat sensitive fields are redacted:

  ```ts
  { authorization: "Bearer xyz", password: "123" }
  ```

  becomes

  ```ts
  { authorization: "[REDACTED]", password: "[REDACTED]" }
  ```

* ✅ Nested sensitive fields are redacted:

  ```ts
  {
    headers: {
      Cookie: "...",
      "X-API-KEY": "..."
    }
  }
  ```

  are recursively sanitized.

* ✅ Circular references are safely replaced with `"[CIRCULAR]"` without crashing.

* ✅ Non-sensitive fields and Winston internal metadata remain unchanged.

## 🏷️ PR Type

* [ ] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [x] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #123`) *(replace with the correct issue number)*
* [x] I have pulled the latest `main` and resolved any conflicts.
