### PR TITLE
fix(stats): count scans with service-role client

### DIFF
--- a/apps/web/app/api/stats/route.ts
+++ b/apps/web/app/api/stats/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
+import { createServiceRoleSupabaseClient } from "@/lib/rateLimitMetrics";
 
 export const revalidate = 60; // Cache for 1 minute (was 3600)
 
 export async function GET() {
     try {
+        const serviceRoleSupabase = createServiceRoleSupabaseClient();
         const [bannedRes, recalledRes, counterfeitRes, nsqRes, scansRes, pharmaciesRes] =
             await Promise.all([
                 supabase
@@ -23,7 +25,9 @@ export async function GET() {
                     .from("drug_alerts")
                     .select("*", { count: "exact", head: true })
                     .eq("alert_type", "NSQ"),
-                supabase.from("scan_history").select("*", { count: "exact", head: true }),
+                serviceRoleSupabase
+                    .from("scan_history")
+                    .select("*", { count: "exact", head: true }),
                 supabase
                     .from("pharmacies")
                     .select("*", { count: "exact", head: true })

--- a/apps/web/lib/rateLimitMetrics.ts
+++ b/apps/web/lib/rateLimitMetrics.ts
@@ -46,7 +46,7 @@ export function createServiceRoleSupabaseClient() {
     const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
     if (!serviceRoleKey) {
-        throw new Error("SUPABASE_SERVICE_ROLE_KEY is required for rate-limit metrics writes.");
+        throw new Error("SUPABASE_SERVICE_ROLE_KEY is required for privileged server operations.");
     }
 
     return createClient(getSupabaseUrl(), serviceRoleKey, {

--- a/apps/web/tests/stats-route.test.ts
+++ b/apps/web/tests/stats-route.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, jest, beforeEach } from "@jest/globals";
-import { GET } from "../app/api/stats/route";
 
-// Setup mocks for supabase
-const mockEq = jest.fn();
-const mockSelect = jest.fn();
 const mockFrom = jest.fn();
+const mockServiceRoleFrom = jest.fn();
+const mockCreateServiceRoleSupabaseClient = jest.fn(() => ({
+    from: mockServiceRoleFrom,
+}));
 
 jest.mock("@/lib/supabase", () => ({
     supabase: {
@@ -12,60 +12,70 @@ jest.mock("@/lib/supabase", () => ({
     },
 }));
 
+jest.mock("@/lib/rateLimitMetrics", () => ({
+    createServiceRoleSupabaseClient: mockCreateServiceRoleSupabaseClient,
+}));
+
+import { GET } from "../app/api/stats/route";
+
+type CountResult = {
+    count: number | null;
+    error: Error | null;
+};
+
+const alertCounts: Record<string, number> = {
+    Banned: 10,
+    Recalled: 15,
+    Spurious: 5,
+    NSQ: 20,
+};
+
+function arrangePublicStatsQueries() {
+    mockFrom.mockImplementation((table: string) => {
+        if (table === "drug_alerts") {
+            return {
+                select: jest.fn(() => ({
+                    eq: jest.fn((_column: string, value: string) =>
+                        Promise.resolve({
+                            count: alertCounts[value] ?? 0,
+                            error: null,
+                        })
+                    ),
+                })),
+            };
+        }
+
+        if (table === "pharmacies") {
+            return {
+                select: jest.fn(() => ({
+                    eq: jest.fn(() => Promise.resolve({ count: 50, error: null })),
+                })),
+            };
+        }
+
+        throw new Error(`Unexpected anonymous table query: ${table}`);
+    });
+}
+
+function arrangeScanCount(result: CountResult) {
+    const select = jest.fn(() => Promise.resolve(result));
+    mockServiceRoleFrom.mockImplementation((table: string) => {
+        if (table !== "scan_history") {
+            throw new Error(`Unexpected service-role table query: ${table}`);
+        }
+        return { select };
+    });
+    return select;
+}
+
 describe("GET /api/stats", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        arrangePublicStatsQueries();
     });
 
-    it("returns correct count statistics when supabase queries succeed", async () => {
-        // Setup mock implementations for the chain
-        mockFrom.mockImplementation((table: string) => {
-            if (table === "drug_alerts") {
-                return {
-                    select: jest.fn().mockImplementation(() => {
-                        return {
-                            eq: jest.fn().mockImplementation((col: string, val: string) => {
-                                let countVal = 0;
-                                if (val === "banned") countVal = 10;
-                                else if (val === "recalled") countVal = 15;
-                                else if (val === "counterfeit") countVal = 5;
-                                else if (val === "nsq") countVal = 20;
-
-                                return Promise.resolve({
-                                    count: countVal,
-                                    error: null,
-                                });
-                            }),
-                        };
-                    }),
-                };
-            }
-            if (table === "scan_history") {
-                return {
-                    select: jest.fn().mockImplementation(() => {
-                        return Promise.resolve({
-                            count: 100,
-                            error: null,
-                        });
-                    }),
-                };
-            }
-            if (table === "pharmacies") {
-                return {
-                    select: jest.fn().mockImplementation(() => {
-                        return {
-                            eq: jest.fn().mockImplementation((col: string, val: boolean) => {
-                                return Promise.resolve({
-                                    count: 50,
-                                    error: null,
-                                });
-                            }),
-                        };
-                    }),
-                };
-            }
-            return {};
-        });
+    it("returns aggregate statistics using the service-role client for scan history", async () => {
+        const scanSelect = arrangeScanCount({ count: 100, error: null });
 
         const response = await GET();
         expect(response.status).toBe(200);
@@ -79,55 +89,33 @@ describe("GET /api/stats", () => {
             totalScans: 100,
             verifiedPharmacies: 50,
         });
+        expect(mockCreateServiceRoleSupabaseClient).toHaveBeenCalledTimes(1);
+        expect(mockServiceRoleFrom).toHaveBeenCalledWith("scan_history");
+        expect(mockFrom).not.toHaveBeenCalledWith("scan_history");
+        expect(scanSelect).toHaveBeenCalledWith("*", { count: "exact", head: true });
+        expect(data).not.toHaveProperty("scan_history");
+        expect(data).not.toHaveProperty("scans");
     });
 
-    it("returns 500 error response if any supabase query fails", async () => {
-        mockFrom.mockImplementation((table: string) => {
-            if (table === "drug_alerts") {
-                return {
-                    select: jest.fn().mockImplementation(() => {
-                        return {
-                            eq: jest.fn().mockImplementation((col: string, val: string) => {
-                                if (val === "banned") {
-                                    return Promise.resolve({
-                                        count: null,
-                                        error: new Error("Database query failed"),
-                                    });
-                                }
-                                return Promise.resolve({ count: 0, error: null });
-                            }),
-                        };
-                    }),
-                };
-            }
-            if (table === "scan_history") {
-                return {
-                    select: jest.fn().mockImplementation(() => {
-                        return Promise.resolve({
-                            count: 0,
-                            error: null,
-                        });
-                    }),
-                };
-            }
-            if (table === "pharmacies") {
-                return {
-                    select: jest.fn().mockImplementation(() => {
-                        return {
-                            eq: jest.fn().mockImplementation((col: string, val: boolean) => {
-                                return Promise.resolve({
-                                    count: 0,
-                                    error: null,
-                                });
-                            }),
-                        };
-                    }),
-                };
-            }
-            return {};
-        });
+    it("preserves a legitimate zero scan count", async () => {
+        arrangeScanCount({ count: 0, error: null });
 
-        // Suppress console.error output in tests for expected errors
+        const response = await GET();
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({
+            banned: 10,
+            recalled: 15,
+            counterfeit: 5,
+            nsq: 20,
+            totalScans: 0,
+            verifiedPharmacies: 50,
+        });
+    });
+
+    it("returns 500 instead of reporting zero when the scan count query fails", async () => {
+        arrangeScanCount({ count: null, error: new Error("Database query failed") });
+
         const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
         const response = await GET();
@@ -135,6 +123,7 @@ describe("GET /api/stats", () => {
 
         const data = await response.json();
         expect(data).toEqual({ error: "Internal Server Error" });
+        expect(data).not.toHaveProperty("totalScans");
 
         consoleErrorSpy.mockRestore();
     });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3800**

### Summary

This fixes an issue where the public statistics endpoint always reported `totalScans` as `0`.

The endpoint previously queried `scan_history` using the anonymous Supabase client. Since the table is protected by RLS and only accessible to the service role, the count query always returned zero despite existing scan records.

This change:

- uses the existing server-only service-role Supabase client for the aggregate `scan_history` count;
- preserves existing RLS policies;
- continues returning only the aggregate count (no scan records);
- returns a server error if the privileged count query fails instead of reporting an incorrect zero;
- adds regression tests covering successful, zero-count, and failure scenarios.

## 📸 Proof of Work

### Tests

```text
PASS tests/stats-route.test.ts
PASS tests/rate-limit-metrics-cron-route.test.ts

Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
```

### TypeScript

```text
npx.cmd tsc --noEmit -p apps/web/tsconfig.json
✓ Passed
```

### ESLint

```text
npx.cmd eslint apps/web/app/api/stats/route.ts apps/web/lib/rateLimitMetrics.ts apps/web/tests/stats-route.test.ts
✓ Passed
```

### Prettier

```text
Checking formatting...
All matched files use Prettier code style.
```

### Git

```text
git diff --check
✓ Passed
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`

## 🔐 Security Notes

- Existing RLS policies remain unchanged.
- Anonymous users still cannot read `scan_history`.
- The service-role key remains server-side only.
- Only the aggregate scan count is queried.
- The privileged query uses `head: true`, so no scan records are retrieved or exposed.

## ✅ Checklist

- [x] Scoped only to issue #3800.
- [x] Existing RLS protections remain intact.
- [x] No service-role credentials are exposed.
- [x] Regression tests added.
- [x] Relevant tests pass.
- [x] Type checking completed.
- [x] Linting completed.
- [x] `git diff --check` passes.