### PR TITLE
perf(ml): add Redis circuit breaker to triage flow to avoid double-timeout

### DIFF
--- a/apps/ml/services/triage_graph.py
+++ b/apps/ml/services/triage_graph.py
@@ -1,5 +1,6 @@
 import os
 import json
+import time
 import logging
 from typing import List, Dict, Any, Optional, TypedDict
 from pydantic import BaseModel, Field
@@ -29,15 +30,77 @@ _PERSISTED_STATE_FIELDS = (
 )
 
 
+# ── Redis Circuit Breaker ────────────────────────────────────────────────────
+# A single, module-wide circuit breaker shared by every Redis touchpoint in the
+# triage flow (native checkpointer + manual JSON persistence). When Redis is
+# genuinely down, the native checkpointer call and the manual _load/_save calls
+# would each block until their own timeout, stacking into a "double timeout" on
+# a single request. After `failure_threshold` consecutive failures this breaker
+# "opens": subsequent Redis calls short-circuit instantly, so the request serves
+# the stateless in-memory triage response without waiting on Redis at all. After
+# `cooldown_seconds` it half-opens to let the next call test whether Redis has
+# recovered.
+
+
+class _RedisCircuitBreaker:
+    def __init__(self, failure_threshold: int = 3, cooldown_seconds: float = 60.0) -> None:
+        self._failures = 0
+        self._opened_at: Optional[float] = None
+        self._threshold = max(1, failure_threshold)
+        self._cooldown = cooldown_seconds
+
+    def is_open(self) -> bool:
+        """Whether Redis calls should currently be skipped.
+
+        Half-opens automatically once the cooldown has elapsed, so the next
+        call is allowed through to probe whether Redis has recovered.
+        """
+        if self._opened_at is None:
+            return False
+        if time.monotonic() - self._opened_at >= self._cooldown:
+            self._opened_at = None
+            self._failures = 0
+            return False
+        return True
+
+    def record_success(self) -> None:
+        self._failures = 0
+        self._opened_at = None
+
+    def record_failure(self) -> None:
+        self._failures += 1
+        if self._failures >= self._threshold:
+            self._opened_at = time.monotonic()
+
+
+def _breaker_int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, default))
+    except (TypeError, ValueError):
+        return default
+
+
+# Shared across all sessions — Redis health is a global condition, not per-session.
+_redis_breaker = _RedisCircuitBreaker(
+    failure_threshold=_breaker_int_env("TRIAGE_REDIS_BREAKER_THRESHOLD", 3),
+    cooldown_seconds=_breaker_int_env("TRIAGE_REDIS_BREAKER_COOLDOWN_SECONDS", 60),
+)
+
+
 def _session_key(session_id: str) -> str:
     return f"{SESSION_KEY_PREFIX}{session_id}"
 
 
 async def _load_session_state(session_id: str) -> Optional[Dict[str, Any]]:
     """Fetch previously persisted triage state for a session_id, if any."""
+    if _redis_breaker.is_open():
+        # Redis is presumed down — skip the call to avoid a blocking timeout.
+        return None
     try:
         raw = await redis_client.get(_session_key(session_id))
+        _redis_breaker.record_success()
     except Exception:
+        _redis_breaker.record_failure()
         logging.exception("Failed to load triage session '%s' from Redis.", session_id)
         return None
 
@@ -53,6 +116,8 @@ async def _load_session_state(session_id: str) -> Optional[Dict[str, Any]]:
 
 async def _save_session_state(session_id: str, state: Dict[str, Any]) -> None:
     """Persist the relevant subset of triage state for session_id with a TTL."""
+    if _redis_breaker.is_open():
+        return
     to_store = {field: state.get(field) for field in _PERSISTED_STATE_FIELDS}
     try:
         await redis_client.set(
@@ -60,7 +125,9 @@ async def _save_session_state(session_id: str, state: Dict[str, Any]) -> None:
             json.dumps(to_store),
             ex=SESSION_TTL_SECONDS,
         )
