### PR TITLE
feat(web): queue dose logs while offline

### DIFF
--- a/apps/web/app/[locale]/schedule/page.tsx
+++ b/apps/web/app/[locale]/schedule/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { DoseQueuedOfflineError } from "@/lib/apiWithRetry";
+
 import {
     AlertTriangle,
     CheckCircle2,
@@ -89,11 +91,19 @@ function DoseButton({
             toast.success(status === "taken" ? t("doseLoggedSuccess") : t("doseSkippedSuccess"), {
                 id: `dose-${scheduleId}-${time}`,
             });
-        } catch {
-            // Revert optimistic update
-            onStatusChange(time, previousStatus);
-            setActionError(t("doseErrorMessage"));
-            toast.error(t("doseErrorMessage"), { id: `dose-${scheduleId}-${time}` });
+        } catch (err) {
+            if (err instanceof DoseQueuedOfflineError) {
+                // Don't revert — dose stays "taken"/"skipped" optimistically.
+                // It's safely queued in localStorage and will sync automatically.
+                toast.success(t("doseQueuedOffline"), {
+                    id: `dose-${scheduleId}-${time}`,
+                });
+            } else {
+                // Genuine failure (validation, auth, server error) — revert as before
+                onStatusChange(time, previousStatus);
+                setActionError(t("doseErrorMessage"));
+                toast.error(t("doseErrorMessage"), { id: `dose-${scheduleId}-${time}` });
+            }
         } finally {
             setLoading(false);
         }

--- a/apps/web/lib/apiWithRetry.ts
+++ b/apps/web/lib/apiWithRetry.ts
@@ -311,3 +311,10 @@ class OfflineRequestQueue {
 }
 
 export const offlineRequestQueue = new OfflineRequestQueue();
+
+export class DoseQueuedOfflineError extends Error {
+    constructor() {
+        super("Request queued for background sync");
+        this.name = "DoseQueuedOfflineError";
+    }
+}

--- a/apps/web/lib/scheduleApi.ts
+++ b/apps/web/lib/scheduleApi.ts
@@ -1,5 +1,5 @@
 import { API_BASE, getCsrfToken } from "./api";
-import { fetchWithRetry } from "./apiWithRetry";
+import { fetchWithRetry, offlineRequestQueue, DoseQueuedOfflineError } from "./apiWithRetry";
 
 export interface Schedule {
     id: string;
@@ -212,17 +212,47 @@ export async function logDose(
     scheduleId: string,
     data: { log_date: string; log_time: string; status: "taken" | "skipped" }
 ): Promise<DoseLog> {
-    const res = await scheduleMutationFetch(`${API_BASE}/api/schedules/${scheduleId}/doses`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json", ...authHeaders() },
-        body: JSON.stringify(data),
-    });
-    if (!res.ok) {
-        const body = await res.json().catch(() => ({ error: "Unknown error" }));
-        throw new Error(body.error ?? "Failed to log dose");
+    const url = `${API_BASE}/api/schedules/${scheduleId}/doses`;
+    const body = JSON.stringify(data);
+
+    try {
+        const res = await scheduleMutationFetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", ...authHeaders() },
+            body,
+        });
+        if (!res.ok) {
+            const errBody = await res.json().catch(() => ({ error: "Unknown error" }));
+            throw new Error(errBody.error ?? "Failed to log dose");
+        }
+        const json = await res.json();
+        return json.dose;
+    } catch (err) {
+        const isOffline = typeof window !== "undefined" && !window.navigator.onLine;
+        const isNetworkError =
+            err instanceof Error &&
+            (err.message.toLowerCase().includes("offline") ||
+                err.message.toLowerCase().includes("failed to fetch") ||
+                err.name === "TypeError");
+
+        // Only queue genuine connectivity failures — not validation/auth errors (400/401/403/404)
+        if (isOffline || isNetworkError) {
+            const csrfToken = await getCsrfToken();
+            offlineRequestQueue.add(url, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    ...authHeaders(),
+                    "x-csrf-token": csrfToken,
+                },
+                credentials: "include",
+                body,
+            });
+            throw new DoseQueuedOfflineError();
+        }
+
+        throw err;
     }
-    const json = await res.json();
-    return json.dose;
 }
 
 /**

--- a/apps/web/tests/integration/offline-queue.test.ts
+++ b/apps/web/tests/integration/offline-queue.test.ts
@@ -17,11 +17,13 @@ jest.mock("uuid", () => ({
 }));
 import { enqueueScan, flushQueue, initOnlineListener } from "../../lib/offline/queue";
 import { getSyncDB } from "../../lib/offline/db";
+import { logDose } from "../../lib/scheduleApi";
+import { offlineRequestQueue, DoseQueuedOfflineError } from "../../lib/apiWithRetry";
+
+// Mock network requuest made during queue synchronization.
+const fetchMock = jest.fn();
 
 describe("Offline Queue Integration", () => {
-    // Mock network requuest made during queue synchronization.
-    const fetchMock = jest.fn();
-
     beforeEach(async () => {
         // Rset fetch mock before every test.
         globalThis.fetch = fetchMock as any;
@@ -47,6 +49,8 @@ describe("Offline Queue Integration", () => {
     });
 
     it("queues a scan while offline", async () => {
+        globalThis.fetch = fetchMock as any;
+        fetchMock.mockReset();
         await enqueueScan({
             metadata: {
                 barcode: "123456",
@@ -171,5 +175,25 @@ describe("Offline Queue Integration", () => {
 
         // Retry count should increase after a failed sync
         expect(items[0].attemptCount).toBe(1);
+    });
+});
+
+describe("logDose offline queue", () => {
+    it("queues dose log when offline instead of throwing generic error", async () => {
+        globalThis.fetch = fetchMock as any;
+        fetchMock.mockReset();
+        Object.defineProperty(window.navigator, "onLine", {
+            value: false,
+            configurable: true,
+        });
+        await expect(
+            logDose("schedule-1", {
+                log_date: "2026-07-20",
+                log_time: "09:00",
+                status: "taken",
+            })
+        ).rejects.toThrow(DoseQueuedOfflineError);
+        const queued = offlineRequestQueue.getAll();
+        expect(queued.some((r) => r.url.includes("/doses"))).toBe(true);
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3641**
- **Summary:**
  - Queue dose log requests when the device is offline instead of failing immediately.
  - Introduce a dedicated `DoseQueuedOfflineError` to distinguish queued offline requests from genuine failures.
  - Preserve optimistic UI updates for queued requests while continuing to roll back on actual server or validation errors.
  - Add integration tests covering offline dose queue behavior.

## 📸 Proof of Work (Screenshots / Logs)

### Offline queue behavior
- [ ] Screenshot / GIF showing dose logging while offline.
- [ ] Screenshot / GIF showing automatic sync after reconnecting.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3641`)
- [x] I have pulled the latest `main` and resolved any conflicts