### PR TITLE
fix(api): expire stale persisted safety profiles

### DIFF
--- a/apps/api/src/routes/safety.ts
+++ b/apps/api/src/routes/safety.ts
@@ -63,7 +63,8 @@ async function getDbCachedProfile(genericName: string) {
     if (!data?.profile_json) return null;
 
     const updatedAtMs = new Date(data.updated_at).getTime();
-    const isFresh = Number.isFinite(updatedAtMs) && Date.now() - updatedAtMs < REDIS_TTL_SEC * 1000;
+    const nowMs = Date.now();
+    const isFresh = Number.isFinite(updatedAtMs) && updatedAtMs <= nowMs && nowMs - updatedAtMs < REDIS_TTL_SEC * 1000;
 
     return isFresh ? data.profile_json : null;
 }

--- a/apps/api/src/routes/safety.ts
+++ b/apps/api/src/routes/safety.ts
@@ -51,7 +51,7 @@ async function resolveGenericName(query: string): Promise<string> {
 async function getDbCachedProfile(genericName: string) {
     const { data, error } = await supabase
         .from("medicine_safety_profiles")
-        .select("profile_json")
+        .select("profile_json, updated_at")
         .eq("generic_name", genericName)
         .maybeSingle();
 
@@ -60,7 +60,12 @@ async function getDbCachedProfile(genericName: string) {
         return null;
     }
 
-    return data?.profile_json ?? null;
+    if (!data?.profile_json) return null;
+
+    const updatedAtMs = new Date(data.updated_at).getTime();
+    const isFresh = Number.isFinite(updatedAtMs) && Date.now() - updatedAtMs < REDIS_TTL_SEC * 1000;
+
+    return isFresh ? data.profile_json : null;
 }
 
 // ── Helper: persist profile to Supabase DB cache ─────────────────────────────

--- a/apps/api/tests/safety.test.ts
+++ b/apps/api/tests/safety.test.ts
@@ -1,0 +1,186 @@
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || "http://localhost:54321";
+process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "test-anon-key";
+
+const mockRpc = jest.fn();
+const mockFrom = jest.fn();
+const mockSelect = jest.fn();
+const mockEq = jest.fn();
+const mockMaybeSingle = jest.fn();
+const mockUpsert = jest.fn();
+
+jest.mock("../src/db/client", () => ({
+    supabase: {
+        rpc: mockRpc,
+        from: mockFrom,
+    },
+}));
+
+const mockRedisClient = {
+    isOpen: true,
+    get: jest.fn(),
+    set: jest.fn(),
+};
+
+jest.mock("../src/utils/redis", () => ({
+    redisClient: mockRedisClient,
+}));
+
+const mockFetchOpenFdaContext = jest.fn();
+jest.mock("../src/services/openfda.service", () => ({
+    fetchOpenFdaContext: mockFetchOpenFdaContext,
+}));
+
+const mockGenerateSafetyProfile = jest.fn();
+jest.mock("../src/services/llm.service", () => ({
+    generateSafetyProfile: mockGenerateSafetyProfile,
+}));
+
+jest.mock("../src/middleware/rateLimit", () => ({
+    scanQueryLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock("../src/utils/logger", () => ({
+    __esModule: true,
+    default: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+import express from "express";
+import request from "supertest";
+import safetyRouter from "../src/routes/safety";
+
+const PROFILE_TTL_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date("2026-07-21T12:00:00.000Z");
+const cachedProfile = { medicine: "cached profile" };
+const generatedProfile = { medicine: "generated profile" };
+
+const app = express();
+app.use("/api/medicine/safety", safetyRouter);
+
+function mockDbProfile(data: unknown) {
+    mockMaybeSingle.mockResolvedValue({ data, error: null });
+}
+
+describe("GET /api/medicine/safety", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers().setSystemTime(NOW);
+
+        mockRpc.mockResolvedValue({
+            data: [{ generic_name: "telmisartan" }],
+            error: null,
+        });
+        mockRedisClient.isOpen = true;
+        mockRedisClient.get.mockResolvedValue(null);
+        mockRedisClient.set.mockResolvedValue("OK");
+
+        mockSelect.mockReturnValue({ eq: mockEq });
+        mockEq.mockReturnValue({ maybeSingle: mockMaybeSingle });
+        mockUpsert.mockResolvedValue({ error: null });
+        mockFrom.mockReturnValue({
+            select: mockSelect,
+            upsert: mockUpsert,
+        });
+
+        mockFetchOpenFdaContext.mockResolvedValue("current safety context");
+        mockGenerateSafetyProfile.mockResolvedValue(generatedProfile);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("returns a Redis hit without querying the database or generator", async () => {
+        mockRedisClient.get.mockResolvedValue(JSON.stringify(cachedProfile));
+
+        const res = await request(app).get("/api/medicine/safety?q=Telma");
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual(cachedProfile);
+        expect(res.headers["x-cache-source"]).toBe("redis");
+        expect(mockFrom).not.toHaveBeenCalled();
+        expect(mockGenerateSafetyProfile).not.toHaveBeenCalled();
+    });
+
+    it("returns a fresh database profile and backfills Redis", async () => {
+        mockDbProfile({
+            profile_json: cachedProfile,
+            updated_at: new Date(NOW.getTime() - PROFILE_TTL_MS + 1).toISOString(),
+        });
+
+        const res = await request(app).get("/api/medicine/safety?q=Telma");
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual(cachedProfile);
+        expect(res.headers["x-cache-source"]).toBe("supabase");
+        expect(mockSelect).toHaveBeenCalledWith("profile_json, updated_at");
+        expect(mockGenerateSafetyProfile).not.toHaveBeenCalled();
+        expect(mockRedisClient.set).toHaveBeenCalledWith(
+            "medicine_safety:telmisartan",
+            JSON.stringify(cachedProfile),
+            { EX: 86400 }
+        );
+    });
+
+    it("regenerates and persists a stale database profile", async () => {
+        mockDbProfile({
+            profile_json: cachedProfile,
+            updated_at: new Date(NOW.getTime() - PROFILE_TTL_MS - 1).toISOString(),
+        });
+
+        const res = await request(app).get("/api/medicine/safety?q=Telma");
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual(generatedProfile);
+        expect(res.headers["x-cache-source"]).toBe("llm-generated");
+        expect(mockGenerateSafetyProfile).toHaveBeenCalledWith(
+            "telmisartan",
+            "current safety context"
+        );
+        expect(mockUpsert).toHaveBeenCalledWith(
+            {
+                generic_name: "telmisartan",
+                profile_json: generatedProfile,
+                updated_at: NOW.toISOString(),
+            },
+            { onConflict: "generic_name" }
+        );
+        expect(mockRedisClient.set).toHaveBeenCalledWith(
+            "medicine_safety:telmisartan",
+            JSON.stringify(generatedProfile),
+            { EX: 86400 }
+        );
+        expect(mockUpsert.mock.invocationCallOrder[0]).toBeLessThan(
+            mockRedisClient.set.mock.invocationCallOrder[0]
+        );
+    });
+
+    it("preserves generation and persistence when no database profile exists", async () => {
+        mockDbProfile(null);
+
+        const res = await request(app).get("/api/medicine/safety?q=Telma");
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual(generatedProfile);
+        expect(mockGenerateSafetyProfile).toHaveBeenCalledTimes(1);
+        expect(mockUpsert).toHaveBeenCalledTimes(1);
+        expect(mockRedisClient.set).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats a profile exactly at the freshness limit as stale", async () => {
+        mockDbProfile({
+            profile_json: cachedProfile,
+            updated_at: new Date(NOW.getTime() - PROFILE_TTL_MS).toISOString(),
+        });
+
+        const res = await request(app).get("/api/medicine/safety?q=Telma");
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual(generatedProfile);
+        expect(mockGenerateSafetyProfile).toHaveBeenCalledTimes(1);
+        expect(mockUpsert).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3802**

### Summary

Persisted medicine safety profiles were treated as permanently valid once stored in the database. Although Redis entries expired after 24 hours, an expired cache entry was repopulated using the same persisted profile without checking whether it had become stale.

This PR adds a freshness check for persisted profiles before they are reused. Profiles within the configured freshness window continue to be served normally, while stale profiles are regenerated using the existing safety profile generation flow, persisted back to the database, and cached in Redis.

## 🐛 Root Cause

The database fallback only retrieved the persisted profile content and did not validate its age. As a result, Redis expiration alone was insufficient to refresh outdated safety information because the same persisted profile was repeatedly restored into the cache.

## ✅ Fix

- Selects `updated_at` alongside the persisted profile.
- Validates profile freshness using the existing 24-hour Redis TTL.
- Reuses persisted profiles only when they are still fresh.
- Treats profiles at or beyond the freshness window as stale.
- Treats missing or invalid timestamps as stale.
- Regenerates stale profiles through the existing generation flow.
- Invokes the existing persistence step before writing the refreshed profile to Redis.
- Preserves the existing API response format and Redis caching behavior for fresh profiles.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Test Results

```text
$env:NODE_OPTIONS='--experimental-vm-modules'
npx.cmd jest --config jest.config.js --forceExit --silent --runInBand tests/safety.test.ts

PASS tests/safety.test.ts

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
```

### TypeScript

```text
npx.cmd tsc --noEmit -p apps/api/tsconfig.json

Exit code: 0
```

### Prettier

```text
npx.cmd prettier --check apps/api/src/routes/safety.ts apps/api/tests/safety.test.ts

Checking formatting...
All matched files use Prettier code style!
```

### Git Diff Validation

```text
git diff --check

Exit code: 0
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## 🧪 Testing

Regression tests cover:

- Redis hit bypasses the database and generator.
- Redis miss with a fresh persisted profile.
- Redis miss with a stale persisted profile.
- Redis miss without a persisted profile.
- Profiles exactly at the 24-hour freshness boundary.
- Persistence is invoked before the refreshed profile is cached.

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3802`)
- [x] I have pulled the latest `main` and resolved any conflicts
- [x] Scoped only to issue #3802.
- [x] Fresh persisted profiles continue to be reused.
- [x] Stale persisted profiles regenerate correctly.
- [x] Exact TTL boundary is covered.
- [x] Regression tests added.
- [x] Relevant tests pass.
- [x] TypeScript checks pass.
- [x] Formatting checks pass.
- [x] `git diff --check` passes.