### PR TITLE
perf(map): fetch scan-activity heatmap lazily on first layer selection

### DIFF
--- a/apps/web/app/[locale]/map/page.tsx
+++ b/apps/web/app/[locale]/map/page.tsx
@@ -396,18 +396,40 @@ export default function PharmacyMapPage() {
 
     const pendingBoundsRef = useRef<MapBounds | null>(null);
     const initialFetchDone = useRef(false);
+    const scanHotspotsFetchedRef = useRef(false);
 
-    // Load the privacy-safe (server-binned) scan-activity heatmap once on mount.
+    // Lazily load the privacy-safe (server-binned) scan-activity heatmap the
+    // first time a layer that renders it is selected, rather than on every page
+    // load. Once fetched, the result is cached in `scanHotspots` state and the
+    // ref stops any further network calls when toggling modes back and forth.
     // Silently no-ops for users without access, keeping the map unchanged.
     useEffect(() => {
+        if (heatmapMode !== "scans" && heatmapMode !== "combined") return;
+        if (scanHotspotsFetchedRef.current) return;
+
+        scanHotspotsFetchedRef.current = true;
         const controller = new AbortController();
-        fetchScanActivityHotspots(controller.signal).then((hotspots) => {
-            if (!controller.signal.aborted) {
+
+        fetchScanActivityHotspots(controller.signal)
+            .then((hotspots) => {
+                if (controller.signal.aborted) {
+                    // Cancelled by unmount or a quick mode change before it
+                    // resolved — let a later toggle retry instead of caching
+                    // an incomplete result.
+                    scanHotspotsFetchedRef.current = false;
+                    return;
+                }
                 setScanHotspots(hotspots);
-            }
-        });
+            })
+            .catch(() => {
+                // Defensive: fetchScanActivityHotspots handles its own errors
+                // and resolves with [] today, but an unexpected rejection must
+                // not latch the ref and block every future retry.
+                scanHotspotsFetchedRef.current = false;
+            });
+
         return () => controller.abort();
-    }, []);
+    }, [heatmapMode]);
 
     useEffect(() => {
         if (typeof window !== "undefined") {
@@ -830,17 +852,16 @@ export default function PharmacyMapPage() {
         { id: "none", label: "Markers", description: "Show pharmacy markers only" },
         { id: "density", label: "Density", description: "Highlight pharmacy-dense areas" },
         { id: "counterfeit", label: "Counterfeit", description: "Show report-risk clusters" },
-        // Only surfaced when the privacy-safe endpoint returns data (i.e. the
-        // viewer is authorized), so unauthorized users don't see an empty layer.
-        ...(scanHotspots.length > 0
-            ? [
-                  {
-                      id: "scans" as const,
-                      label: "Scan Activity",
-                      description: "Anonymized, location-binned scan density",
-                  },
-              ]
-            : []),
+        // Always offered: the scan layer is now fetched lazily on first
+        // selection, so whether data exists isn't known until the user asks for
+        // it. Gating this option on `scanHotspots.length` would make it
+        // unclickable and the layer unreachable. Viewers without access simply
+        // see an empty layer.
+        {
+            id: "scans",
+            label: "Scan Activity",
+            description: "Anonymized, location-binned scan density",
+        },
         { id: "combined", label: "Combined", description: "Show density and report risk together" },
     ];
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #** 3757
- **Summary:** The scan-activity heatmap was fetched unconditionally on mount, so every visitor paid for a `/api/analytics/heatmap` request even though the layer only renders in `"scans"` / `"combined"` mode — and most visitors aren't authorized for that endpoint at all.
  - Keyed the effect on `heatmapMode`, bailing out unless the selected mode actually renders the layer.
  - Added `scanHotspotsFetchedRef` so toggling modes back and forth reuses the cached `scanHotspots` state instead of refetching.
  - Preserved the `AbortController` cleanup, and reset the ref when a request is **aborted** (unmount / quick mode change) so a cancelled fetch doesn't cache an incomplete result and permanently block retries. Note: my original plan proposed resetting in `.catch()`, but `fetchScanActivityHotspots` handles its own errors and resolves with `[]`, so it never rejects — abort is the real retry case. A `.catch()` remains only as defensive insurance.
  - **Also removed the `scanHotspots.length > 0` gate on the "Scan Activity" option.** That gate was only viable while the fetch was eager; with a lazy fetch it made the option unclickable and the layer unreachable, since the data it gated on could never load. Viewers without access now simply see an empty layer.
  - Scope: `apps/web/app/[locale]/map/page.tsx` only.

## 📸 Proof of Work (Screenshots / Logs)

Verified with a throwaway React Testing Library test driving the real toggles (run against both the old and new code to confirm it actually detects the regression):

| Behaviour | Before | After |
| --- | --- | --- |
| Fetch on mount (`heatmapMode: "none"`) | 1 call | **0 calls** |
| "Scan Activity" toggle reachable before data loads | hidden | **present** |
| First selection of "scans" | — | **exactly 1 fetch** |
| Toggle away → back → "Combined" | — | **still 1 fetch (cached)** |
| Selecting "Combined" first | no fetch | **1 fetch** |

_<optionally attach a DevTools Network screenshot showing no `/analytics/heatmap` request on load, then one request after selecting "Scan Activity">_

## 🏷️ PR Type

- [x] ⚡ `type: performance`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3757`)
- [x] I have pulled the latest `main` and resolved any conflicts
