### PR TITLE
fix(ml): restore TLS verification in CDSCO alert agent

### DIFF
--- a/apps/ml/agent/cdsco_alert_agent.py
+++ b/apps/ml/agent/cdsco_alert_agent.py
@@ -106,9 +106,10 @@ def scrape_cdsco_alerts():
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
     }
     try:
-        # TLS verification enabled for security as requested by the review.
-        # If CDSCO presents a known CA issue, pin it explicitly.
-        response = requests.get(CDSCO_ALERTS_URL, headers=headers, verify=False, timeout=15)
+        # TLS verification stays on. Alerts scraped here are written to
+        # drug_alerts with the service role key and pushed to users, so an
+        # unverified connection lets a network attacker fabricate recalls.
+        response = requests.get(CDSCO_ALERTS_URL, headers=headers, timeout=15)
         response.raise_for_status()
     except requests.RequestException as e:
         logging.error(f"Failed to fetch CDSCO alerts page: {e}")
@@ -141,7 +142,7 @@ def process_alert_pdf(pdf_url: str):
     }
     try:
         logging.info(f"Downloading PDF (or wrapper): {pdf_url}")
-        response = requests.get(pdf_url, headers=headers, verify=False, timeout=30)
+        response = requests.get(pdf_url, headers=headers, timeout=30)
         response.raise_for_status()
         
         content = response.content
@@ -157,7 +158,7 @@ def process_alert_pdf(pdf_url: str):
                 real_pdf_url = urljoin(CDSCO_ALERTS_URL, real_pdf_path)
                 real_pdf_url = real_pdf_url.replace(" ", "%20")
                 logging.info(f"Downloading real PDF: {real_pdf_url}")
-                response = requests.get(real_pdf_url, headers=headers, verify=False, timeout=30)
+                response = requests.get(real_pdf_url, headers=headers, timeout=30)
                 response.raise_for_status()
                 content = response.content
     except requests.RequestException as e:


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3772**
- **Summary:**

The CDSCO alert agent passed `verify=False` on its network calls while a comment right above claimed "TLS verification enabled for security". That scraped data gets upserted into `drug_alerts` with the service role key and then pushed to users as government safety warnings, so an on-path attacker could serve fabricated recalls over an unverified connection and they'd land in front of users as legitimate alerts.

This removes `verify=False` from all three requests (the alerts page fetch and both PDF downloads) so certificates are validated normally, and rewrites the misleading comment to say what the code actually does and why it matters.

I didn't add certificate pinning: normal validation is the correct default, and the issue only calls for pinning "if needed". If CDSCO turns out to present a genuinely broken chain in production, the follow-up is to pin their cert explicitly with a documented reason rather than switching verification back off globally.

## 📸 Proof of Work (Screenshots / Logs)

Backend agent change, no UI. After the change there are no `verify=False` calls left and no now-dead `urllib3` warning suppression:

```
$ grep -n "verify=False" apps/ml/agent/cdsco_alert_agent.py
(no matches)

$ grep -n "disable_warnings\|InsecureRequestWarning\|urllib3" apps/ml/agent/cdsco_alert_agent.py
(no matches)
```

Diff is 3 lines changed across the three request calls plus the comment.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3772`)
- [x] I have pulled the latest `main` and resolved any conflicts
