### PR TITLE
feat(web): serve stale cached GET responses during CSRF refresh

### DIFF
--- a/apps/web/lib/apiWithRetry.ts
+++ b/apps/web/lib/apiWithRetry.ts
@@ -1,6 +1,34 @@
 import { toast } from "sonner";
 import { refreshCsrfToken } from "./csrf";
 
+// Ensures only one CSRF refresh is in-flight at a time, whether triggered
+// by the client's own 403 handling below or by the Service Worker's
+// "CSRF_REFRESH_NEEDED" message.
+let csrfRefreshInFlight: Promise<string> | null = null;
+
+function silentlyRefreshCsrfToken(): Promise<string> {
+    if (!csrfRefreshInFlight) {
+        csrfRefreshInFlight = refreshCsrfToken().finally(() => {
+            csrfRefreshInFlight = null;
+        });
+    }
+    return csrfRefreshInFlight;
+}
+
+// Listen for the Service Worker telling us it served stale cached data
+// because of a CSRF 403 — refresh the token in the background so the
+// next real request doesn't fail.
+if (typeof window !== "undefined" && "serviceWorker" in navigator) {
+    navigator.serviceWorker.addEventListener("message", (event) => {
+        if (event.data?.type === "CSRF_REFRESH_NEEDED") {
+            silentlyRefreshCsrfToken().catch(() => {
+                // Non-fatal — the next real request will still trigger the
+                // existing refresh-and-retry flow inside fetchWithRetry.
+            });
+        }
+    });
+}
+
 export interface RetryConfig {
     maxRetries?: number;
     initialDelayMs?: number;
@@ -110,7 +138,7 @@ export async function fetchWithRetry(
 
                     if (isCsrfError) {
                         try {
-                            const newToken = await refreshCsrfToken();
+                            const newToken = await silentlyRefreshCsrfToken();
 
                             const newOptions = { ...fetchOptions };
                             if (newOptions.headers) {

--- a/apps/web/worker/index.js
+++ b/apps/web/worker/index.js
@@ -328,6 +328,28 @@ async function networkFirstWithCache(request, cacheName) {
         });
         clearTimeout(timeoutId);
 
+        // ── CSRF 403 optimization ─────────────────────────────────────────
+        // If the API returns a 403 CSRF error for a GET request, don't make
+        // the UI wait for the client's token-refresh-and-retry cycle.
+        // Serve stale cached data immediately (if we have it) and let the
+        // client silently refresh the token in the background.
+        if (request.method === "GET" && networkResponse.status === 403) {
+            const clonedForCheck = networkResponse.clone();
+            const bodyText = await clonedForCheck.text().catch(() => "");
+            const isCsrfError =
+                bodyText.toLowerCase().includes("csrf") || bodyText.toLowerCase().includes("token");
+
+            if (isCsrfError) {
+                const cachedResponse = await cache.match(request);
+                if (cachedResponse) {
+                    notifyClientsCsrfRefresh();
+                    return cachedResponse;
+                }
+                // No cache available — fall through and return the 403 as-is
+                // so the client's existing refresh-and-retry logic handles it.
+            }
+        }
+
         if (networkResponse.ok) {
             cache.put(request, networkResponse.clone()).catch(() => {});
         }
@@ -343,6 +365,17 @@ async function networkFirstWithCache(request, cacheName) {
             }),
             { status: 503, headers: { "Content-Type": "application/json" } }
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CSRF REFRESH NOTIFY — tell open clients to silently refresh the CSRF token
+// after we've served stale cached data for a 403 CSRF response.
+// ---------------------------------------------------------------------------
+async function notifyClientsCsrfRefresh() {
+    const clients = await self.clients.matchAll({ type: "window" });
+    for (const client of clients) {
+        client.postMessage({ type: "CSRF_REFRESH_NEEDED" });
     }
 }
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

---

## 📋 PR Summary & Link

- **Closes #3648**
- **Summary:**
  Improve Service Worker handling for cached GET API requests during CSRF token refresh. When a cached GET request receives a CSRF-related 403 response, the Service Worker now serves the cached response immediately (if available) and notifies the client to silently refresh the CSRF token. The client deduplicates concurrent CSRF refresh requests to avoid multiple refresh operations while preserving the existing retry flow.

---

## 📸 Proof of Work (Screenshots / Logs)

### Test Results

```text
PASS tests/offline.test.tsx
PASS tests/chat-route.test.ts
PASS tests/pharmacy-map-offline-cache.test.tsx
PASS tests/voice-transcribe-route.test.ts
PASS tests/image-enhancer.test.ts
...
