### PR TITLE
fix(api): remove arbitrary nearest pharmacy fallback

### DIFF
--- a/apps/api/src/routes/alternatives.ts
+++ b/apps/api/src/routes/alternatives.ts
@@ -8,27 +8,6 @@ import { redisClient } from "../utils/redis";
 
 const router = Router();
 
-interface StoreLocation {
-    lat?: string | number;
-    lng?: string | number;
-    location?: {
-        coordinates?: [number, number];
-    };
-}
-
-function extractCoordinates(p: StoreLocation): { lat: number; lng: number } {
-    if (p.lat !== undefined && p.lng !== undefined) {
-        return { lat: Number(p.lat), lng: Number(p.lng) };
-    }
-    if (p.location && typeof p.location === "object" && p.location.coordinates) {
-        return {
-            lat: Number(p.location.coordinates[1]),
-            lng: Number(p.location.coordinates[0]),
-        };
-    }
-    return { lat: 0, lng: 0 };
-}
-
 /**
  * @openapi
  * /api/v1/alternatives/{medicine_id}:
@@ -206,31 +185,14 @@ router.get(
                     }
                 );
 
-                if (!rpcError && rpcData && rpcData.length > 0) {
+                if (rpcError) {
+                    logger.warn("Nearest pharmacy lookup failed", { error: rpcError });
+                } else if (rpcData && rpcData.length > 0) {
                     nearestStore = {
                         name: rpcData[0].name,
                         lat: Number(rpcData[0].lat),
                         lng: Number(rpcData[0].lng),
                         distance: `${Number(rpcData[0].distance).toFixed(1)} km`,
-                    };
-                }
-            }
-
-            // Fallback: Get first pharmacy in database as a default store
-            if (!nearestStore) {
-                const { data: defaultStores } = await supabase
-                    .from("pharmacies")
-                    .select("name, address, location, phone_number, is_verified, district, state")
-                    .limit(1);
-
-                if (defaultStores && defaultStores.length > 0) {
-                    const store = defaultStores[0];
-                    const coords = extractCoordinates(store);
-                    nearestStore = {
-                        name: store.name,
-                        lat: coords.lat,
-                        lng: coords.lng,
-                        distance: "Nearest store",
                     };
                 }
             }

--- a/apps/api/tests/alternatives.test.ts
+++ b/apps/api/tests/alternatives.test.ts
@@ -20,6 +20,32 @@ jest.mock("../src/db/client", () => {
 import { supabase } from "../src/db/client";
 
 describe("GET /api/v1/alternatives/:medicine_id", () => {
+    const mockAlternativeLookup = () => {
+        ((supabase.from as jest.Mock)().maybeSingle as jest.Mock)
+            .mockResolvedValueOnce({
+                data: {
+                    id: "med-123",
+                    brand_name: "Lipitor",
+                    generic_name: "Atorvastatin 10mg",
+                    mrp: 120.0,
+                    jan_aushadhi_price: 15.0,
+                },
+                error: null,
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    brand_medicine_id: "med-123",
+                    generic_medicine_id: "gen-456",
+                    brand_name: "Lipitor",
+                    generic_name: "Atorvastatin 10mg (Generic)",
+                    brand_price: 120.0,
+                    jan_aushadhi_price: 15.0,
+                    savings_percentage: 88,
+                },
+                error: null,
+            });
+    };
+
     beforeEach(() => {
         jest.clearAllMocks();
     });
@@ -34,41 +60,27 @@ describe("GET /api/v1/alternatives/:medicine_id", () => {
         expect(res.headers["cache-control"]).toContain("public");
     });
 
-    it("should return generic alternative mapping and nearest store information", async () => {
-        // Mock medicine lookup
-        ((supabase.from as jest.Mock)().maybeSingle as jest.Mock)
-            .mockResolvedValueOnce({
-                data: {
-                    id: "med-123",
-                    brand_name: "Lipitor",
-                    generic_name: "Atorvastatin 10mg",
-                    mrp: 120.0,
-                    jan_aushadhi_price: 15.0,
-                },
-                error: null,
-            })
-            // Mock alternative lookup
-            .mockResolvedValueOnce({
-                data: {
-                    brand_medicine_id: "med-123",
-                    generic_medicine_id: "gen-456",
-                    brand_name: "Lipitor",
-                    generic_name: "Atorvastatin 10mg (Generic)",
-                    brand_price: 120.0,
-                    jan_aushadhi_price: 15.0,
-                    savings_percentage: 88,
-                },
-                error: null,
-            });
+    it("returns null nearest_store without coordinates and skips pharmacy lookup", async () => {
+        mockAlternativeLookup();
 
-        // Mock nearest store RPC call
+        const res = await request(app).get("/api/v1/alternatives/Lipitor");
+
+        expect(res.status).toBe(200);
+        expect(res.body.nearest_store).toBeNull();
+        expect(supabase.rpc).not.toHaveBeenCalled();
+        expect(supabase.from).not.toHaveBeenCalledWith("pharmacies");
+    });
+
+    it("returns the nearest store from a successful coordinate lookup", async () => {
+        mockAlternativeLookup();
+
         (supabase.rpc as jest.Mock).mockResolvedValueOnce({
             data: [
                 {
                     name: "PMBJP Store 1",
-                    lat: 12.97,
-                    lng: 77.59,
-                    distance: 2.5,
+                    lat: "12.97",
+                    lng: "77.59",
+                    distance: "2.54",
                 },
             ],
             error: null,
@@ -81,6 +93,56 @@ describe("GET /api/v1/alternatives/:medicine_id", () => {
         expect(res.status).toBe(200);
         expect(res.body.brand_name).toBe("Lipitor");
         expect(res.body.savings_percentage).toBe(88);
-        expect(res.body.nearest_store.name).toBe("PMBJP Store 1");
+        expect(res.body.nearest_store).toEqual({
+            name: "PMBJP Store 1",
+            lat: 12.97,
+            lng: 77.59,
+            distance: "2.5 km",
+        });
+        expect(supabase.from).not.toHaveBeenCalledWith("pharmacies");
+    });
+
+    it("returns null nearest_store when the coordinate lookup is empty", async () => {
+        mockAlternativeLookup();
+        (supabase.rpc as jest.Mock).mockResolvedValueOnce({ data: [], error: null });
+
+        const res = await request(app)
+            .get("/api/v1/alternatives/Lipitor")
+            .query({ lat: 12.97, lng: 77.59 });
+
+        expect(res.status).toBe(200);
+        expect(res.body.nearest_store).toBeNull();
+        expect(supabase.from).not.toHaveBeenCalledWith("pharmacies");
+    });
+
+    it("preserves the alternative response when the coordinate lookup fails", async () => {
+        mockAlternativeLookup();
+        (supabase.rpc as jest.Mock).mockResolvedValueOnce({
+            data: null,
+            error: { message: "RPC unavailable" },
+        });
+
+        const res = await request(app)
+            .get("/api/v1/alternatives/Lipitor")
+            .query({ lat: 12.97, lng: 77.59 });
+
+        expect(res.status).toBe(200);
+        expect(res.body.brand_name).toBe("Lipitor");
+        expect(res.body.nearest_store).toBeNull();
+        expect(supabase.from).not.toHaveBeenCalledWith("pharmacies");
+    });
+
+    it("keeps the existing 404 response when no generic alternative exists", async () => {
+        ((supabase.from as jest.Mock)().maybeSingle as jest.Mock)
+            .mockResolvedValueOnce({ data: null, error: null })
+            .mockResolvedValueOnce({ data: null, error: null })
+            .mockResolvedValueOnce({ data: null, error: null });
+
+        const res = await request(app).get("/api/v1/alternatives/UnknownMedicine");
+
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe("No generic alternative found for this medicine");
+        expect(supabase.rpc).not.toHaveBeenCalled();
+        expect(supabase.from).not.toHaveBeenCalledWith("pharmacies");
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3779**
- **Summary:**
  - Removed the location-unaware pharmacy fallback from the alternatives endpoint.
  - `nearest_store` is now returned only when a valid coordinate-based lookup succeeds.
  - Preserved the generic alternative response when the nearest-pharmacy RPC returns no results or an error.
  - Added focused tests covering missing coordinates, successful lookups, empty RPC results, RPC failures, and the existing 404 behavior.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _This change affects the backend API only. Validation logs are provided below._

### Validation

```text
✓ Focused alternatives test suite: 6/6 passed
✓ API build / TypeScript compilation: passed
✓ Prettier check: passed
✓ git diff --check: passed
✓ Commit hook (formatting & circular dependency check): passed
✓ npm audit: 0 vulnerabilities

Broader API suite:
54 suites passed, 2 unrelated suites failed
568 tests passed, 12 failed, 1 skipped

Existing unrelated failures:
- pharmacies.test.ts
- ml.test.ts
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3779`)
- [x] I have pulled the latest `main` and resolved any conflicts.
- [x] I tested my changes locally.
- [x] I added or updated tests where necessary.
- [x] I did not modify unrelated files.