### PR TITLE
feat(web): cache medication schedules for offline reading

### DIFF
--- a/apps/web/app/[locale]/profile/page.tsx
+++ b/apps/web/app/[locale]/profile/page.tsx
@@ -6,6 +6,7 @@ import { Link, useRouter } from "@/i18n/routing";
 import { User, ShieldCheck, Bell, ChevronRight, ArrowLeft, LogIn, LogOut } from "lucide-react";
 import ABHABadge from "@/components/ABHABadge";
 import { useSession } from "@/src/components/AuthProvider";
+import { clearReadCache } from "@/lib/offline/db";
 
 const ACCESS_TOKEN_KEY = "sb-access-token";
 
@@ -131,6 +132,9 @@ export default function ProfilePage() {
     };
     const handleSignOut = () => {
         localStorage.removeItem(ACCESS_TOKEN_KEY);
+        // Wipe cached schedules/summary (PHI) so the next person on a shared
+        // device can't read them offline. Fire-and-forget — never block sign-out.
+        void clearReadCache();
         setSession({ status: "guest" });
         router.push("/");
     };

--- a/apps/web/app/[locale]/schedule/page.tsx
+++ b/apps/web/app/[locale]/schedule/page.tsx
@@ -11,8 +11,10 @@ import {
     Pill,
     Plus,
     RefreshCw,
+    WifiOff,
     XCircle,
 } from "lucide-react";
+import { useOfflineStatus } from "@/hooks/useOfflineStatus";
 import { Link } from "@/i18n/routing";
 import { PageHeader } from "../components/PageHeader";
 import Card from "@/components/Card";
@@ -156,11 +158,12 @@ type LoadState =
     | { kind: "loading" }
     | { kind: "authError" }
     | { kind: "networkError"; message: string }
-    | { kind: "ready"; data: TodaySchedule[]; date: string };
+    | { kind: "ready"; data: TodaySchedule[]; date: string; fromCache: boolean };
 
 export default function SchedulePage() {
     const t = useTranslations("schedule");
     const { token, isLoading: authLoading } = useSession();
+    const { registerRetryCallback, unregisterRetryCallback } = useOfflineStatus();
     const [state, setState] = useState<LoadState>({ kind: "loading" });
     const [doseStatus, setDoseStatus] = useState<Record<string, string>>({});
 
@@ -183,7 +186,12 @@ export default function SchedulePage() {
                 }
             }
             setDoseStatus(statusMap);
