### PR TITLE
perf(ml): centralize Redis circuit breaker state across workers

### DIFF
--- a/apps/ml/requirements.txt
+++ b/apps/ml/requirements.txt
@@ -6,6 +6,7 @@ python-dotenv>=1.2.2
 pytesseract>=0.3.10
 Pillow>=12.3.0
 python-multipart>=0.0.31
+filelock>=3.20.3
 
 # Scraping
 playwright>=1.49.0          # Headless browser - needed for JS-rendered sites like Jan Aushadhi

--- a/apps/ml/services/triage_graph.py
+++ b/apps/ml/services/triage_graph.py
@@ -2,11 +2,15 @@ import os
 import json
 import time
 import logging
+import tempfile
+import threading
+from pathlib import Path
 from typing import List, Dict, Any, Optional, TypedDict
 from pydantic import BaseModel, Field
 from dotenv import load_dotenv
 from services.retrieval import retrieve_relevant_medicines
 from utils.database import redis_client, REDIS_URL
+from filelock import FileLock
 
 load_dotenv()
 
@@ -41,38 +45,95 @@ _PERSISTED_STATE_FIELDS = (
 # `cooldown_seconds` it half-opens to let the next call test whether Redis has
 # recovered.
 
+# ── Shared cross-process state file ──────────────────────────────────────────
+# time.monotonic() cannot be shared across processes (it's per-process), so
+# the persisted state uses time.time() (wall-clock) instead. A FileLock
+# guards every read-modify-write cycle so concurrent Uvicorn/Gunicorn workers
+# never race on the same file.
+_BREAKER_STATE_DIR = Path(os.getenv("TRIAGE_BREAKER_STATE_DIR", tempfile.gettempdir()))
+_BREAKER_STATE_FILE = _BREAKER_STATE_DIR / "sahidawa_redis_breaker_state.json"
+_BREAKER_LOCK_FILE = str(_BREAKER_STATE_FILE) + ".lock"
+_BREAKER_LOCK_TIMEOUT_SECONDS = 2.0
+
 
 class _RedisCircuitBreaker:
+    """Circuit breaker whose open/closed state is shared across every worker
+    process via a lock-guarded JSON file on disk (Redis itself can't be used
+    for this state — it's precisely what we're tracking the health of).
+
+    Semantics (closed → open → half-open → closed) are unchanged from the
+    original in-memory version; only the storage backend changed.
+    """
+
     def __init__(self, failure_threshold: int = 3, cooldown_seconds: float = 60.0) -> None:
-        self._failures = 0
-        self._opened_at: Optional[float] = None
         self._threshold = max(1, failure_threshold)
         self._cooldown = cooldown_seconds
+        # Thread-safety within a single process; FileLock below handles
+        # process-safety across workers.
+        self._thread_lock = threading.Lock()
+        self._file_lock = FileLock(_BREAKER_LOCK_FILE, timeout=_BREAKER_LOCK_TIMEOUT_SECONDS)
+
+    def _read_state(self) -> Dict[str, Any]:
+        try:
+            raw = _BREAKER_STATE_FILE.read_text()
+            data = json.loads(raw)
+            return {
+                "failures": int(data.get("failures", 0)),
+                "opened_at": data.get("opened_at"),
+            }
+        except (FileNotFoundError, ValueError, TypeError, json.JSONDecodeError):
+            return {"failures": 0, "opened_at": None}
+
+    def _write_state(self, failures: int, opened_at: Optional[float]) -> None:
+        # Atomic write: write to a temp file in the same dir, then os.replace
+        # so concurrent readers never see a partially-written file.
+        _BREAKER_STATE_DIR.mkdir(parents=True, exist_ok=True)
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=_BREAKER_STATE_DIR, suffix=".tmp")
+        try:
+            with os.fdopen(tmp_fd, "w") as f:
+                json.dump({"failures": failures, "opened_at": opened_at}, f)
+            os.replace(tmp_path, _BREAKER_STATE_FILE)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def is_open(self) -> bool:
         """Whether Redis calls should currently be skipped.
 
         Half-opens automatically once the cooldown has elapsed, so the next
-        call is allowed through to probe whether Redis has recovered.
+        call across ANY worker is allowed through to probe recovery.
         """
-        if self._opened_at is None:
-            return False
-        if time.monotonic() - self._opened_at >= self._cooldown:
-            self._opened_at = None
-            self._failures = 0
-            return False
-        return True
+        with self._thread_lock, self._file_lock:
+            state = self._read_state()
+            opened_at = state["opened_at"]
+
+            if opened_at is None:
+                return False
+
+            if time.time() - opened_at >= self._cooldown:
+                self._write_state(failures=0, opened_at=None)
+                return False
+
+            return True
 
     def record_success(self) -> None:
-        self._failures = 0
-        self._opened_at = None
+        with self._thread_lock, self._file_lock:
+            self._write_state(failures=0, opened_at=None)
 
     def record_failure(self) -> None:
-        self._failures += 1
-        if self._failures >= self._threshold:
-            self._opened_at = time.monotonic()
+        with self._thread_lock, self._file_lock:
+            state = self._read_state()
+            failures = state["failures"] + 1
+            opened_at = state["opened_at"]
 
+            if failures >= self._threshold and opened_at is None:
+                opened_at = time.time()
 
+            self._write_state(failures=failures, opened_at=opened_at)
+            
 def _breaker_int_env(name: str, default: int) -> int:
     try:
         return int(os.getenv(name, default))

--- a/apps/ml/tests/test_triage_session_persistence.py
+++ b/apps/ml/tests/test_triage_session_persistence.py
@@ -23,6 +23,21 @@ def _reset_redis_breaker():
     yield
     triage_graph._redis_breaker.record_success()
 
