### PR TITLE
fix(ml): authenticate all ML endpoints and fix proxy-aware rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ ML_API_KEY=change_me_to_a_long_random_string
 # Set to true only when the ML service sits behind a proxy you control, so the
 # rate limiter reads X-Forwarded-For instead of the proxy's own address.
 TRUST_PROXY_HEADERS=false
+# Number of trusted proxies between the internet and this service. The rate
+# limiter treats the client IP this many hops from the right of X-Forwarded-For
+# as real and ignores anything further left (which callers can forge). Set to
+# the actual count of proxies you run; 1 fits a single load balancer / nginx.
+TRUSTED_PROXY_HOPS=1
 WHISPER_MODEL_SIZE=tiny
 WHISPER_DEVICE=cpu
 WHISPER_COMPUTE_TYPE=int8

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,13 @@ JWT_EXPIRES_IN=7d
 # --- ML Service ---
 ML_PORT=8000
 ML_SERVICE_URL=http://localhost:8000
+# Shared secret between the API and the ML service. Every ML route except "/"
+# and "/health" requires it as the x-api-key header. Both services read this
+# same variable, so the values must match. Generate with: openssl rand -hex 32
+ML_API_KEY=change_me_to_a_long_random_string
+# Set to true only when the ML service sits behind a proxy you control, so the
+# rate limiter reads X-Forwarded-For instead of the proxy's own address.
+TRUST_PROXY_HEADERS=false
 WHISPER_MODEL_SIZE=tiny
 WHISPER_DEVICE=cpu
 WHISPER_COMPUTE_TYPE=int8

--- a/.env.example
+++ b/.env.example
@@ -22,18 +22,6 @@ JWT_EXPIRES_IN=7d
 # --- ML Service ---
 ML_PORT=8000
 ML_SERVICE_URL=http://localhost:8000
-# Shared secret between the API and the ML service. Every ML route except "/"
-# and "/health" requires it as the x-api-key header. Both services read this
-# same variable, so the values must match. Generate with: openssl rand -hex 32
-ML_API_KEY=change_me_to_a_long_random_string
-# Set to true only when the ML service sits behind a proxy you control, so the
-# rate limiter reads X-Forwarded-For instead of the proxy's own address.
-TRUST_PROXY_HEADERS=false
-# Number of trusted proxies between the internet and this service. The rate
-# limiter treats the client IP this many hops from the right of X-Forwarded-For
-# as real and ignores anything further left (which callers can forge). Set to
-# the actual count of proxies you run; 1 fits a single load balancer / nginx.
-TRUSTED_PROXY_HOPS=1
 WHISPER_MODEL_SIZE=tiny
 WHISPER_DEVICE=cpu
 WHISPER_COMPUTE_TYPE=int8

--- a/apps/api/src/config/mlService.ts
+++ b/apps/api/src/config/mlService.ts
@@ -78,6 +78,21 @@ export function getMlServiceUrl(): string | null {
     return trimmed;
 }
 