+        _redis_breaker.record_success()
     except Exception:
+        _redis_breaker.record_failure()
         logging.exception("Failed to save triage session '%s' to Redis.", session_id)
 
 
@@ -70,9 +137,13 @@ async def _clear_session_state(session_id: str) -> bool:
     Returns True if a stored session was removed, False if there was nothing
     to clear (unknown/expired session_id) or the delete failed.
     """
+    if _redis_breaker.is_open():
+        return False
     try:
         removed = await redis_client.delete(_session_key(session_id))
+        _redis_breaker.record_success()
     except Exception:
+        _redis_breaker.record_failure()
         logging.exception("Failed to clear triage session '%s' from Redis.", session_id)
         return False
 
@@ -668,10 +739,16 @@ async def run_triage_flow(
     # ── Native checkpointer path ──────────────────────────────────────────────
     # _native_triage_app was compiled with the AsyncRedisSaver; it requires a
     # thread_id config so LangGraph can read/write the correct checkpoint.
-    if CHECKPOINTER_MODE == "native" and session_id and _native_triage_app is not None:
+    if (
+        CHECKPOINTER_MODE == "native"
+        and session_id
+        and _native_triage_app is not None
+        and not _redis_breaker.is_open()
+    ):
         config = {"configurable": {"thread_id": session_id}}
         try:
             final_state = await _native_triage_app.ainvoke(initial_state, config=config)
+            _redis_breaker.record_success()
             result = _format_triage_result(final_state)
 
             # Shadow-write to the manual key namespace.  Cheap (just a Redis
@@ -687,6 +764,7 @@ async def run_triage_flow(
 
             return result
         except Exception:
+            _redis_breaker.record_failure()
             logging.exception(
                 "Native checkpointer call failed mid-run for session '%s'; "
                 "falling through to manual Redis persistence.",

--- a/apps/ml/tests/test_triage_session_persistence.py
+++ b/apps/ml/tests/test_triage_session_persistence.py
@@ -16,6 +16,14 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _reset_redis_breaker():
+    """Keep the module-level Redis circuit breaker isolated between tests."""
+    triage_graph._redis_breaker.record_success()  # force a known, closed state
+    yield
+    triage_graph._redis_breaker.record_success()
+
+
 class FakeRedis:
     """Minimal in-memory stand-in for the async Redis client used in tests."""
 
@@ -35,6 +43,93 @@ class FakeRedis:
             if self.store.pop(key, None) is not None:
                 removed += 1
         return removed
+
+
+# ---------------------------------------------------------------------------
+# services.triage_graph — Redis circuit breaker
+# ---------------------------------------------------------------------------
+
+def test_redis_circuit_breaker_opens_after_threshold():
+    breaker = triage_graph._RedisCircuitBreaker(failure_threshold=3, cooldown_seconds=60)
+
+    breaker.record_failure()
+    breaker.record_failure()
+    assert breaker.is_open() is False  # below threshold
+
+    breaker.record_failure()
+    assert breaker.is_open() is True  # threshold reached — circuit opens
+
+
+def test_redis_circuit_breaker_success_resets_failure_streak():
+    breaker = triage_graph._RedisCircuitBreaker(failure_threshold=3, cooldown_seconds=60)
+
+    breaker.record_failure()
+    breaker.record_failure()
+    breaker.record_success()  # a single success clears the streak
+    breaker.record_failure()
+    breaker.record_failure()
+    assert breaker.is_open() is False  # only 2 consecutive failures since the reset
+
+
+def test_redis_circuit_breaker_half_opens_after_cooldown(monkeypatch):
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(triage_graph.time, "monotonic", lambda: clock["now"])
+    breaker = triage_graph._RedisCircuitBreaker(failure_threshold=1, cooldown_seconds=60)
+
+    breaker.record_failure()
+    assert breaker.is_open() is True  # within cooldown, stays open
+
+    clock["now"] += 61  # advance past the cooldown window
+    assert breaker.is_open() is False  # half-opens to probe recovery
+
+
+def test_open_breaker_short_circuits_load_without_touching_redis(monkeypatch):
+    class ExplodingRedis:
+        async def get(self, key):
+            raise AssertionError("Redis must not be called while the circuit is open")
+
+    monkeypatch.setattr(triage_graph, "redis_client", ExplodingRedis())
+    monkeypatch.setattr(triage_graph._redis_breaker, "is_open", lambda: True)
+
+    # Returns immediately with no session state, without ever hitting Redis.
+    assert asyncio.run(triage_graph._load_session_state("any-session")) is None
+
+
+@pytest.mark.anyio
+async def test_open_breaker_serves_stateless_fallback(monkeypatch):
+    monkeypatch.setattr(triage_graph, "LANGGRAPH_AVAILABLE", True)
+    monkeypatch.setattr(triage_graph._redis_breaker, "is_open", lambda: True)
+
+    class ExplodingRedis:
+        async def get(self, key):
+            raise AssertionError("Redis must not be read while the circuit is open")
+
+        async def set(self, key, value, ex=None):
+            raise AssertionError("Redis must not be written while the circuit is open")
+
+    monkeypatch.setattr(triage_graph, "redis_client", ExplodingRedis())
+
+    fake_app = MagicMock()
+    fake_app.ainvoke = AsyncMock(
+        return_value={
+            "response": "Here is some general guidance.",
+            "emergency_detected": False,
+            "language": "English",
+            "final_summary": "",
+            "recommendations": [],
+            "disclaimer": "",
+            "collected_info": {},
+        }
+    )
+    monkeypatch.setattr(triage_graph, "triage_app", fake_app)
+
+    result = await triage_graph.run_triage_flow(
+        [{"role": "user", "content": "hi"}], session_id="s-open"
+    )
+
+    # With the circuit open, the stateless graph runs and Redis is never touched.
+    fake_app.ainvoke.assert_awaited_once()
+    assert result["response"] == "Here is some general guidance."
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #** 3744
- **Summary:** On a genuine Redis outage the triage flow stalled twice on a single request: `_native_triage_app.ainvoke` blocked until its timeout, then the manual fallback immediately called `_load_session_state -> redis_client.get()` and blocked again before finally serving the stateless response. (`redis_client` sets no `socket_timeout`, so these aren't fast failures.)
  - Added a lightweight, async-safe circuit breaker directly in `triage_graph.py` — **no new dependency**, so `requirements.txt` is unchanged. The popular `circuitbreaker` package is sync/decorator-based and doesn't compose with these `async def` Redis calls.
  - A **single module-level breaker** is shared across all sessions, since Redis health is a global condition, not per-session.
  - Guarded every Redis touchpoint with `is_open()`: the native checkpointer path, `_load_session_state`, `_save_session_state`, and `_clear_session_state`. When open they short-circuit instantly and the request serves `triage_app.ainvoke` with no persistence.
  - After `failure_threshold` (default 3) consecutive failures the circuit opens for `cooldown_seconds` (default 60), then half-opens to probe recovery. Tunable via `TRIAGE_REDIS_BREAKER_THRESHOLD` / `TRIAGE_REDIS_BREAKER_COOLDOWN_SECONDS`.
  - Note: I also guarded `_clear_session_state` (a fourth Redis call not in my original plan) — leaving it unguarded would still hang during an outage.
  - Added breaker unit + integration tests, plus an autouse fixture isolating the shared breaker between tests, to the existing `tests/test_triage_session_persistence.py`.



## 🏷️ PR Type

- [x] ⚡ `type: performance`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3744`)
- [x] I have pulled the latest `main` and resolved any conflicts
- [x] I have written tests for new functionality

LinkedIn: https://www.linkedin.com/in/saatwik-kumar-yadav-523536337/