### PR TITLE
fix(web): prevent caching authenticated API responses

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,8 +1,10 @@
 import { execSync } from "node:child_process";
 import createNextIntlPlugin from "next-intl/plugin";
-import withPWAInit from "@ducanh2912/next-pwa";
+import withPWAInit, { runtimeCaching as defaultRuntimeCaching } from "@ducanh2912/next-pwa";
+import { createWorkboxRuntimeCaching } from "./worker/workboxRuntimeCaching.mjs";
 
 const withNextIntl = createNextIntlPlugin();
+const workboxRuntimeCaching = createWorkboxRuntimeCaching(defaultRuntimeCaching);
 
 const withPWA = withPWAInit({
     dest: "public",
@@ -12,6 +14,7 @@ const withPWA = withPWAInit({
     swcMinify: true,
     workboxOptions: {
         disableDevLogs: true,
+        runtimeCaching: workboxRuntimeCaching,
     },
 });
 
@@ -35,8 +38,19 @@ const nextConfig = {
     env: {
         NEXT_PUBLIC_BUILD_ID: buildId,
     },
-    transpilePackages: ["@sahidawa/validators", "@sahidawa/types", "@sahidawa/shared", "@zxing/library", "@zxing/browser"],
-    serverExternalPackages: ["lightningcss", "@tailwindcss/postcss", "@tailwindcss/node", "@tailwindcss/oxide"],
+    transpilePackages: [
+        "@sahidawa/validators",
+        "@sahidawa/types",
+        "@sahidawa/shared",
+        "@zxing/library",
+        "@zxing/browser",
+    ],
+    serverExternalPackages: [
+        "lightningcss",
+        "@tailwindcss/postcss",
+        "@tailwindcss/node",
+        "@tailwindcss/oxide",
+    ],
     images: {
         formats: ["image/avif", "image/webp"],
         deviceSizes: [320, 420, 640, 750, 1080],
@@ -54,8 +68,14 @@ const nextConfig = {
                     { key: "X-Frame-Options", value: "DENY" },
                     { key: "X-Content-Type-Options", value: "nosniff" },
                     { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
-                    { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
-                    { key: "Permissions-Policy", value: "camera=(self), microphone=(self), geolocation=(self)" },
+                    {
+                        key: "Strict-Transport-Security",
+                        value: "max-age=63072000; includeSubDomains; preload",
+                    },
+                    {
+                        key: "Permissions-Policy",
+                        value: "camera=(self), microphone=(self), geolocation=(self)",
+                    },
                     // CSP removed — now handled dynamically per-request in middleware.ts
                 ],
             },

--- a/apps/web/tests/service-worker-cache-security.test.ts
+++ b/apps/web/tests/service-worker-cache-security.test.ts
@@ -1,0 +1,331 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import vm from "vm";
+
+const workerSource = readFileSync(join(process.cwd(), "worker/index.js"), "utf8");
+const nextConfigSource = readFileSync(join(process.cwd(), "next.config.mjs"), "utf8");
+const workboxPolicySource = readFileSync(
+    join(process.cwd(), "worker/workboxRuntimeCaching.mjs"),
+    "utf8"
+);
+
+function inspectProductionWorkboxPolicy() {
+    const context: Record<string, unknown> = { RegExp };
+    vm.runInNewContext(
+        workboxPolicySource
+            .replace(
+                "export function createWorkboxRuntimeCaching",
+                "function createWorkboxRuntimeCaching"
+            )
+            .concat("\nglobalThis.__createWorkboxRuntimeCaching = createWorkboxRuntimeCaching;"),
+        context
+    );
+    const createPolicy = context.__createWorkboxRuntimeCaching as (rules: Array<unknown>) => Array<{
+        urlPattern: (context: { sameOrigin: boolean; url: URL }) => boolean;
+        options?: { cacheName?: string };
+    }>;
+    const rules = createPolicy([
+        { urlPattern: () => true, options: { cacheName: "apis" } },
+        { urlPattern: /\.json$/, options: { cacheName: "static-data-assets" } },
+        { urlPattern: /\.js$/, options: { cacheName: "static-js-assets" } },
+        { urlPattern: /\.png$/, options: { cacheName: "static-image-assets" } },
+    ]);
+    const matches = [
+        "/api/schedules",
+        "/api/private.json",
+        "/api/private.js",
+        "/api/private.png",
+    ].map((pathname) => {
+        const url = new URL(pathname, "https://sahidawa.test");
+        return rules.some((rule) => rule.urlPattern({ url, sameOrigin: true }));
+    });
+    const staticUrl = new URL("/public/data.json", "https://sahidawa.test");
+    const staticDataStillMatches = rules.some((rule) =>
+        rule.urlPattern({ url: staticUrl, sameOrigin: true })
+    );
+    return {
+        cacheNames: rules.map((rule) => rule.options?.cacheName),
+        matches,
+        staticDataStillMatches,
+    };
+}
+
+type WorkerHandler = (event: any) => void;
+
+function createWorkerHarness() {
+    const handlers = new Map<string, WorkerHandler>();
+    const match = jest.fn<Promise<Response | undefined>, [Request]>().mockResolvedValue(undefined);
+    const put = jest.fn<Promise<void>, [Request, Response]>().mockResolvedValue(undefined);
+    const cache = { addAll: jest.fn().mockResolvedValue(undefined), match, put };
+    const caches = {
+        open: jest.fn().mockResolvedValue(cache),
+        keys: jest.fn().mockResolvedValue([]),
+        delete: jest.fn().mockResolvedValue(true),
+    };
+    const fetchMock = jest.fn<Promise<Response>, [Request, RequestInit?]>();
+    const self = {
+        location: new URL("https://sahidawa.test"),
+        addEventListener: jest.fn((type: string, handler: WorkerHandler) => {
+            handlers.set(type, handler);
+        }),
+        skipWaiting: jest.fn(),
+        clients: {
+            claim: jest.fn(),
+            matchAll: jest.fn().mockResolvedValue([]),
+        },
+        crypto: globalThis.crypto,
+        registration: { showNotification: jest.fn() },
+    };
+
+    vm.runInNewContext(workerSource, {
+        self,
+        caches,
+        fetch: fetchMock,
+        Request,
+        Response,
+        Headers,
+        URL,
+        AbortController,
+        setTimeout,
+        clearTimeout,
+        console,
+        indexedDB,
+        Promise,
+        JSON,
+        Date,
+        Uint8Array,
+    });
+
+    async function dispatch(request: Request): Promise<Response> {
+        const fetchHandler = handlers.get("fetch");
+        if (!fetchHandler) throw new Error("Service worker fetch handler was not registered");
+
+        let responsePromise: Promise<Response> | undefined;
+        fetchHandler({
+            request,
+            respondWith(response) {
+                responsePromise = response;
+            },
+        });
+
+        if (!responsePromise) throw new Error("Service worker did not handle the request");
+        return responsePromise;
+    }
+
+    async function activate(): Promise<void> {
+        const activateHandler = handlers.get("activate");
+        if (!activateHandler) throw new Error("Service worker activate handler was not registered");
+
+        let activation: Promise<unknown> | undefined;
+        activateHandler({
+            waitUntil(promise: Promise<unknown>) {
+                activation = promise;
+            },
+        });
+        if (!activation) throw new Error("Service worker activation did not register work");
+        await activation;
+    }
+
+    return { activate, cache, caches, dispatch, fetchMock, match, put };
+}
+
+describe("production Workbox API cache boundary", () => {
+    it("contains no broad API cache and no runtime rule matches same-origin API URLs", () => {
+        const inspection = inspectProductionWorkboxPolicy();
+
+        expect(nextConfigSource).toContain("createWorkboxRuntimeCaching(defaultRuntimeCaching)");
+        expect(nextConfigSource).toContain("runtimeCaching: workboxRuntimeCaching");
+        expect(inspection.cacheNames).not.toContain("apis");
+        expect(inspection.matches).toEqual([false, false, false, false]);
+        expect(inspection.staticDataStillMatches).toBe(true);
+    });
+});
+
+describe("service worker shared API cache security", () => {
+    it("bypasses shared caches for Authorization requests, including offline fallback", async () => {
+        const harness = createWorkerHarness();
+        harness.match.mockResolvedValue(new Response("another user's schedule"));
+        harness.fetchMock.mockRejectedValue(new TypeError("offline"));
+
+        const response = await harness.dispatch(
+            new Request("https://sahidawa.test/api/schedules", {
+                headers: { Authorization: "Bearer test-token" },
+            })
+        );
+
+        expect(harness.fetchMock).toHaveBeenCalledTimes(1);
+        expect(harness.caches.open).not.toHaveBeenCalled();
+        expect(harness.match).not.toHaveBeenCalled();
+        expect(harness.put).not.toHaveBeenCalled();
+        expect(response.status).toBe(503);
+        await expect(response.json()).resolves.toMatchObject({ offline: true });
+    });
+
+    it("caches an allowlisted public GET without forwarding ambient credentials", async () => {
+        const harness = createWorkerHarness();
+        harness.fetchMock.mockResolvedValue(
+            new Response(JSON.stringify({ data: [] }), {
+                headers: { "Content-Type": "application/json" },
+            })
+        );
+
+        const response = await harness.dispatch(
+            new Request("https://sahidawa.test/api/v1/alerts?page=1")
+        );
+
+        expect(response.status).toBe(200);
+        expect(harness.put).toHaveBeenCalledTimes(1);
+        const networkRequest = harness.fetchMock.mock.calls[0][0];
+        const cachedRequest = harness.put.mock.calls[0][0];
+        expect(networkRequest.credentials).toBe("omit");
+        expect(cachedRequest.credentials).toBe("omit");
+    });
+
+    it("uses a cached allowlisted public GET when the network fails", async () => {
+        const harness = createWorkerHarness();
+        harness.fetchMock.mockRejectedValue(new TypeError("offline"));
+        harness.match.mockResolvedValue(new Response("public alerts"));
+
+        const response = await harness.dispatch(
+            new Request("https://sahidawa.test/api/v1/alerts?page=1")
+        );
+
+        expect(await response.text()).toBe("public alerts");
+        expect(harness.match).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(["POST", "PATCH", "PUT", "DELETE"])(
+        "never reads or writes shared caches for %s API requests",
+        async (method) => {
+            const harness = createWorkerHarness();
+            harness.fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+            await harness.dispatch(new Request("https://sahidawa.test/api/v1/alerts", { method }));
+
+            expect(harness.caches.open).not.toHaveBeenCalled();
+            expect(harness.match).not.toHaveBeenCalled();
+            expect(harness.put).not.toHaveBeenCalled();
+        }
+    );
+
+    it.each(["private, max-age=60", "no-store"])(
+        "does not cache public responses marked Cache-Control: %s",
+        async (cacheControl) => {
+            const harness = createWorkerHarness();
+            harness.fetchMock.mockResolvedValue(
+                new Response("public", { headers: { "Cache-Control": cacheControl } })
+            );
+
+            await harness.dispatch(new Request("https://sahidawa.test/api/stats"));
+
+            expect(harness.put).not.toHaveBeenCalled();
+        }
+    );
+
+    it("does not cache responses that set cookies", async () => {
+        const harness = createWorkerHarness();
+        harness.fetchMock.mockResolvedValue(
+            new Response("public", { headers: { "Set-Cookie": "session=secret; HttpOnly" } })
+        );
+
+        await harness.dispatch(new Request("https://sahidawa.test/api/stats"));
+
+        expect(harness.put).not.toHaveBeenCalled();
+    });
+
+    it("does not cache redirected public responses", async () => {
+        const harness = createWorkerHarness();
+        const response = new Response("redirected content");
+        Object.defineProperty(response, "redirected", { value: true });
+        harness.fetchMock.mockResolvedValue(response);
+
+        await harness.dispatch(new Request("https://sahidawa.test/api/stats"));
+
+        expect(harness.put).not.toHaveBeenCalled();
+    });
+
+    it.each(["/api/stats-private", "/api/verify/batch-private/BN"])(
+        "does not let the allowlist match the private sibling %s",
+        async (pathname) => {
+            const harness = createWorkerHarness();
+            harness.fetchMock.mockResolvedValue(new Response("private"));
+
+            await harness.dispatch(new Request(`https://sahidawa.test${pathname}`));
+
+            expect(harness.caches.open).not.toHaveBeenCalled();
+            expect(harness.match).not.toHaveBeenCalled();
+            expect(harness.put).not.toHaveBeenCalled();
+        }
+    );
+
+    it("matches and caches the intended batch path boundary", async () => {
+        const harness = createWorkerHarness();
+        harness.fetchMock.mockResolvedValue(new Response("public batch"));
+
+        await harness.dispatch(new Request("https://sahidawa.test/api/verify/batch/BN?page=2"));
+
+        expect(harness.put).toHaveBeenCalledTimes(1);
+        expect(harness.put.mock.calls[0][0].url).toBe(
+            "https://sahidawa.test/api/verify/batch/BN?page=2"
+        );
+    });
+
+    it("bypasses shared caches for a private route without an Authorization header", async () => {
+        const harness = createWorkerHarness();
+        harness.fetchMock.mockResolvedValue(new Response(JSON.stringify({ schedules: [] })));
+
+        await harness.dispatch(new Request("https://sahidawa.test/api/schedules"));
+
+        expect(harness.caches.open).not.toHaveBeenCalled();
+        expect(harness.match).not.toHaveBeenCalled();
+        expect(harness.put).not.toHaveBeenCalled();
+    });
+
+    it("bypasses shared caches when credentials are explicitly included", async () => {
+        const harness = createWorkerHarness();
+        harness.fetchMock.mockResolvedValue(new Response("alerts"));
+
+        await harness.dispatch(
+            new Request("https://sahidawa.test/api/v1/alerts", { credentials: "include" })
+        );
+
+        expect(harness.caches.open).not.toHaveBeenCalled();
+        expect(harness.put).not.toHaveBeenCalled();
+    });
+
+    it("cannot use the CSRF cached fallback for an authenticated request", async () => {
+        const harness = createWorkerHarness();
+        harness.match.mockResolvedValue(new Response("cached private content"));
+        harness.fetchMock.mockResolvedValue(new Response("CSRF token invalid", { status: 403 }));
+
+        const response = await harness.dispatch(
+            new Request("https://sahidawa.test/api/schedules", {
+                headers: { Authorization: "Bearer test-token" },
+            })
+        );
+
+        expect(response.status).toBe(403);
+        expect(harness.caches.open).not.toHaveBeenCalled();
+        expect(harness.match).not.toHaveBeenCalled();
+    });
+
+    it("deletes legacy API caches while preserving unrelated Workbox caches", async () => {
+        const harness = createWorkerHarness();
+        harness.caches.keys.mockResolvedValue([
+            "apis",
+            "sahidawa-api-old-version",
+            "sahidawa-api-3816-public-api-only",
+            "workbox-precache-v2-https://sahidawa.test/",
+            "pages",
+            "static-image-assets",
+            "google-fonts-webfonts",
+        ]);
+
+        await harness.activate();
+
+        expect(harness.caches.delete.mock.calls.map(([name]) => name)).toEqual([
+            "apis",
+            "sahidawa-api-old-version",
+        ]);
+    });
+});

--- a/apps/web/worker/index.js
+++ b/apps/web/worker/index.js
@@ -64,10 +64,9 @@ const PUBLIC_API_ROUTES = [
 function isPublicCacheableApiRequest(request, url) {
     if (request.method !== "GET" || request.credentials === "include") return false;
 
-    const authenticationHeaders = [
         "authorization",
         "proxy-authorization",
-        "cookie",
+        // "cookie", // Forbidden header; not readable in service workers.
         "x-api-key",
         "x-api-secret",
         "x-csrf-token",

--- a/apps/web/worker/index.js
+++ b/apps/web/worker/index.js
@@ -8,7 +8,7 @@
  * @version 2.0.0
  */
 
-const CACHE_VERSION = "9de5be83-pwa";
+const CACHE_VERSION = "3816-public-api-only";
 
 /** Navigation / shell pages */
 const OFFLINE_CACHE_NAME = `sahidawa-offline-${CACHE_VERSION}`;
@@ -51,6 +51,44 @@ const PRECACHE_PAGES = [
     "/ta/scan",
 ];
 
+/** Public API reads whose responses are identical for every user. */
+const PUBLIC_API_ROUTES = [
+    (pathname) => pathname === "/api/v1/alerts",
+    (pathname) => pathname === "/api/stats",
+    (pathname) => pathname === "/api/medicines/search",
+    (pathname) => pathname === "/api/medicine/safety",
+    (pathname) => pathname.startsWith("/api/verify/batch/"),
+];
+
+/** Shared service-worker caches may contain public data only. */
+function isPublicCacheableApiRequest(request, url) {
+    if (request.method !== "GET" || request.credentials === "include") return false;
+
+    const authenticationHeaders = [
+        "authorization",
+        "proxy-authorization",
+        "cookie",
+        "x-api-key",
+        "x-api-secret",
+        "x-csrf-token",
+    ];
+    if (authenticationHeaders.some((header) => request.headers.has(header))) return false;
+
+    return PUBLIC_API_ROUTES.some((matches) => matches(url.pathname));
+}
+
+function isPublicCacheableApiResponse(response) {
+    if (!response?.ok || response.redirected || response.headers.has("set-cookie")) return false;
+
+    const cacheControl = response.headers.get("cache-control")?.toLowerCase() ?? "";
+    return !cacheControl.includes("no-store") && !cacheControl.includes("private");
+}
+
+function createPublicApiRequest(request) {
+    // Public reads never need ambient cookies from the browser's default credentials mode.
+    return new Request(request, { credentials: "omit" });
+}
+
 // ---------------------------------------------------------------------------
 // INSTALL — precache core shell pages
 // ---------------------------------------------------------------------------
@@ -81,12 +119,17 @@ self.addEventListener("activate", (event) => {
         TILES_CACHE_NAME,
         RSC_CACHE_NAME,
     ]);
+    const legacyUnsafeApiCaches = new Set(["apis"]);
 
     event.waitUntil(
         caches.keys().then((cacheNames) =>
             Promise.all(
                 cacheNames
-                    .filter((name) => !validCaches.has(name))
+                    .filter(
+                        (name) =>
+                            legacyUnsafeApiCaches.has(name) ||
+                            (name.startsWith("sahidawa-") && !validCaches.has(name))
+                    )
                     .map((name) => {
                         console.log(`[SW] Deleting stale cache: ${name}`);
                         return caches.delete(name);
@@ -163,7 +206,7 @@ self.addEventListener("fetch", (event) => {
         url.pathname.startsWith("/api/v1/scan/") ||
         url.pathname.startsWith("/api/v1/lasa/")
     ) {
-        event.respondWith(networkFirstWithCache(request, MEDICINE_CACHE_NAME));
+        event.respondWith(handleApiRequest(request, url, MEDICINE_CACHE_NAME));
         return;
     }
 
@@ -189,7 +232,7 @@ self.addEventListener("fetch", (event) => {
     // (alerts must be fresh; other API endpoints like reports)
     // -------------------------------------------------------------------------
     if (url.pathname.startsWith("/api/")) {
-        event.respondWith(networkFirstWithCache(request, API_CACHE_NAME));
+        event.respondWith(handleApiRequest(request, url, API_CACHE_NAME));
         return;
     }
 
@@ -315,18 +358,49 @@ async function staleWhileRevalidate(request, cacheName) {
  *   2. On success: update the cache and return.
  *   3. On failure: serve from cache (if available) or return a 503 JSON.
  */
+async function handleApiRequest(request, url, cacheName) {
+    if (!isPublicCacheableApiRequest(request, url)) {
+        return fetchWithoutCache(request);
+    }
+
+    return networkFirstWithCache(createPublicApiRequest(request), cacheName);
+}
+
+async function fetchWithoutCache(request) {
+    try {
+        return await fetchWithTimeout(request);
+    } catch {
+        return createOfflineApiResponse();
+    }
+}
+
+async function fetchWithTimeout(request) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 8000);
+
+    try {
+        return await fetch(request, { signal: controller.signal });
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}
+
+function createOfflineApiResponse() {
+    return new Response(
+        JSON.stringify({
+            error: "You are offline and this data is not cached.",
+            offline: true,
+        }),
+        { status: 503, headers: { "Content-Type": "application/json" } }
+    );
+}
+
 async function networkFirstWithCache(request, cacheName) {
     const cache = await caches.open(cacheName);
 
     try {
         // 8s timeout for API calls — important for slow networks
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 8000);
-
-        const networkResponse = await fetch(request, {
-            signal: controller.signal,
-        });
-        clearTimeout(timeoutId);
+        const networkResponse = await fetchWithTimeout(request);
 
         // ── CSRF 403 optimization ─────────────────────────────────────────
         // If the API returns a 403 CSRF error for a GET request, don't make
@@ -350,7 +424,7 @@ async function networkFirstWithCache(request, cacheName) {
             }
         }
 
-        if (networkResponse.ok) {
+        if (isPublicCacheableApiResponse(networkResponse)) {
             cache.put(request, networkResponse.clone()).catch(() => {});
         }
         return networkResponse;
@@ -358,13 +432,7 @@ async function networkFirstWithCache(request, cacheName) {
         const cachedResponse = await cache.match(request);
         if (cachedResponse) return cachedResponse;
 
-        return new Response(
-            JSON.stringify({
-                error: "You are offline and this data is not cached.",
-                offline: true,
-            }),
-            { status: 503, headers: { "Content-Type": "application/json" } }
-        );
+        return createOfflineApiResponse();
     }
 }
 

--- a/apps/web/worker/workboxRuntimeCaching.mjs
+++ b/apps/web/worker/workboxRuntimeCaching.mjs
@@ -1,0 +1,22 @@
+function matchesPattern(pattern, context) {
+    if (pattern instanceof RegExp) {
+        pattern.lastIndex = 0;
+        return pattern.test(context.url.href);
+    }
+    if (typeof pattern === "function") return pattern(context);
+    if (typeof pattern === "string") return context.url.href.startsWith(pattern);
+    return false;
+}
+
+/** Workbox must never compete with the custom worker for same-origin API requests. */
+export function createWorkboxRuntimeCaching(defaultRuntimeCaching) {
+    return defaultRuntimeCaching
+        .filter((entry) => entry.options?.cacheName !== "apis")
+        .map((entry) => ({
+            ...entry,
+            urlPattern: (context) => {
+                if (context.sameOrigin && context.url.pathname.startsWith("/api/")) return false;
+                return matchesPattern(entry.urlPattern, context);
+            },
+        }));
+}


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3816**
- **Summary:**
  - Removed the broad Workbox runtime caching rule that matched same-origin `/api/*` requests.
  - Made the custom service worker the single authority for API caching decisions.
  - Restricted shared API caching to explicitly allowlisted public GET endpoints only.
  - Bypassed shared caching for authenticated, credentialed, private, redirected, and non-GET API requests.
  - Limited cache cleanup during activation to legacy API caches and obsolete SahiDawa-owned cache versions while preserving other Workbox caches.
  - Added regression tests covering Workbox runtime configuration, allowlist boundaries, redirect handling, activation cleanup, offline behavior, and cache safety.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Tests Executed

```text
npm.cmd test -- --runInBand tests/service-worker-cache-security.test.ts
✓ 19 tests passed

npm.cmd test -- --runInBand tests/offline.test.ts tests/service-worker-cache-security.test.ts
✓ 43 tests passed
✓ 10 skipped (existing)

npx.cmd tsc --noEmit
✓ Passed

npx.cmd eslint tests/service-worker-cache-security.test.ts worker/workboxRuntimeCaching.mjs next.config.mjs
✓ Passed

git diff --check
✓ Passed
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] 🔒 `type: security`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3816`)
- [x] I have pulled the latest `main` and resolved any conflicts