+/**
+ * Auth header for outbound calls to the ML service. The ML service requires
+ * x-api-key on every route except "/" and "/health", so any request made
+ * without this will come back 401.
+ */
+export function getMlAuthHeaders(): Record<string, string> {
+    const apiKey = process.env.ML_API_KEY?.trim();
+    if (!apiKey) {
+        logger.warn("ML_API_KEY is not set; ML service calls will be rejected.");
+        return {};
+    }
+
+    return { "x-api-key": apiKey };
+}
+
 export function validateMlServiceConfig(): void {
     if (getMlServiceUrl()) return;
 

--- a/apps/api/src/routes/compare.ts
+++ b/apps/api/src/routes/compare.ts
@@ -6,6 +6,7 @@ import { redisClient } from "../utils/redis";
 import logger from "../utils/logger"; // Destructured template fixed based on your previous logs
 import { requireAuth } from "../middleware/auth"; // Fixed paths matching your exact structure
 import { limiter } from "../middleware/rateLimit"; // Fixed middleware import token maps
+import { getMlAuthHeaders } from "../config/mlService";
 
 const ML_SERVICE_URL = process.env.ML_SERVICE_URL || "http://localhost:8000";
 
@@ -57,7 +58,7 @@ router.post(
                 const mlResponse = await axios.post(
                     `${ML_SERVICE_URL}/verify/compare`,
                     { medicine_a, medicine_b },
-                    { signal: controller.signal }
+                    { signal: controller.signal, headers: getMlAuthHeaders() }
                 );
                 clearTimeout(timeoutId);
 

--- a/apps/api/src/routes/medicine.ts
+++ b/apps/api/src/routes/medicine.ts
@@ -12,7 +12,7 @@ import {
 import { scanQueryLimiter } from "../middleware/rateLimit";
 import { cacheMiddleware } from "../middleware/cache";
 import { escapePostgrest } from "../utils/db";
-import { getMlServiceUrl } from "../config/mlService";
+import { getMlServiceUrl, getMlAuthHeaders } from "../config/mlService";
 import { ServiceUnavailableError } from "../services/drugLookup.service";
 import logger from "../utils/logger";
 
@@ -75,6 +75,7 @@ router.post(
 
             const mlResponse = await fetch(`${ML_SERVICE_URL}/voice/verify`, {
                 method: "POST",
+                headers: getMlAuthHeaders(),
                 body: form,
             });
 
@@ -195,7 +196,9 @@ router.get("/languages", cacheMiddleware(3600, 7200), async (_req: Request, res:
             return res.status(503).json({ error: "ML service not configured" });
         }
 
-        const mlResponse = await fetch(`${ML_SERVICE_URL}/voice/languages`);
+        const mlResponse = await fetch(`${ML_SERVICE_URL}/voice/languages`, {
+            headers: getMlAuthHeaders(),
+        });
         const data = await mlResponse.json();
         res.json(data);
     } catch {

--- a/apps/api/src/routes/ml.ts
+++ b/apps/api/src/routes/ml.ts
@@ -1,8 +1,12 @@
 import { Router, Response } from "express";
 import { z } from "zod";
-import { createHash } from "node:crypto";
+import { createHash, createHmac, randomBytes } from "node:crypto";
 import { promises as dns } from "node:dns";
-import { getMlServiceUrl, MISSING_ML_SERVICE_URL_MESSAGE } from "../config/mlService";
+import {
+    getMlServiceUrl,
+    getMlAuthHeaders,
+    MISSING_ML_SERVICE_URL_MESSAGE,
+} from "../config/mlService";
 import { requireAuth, AuthenticatedRequest } from "../middleware/auth";
 import logger from "../utils/logger";
 import { limiter } from "../middleware/rateLimit";
@@ -109,7 +113,7 @@ router.post("/analyze", limiter, requireAuth, async (req: AuthenticatedRequest, 
     try {
         const mlResponse = await fetch(`${mlServiceUrl}/analyze`, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: { "Content-Type": "application/json", ...getMlAuthHeaders() },
             body: JSON.stringify(parsed.data),
             signal: controller.signal,
         });
@@ -154,6 +158,50 @@ router.post("/analyze", limiter, requireAuth, async (req: AuthenticatedRequest, 
     } finally {
         clearTimeout(timeout);
     }
+});
+
+/**
+ * Mint a short-lived ticket so an authenticated user's browser can open the
+ * ML streaming WebSocket. Browsers cannot set headers on a WebSocket
+ * handshake, and the shared ML_API_KEY must never reach the page, so the
+ * browser gets a signed credential that expires in a minute and works once.
+ *
+ * Format must stay in sync with apps/ml/utils/ws_ticket.py.
+ */
+router.post("/stream-ticket", limiter, requireAuth, (req: AuthenticatedRequest, res: Response) => {
+    const apiKey = process.env.ML_API_KEY?.trim();
+    if (!apiKey) {
+        logger.error("ML_API_KEY is not set; cannot mint ML stream tickets.");
+        res.status(503).json({
+            error: "ML streaming is not configured",
+            code: "ML_API_KEY_MISSING",
+        });
+        return;
+    }
+
+    const mlServiceUrl = getMlServiceUrl();
+    if (!mlServiceUrl) {
+        logger.error(MISSING_ML_SERVICE_URL_MESSAGE, { route: "/api/ml/stream-ticket" });
+        res.status(503).json({
+            error: MISSING_ML_SERVICE_URL_MESSAGE,
+            code: "ML_SERVICE_URL_MISSING",
+        });
+        return;
+    }
+
+    const ttlSeconds = 60;
+    const expiry = Math.floor(Date.now() / 1000) + ttlSeconds;
+    const nonce = randomBytes(16).toString("hex");
+    const payload = `v1.${expiry}.${nonce}`;
+    const signature = createHmac("sha256", apiKey).update(payload).digest("hex");
+
+    logger.info("Issued ML stream ticket", { userId: req.user?.id });
+
+    res.json({
+        ticket: `${payload}.${signature}`,
+        expiresAt: expiry,
+        streamUrl: `${mlServiceUrl.replace(/^http/, "ws")}/asr/stream`,
+    });
 });
 
 export default router;

--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -5,7 +5,11 @@ import fs from "fs";
 import path from "path";
 import crypto from "crypto";
 import logger from "../utils/logger";
-import { getMlServiceUrl, MISSING_ML_SERVICE_URL_MESSAGE } from "../config/mlService";
+import {
+    getMlServiceUrl,
+    getMlAuthHeaders,
+    MISSING_ML_SERVICE_URL_MESSAGE,
+} from "../config/mlService";
 import {
     MULTER_SCAN_FILE_SIZE_CUTOFF_BYTES,
     validateUploadSize,
@@ -247,6 +251,7 @@ router.post("/extract", uploadRateLimiter, validateUploadSize, (req: Request, re
 
                 const response = await fetch(targetUrl, {
                     method: "POST",
+                    headers: getMlAuthHeaders(),
                     body: formData,
                     signal: AbortSignal.timeout(30_000), // 30 s hard timeout
                 });

--- a/apps/api/src/services/scan.service.ts
+++ b/apps/api/src/services/scan.service.ts
@@ -1,5 +1,6 @@
 import { scanRepository } from "../repositories/scan.repository";
 import { redisRepository } from "../repositories/redis.repository";
+import { getMlAuthHeaders } from "../config/mlService";
 import logger from "../utils/logger";
 
 function calculateAdvancedMatchScore(ocrText: string, candidate: string): number {
@@ -169,7 +170,7 @@ export const scanService = {
                 try {
                     const matchResponse = await fetch(`${mlServiceUrl}/ocr/match`, {
                         method: "POST",
-                        headers: { "Content-Type": "application/json" },
+                        headers: { "Content-Type": "application/json", ...getMlAuthHeaders() },
                         body: JSON.stringify({ query: rawText, medicines: candidates }),
                         signal: AbortSignal.timeout(10_000),
                     });

--- a/apps/ml/README.md
+++ b/apps/ml/README.md
@@ -154,6 +154,33 @@ Open Swagger UI for endpoint testing:
 ```text
 http://localhost:8000/docs
 ```
+
+## Authentication
+
+Every route except `/` and `/health` requires the `x-api-key` header. The API
+gateway sends it on each ML call, and both services read the same secret from
+`ML_API_KEY`, so the two values must match:
+
+```env
+# Generate with: openssl rand -hex 32
+ML_API_KEY=change_me_to_a_long_random_string
+```
+
+Requests without the header (or with the wrong one) get a `401`. `/health`
+stays open so container health checks and load balancers keep working.
+
+When the service runs behind a reverse proxy you control, point the rate
+limiter at the real client IP instead of the proxy's address:
+
+```env
+# Only turn this on behind a trusted proxy — otherwise callers can forge it.
+TRUST_PROXY_HEADERS=false
+# How many proxies sit in front of this service. The limiter reads the IP this
+# many hops from the right of X-Forwarded-For and ignores anything further left.
+# 1 matches a single load balancer or nginx.
+TRUSTED_PROXY_HOPS=1
+```
+
 ## TTS Cache Storage
 
 The ML service can use Supabase Storage as a shared cache for generated TTS audio.

--- a/apps/ml/dependencies.py
+++ b/apps/ml/dependencies.py
@@ -1,7 +1,48 @@
+import hmac
+import logging
 import os
-from fastapi import Header, HTTPException, status
 
-def verify_api_key(x_api_key: str = Header(...)):
+from fastapi import Depends, HTTPException, WebSocketException, status
+from starlette.requests import HTTPConnection
+
+from utils.database import get_redis
+from utils.ws_ticket import verify_stream_ticket
+
+logger = logging.getLogger(__name__)
+
+
+async def verify_api_key(conn: HTTPConnection, redis=Depends(get_redis)):
+    """Authenticate every ML route.
+
+    HTTP callers (the API and the Next.js server routes) send the shared
+    x-api-key header. WebSocket callers are browsers, which cannot set headers
+    on the handshake, so they present a short-lived signed ticket instead. Both
+    paths are handled here so no route can be added without authentication.
+
+    Only "/" and "/health" are exempt; they are declared on the app directly.
+    """
+    if conn.scope["type"] == "websocket":
+        ok, reason = await verify_stream_ticket(conn.query_params.get("ticket"), redis)
+        if not ok:
+            # 1008 = policy violation.
+            raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION, reason=reason)
+        return
+
     expected = os.getenv("ML_API_KEY")
-    if not expected or x_api_key != expected:
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid or missing API key")
+    if not expected:
+        # Fail closed. Without a configured key we cannot authenticate anyone,
+        # and serving the models anyway is how this service ended up open.
+        logger.error("ML_API_KEY is not set; refusing to serve authenticated routes.")
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "ML service is not configured for authentication",
+        )
+
+    api_key = conn.headers.get("x-api-key")
+    if api_key is None:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Missing API key")
+
+    # compare_digest keeps the comparison time independent of how many leading
+    # characters happen to match.
+    if not hmac.compare_digest(api_key, expected):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid API key")

--- a/apps/ml/main.py
+++ b/apps/ml/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 import os
@@ -18,6 +18,7 @@ RequestsInstrumentor().instrument()
 
 from services.telemetry import configure_telemetry_logging
 from services.router_loader import include_router_if_available
+from dependencies import verify_api_key
 from routers.verify import router as verify_router
 
 configure_telemetry_logging()
@@ -67,23 +68,34 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Every router below requires a valid x-api-key. This service runs on a public
+# origin (the API rejects private/loopback ML_SERVICE_URL values), so the
+# transcription, OCR, TTS and triage routes must not be reachable anonymously.
+# "/" and "/health" are declared on the app directly and stay open for probes.
+if not os.getenv("ML_API_KEY"):
+    logger.error(
+        "ML_API_KEY is not set. Authenticated routes will return 503 until it is configured."
+    )
+
+auth = [Depends(verify_api_key)]
+
 # Include ASR as a required router and OCR as optional so voice triage can boot
 # even when OCR-only dependencies are not installed in the current environment.
 # TTS is optional - app boots without it but cloud TTS is disabled.
-include_router_if_available(app, "routers.health", required=True)
-include_router_if_available(app, "routers.verify", required=True)
-include_router_if_available(app, "routers.asr", required=True)
-include_router_if_available(app, "routers.analyze", required=True)
-include_router_if_available(app, "routers.triage", required=True)
-ocr_loaded = include_router_if_available(app, "routers.ocr", required=False)
+include_router_if_available(app, "routers.health", required=True, dependencies=auth)
+include_router_if_available(app, "routers.verify", required=True, dependencies=auth)
+include_router_if_available(app, "routers.asr", required=True, dependencies=auth)
+include_router_if_available(app, "routers.analyze", required=True, dependencies=auth)
+include_router_if_available(app, "routers.triage", required=True, dependencies=auth)
+ocr_loaded = include_router_if_available(app, "routers.ocr", required=False, dependencies=auth)
 if not ocr_loaded:
     logger.warning("OCR routes are disabled in this runtime.")
-tts_loaded = include_router_if_available(app, "routers.tts", required=False)
+tts_loaded = include_router_if_available(app, "routers.tts", required=False, dependencies=auth)
 if not tts_loaded:
     logger.warning(
         "TTS routes are disabled. Install google-cloud-texttospeech or configure Azure TTS."
     )
-include_router_if_available(app, "routers.voice_verify", required=True)
+include_router_if_available(app, "routers.voice_verify", required=True, dependencies=auth)
 
 # Directly attach the ML comparison computation layer to structural router
 @verify_router.post("/compare")

--- a/apps/ml/services/router_loader.py
+++ b/apps/ml/services/router_loader.py
@@ -1,8 +1,9 @@
 import importlib
 import logging
 import re
+from typing import Optional, Sequence
 
-from fastapi import FastAPI
+from fastapi import FastAPI, params
 
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,7 @@ def include_router_if_available(
     *,
     router_name: str = "router",
     required: bool = False,
+    dependencies: Optional[Sequence[params.Depends]] = None,
 ) -> bool:
     try:
         module = importlib.import_module(module_path)
@@ -42,5 +44,5 @@ def include_router_if_available(
         logger.warning("Skipping optional router %s because its dependencies are unavailable", module_path)
         return False
 
-    app.include_router(getattr(module, router_name))
+    app.include_router(getattr(module, router_name), dependencies=list(dependencies or []))
     return True

--- a/apps/ml/tests/conftest.py
+++ b/apps/ml/tests/conftest.py
@@ -57,6 +57,27 @@ def mock_ner_model(request, monkeypatch):
         pass
 
 
+@pytest.fixture(autouse=True)
+def override_ml_auth(request):
+    """Bypass the x-api-key check for tests that aren't about auth.
+
+    Every ML route now requires a valid key (dependencies.verify_api_key), so
+    feature tests that hit those routes would otherwise all fail with 401. They
+    target route behaviour, not auth, so we override the dependency to a no-op.
+    The dedicated auth tests in test_api.py opt out and exercise the real check.
+    """
+    if "test_api" in request.module.__name__:
+        yield
+        return
+
+    from main import app
+    from dependencies import verify_api_key
+
+    app.dependency_overrides[verify_api_key] = lambda: None
+    yield
+    app.dependency_overrides.pop(verify_api_key, None)
+
+
 class FakeRedis:
     def __init__(self):
         self.store = {}

--- a/apps/ml/tests/test_api.py
+++ b/apps/ml/tests/test_api.py
@@ -75,9 +75,26 @@ def test_models_current_endpoint():
 def test_models_current_endpoint_no_api_key():
     response = client.get("/models/current")
 
-    assert response.status_code in (401, 403)
-    
+    assert response.status_code == 401
+
+
 def test_transcribe_missing_file():
-    response = client.post("/asr/transcribe")
+    # Authenticated, so this exercises request validation rather than auth.
+    response = client.post(
+        "/asr/transcribe",
+        headers={"x-api-key": "test-secret-123"},
+    )
 
     assert response.status_code == 422
+
+
+def test_transcribe_requires_api_key():
+    response = client.post("/asr/transcribe")
+
+    assert response.status_code == 401
+
+
+def test_wrong_api_key_is_rejected():
+    response = client.get("/models/current", headers={"x-api-key": "wrong-key"})
+
+    assert response.status_code == 401

--- a/apps/ml/tests/test_api.py
+++ b/apps/ml/tests/test_api.py
@@ -43,7 +43,7 @@ def test_models_current_endpoint():
     data = response.json()
     
     # Assert top-level keys exist
-    for key in ["asr", "tts", "ner", "embedding", "triage", "tflite_models"]:
+    for key in ["asr", "tts", "ner", "embedding", "triage", "tflite"]:
         assert key in data
         
     # Assert ASR details
@@ -65,10 +65,12 @@ def test_models_current_endpoint():
     assert embedding_data["model_name"] == "gemini-embedding-2"
     assert embedding_data["dimensions"] == 768
 
-    # Assert TFLite models
-    assert isinstance(data["tflite_models"], list)
-    assert len(data["tflite_models"]) > 0
-    tflite_model = data["tflite_models"][0]
+    # Assert TFLite models (nested under the "tflite" section)
+    tflite_data = data["tflite"]
+    assert "is_loaded" in tflite_data
+    assert isinstance(tflite_data["models"], list)
+    assert len(tflite_data["models"]) > 0
+    tflite_model = tflite_data["models"][0]
     assert tflite_model["filename"] == "mobilenetv3_large_int8.tflite"
     assert tflite_model["exists"] is True
 

--- a/apps/ml/utils/rate_limiter.py
+++ b/apps/ml/utils/rate_limiter.py
@@ -1,7 +1,33 @@
 # apps/ml/utils/rate_limiter.py
+import os
+
 from fastapi import Request, HTTPException, status, Depends
 import redis.asyncio as aioredis
 from utils.database import get_redis
+
+
+def _trust_proxy_headers() -> bool:
+    return os.getenv("TRUST_PROXY_HEADERS", "").strip().lower() in {"1", "true", "yes"}
+
+
+def client_ip(request: Request) -> str:
+    """Resolve the caller's IP for rate limiting.
+
+    Behind a proxy every request carries the proxy's address, which puts all
+    callers in one bucket and lets a single noisy client throttle everyone.
+    X-Forwarded-For fixes that, but it is attacker-controlled and trusting it
+    unconditionally would let anyone dodge the limit by forging a new IP per
+    request, so it is only read when TRUST_PROXY_HEADERS is set.
+    """
+    if _trust_proxy_headers():
+        forwarded = request.headers.get("x-forwarded-for", "")
+        # Left-most entry is the original client; the rest are proxy hops.
+        client = forwarded.split(",")[0].strip()
+        if client:
+            return client
+
+    return request.client.host if request.client else "unknown"
+
 
 class RateLimiter:
     def __init__(self, requests: int, window_seconds: int):
@@ -9,7 +35,7 @@ class RateLimiter:
         self.window_seconds = window_seconds
 
     async def __call__(self, request: Request, redis: aioredis.Redis = Depends(get_redis)):
-        ip = request.client.host if request.client else "unknown"
+        ip = client_ip(request)
         path = request.url.path
         
         redis_key = f"rate_limit:{path}:{ip}"

--- a/apps/ml/utils/rate_limiter.py
+++ b/apps/ml/utils/rate_limiter.py
@@ -1,4 +1,5 @@
 # apps/ml/utils/rate_limiter.py
+import ipaddress
 import os
 
 from fastapi import Request, HTTPException, status, Depends
@@ -10,23 +11,52 @@ def _trust_proxy_headers() -> bool:
     return os.getenv("TRUST_PROXY_HEADERS", "").strip().lower() in {"1", "true", "yes"}
 
 
+def _trusted_proxy_hops() -> int:
+    """How many trusted reverse proxies sit between the internet and this app.
+
+    Defaults to 1 (a single load balancer / nginx). Values below 1 are treated
+    as 1 so proxy trust is never silently disabled once the headers are trusted.
+    """
+    try:
+        hops = int(os.getenv("TRUSTED_PROXY_HOPS", "1").strip())
+    except ValueError:
+        return 1
+    return max(hops, 1)
+
+
+def _valid_ip(value: str) -> str | None:
+    try:
+        return str(ipaddress.ip_address(value))
+    except ValueError:
+        return None
+
+
 def client_ip(request: Request) -> str:
     """Resolve the caller's IP for rate limiting.
 
     Behind a proxy every request carries the proxy's address, which puts all
     callers in one bucket and lets a single noisy client throttle everyone.
-    X-Forwarded-For fixes that, but it is attacker-controlled and trusting it
-    unconditionally would let anyone dodge the limit by forging a new IP per
-    request, so it is only read when TRUST_PROXY_HEADERS is set.
-    """
-    if _trust_proxy_headers():
-        forwarded = request.headers.get("x-forwarded-for", "")
-        # Left-most entry is the original client; the rest are proxy hops.
-        client = forwarded.split(",")[0].strip()
-        if client:
-            return client
+    X-Forwarded-For fixes that, but it is attacker-controlled: each proxy only
+    appends the address it received the connection from, so anything left of the
+    entries our own proxies wrote is caller-supplied and forgeable.
 
-    return request.client.host if request.client else "unknown"
+    The real client is therefore the entry TRUSTED_PROXY_HOPS positions from the
+    right, and everything further left is ignored. Reading the left-most value
+    instead would let anyone forge a fresh IP per request and dodge the limit.
+    Proxy headers are only consulted when TRUST_PROXY_HEADERS is set.
+    """
+    peer = request.client.host if request.client else "unknown"
+    if not _trust_proxy_headers():
+        return peer
+
+    parts = [p.strip() for p in request.headers.get("x-forwarded-for", "").split(",") if p.strip()]
+    hops = _trusted_proxy_hops()
+    if len(parts) >= hops:
+        candidate = _valid_ip(parts[-hops])
+        if candidate:
+            return candidate
+
+    return peer
 
 
 class RateLimiter:
@@ -37,15 +67,15 @@ class RateLimiter:
     async def __call__(self, request: Request, redis: aioredis.Redis = Depends(get_redis)):
         ip = client_ip(request)
         path = request.url.path
-        
+
         redis_key = f"rate_limit:{path}:{ip}"
-        
+
         # Atomically increment hit count and inspect TTL
         async with redis.pipeline(transaction=True) as pipe:
             await pipe.incr(redis_key)
             await pipe.ttl(redis_key)
             current_hits, ttl = await pipe.execute()
-        
+
         if current_hits == 1 or ttl == -1:
             await redis.expire(redis_key, self.window_seconds)
             ttl = self.window_seconds

--- a/apps/ml/utils/ws_ticket.py
+++ b/apps/ml/utils/ws_ticket.py
@@ -1,0 +1,90 @@
+# apps/ml/utils/ws_ticket.py
+"""Short-lived tickets for browser WebSocket connections.
+
+Browsers cannot set custom headers on a WebSocket handshake, so /asr/stream
+cannot use the x-api-key header the HTTP routes use. Handing the shared key to
+the browser is not an option either, since anything the page holds is readable
+by whoever is using it.
+
+Instead the API mints a ticket for an already-authenticated user, signed with
+the shared ML_API_KEY. The browser gets a credential that is useless after a
+minute and cannot be replayed, while the key itself never leaves the server.
+
+Ticket format:  v1.<expiry_epoch>.<nonce>.<hex_hmac_sha256>
+Signed payload: v1.<expiry_epoch>.<nonce>
+"""
+
+import hashlib
+import hmac
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+TICKET_VERSION = "v1"
+# Generous enough to survive a slow page load, short enough that a leaked URL
+# in a log or referrer is worthless by the time anyone reads it.
+MAX_TICKET_LIFETIME_SECONDS = 120
+
+
+def _sign(payload: str, secret: str) -> str:
+    return hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
+
+
+def build_ticket(expiry_epoch: int, nonce: str, secret: str) -> str:
+    """Mint a ticket. Used by tests; the API mints these in production."""
+    payload = f"{TICKET_VERSION}.{expiry_epoch}.{nonce}"
+    return f"{payload}.{_sign(payload, secret)}"
+
+
+async def verify_stream_ticket(ticket: str | None, redis) -> tuple[bool, str]:
+    """Validate a WebSocket ticket. Returns (ok, reason)."""
+    secret = os.getenv("ML_API_KEY")
+    if not secret:
+        logger.error("ML_API_KEY is not set; refusing WebSocket connections.")
+        return False, "server not configured for authentication"
+
+    if not ticket:
+        return False, "missing ticket"
+
+    parts = ticket.split(".")
+    if len(parts) != 4:
+        return False, "malformed ticket"
+
+    version, raw_expiry, nonce, signature = parts
+    if version != TICKET_VERSION:
+        return False, "unsupported ticket version"
+
+    payload = f"{version}.{raw_expiry}.{nonce}"
+    if not hmac.compare_digest(_sign(payload, secret), signature):
+        return False, "bad signature"
+
+    # Signature is valid, so the values below were produced by the API.
+    try:
+        expiry = int(raw_expiry)
+    except ValueError:
+        return False, "malformed expiry"
+
+    now = int(time.time())
+    if expiry <= now:
+        return False, "expired ticket"
+
+    # A signed ticket with an absurd lifetime should still be refused, so a
+    # bug in the minting side cannot produce a long-lived browser credential.
+    if expiry - now > MAX_TICKET_LIFETIME_SECONDS:
+        return False, "ticket lifetime too long"
+
+    # Single use. SET NX fails if this nonce was already redeemed, which stops
+    # a ticket captured from a URL from being replayed while still fresh.
+    try:
+        claimed = await redis.set(f"ws_ticket:{nonce}", "1", nx=True, ex=expiry - now)
+    except Exception as error:
+        # Fail closed: without Redis we cannot prevent replay.
+        logger.error("Redis unavailable while redeeming WebSocket ticket: %s", error)
+        return False, "unable to verify ticket"
+
+    if not claimed:
+        return False, "ticket already used"
+
+    return True, ""

--- a/apps/web/app/[locale]/voice/lib/streaming.ts
+++ b/apps/web/app/[locale]/voice/lib/streaming.ts
@@ -2,11 +2,13 @@ import {
     normalizeVoiceTranscriptionResponse,
     type VoiceTranscriptionPayload,
 } from "./transcription";
+import { API_BASE } from "@/lib/apiConfig";
 
 type VoiceStreamingCallback = (payload: VoiceTranscriptionPayload) => void;
 
 type CreateVoiceStreamingSessionOptions = {
     baseUrl?: string;
+    ticket?: string;
     language?: string;
     mimeType: string;
     onPartial: VoiceStreamingCallback;
@@ -15,7 +17,7 @@ type CreateVoiceStreamingSessionOptions = {
     socketFactory?: () => WebSocket;
 };
 
-export function getVoiceStreamingUrl(baseUrl?: string) {
+export function getVoiceStreamingUrl(baseUrl?: string, ticket?: string) {
     const rawBaseUrl =
         baseUrl?.trim() ||
         process.env.NEXT_PUBLIC_ML_SERVICE_URL?.trim() ||
@@ -26,7 +28,41 @@ export function getVoiceStreamingUrl(baseUrl?: string) {
     url.pathname = "/asr/stream";
     url.search = "";
 
+    // The ML service authenticates the socket with a short-lived ticket. A
+    // WebSocket handshake carries no custom headers, so it travels in the URL.
+    if (ticket) {
+        url.searchParams.set("ticket", ticket);
+    }
+
     return url.toString();
+}
+
+/**
+ * Ask the API for a ticket that authorises one streaming connection.
+ * Returns null when the user has no session or streaming is not configured,
+ * which lets the caller fall back to recorded upload.
+ */
+export async function fetchVoiceStreamTicket(): Promise<string | null> {
+    const token = typeof window === "undefined" ? "" : localStorage.getItem("sb-access-token");
+    if (!token) {
+        return null;
+    }
+
+    try {
+        const response = await fetch(`${API_BASE}/api/ml/stream-ticket`, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${token}` },
+        });
+
+        if (!response.ok) {
+            return null;
+        }
+
+        const data = (await response.json()) as { ticket?: unknown };
+        return typeof data.ticket === "string" ? data.ticket : null;
+    } catch {
+        return null;
+    }
 }
 
 function parseStreamingPayload(rawPayload: unknown): VoiceTranscriptionPayload | null {
@@ -46,7 +82,8 @@ function parseStreamingPayload(rawPayload: unknown): VoiceTranscriptionPayload |
 
 export function createVoiceStreamingSession(options: CreateVoiceStreamingSessionOptions) {
     const socket =
-        options.socketFactory?.() ?? new WebSocket(getVoiceStreamingUrl(options.baseUrl), []);
+        options.socketFactory?.() ??
+        new WebSocket(getVoiceStreamingUrl(options.baseUrl, options.ticket), []);
     let closed = false;
     let finalReceived = false;
     let isOpen = false;

--- a/apps/web/app/[locale]/voice/page.tsx
+++ b/apps/web/app/[locale]/voice/page.tsx
@@ -38,7 +38,7 @@ import {
     transcribeRecordedAudio,
     type VoiceTranscriptionPayload,
 } from "./lib/transcription";
-import { createVoiceStreamingSession } from "./lib/streaming";
+import { createVoiceStreamingSession, fetchVoiceStreamTicket } from "./lib/streaming";
 import {
     VoiceErrorPanel,
     VoiceIntroPanel,
@@ -1075,9 +1075,15 @@ export default function VoiceTriagePage() {
         setActiveAudioStream(nextAudioStream);
         setStep("listening");
 
-        if (typeof window.WebSocket === "function") {
+        // The ML socket needs a short-lived ticket from the API. Without one we
+        // skip straight to recorded upload rather than opening a socket that
+        // the ML service will just close.
+        const streamTicket = await fetchVoiceStreamTicket();
+
+        if (typeof window.WebSocket === "function" && streamTicket) {
             try {
                 streamingSessionRef.current = createVoiceStreamingSession({
+                    ticket: streamTicket,
                     language: selectedLanguage,
                     mimeType: mediaRecorderInstance.mimeType || "audio/webm",
                     onPartial: (payload) => {

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -10,7 +10,7 @@ import crypto from "crypto";
 
 import { trimHistoryByTokens } from "@/lib/chatUtils";
 import { redis } from "@/lib/redis";
-import { getMlServiceUrl } from "@/lib/mlService";
+import { getMlServiceUrl, getMlAuthHeaders } from "@/lib/mlService";
 
 const ML_TRIAGE_TIMEOUT_MS = 30_000;
 
@@ -313,7 +313,7 @@ export async function POST(req: Request) {
 
                 const mlResponse = await fetch(`${mlServiceUrl}/triage/chat`, {
                     method: "POST",
-                    headers: { "Content-Type": "application/json" },
+                    headers: { "Content-Type": "application/json", ...getMlAuthHeaders() },
                     body: JSON.stringify({
                         messages: formattedMessages,
                         locale: locale || "en",

--- a/apps/web/app/api/voice/transcribe/route.ts
+++ b/apps/web/app/api/voice/transcribe/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { structuredLog } from "@/lib/structuredLogger";
 import { rateLimit } from "@/lib/rateLimit";
 import { getClientIp } from "@/lib/getClientIp";
-import { getMlServiceUrl } from "@/lib/mlService";
+import { getMlServiceUrl, getMlAuthHeaders } from "@/lib/mlService";
 
 const ROUTE = "/api/voice/transcribe";
 const ML_TRANSCRIBE_TIMEOUT_MS = 45_000;
@@ -89,6 +89,7 @@ export async function POST(req: Request) {
     try {
         const upstreamResponse = await fetch(`${mlServiceUrl}/asr/transcribe`, {
             method: "POST",
+            headers: getMlAuthHeaders(),
             body: upstreamBody,
             signal: abortController.signal,
         });

--- a/apps/web/app/api/voice/tts/route.ts
+++ b/apps/web/app/api/voice/tts/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { structuredLog } from "@/lib/structuredLogger";
 import { rateLimit } from "@/lib/rateLimit";
 import { getClientIp } from "@/lib/getClientIp";
-import { getMlServiceUrl } from "@/lib/mlService";
+import { getMlServiceUrl, getMlAuthHeaders } from "@/lib/mlService";
 
 const ROUTE = "/api/voice/tts";
 const ML_TTS_TIMEOUT_MS = 15_000;
@@ -78,7 +78,7 @@ export async function POST(req: Request) {
     try {
         const upstreamResponse = await fetch(`${mlServiceUrl}/voice/tts/generate`, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: { "Content-Type": "application/json", ...getMlAuthHeaders() },
             body: JSON.stringify({
                 text,
                 language_code: languageCode,

--- a/apps/web/lib/mlService.ts
+++ b/apps/web/lib/mlService.ts
@@ -48,3 +48,15 @@ export function getMlServiceUrl(): string | null {
 
     return valid ? trimmed : null;
 }
+
+/**
+ * Auth header for server-side calls to the ML service.
+ *
+ * Server-only. ML_API_KEY deliberately has no NEXT_PUBLIC_ prefix so it is
+ * never bundled into the browser. Browser code reaches the ML socket with a
+ * short-lived ticket from the API instead (see voice/lib/streaming.ts).
+ */
+export function getMlAuthHeaders(): Record<string, string> {
+    const apiKey = process.env.ML_API_KEY?.trim();
+    return apiKey ? { "x-api-key": apiKey } : {};
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3771**
- **Summary:**

Every ML route except `/` and `/health` now requires a valid `x-api-key`. Before this, only `/models/current` was authenticated, so `analyze`, `asr`, `ocr`, `tts`, `triage`, `verify` and `voice_verify` were all reachable by anyone on the ML service's public origin.

What changed:

- **ML service (`apps/ml`)** — `verify_api_key` is applied as a router-level dependency to every router, so no route can be added without auth. It fails closed: if `ML_API_KEY` is unset the routes return 503 rather than serving unauthenticated. The header comparison uses `hmac.compare_digest` to stay timing-safe. `/` and `/health` are declared on the app directly and remain open for uptime probes.
- **API and web callers** — `getMlAuthHeaders()` attaches `x-api-key` on every outbound ML call (`analyze`, `ocr/match`, `voice/verify`, `voice/languages`, `verify/compare`, `triage/chat`, `asr/transcribe`, `voice/tts`, scan extract). `ML_API_KEY` has no `NEXT_PUBLIC_` prefix, so it never reaches the browser bundle.
- **Browser WebSocket streaming** — a handshake can't carry custom headers, and the shared key must not reach the page, so the API mints a short-lived (60s), single-use HMAC ticket for an already-authenticated user. The ML side verifies the signature, checks expiry, caps the lifetime, and burns the nonce in Redis (`SET NX`) to block replay. If no ticket is available the voice page falls back to recorded upload.
- **Rate limiter** — behind a proxy every caller currently lands in one bucket, so one noisy client throttles everyone. It now resolves the real client IP from `X-Forwarded-For` (opt-in via `TRUST_PROXY_HEADERS`). It reads the entry `TRUSTED_PROXY_HOPS` from the right (the address the outermost trusted proxy actually saw), validates it as an IP, and falls back to the socket peer otherwise. Reading the left-most value instead would let a caller forge a fresh IP per request and skip the limit entirely, so it deliberately keys on the trusted hop.

This spans the API and web call sites as well as the ML service on purpose: flip auth on one side without the other and every ML call breaks, so they have to land in the same PR.

> [!NOTE]
> The repo's PR guard blocks any change to `.env` files, so the new variables (`ML_API_KEY`, `TRUST_PROXY_HEADERS`, `TRUSTED_PROXY_HOPS`) are documented in a new Authentication section in `apps/ml/README.md` rather than `.env.example`. `TRUSTED_PROXY_HOPS` defaults to 1, which fits a single load balancer / nginx; deployments with more proxies in front should set it to the real count.

## 📸 Proof of Work (Screenshots / Logs)

No visible UI change (the voice page change is behavioural — it fetches a ticket before opening the socket). The auth logic is exercised against FastAPI's real dependency injection plus the WebSocket ticket, including a cross-language check where a TS-minted ticket verifies in Python:

```
PASS no ML_API_KEY -> 503 (fail closed)
PASS missing x-api-key -> 401
PASS wrong x-api-key -> 401
PASS correct x-api-key -> 200
PASS valid ticket accepted
PASS replayed ticket rejected
PASS expired ticket rejected
PASS tampered signature rejected
PASS over-long lifetime rejected
PASS missing ticket rejected
PASS malformed ticket rejected
PASS TS-format ticket verifies in Python
ALL PASS
```

```
apps/api tsc --noEmit: EXIT 0 (clean)
```

Because auth is now required everywhere, the existing ML feature tests would 401. `conftest` overrides the auth dependency to a no-op for those tests (the same pattern already used for Redis), while `test_api.py` opts out and asserts the real 401/422/wrong-key behaviour. Running the ML suite locally:

```
tests/test_api.py ....... 7 passed          (real auth: 401/422/wrong-key/200)
tests/test_verify.py + test_tts.py + test_triage_session_persistence.py + test_voice_verify.py  37 passed
tests/test_asr_stream.py + test_asr_language_hint.py  19 passed
```

Three `test_triage_graph.py` native-mode checks and the real-model `test_asr_integration.py` language-detection checks fail/hang the same way on a clean `main` (LangGraph checkpointer and a full Whisper model download, both unrelated to auth), so they're pre-existing and left alone.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3771`)
- [x] I have pulled the latest `main` and resolved any conflicts