-            setState({ kind: "ready", data: summary.schedules, date: summary.date });
+            setState({
+                kind: "ready",
+                data: summary.schedules,
+                date: summary.date,
+                fromCache: summary.fromCache ?? false,
+            });
         } catch {
             setState({
                 kind: "networkError",
@@ -197,6 +205,13 @@ export default function SchedulePage() {
             fetchData();
         }
     }, [authLoading, fetchData]);
+
+    // Silently refresh the schedule (and its offline cache) when connectivity
+    // returns, reusing the shared reconnect-retry mechanism.
+    useEffect(() => {
+        registerRetryCallback(fetchData);
+        return () => unregisterRetryCallback(fetchData);
+    }, [registerRetryCallback, unregisterRetryCallback, fetchData]);
 
     const handleDoseChange = (
         scheduleId: string,
@@ -232,6 +247,15 @@ export default function SchedulePage() {
                         <p className="mt-0.5 text-sm text-(--color-text-secondary)">
                             {t("headingDescription")}
                         </p>
+                        {state.kind === "ready" && state.fromCache && (
+                            <span
+                                role="status"
+                                className="mt-2 inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+                            >
+                                <WifiOff size={12} />
+                                Offline Mode
+                            </span>
+                        )}
                     </div>
                     <div className="flex gap-2">
                         <button

--- a/apps/web/lib/offline/db.ts
+++ b/apps/web/lib/offline/db.ts
@@ -32,9 +32,9 @@ interface SyncDB extends DBSchema {
         };
     };
     readCache: {
-        key: string; // cacheKey
+        key: string; // `${baseKey}:${userId}`
         value: {
-            cacheKey: ReadCacheKey;
+            cacheKey: string;
             data: unknown;
             cachedAt: number;
         };
@@ -66,29 +66,64 @@ export function getSyncDB() {
 }
 
 /**
- * Persist the latest successful response for a read endpoint. Best-effort: a
- * caching failure (e.g. IndexedDB unavailable) is swallowed so it never
- * disrupts the request that produced the data.
+ * Namespace a cache entry by its owning user. IndexedDB is shared across the
+ * whole origin and survives logout, so read-cache entries MUST be scoped to the
+ * authenticated user — otherwise a second person on a shared device could be
+ * served the first user's cached PHI while offline.
  */
-export async function readCachePut(cacheKey: ReadCacheKey, data: unknown): Promise<void> {
+function scopedCacheKey(baseKey: ReadCacheKey, userId: string): string {
+    return `${baseKey}:${userId}`;
+}
+
+/**
+ * Persist the latest successful response for a read endpoint, scoped to the
+ * given user. No-ops when the user is unknown (nothing is cached un-attributed).
+ * Best-effort: a caching failure (e.g. IndexedDB unavailable) is swallowed so
+ * it never disrupts the request that produced the data.
+ */
+export async function readCachePut(
+    baseKey: ReadCacheKey,
+    userId: string,
+    data: unknown
+): Promise<void> {
+    if (!userId) return;
     try {
         const db = await getSyncDB();
-        await db.put("readCache", { cacheKey, data, cachedAt: Date.now() });
+        await db.put("readCache", {
+            cacheKey: scopedCacheKey(baseKey, userId),
+            data,
+            cachedAt: Date.now(),
+        });
     } catch {
         // Ignore — the network response has already been returned to the caller.
     }
 }
 
 /**
- * Read a previously cached response for a read endpoint, or null when there is
- * nothing cached (or IndexedDB is unavailable).
+ * Read this user's cached response for a read endpoint, or null when there is
+ * nothing cached for them (or the user is unknown / IndexedDB is unavailable).
  */
-export async function readCacheGet<T>(cacheKey: ReadCacheKey): Promise<T | null> {
+export async function readCacheGet<T>(baseKey: ReadCacheKey, userId: string): Promise<T | null> {
+    if (!userId) return null;
     try {
         const db = await getSyncDB();
-        const entry = await db.get("readCache", cacheKey);
+        const entry = await db.get("readCache", scopedCacheKey(baseKey, userId));
         return entry ? (entry.data as T) : null;
     } catch {
         return null;
+    }
+}
+
+/**
+ * Wipe every cached read-endpoint response. Called on explicit sign-out so a
+ * user's cached schedule/summary never lingers on the device for whoever signs
+ * in next. Best-effort — a cleanup failure must not block sign-out.
+ */
+export async function clearReadCache(): Promise<void> {
+    try {
+        const db = await getSyncDB();
+        await db.clear("readCache");
+    } catch {
+        // Ignore — sign-out proceeds regardless.
     }
 }

--- a/apps/web/lib/offline/db.ts
+++ b/apps/web/lib/offline/db.ts
@@ -1,5 +1,8 @@
 import { openDB, DBSchema, IDBPDatabase } from "idb";
 
+/** Read endpoints whose latest successful response we cache for offline reads. */
+export type ReadCacheKey = "schedules" | "todaySummary";
+
 interface SyncDB extends DBSchema {
     pendingScans: {
         key: string; // idempotencyKey
@@ -28,14 +31,22 @@ interface SyncDB extends DBSchema {
             imageBlob?: Blob;
         };
     };
+    readCache: {
+        key: string; // cacheKey
+        value: {
+            cacheKey: ReadCacheKey;
+            data: unknown;
+            cachedAt: number;
+        };
+    };
 }
 
 let dbPromise: Promise<IDBPDatabase<SyncDB>> | null = null;
 
 export function getSyncDB() {
     if (!dbPromise) {
-        // Changed version from 1 to 2 to trigger the upgrade
-        dbPromise = openDB<SyncDB>("sahidawa-sync", 2, {
+        // Version 3 adds the readCache store (offline read caching for schedules).
+        dbPromise = openDB<SyncDB>("sahidawa-sync", 3, {
             upgrade(db) {
                 if (!db.objectStoreNames.contains("pendingScans")) {
                     db.createObjectStore("pendingScans", { keyPath: "idempotencyKey" });
@@ -44,8 +55,40 @@ export function getSyncDB() {
                 if (!db.objectStoreNames.contains("pendingReports")) {
                     db.createObjectStore("pendingReports", { keyPath: "idempotencyKey" });
                 }
+                // Read-cache for offline viewing of medication schedules / today summary
+                if (!db.objectStoreNames.contains("readCache")) {
+                    db.createObjectStore("readCache", { keyPath: "cacheKey" });
+                }
             },
         });
     }
     return dbPromise;
+}
+
+/**
+ * Persist the latest successful response for a read endpoint. Best-effort: a
+ * caching failure (e.g. IndexedDB unavailable) is swallowed so it never
+ * disrupts the request that produced the data.
+ */
+export async function readCachePut(cacheKey: ReadCacheKey, data: unknown): Promise<void> {
+    try {
+        const db = await getSyncDB();
+        await db.put("readCache", { cacheKey, data, cachedAt: Date.now() });
+    } catch {
+        // Ignore — the network response has already been returned to the caller.
+    }
+}
+
+/**
+ * Read a previously cached response for a read endpoint, or null when there is
+ * nothing cached (or IndexedDB is unavailable).
+ */
+export async function readCacheGet<T>(cacheKey: ReadCacheKey): Promise<T | null> {
+    try {
+        const db = await getSyncDB();
+        const entry = await db.get("readCache", cacheKey);
+        return entry ? (entry.data as T) : null;
+    } catch {
+        return null;
+    }
 }

--- a/apps/web/lib/scheduleApi.ts
+++ b/apps/web/lib/scheduleApi.ts
@@ -51,6 +51,30 @@ function getToken(): string {
     return localStorage.getItem("sb-access-token") ?? "";
 }
 
+/**
+ * Extract the authenticated user's id (the JWT `sub` claim) from the Supabase
+ * access token, used only to namespace the offline read cache per user so a
+ * shared device never serves one user's cached PHI to another.
+ *
+ * The token is not verified here — that's the server's job. A forged `sub` can
+ * only ever scope a cache entry to itself, so it cannot expose another user's
+ * cached data. Returns "" when no valid token is present (e.g. after logout),
+ * which disables read caching entirely for that request.
+ */
+function getUserId(): string {
+    const token = getToken();
+    const parts = token.split(".");
+    if (parts.length !== 3) return "";
+    try {
+        const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+        const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+        const payload = JSON.parse(atob(padded));
+        return typeof payload?.sub === "string" ? payload.sub : "";
+    } catch {
+        return "";
+    }
+}
+
 function authHeaders(): Record<string, string> {
     const token = getToken();
     return token ? { Authorization: `Bearer ${token}` } : {};
@@ -87,14 +111,14 @@ export async function fetchSchedules(): Promise<Schedule[]> {
     } catch (err) {
         // fetch() itself throwing means a genuine network/offline failure (a
         // reachable server that returns an HTTP error resolves normally, below).
-        const cached = await readCacheGet<Schedule[]>("schedules");
+        const cached = await readCacheGet<Schedule[]>("schedules", getUserId());
         if (cached) return cached;
         throw err;
     }
     if (!res.ok) throw new Error("Failed to fetch schedules");
     const json = await res.json();
     const schedules: Schedule[] = json.schedules ?? [];
-    void readCachePut("schedules", schedules);
+    void readCachePut("schedules", getUserId(), schedules);
     return schedules;
 }
 
@@ -333,13 +357,14 @@ export async function fetchTodaySummary(): Promise<{
         });
     } catch (err) {
         const cached = await readCacheGet<{ date: string; schedules: TodaySchedule[] }>(
-            "todaySummary"
+            "todaySummary",
+            getUserId()
         );
         if (cached) return { ...cached, fromCache: true };
         throw err;
     }
     if (!res.ok) throw new Error("Failed to fetch today summary");
     const data = (await res.json()) as { date: string; schedules: TodaySchedule[] };
-    void readCachePut("todaySummary", data);
+    void readCachePut("todaySummary", getUserId(), data);
     return data;
 }

--- a/apps/web/lib/scheduleApi.ts
+++ b/apps/web/lib/scheduleApi.ts
@@ -1,5 +1,6 @@
 import { API_BASE, getCsrfToken } from "./api";
 import { fetchWithRetry, offlineRequestQueue, DoseQueuedOfflineError } from "./apiWithRetry";
+import { readCacheGet, readCachePut } from "./offline/db";
 
 export interface Schedule {
     id: string;
@@ -70,17 +71,31 @@ async function scheduleMutationFetch(url: string, options: RequestInit): Promise
 /**
  * Fetches all medication schedules for the authenticated user.
  *
+ * On success the response is cached locally so it can be served while offline.
+ *
  * @returns {Promise<Schedule[]>} A promise that resolves to an array of Schedule objects.
  *                                Returns an empty array if the API response contains no schedules.
- * @throws {Error} Throws "Failed to fetch schedules" if the API returns a non-2xx response.
+ * @throws {Error} Throws "Failed to fetch schedules" on a non-2xx response, or the underlying
+ *                 network error when offline and no cached copy is available.
  */
 export async function fetchSchedules(): Promise<Schedule[]> {
-    const res = await fetch(`${API_BASE}/api/schedules`, {
-        headers: authHeaders(),
-    });
+    let res: Response;
+    try {
+        res = await fetch(`${API_BASE}/api/schedules`, {
+            headers: authHeaders(),
+        });
+    } catch (err) {
+        // fetch() itself throwing means a genuine network/offline failure (a
+        // reachable server that returns an HTTP error resolves normally, below).
+        const cached = await readCacheGet<Schedule[]>("schedules");
+        if (cached) return cached;
+        throw err;
+    }
     if (!res.ok) throw new Error("Failed to fetch schedules");
     const json = await res.json();
-    return json.schedules ?? [];
+    const schedules: Schedule[] = json.schedules ?? [];
+    void readCachePut("schedules", schedules);
+    return schedules;
 }
 
 /**
@@ -297,17 +312,34 @@ export async function fetchAdherenceStats(
 /**
  * Fetches today's summary of all scheduled doses for the authenticated user.
  *
- * @returns {Promise<{ date: string; schedules: TodaySchedule[] }>} A promise that resolves to an
- *          object containing today's date and the list of today's scheduled doses with their statuses.
- * @throws {Error} Throws "Failed to fetch today summary" if the API returns a non-2xx response.
+ * On success the response is cached locally. When offline, the last cached copy
+ * is returned instead with `fromCache: true` so the UI can flag stale data.
+ *
+ * @returns {Promise<{ date: string; schedules: TodaySchedule[]; fromCache?: boolean }>} A promise
+ *          that resolves to today's date and scheduled doses. `fromCache` is set only when the
+ *          data was served from the offline cache after a network failure.
+ * @throws {Error} Throws "Failed to fetch today summary" on a non-2xx response, or the underlying
+ *                 network error when offline and no cached copy is available.
  */
 export async function fetchTodaySummary(): Promise<{
     date: string;
     schedules: TodaySchedule[];
+    fromCache?: boolean;
 }> {
-    const res = await fetch(`${API_BASE}/api/schedules/today/summary`, {
-        headers: authHeaders(),
-    });
+    let res: Response;
+    try {
+        res = await fetch(`${API_BASE}/api/schedules/today/summary`, {
+            headers: authHeaders(),
+        });
+    } catch (err) {
+        const cached = await readCacheGet<{ date: string; schedules: TodaySchedule[] }>(
+            "todaySummary"
+        );
+        if (cached) return { ...cached, fromCache: true };
+        throw err;
+    }
     if (!res.ok) throw new Error("Failed to fetch today summary");
-    return res.json() as Promise<{ date: string; schedules: TodaySchedule[] }>;
+    const data = (await res.json()) as { date: string; schedules: TodaySchedule[] };
+    void readCachePut("todaySummary", data);
+    return data;
 }


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3774
- **Summary:** `fetchSchedules()` and `fetchTodaySummary()` were plain `fetch()` calls with no fallback, so launching the PWA offline left the schedule dashboard blank. This adds an IndexedDB offline read cache so patients can always see their timings.
  - **`lib/offline/db.ts`:** bumped the sync DB to v3 and added a `readCache` key/value store + best-effort `readCachePut`/`readCacheGet` helpers, kept separate from the existing `pendingScans`/`pendingReports` write queues so PR #3768's offline dose-log queue is untouched.
  - **`lib/scheduleApi.ts`:** on success, cache the response; when `fetch()` itself throws (genuine offline/network failure — a reachable server returning an HTTP error still surfaces as before), fall back to the cached copy. `fetchTodaySummary` returns `fromCache: true` on the fallback path so the UI can flag stale data. Success return shapes are unchanged.
  - **`app/[locale]/schedule/page.tsx`:** shows an "Offline Mode" badge when rendering cached data, and registers a reconnect-retry callback (via the existing `useOfflineStatus` hook) that silently refreshes the schedule and its cache when connectivity returns.
  - Two deliberate choices: (a) cache fallback only on a thrown `fetch()` (airplane mode), not on HTTP errors — avoids serving stale data when the server is reachable, and sidesteps a "failed to fetch" message collision; (b) `fromCache` is only added on the fallback return, keeping success shapes (and the existing `scheduleApi.test.ts`) intact.
  - Scope: `lib/offline/db.ts`, `lib/scheduleApi.ts`, `app/[locale]/schedule/page.tsx`. Not touching `worker/index.js` — this is per-user auth-scoped JSON, better suited to IndexedDB than a Service Worker cache (which we use for static assets like map tiles).



## 🏷️ PR Type

- [x] ✨ `type: feature`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3774`)
- [x] I have pulled the latest `main` and resolved any conflicts
