### PR TITLE
fix(etl): add fallback pagination for CDSCO scraper

### DIFF
--- a/apps/etl/src/scrapers/cdsco.py
+++ b/apps/etl/src/scrapers/cdsco.py
@@ -140,6 +140,45 @@ class CDSCOScraper:
             raise parse_err
 
         return self._validate_records(data.get("aaData", []), page_num)
+    
+    def _fetch_sequential_until_empty(self, page_size: int) -> Path:
+        """
+        Fallback pagination strategy used when the API doesn't return a
+        reliable total-record count. Fetches pages one at a time until
+        an empty page is returned (robust exit condition).
+        """
+        all_records = []
+        page_num = 1
+        display_start = 0
+
+        while True:
+            records = self._fetch_single_page(page_num, display_start, page_size)
+
+            if not records:
+                logger.info(f"[CDSCO] Empty page {page_num} received — stopping pagination.")
+                break
+
+            all_records.extend(records)
+
+            # Exit early if the API returned fewer records than requested —
+            # a strong signal that we've reached the last page.
+            if len(records) < page_size:
+                logger.info(
+                    f"[CDSCO] Page {page_num} returned {len(records)} < {page_size} records — "
+                    "reached the last page."
+                )
+                break
+
+            page_num += 1
+            display_start += page_size
+
+        logger.info(f"[CDSCO] Sequential pagination completed. Total records fetched: {len(all_records)}")
+
+        SEEDS_DIR.mkdir(parents=True, exist_ok=True)
+        df = pd.DataFrame(all_records)
+        df.to_csv(REFERENCE_CSV, index=False)
+        logger.info(f"[CDSCO] Saved to {REFERENCE_CSV}")
+        return REFERENCE_CSV
 
     def fetch_and_save(self, force: bool = False) -> Path:
         """
@@ -176,7 +215,11 @@ class CDSCOScraper:
             total_records = probe_data.get("iTotalDisplayRecords") or probe_data.get("iTotalRecords") or 0
             
             if total_records == 0:
-                raise ValueError("Could not extract a valid total record count from CDSCO API metadata metadata fields.")
+                logger.warning(
+                    "[CDSCO] Could not extract a valid total record count from API metadata. "
+                    "Falling back to sequential fetch-until-empty mode."
+                )
+                return self._fetch_sequential_until_empty(page_size)
 
             # Step 2: Dynamically calculate exact max pages needed
             max_pages = math.ceil(total_records / page_size)


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3684**
- **Summary:**
  - Added a sequential pagination fallback when the CDSCO API does not return a valid total record count.
  - Implemented a robust exit condition that stops pagination on empty or partial pages.
  - Preserved the existing parallel pagination flow while improving scraper reliability for incomplete API metadata.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Tested locally

- ✅ Existing metadata-based pagination continues to work.
- ✅ Sequential fallback is triggered when pagination metadata is unavailable.
- ✅ Pagination stops correctly on empty pages.
- ✅ Pagination stops correctly when the last page returns fewer records than the page size.
- ✅ Scraped records are aggregated and saved to the reference CSV successfully.

*(Attach terminal logs or screenshots here.)*

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3684`)
- [x] I have pulled the latest `main` and resolved any conflicts