### PR TITLE
fix: improve privacy consent banner visibility in light and dark mode

### DIFF
--- a/apps/web/components/PrivacyConsentBanner.tsx
+++ b/apps/web/components/PrivacyConsentBanner.tsx
@@ -12,7 +12,7 @@ export default function PrivacyConsentBanner() {
 
     return (
         <div
-            className="bg-background animate-in fade-in slide-in-from-bottom-5 fixed right-0 bottom-0 left-0 z-50 border-t p-4 shadow-lg transition-transform duration-300 md:p-6"
+            className="animate-in fade-in slide-in-from-bottom-5 fixed right-0 bottom-0 left-0 z-50 border-t border-blue-200 bg-blue-50 p-4 shadow-xl transition-transform duration-300 md:p-6 dark:border-blue-800 dark:bg-slate-900"
             role="dialog"
             aria-labelledby="consent-title"
             aria-describedby="consent-desc"
@@ -21,24 +21,27 @@ export default function PrivacyConsentBanner() {
                 <div className="flex-1">
                     <h2
                         id="consent-title"
-                        className="text-foreground text-lg font-semibold tracking-tight"
+                        className="text-lg font-semibold tracking-tight text-slate-900 dark:text-white"
                     >
                         {t("title")}
                     </h2>
-                    <p id="consent-desc" className="text-muted-foreground mt-1 text-sm">
+                    <p
+                        id="consent-desc"
+                        className="mt-1 text-sm text-slate-700 dark:text-slate-300"
+                    >
                         {t("description")} {t("locationPurpose")} {t("scanHistoryPurpose")}
                     </p>
                 </div>
                 <div className="flex w-full items-center justify-end gap-3 md:w-auto">
                     <button
                         onClick={denyAll}
-                        className="hover:bg-accent rounded-md border px-4 py-2 text-sm font-medium transition-colors"
+                        className="cursor-pointer rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-white dark:hover:bg-slate-700"
                     >
                         {t("denyAll")}
                     </button>
                     <button
                         onClick={acceptAll}
-                        className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm font-medium transition-colors"
+                        className="cursor-pointer rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-400"
                     >
                         {t("acceptAll")}
                     </button>


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- Closes #3812
- Summary:
  - Added a proper background color to the Privacy & Data Consent banner.
  - Improved visibility and readability in both light and dark modes.
  - Updated text, button, and border styling for better contrast and user experience.

## 📸 Proof of Work (Screenshots / Logs)
After fixing the banner visibility:
<img width="1906" height="777" alt="image" src="https://github.com/user-attachments/assets/a4adc778-1956-46c2-9bfd-88d80a57f053" />
<img width="1916" height="762" alt="image" src="https://github.com/user-attachments/assets/67bc2b86-255a-4083-994b-23a873c89d01" />



> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_
This is actual issue before:
<img width="1917" height="765" alt="image" src="https://github.com/user-attachments/assets/f1acb780-4494-4cf0-b26e-aff39db3e129" />


## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [x] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3812`)
- [x] I have pulled the latest `main` and resolved any conflicts
