### PR TITLE
fix(api): fail summary when dose log query fails

### DIFF
--- a/apps/api/src/services/medicineSchedule.service.ts
+++ b/apps/api/src/services/medicineSchedule.service.ts
@@ -511,9 +511,8 @@ export const medicineScheduleService = {
                     today
                 );
 
-            if (!doseLogsError && doseLogsData) {
-                allDoseLogs = doseLogsData;
-            }
+            if (doseLogsError) throw new HttpError(500, "Failed to fetch dose logs");
+            allDoseLogs = doseLogsData ?? [];
         }
 
         const doseLogsBySchedule = new Map<string, any[]>();

--- a/apps/api/tests/medicineSchedules.test.ts
+++ b/apps/api/tests/medicineSchedules.test.ts
@@ -65,7 +65,6 @@ import medicineSchedulesRouter from "../src/routes/medicineSchedules";
 import { redisClient } from "../src/utils/redis";
 import { Request, Response, NextFunction } from "express";
 
-
 const app = express();
 app.use(express.json());
 app.use("/api/schedules", medicineSchedulesRouter);
@@ -868,20 +867,78 @@ describe("GET /api/schedules/today/summary", () => {
             data: [
                 {
                     id: "dose-1",
+                    schedule_id: "sched-1",
                     log_time: "08:00",
                     status: "taken",
+                },
+                {
+                    id: "dose-2",
+                    schedule_id: "sched-1",
+                    log_time: "20:00",
+                    status: "skipped",
                 },
             ],
             error: null,
         });
 
         const res = await request(app)
-            .get("/api/schedules/today/summary")
+            .get("/api/schedules/today/summary?date=2026-06-14&time=12:00")
             .set("Authorization", "Bearer test-token");
 
         expect(res.status).toBe(200);
         expect(res.body.schedules).toHaveLength(1);
         expect(res.body.schedules[0].medicine_name).toBe("Paracetamol");
+        expect(res.body.schedules[0].doses).toEqual([
+            { time: "08:00", status: "taken" },
+            { time: "20:00", status: "skipped" },
+        ]);
+    });
+
+    it("returns 500 without a partial summary when the dose log query fails", async () => {
+        const activeSchedules = [
+            {
+                id: "sched-1",
+                medicine_name: "Paracetamol",
+                dosage: "1 tablet",
+                times: ["08:00", "20:00"],
+                frequency: 2,
+                user_id: "test-user-id",
+                start_date: "2026-01-01",
+                end_date: null,
+                notes: null,
+                is_active: true,
+                created_at: "2026-01-01T00:00:00Z",
+                updated_at: "2026-01-01T00:00:00Z",
+            },
+        ];
+
+        mockedSupabase.select.mockReturnValueOnce(mockedSupabase);
+        mockedSupabase.eq.mockReturnValueOnce(mockedSupabase);
+        mockedSupabase.eq.mockReturnValueOnce(mockedSupabase);
+        mockedSupabase.lte.mockReturnValueOnce(mockedSupabase);
+        mockedSupabase.or.mockResolvedValueOnce({
+            data: activeSchedules,
+            error: null,
+        });
+
+        mockedSupabase.select.mockReturnValueOnce(mockedSupabase);
+        mockedSupabase.in.mockReturnValueOnce(mockedSupabase);
+        mockedSupabase.eq.mockReturnValueOnce(mockedSupabase);
+        mockedSupabase.eq.mockResolvedValueOnce({
+            data: null,
+            error: { message: "sensitive database details" },
+        });
+
+        const res = await request(app)
+            .get("/api/schedules/today/summary?date=2026-06-14&time=12:00")
+            .set("Authorization", "Bearer test-token");
+
+        expect(res.status).toBe(500);
+        expect(res.body).toEqual({ error: "Failed to fetch dose logs" });
+        expect(res.body).not.toHaveProperty("schedules");
+        expect(res.text).not.toContain("sensitive database details");
+        expect(mockedSupabase.from).toHaveBeenNthCalledWith(1, "medicine_schedules");
+        expect(mockedSupabase.from).toHaveBeenNthCalledWith(2, "dose_logs");
     });
 
     it("uses the IST calendar date before UTC midnight", async () => {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3801**

### Summary

The daily schedule summary previously ignored errors returned while loading `dose_logs`. When the query failed, the service continued with an empty dose-log collection and returned a successful response, causing taken or skipped doses to appear as pending.

This PR fixes that behavior by:

- returning an HTTP 500 response when the `dose_logs` query fails;
- preserving the existing behavior for genuine empty dose-log results;
- preventing incomplete medication data from being returned as a successful summary;
- adding regression tests covering successful, empty, and failed dose-log queries.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Test Results

```text
PASS tests/medicineSchedules.test.ts

Test Suites: 1 passed, 1 total
Tests:       41 passed, 41 total
Snapshots:   0 total
```

### TypeScript

```text
npx.cmd tsc --noEmit -p apps/api/tsconfig.json
✓ Passed
```

### Prettier

```text
Checking formatting...
All matched files use Prettier code style!
```

### Git Diff Validation

```text
git diff --check
✓ Passed
```

### ESLint

```text
Could not be executed because the repository does not provide an ESLint 10 flat configuration or an API lint script.
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3801`)
- [x] I have pulled the latest `main` and resolved any conflicts
- [x] The fix is scoped only to issue #3801
- [x] Empty dose-log results still return a valid summary
- [x] Dose-log query failures now return an error instead of a partial summary
- [x] Regression tests were added/updated
- [x] Relevant tests pass
- [x] Type checking passes
- [x] `git diff --check` passes