### PR TITLE
feat(i18n): fail CI when locale files are missing keys present in en.json

### DIFF
--- a/.github/workflows/pr-quality-check.yml
+++ b/.github/workflows/pr-quality-check.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run Web Lint
         run: npm run lint -w web
 
+      - name: Check i18n Translation Keys
+        run: npm run i18n:check-missing -w web
+
       - name: Run PR Quality Checker
         uses: peakoss/anti-slop@v0
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,6 +280,15 @@ Example:
 { "scan.button": "மருந்தை ஸ்கேன் செய்யுங்கள்", "scan.result.real": "இந்த மருந்து உண்மையானது" }
 ```
 
+> [!IMPORTANT]
+> **Adding new UI text?** Add every new key to `apps/web/messages/en.json` (the source of truth) **first**. CI runs an automated check on every PR that fails if any language file is missing a key that exists in `en.json`. Run it locally before pushing to catch gaps early:
+>
+> ```bash
+> npm run i18n:check-missing -w web
+> ```
+>
+> It prints the missing keys per language and exits non-zero if any are found. If you add English text, either add the matching keys to every locale file or coordinate with the translation contributors before merging.
+
 #### UI Components
 
 - Pick a component issue labeled `good-first-issue` + `frontend`

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
         "lint": "eslint .",
         "test": "jest --config jest.config.cjs",
         "test:a11y:voice": "node scripts/voice-a11y-audit.mjs",
+        "i18n:check-missing": "node scripts/check-locale-keys.mjs",
         "format": "prettier --write .",
         "format:check": "prettier --check ."
     },


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3763
- **Summary:** New UI text is added to `en.json` but the matching keys in the 18 other locale files are easy to forget, and nothing caught that automatically.
  - **Note:** a suitable detection script already existed but was orphaned — `apps/web/scripts/check-locale-keys.mjs` (added in #3651) already flattens `en.json` to dot-paths, diffs every `messages/*.json` against it, prints missing keys per locale and exits non-zero. Rather than add a second, duplicate script, this PR wires the existing one into the pipeline.
  - `apps/web/package.json`: adds an `i18n:check-missing` script running it.
  - `.github/workflows/pr-quality-check.yml`: runs `npm run i18n:check-missing -w web` on every PR (in the existing quality-check job), failing the job if any locale is missing a key from `en.json`.
  - `CONTRIBUTING.md`: documents adding new UI text to `en.json` first and running the check locally before pushing.
  - Satisfies all four acceptance criteria: detection script, CI integration, CI fails on missing keys, and contributor docs.



## 🏷️ PR Type

- [x] ✨ `type: feature`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3763`)
- [x] I have pulled the latest `main` and resolved any conflicts
