### PR TITLE
fix(api): stop notification endpoints leaking OTP and user_id in responses

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -168,6 +168,27 @@ interface InMemorySubscriber {
 // (Live view of dbConfig.isSupabaseOffline is read directly inside request handlers)
 const memorySubscribers = new Map<string, InMemorySubscriber>();
 
+// The only subscriber fields any client is allowed to receive. Everything else on
+// a row is either a secret (verification_otp, otp_expires_at) or account-linkage
+// PII (user_id) and must never be serialized into a response. Returning the raw
+// row from /status let an unauthenticated caller read another subscriber's OTP and
+// Supabase user_id just by knowing their phone number, so every subscriber we hand
+// back — from the DB or the in-memory fallback — goes through this projection.
+type PublicSubscriber = Pick<
+    InMemorySubscriber,
+    "phone" | "channels" | "language" | "district" | "is_active"
+>;
+
+function toPublicSubscriber(sub: PublicSubscriber): PublicSubscriber {
+    return {
+        phone: sub.phone,
+        channels: sub.channels,
+        language: sub.language,
+        district: sub.district,
+        is_active: sub.is_active,
+    };
+}
+
 router.get("/status", optionalAuth, async (req: AuthenticatedRequest, res) => {
     try {
         let phone: string | undefined = undefined;
@@ -179,7 +200,9 @@ router.get("/status", optionalAuth, async (req: AuthenticatedRequest, res) => {
             }
             phone = formatted;
         }
-        let query = supabase.from("notification_subscribers").select("*");
+        let query = supabase
+            .from("notification_subscribers")
+            .select("phone, channels, language, district, is_active");
 
         if (req.user) {
             query = query.eq("user_id", req.user.id);
@@ -239,7 +262,7 @@ router.get("/status", optionalAuth, async (req: AuthenticatedRequest, res) => {
             return;
         }
 
-        res.json({ registered: true, subscriber });
+        res.json({ registered: true, subscriber: toPublicSubscriber(subscriber) });
     } catch (err) {
         logger.error({ message: "Error in /status endpoint", error: err });
         res.status(500).json({ error: "Internal server error" });
@@ -432,7 +455,7 @@ router.post(
                 await Promise.allSettled(sends);
             }
 
-            res.status(201).json({ success: true, subscriber: result });
+            res.status(201).json({ success: true, subscriber: toPublicSubscriber(result) });
         } catch (err) {
             logger.error({ message: "Error in /register endpoint", error: err });
             res.status(500).json({ error: "Internal server error" });
@@ -646,7 +669,7 @@ router.patch(
                 return;
             }
 
-            res.json({ success: true, subscriber: data[0] });
+            res.json({ success: true, subscriber: toPublicSubscriber(data[0]) });
         } catch (err) {
             logger.error({ message: "Error in /phone update endpoint", error: err });
             res.status(500).json({ error: "Internal server error" });

--- a/apps/api/tests/notifications.test.ts
+++ b/apps/api/tests/notifications.test.ts
@@ -3,7 +3,9 @@ process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "test-anon-key"
 process.env.TWILIO_AUTH_TOKEN = "test-auth-token";
 process.env.TWILIO_WEBHOOK_PUBLIC_URL = "http://localhost";
 
-// Mock subscriber data
+// Mock subscriber data. Deliberately includes the sensitive columns
+// (user_id, verification_otp, otp_expires_at) so the tests below can assert the
+// route never leaks them into a response.
 const mockSubscriber = {
     id: "sub-123-uuid",
     user_id: "test-user-uuid",
@@ -13,7 +15,13 @@ const mockSubscriber = {
     language: "en",
     district: "South West Delhi",
     is_active: true,
+    status: "active",
+    verification_otp: "123456",
+    otp_expires_at: "2999-01-01T00:00:00.000Z",
 };
+
+// Fields that must never appear on a subscriber object in any HTTP response.
+const SENSITIVE_SUBSCRIBER_FIELDS = ["user_id", "verification_otp", "otp_expires_at"];
 
 let mockAuthenticatedUser: any = {
     id: "test-user-uuid",
@@ -108,7 +116,6 @@ import notificationsRouter from "../src/routes/notifications";
 import { computeTwilioSignature } from "../src/middleware/twilioSignature";
 import { Request, Response, NextFunction } from "express";
 
-
 describe("notifications routes", () => {
     let app: express.Express;
     beforeAll(() => {
@@ -154,6 +161,33 @@ describe("notifications routes", () => {
         expect(response.body.subscriber.phone).toBe("+919876543210");
     });
 
+    it("never leaks OTP or user_id from /status for an authenticated user", async () => {
+        const response = await request(app)
+            .get("/api/notifications/status")
+            .query({ phone: "9876543210" });
+
+        expect(response.status).toBe(200);
+        expect(response.body.registered).toBe(true);
+        for (const field of SENSITIVE_SUBSCRIBER_FIELDS) {
+            expect(response.body.subscriber).not.toHaveProperty(field);
+        }
+    });
+
+    it("never leaks OTP or user_id from /status for an unauthenticated guest lookup", async () => {
+        mockAuthenticatedUser = null; // force the guest-by-phone branch
+
+        const response = await request(app)
+            .get("/api/notifications/status")
+            .query({ phone: "9876543210" });
+
+        expect(response.status).toBe(200);
+        expect(response.body.registered).toBe(true);
+        expect(response.body.subscriber.phone).toBe("+919876543210");
+        for (const field of SENSITIVE_SUBSCRIBER_FIELDS) {
+            expect(response.body.subscriber).not.toHaveProperty(field);
+        }
+    });
+
     it("registers a subscriber successfully", async () => {
         const payload = {
             phone: "9876543210",
@@ -167,6 +201,9 @@ describe("notifications routes", () => {
         expect(response.status).toBe(201);
         expect(response.body.success).toBe(true);
         expect(response.body.subscriber).toBeDefined();
+        for (const field of SENSITIVE_SUBSCRIBER_FIELDS) {
+            expect(response.body.subscriber).not.toHaveProperty(field);
+        }
     });
 
     it("fails registration with invalid payload", async () => {
@@ -192,6 +229,9 @@ describe("notifications routes", () => {
 
         expect(response.status).toBe(200);
         expect(response.body.success).toBe(true);
+        for (const field of SENSITIVE_SUBSCRIBER_FIELDS) {
+            expect(response.body.subscriber).not.toHaveProperty(field);
+        }
         expect(mockQueryBuilder.update).toHaveBeenCalledWith({
             channels: ["whatsapp"],
             district: "South Delhi",


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3810**
- **Summary:**

`GET /api/notifications/status` runs under `optionalAuth`, so it also answers callers who aren't logged in. On the guest path it looked a subscriber up by a `phone` query param and returned the entire row via `select("*")`, which includes `verification_otp`, `otp_expires_at` and the Supabase `user_id`. The API talks to Supabase with the service-role key, so RLS is bypassed and the query scoping in this route is the only access control there is. The guest path had none, so anyone could read a subscriber's OTP and account UUID just by knowing their phone number.

`POST /register` and `PATCH /phone` returned the same full row. Worse, `register` handed the freshly generated OTP straight back in its own response, which defeats the point of the phone-ownership check: register a number you don't own, read the OTP off the response, then verify.

The fix is a small `toPublicSubscriber()` projection that only exposes the fields a client actually uses (`phone`, `channels`, `language`, `district`, `is_active`), applied everywhere a subscriber is returned. `/status` now selects only those columns too, so the OTP isn't even pulled out of the database on that path.

There's no API contract change here. The web client's `SubscriberData` type already reads only those five fields, so nothing on the frontend has to move, and there's no schema or migration.

This is scoped to the data disclosure only. It's separate from #3745, which is about rate limiting the same routes.

## 📸 Proof of Work (Screenshots / Logs)

Backend-only change, no UI. The added tests assert the sensitive fields never show up in any response: authenticated `/status`, unauthenticated guest `/status`, `/register`, and `PATCH /phone`.

```
PASS apps/api/tests/notifications.test.ts
  notifications routes
    ✓ fetches subscription status successfully
    ✓ never leaks OTP or user_id from /status for an authenticated user
    ✓ never leaks OTP or user_id from /status for an unauthenticated guest lookup
    ✓ registers a subscriber successfully
    ✓ updates subscriber details successfully
    ...
Tests:       19 passed, 19 total
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3810`)
- [x] I have pulled the latest `main` and resolved any conflicts