+@pytest.fixture(autouse=True)
+def _isolated_breaker_state_file(tmp_path, monkeypatch):
+    """Point every test at a throwaway state file so tests never share or
+    pollute the real /tmp breaker state across test runs."""
+    state_file = tmp_path / "breaker_state.json"
+    lock_file = str(state_file) + ".lock"
+    monkeypatch.setattr(triage_graph, "_BREAKER_STATE_FILE", state_file)
+    monkeypatch.setattr(triage_graph, "_BREAKER_LOCK_FILE", lock_file)
+    monkeypatch.setattr(triage_graph, "_BREAKER_STATE_DIR", tmp_path)
+    # The module-level _redis_breaker instance captured the lock path at
+    # construction time — rebuild its FileLock to point at the new path too.
+    triage_graph._redis_breaker._file_lock = triage_graph.FileLock(
+        lock_file, timeout=triage_graph._BREAKER_LOCK_TIMEOUT_SECONDS
+    )
+    yield
 
 class FakeRedis:
     """Minimal in-memory stand-in for the async Redis client used in tests."""
@@ -73,8 +88,9 @@ def test_redis_circuit_breaker_success_resets_failure_streak():
 
 def test_redis_circuit_breaker_half_opens_after_cooldown(monkeypatch):
     clock = {"now": 1000.0}
-    monkeypatch.setattr(triage_graph.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(triage_graph.time, "time", lambda: clock["now"])
     breaker = triage_graph._RedisCircuitBreaker(failure_threshold=1, cooldown_seconds=60)
+    breaker._write_state(failures=0, opened_at=None)
 
     breaker.record_failure()
     assert breaker.is_open() is True  # within cooldown, stays open
@@ -490,3 +506,66 @@ def test_triage_clear_is_rate_limited():
         app.dependency_overrides.pop(get_redis, None)
 
     assert response.status_code == 429
+
+def test_circuit_breaker_state_shared_across_instances(tmp_path, monkeypatch):
+    """Simulates two separate worker processes: each gets its OWN
+    _RedisCircuitBreaker instance (as would happen in separate Uvicorn
+    workers), but both point at the same state file. One worker tripping
+    the breaker must be immediately visible to the other."""
+    state_file = tmp_path / "shared_breaker.json"
+    lock_file = str(state_file) + ".lock"
+
+    def make_breaker():
+        b = triage_graph._RedisCircuitBreaker(failure_threshold=2, cooldown_seconds=60)
+        monkeypatch.setattr(b, "_file_lock", triage_graph.FileLock(lock_file, timeout=2.0))
+        # Patch the module-level path lookups used inside _read_state/_write_state
+        monkeypatch.setattr(triage_graph, "_BREAKER_STATE_FILE", state_file)
+        monkeypatch.setattr(triage_graph, "_BREAKER_STATE_DIR", tmp_path)
+        return b
+
+    worker_a_breaker = make_breaker()
+    worker_b_breaker = make_breaker()
+
+    # Worker A independently experiences two Redis failures and trips the breaker.
+    worker_a_breaker.record_failure()
+    worker_a_breaker.record_failure()
+    assert worker_a_breaker.is_open() is True
+
+    # Worker B never called record_failure() itself, but must see the breaker
+    # as open immediately — it reads the same shared state file.
+    assert worker_b_breaker.is_open() is True
+
+
+def test_circuit_breaker_survives_concurrent_writes(tmp_path, monkeypatch):
+    """Two breaker instances (simulating two workers) both recording
+    failures concurrently must not corrupt the state file or lose updates
+    due to a race — the FileLock serializes the read-modify-write cycle."""
+    state_file = tmp_path / "concurrent_breaker.json"
+    lock_file = str(state_file) + ".lock"
+
+    def make_breaker():
+        b = triage_graph._RedisCircuitBreaker(failure_threshold=100, cooldown_seconds=60)
+        monkeypatch.setattr(b, "_file_lock", triage_graph.FileLock(lock_file, timeout=5.0))
+        monkeypatch.setattr(triage_graph, "_BREAKER_STATE_FILE", state_file)
+        monkeypatch.setattr(triage_graph, "_BREAKER_STATE_DIR", tmp_path)
+        return b
+
+    worker_a = make_breaker()
+    worker_b = make_breaker()
+
+    import threading as _threading
+
+    def hammer(breaker, count):
+        for _ in range(count):
+            breaker.record_failure()
+
+    t1 = _threading.Thread(target=hammer, args=(worker_a, 10))
+    t2 = _threading.Thread(target=hammer, args=(worker_b, 10))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    final_state = worker_a._read_state()
+    # No writes should have been lost to a race — exactly 20 recorded.
+    assert final_state["failures"] == 20


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3765**
- **Summary:**
  - Replaced the in-memory Redis circuit breaker with a shared file-backed implementation.
  - Added `FileLock` to synchronize circuit breaker state across multiple worker processes.
  - Implemented atomic state updates using temporary files and `os.replace()`.
  - Switched persisted timestamps to `time.time()` for cross-process compatibility.
  - Added tests for shared state, cross-instance synchronization, and concurrent writes.
  - Updated `filelock` dependency to `>=3.20.3` to satisfy the security audit.

## 📸 Proof of Work (Screenshots / Logs)

- Added unit tests for shared breaker state.
- Added cross-worker synchronization tests.
- Added concurrent write tests.
- Local execution was blocked due to missing project dependency (`numpy`), but the implementation follows the issue requirements and project audit requirements.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3765`)
- [x] I have pulled the latest `main` and resolved any conflicts