### PR TITLE
fix(web): remove hardcoded search fallback

### DIFF
--- a/apps/web/app/[locale]/components/SearchBar.tsx
+++ b/apps/web/app/[locale]/components/SearchBar.tsx
@@ -18,6 +18,15 @@ import { escapePostgrest } from "@/lib/supabase/utils";
 const MAX_SUGGESTIONS = 8;
 /** Debounce delay in milliseconds */
 const DEBOUNCE_MS = 250;
+const SEARCH_UNAVAILABLE_MESSAGE = "Search is temporarily unavailable. Please try again.";
+const SEARCH_OFFLINE_MESSAGE = "Search is unavailable while offline.";
+
+function isAbortError(error: unknown): boolean {
+    return (
+        error instanceof Error &&
+        (error.name === "AbortError" || error.message.toLowerCase().includes("aborted"))
+    );
+}
 
 interface SearchBarProps {
     dark?: boolean;
@@ -196,6 +205,7 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
     const fetchSuggestions = useCallback(async (trimmed: string) => {
         setError(null);
         setNoResults(false);
+        setSuggestions([]);
 
         if (!trimmed) {
             setSuggestions([]);
@@ -205,8 +215,8 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
         }
 
         if (typeof window !== "undefined" && !window.navigator.onLine) {
-            setSuggestions([]);
-            setIsOpen(false);
+            setError(SEARCH_OFFLINE_MESSAGE);
+            setIsOpen(true);
             setIsLoading(false);
             return;
         }
@@ -219,7 +229,6 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
         setIsLoading(true);
 
         try {
-            let useFallback = false;
             let data: { brand_name: string | null; batch_number: string | null }[] | null = null;
 
             try {
@@ -234,47 +243,19 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
 
                 if (response.error) {
                     if (
-                        response.error.message?.includes("Could not find the table") ||
-                        response.error.code === "42P01"
-                    ) {
-                        console.warn(
-                            "[SearchBar] Table missing. Dropping into local data fallback matrix."
-                        );
-                        useFallback = true;
-                    } else if (
                         response.error.message?.includes("AbortError") ||
                         response.error.message?.includes("aborted")
                     ) {
                         // Request was cancelled by a newer keystroke — safe to ignore
                         return;
                     }
-                    // Network errors — silently fall through to fuzzy matcher
-                    if (
-                        response.error.message?.includes("Failed to fetch") ||
-                        response.error.message?.includes("NetworkError") ||
-                        response.error.message?.includes("fetch")
-                    ) {
-                        console.warn(
-                            "[SearchBar] Network error, trying fuzzy fallback:",
-                            response.error.message
-                        );
-                        useFallback = true;
-                    } else {
-                        console.error("[SearchBar] Supabase error:", response.error.message);
-                        setSuggestions([]);
-                        setIsOpen(false);
-                        return;
-                    }
+                    throw new Error(response.error.message || "Medicine search failed");
                 } else {
                     data = response.data;
                 }
-            } catch (dbErr: any) {
-                if (dbErr?.name === "AbortError" || dbErr?.message?.includes("aborted")) return;
-                if (dbErr?.message?.includes("Could not find the table")) {
-                    useFallback = true;
-                } else {
-                    throw dbErr;
-                }
+            } catch (dbErr: unknown) {
+                if (isAbortError(dbErr)) return;
+                throw dbErr;
             }
 
             if (controller.signal.aborted) return;
@@ -283,7 +264,7 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
             const results: string[] = [];
 
             // ── CASE A: Database Operational ─────────────────────────────────────
-            if (!useFallback && data && data.length > 0) {
+            if (data && data.length > 0) {
                 for (const row of data) {
                     const candidates = [row.brand_name, row.batch_number];
                     for (const c of candidates) {
@@ -296,35 +277,8 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
                     if (results.length >= MAX_SUGGESTIONS) break;
                 }
             }
-            // ── CASE B: Failover to UI Validation Testing Pool ────────────────────
-            else if (useFallback) {
-                const mockMedicinesPool = [
-                    { brand_name: "Paracetamol", batch_number: "BATCH-PR750" },
-                    { brand_name: "Peracetamol (Fuzzy Match)", batch_number: "BATCH-PR750" },
-                    { brand_name: "Crocin Advance", batch_number: "BATCH-CR100" },
-                    { brand_name: "Amoxicillin", batch_number: "BATCH-AM250" },
-                    { brand_name: "Calpol 650", batch_number: "BATCH-CP650" },
-                    { brand_name: "Dolo 650", batch_number: "BATCH-DL650" },
-                    { brand_name: "Ibuprofen", batch_number: "BATCH-IB400" },
-                    { brand_name: "Cetirizine", batch_number: "BATCH-CT10" },
-                    { brand_name: "Azithromycin", batch_number: "BATCH-AZ500" },
-                ];
-
-                for (const item of mockMedicinesPool) {
-                    const candidates = [item.brand_name, item.batch_number];
-                    for (const c of candidates) {
-                        if (c && c.toLowerCase().includes(trimmed.toLowerCase()) && !seen.has(c)) {
-                            seen.add(c);
-                            results.push(c);
-                            if (results.length >= MAX_SUGGESTIONS) break;
-                        }
-                    }
-                    if (results.length >= MAX_SUGGESTIONS) break;
-                }
-            }
-
-            // Run local fuzzy matcher if database is working but returns no rows
-            if (!useFallback && results.length < 3) {
+            // Supplement sparse database results with the existing fuzzy search endpoint.
+            if (results.length < 3) {
                 try {
                     const fuzzyResults = await fuzzyMatchBrand(trimmed, controller.signal);
                     for (const match of fuzzyResults) {
@@ -334,20 +288,23 @@ export default function SearchBar({ dark = false, onSearchChange }: SearchBarPro
                             if (results.length >= MAX_SUGGESTIONS) break;
                         }
                     }
-                } catch (fuzzyErr) {
+                } catch (fuzzyErr: unknown) {
+                    if (isAbortError(fuzzyErr)) return;
                     console.warn("[SearchBar] Fuzzy matching fallback error:", fuzzyErr);
                 }
             }
 
+            if (controller.signal.aborted) return;
             setSuggestions(results);
             setNoResults(results.length === 0);
             setIsOpen(true);
             setActiveIndex(-1);
-        } catch (err) {
-            if (err instanceof Error && err.name === "AbortError") return;
+        } catch (err: unknown) {
+            if (isAbortError(err) || controller.signal.aborted) return;
             console.error("[SearchBar] Unexpected error fetching suggestions:", err);
             setSuggestions([]);
-            setError("Unable to fetch medicine suggestions.");
+            setNoResults(false);
+            setError(SEARCH_UNAVAILABLE_MESSAGE);
             setIsOpen(true);
         } finally {
             if (!controller.signal.aborted) {

--- a/apps/web/components/SearchSuggestions.tsx
+++ b/apps/web/components/SearchSuggestions.tsx
@@ -88,7 +88,10 @@ function SearchSuggestions({
 
     if (isLoading) {
         return (
-            <div className="absolute top-full right-0 left-0 z-50 mt-2 rounded-2xl border border-slate-200 bg-white p-4 shadow-xl">
+            <div
+                role="status"
+                className="absolute top-full right-0 left-0 z-50 mt-2 rounded-2xl border border-slate-200 bg-white p-4 shadow-xl"
+            >
                 <div className="flex items-center gap-2 text-sm text-slate-600">
                     <div className="h-4 w-4 animate-spin rounded-full border-2 border-emerald-500 border-t-transparent" />
                     Searching medicines...
@@ -99,7 +102,10 @@ function SearchSuggestions({
 
     if (error) {
         return (
-            <div className="absolute top-full right-0 left-0 z-50 mt-2 rounded-2xl border border-red-200 bg-white p-4 shadow-xl">
+            <div
+                role="alert"
+                className="absolute top-full right-0 left-0 z-50 mt-2 rounded-2xl border border-red-200 bg-white p-4 shadow-xl"
+            >
                 <p className="mb-3 text-sm text-red-600">{error}</p>
                 {onRetry && (
                     <button
@@ -116,7 +122,10 @@ function SearchSuggestions({
 
     if (noResults) {
         return (
-            <div className="absolute top-full right-0 left-0 z-50 mt-2 rounded-2xl border border-slate-200 bg-white p-4 shadow-xl">
+            <div
+                role="status"
+                className="absolute top-full right-0 left-0 z-50 mt-2 rounded-2xl border border-slate-200 bg-white p-4 shadow-xl"
+            >
                 <p className="text-sm text-slate-600">
                     No medicines found. Try another medicine name or batch number.
                 </p>

--- a/apps/web/tests/SearchBar.test.tsx
+++ b/apps/web/tests/SearchBar.test.tsx
@@ -1,0 +1,202 @@
+import React from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import SearchBar from "../app/[locale]/components/SearchBar";
+import { fuzzyMatchBrand } from "@/lib/api";
+import { supabase } from "@/lib/supabase";
+
+jest.mock("next-intl", () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+jest.mock("lucide-react", () => ({
+    Search: () => <span aria-hidden="true">search</span>,
+    X: () => <span aria-hidden="true">close</span>,
+    Clock: () => <span aria-hidden="true">clock</span>,
+    Pin: () => <span aria-hidden="true">pin</span>,
+}));
+
+jest.mock("@tanstack/react-virtual", () => ({
+    useVirtualizer: ({ count }: { count: number }) => ({
+        getTotalSize: () => count * 48,
+        getVirtualItems: () =>
+            Array.from({ length: count }, (_, index) => ({
+                index,
+                start: index * 48,
+                measureElement: jest.fn(),
+            })),
+        scrollToIndex: jest.fn(),
+        measureElement: jest.fn(),
+    }),
+}));
+
+jest.mock("@/lib/api", () => ({
+    fuzzyMatchBrand: jest.fn(),
+}));
+
+jest.mock("@/lib/supabase", () => ({
+    supabase: { from: jest.fn() },
+}));
+
+type MedicineRow = { brand_name: string | null; batch_number: string | null };
+type QueryResponse = {
+    data: MedicineRow[] | null;
+    error: { message: string; code?: string } | null;
+};
+
+const mockedFuzzyMatchBrand = fuzzyMatchBrand as jest.MockedFunction<typeof fuzzyMatchBrand>;
+const mockedFrom = supabase.from as jest.Mock;
+
+function createQueryBuilder(responses: Array<Promise<QueryResponse>>) {
+    const builder = {
+        select: jest.fn(),
+        or: jest.fn(),
+        abortSignal: jest.fn(),
+        limit: jest.fn(),
+    };
+    builder.select.mockReturnValue(builder);
+    builder.or.mockReturnValue(builder);
+    builder.abortSignal.mockReturnValue(builder);
+    builder.limit.mockImplementation(() => {
+        const response = responses.shift();
+        if (!response) throw new Error("No mocked Supabase response remains");
+        return response;
+    });
+    mockedFrom.mockReturnValue(builder);
+    return builder;
+}
+
+async function enterQuery(value: string) {
+    fireEvent.change(screen.getByRole("combobox"), { target: { value } });
+    await act(async () => {
+        jest.advanceTimersByTime(300);
+        await Promise.resolve();
+        await Promise.resolve();
+    });
+}
+
+describe("SearchBar suggestion failures", () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.clearAllMocks();
+        localStorage.clear();
+        Object.defineProperty(window.navigator, "onLine", { configurable: true, value: true });
+        mockedFuzzyMatchBrand.mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+    });
+
+    it("shows an unavailable state without fabricated suggestions on network failure", async () => {
+        const onSearchChange = jest.fn();
+        createQueryBuilder([Promise.reject(new TypeError("Failed to fetch"))]);
+        render(<SearchBar onSearchChange={onSearchChange} />);
+
+        await enterQuery("Crocin");
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+            "Search is temporarily unavailable. Please try again."
+        );
+        expect(screen.queryByText("Crocin Advance")).not.toBeInTheDocument();
+        expect(screen.queryByText("Dolo 650")).not.toBeInTheDocument();
+        expect(screen.queryByText("BATCH-CR100")).not.toBeInTheDocument();
+        expect(screen.queryByText("BATCH-DL650")).not.toBeInTheDocument();
+        expect(screen.getByRole("combobox")).toHaveValue("Crocin");
+        expect(onSearchChange).not.toHaveBeenCalledWith("Crocin");
+    });
+
+    it("renders genuine results and preserves selection behavior", async () => {
+        const onSearchChange = jest.fn();
+        createQueryBuilder([
+            Promise.resolve({
+                data: [{ brand_name: "Verified Medicine", batch_number: "REAL-2026" }],
+                error: null,
+            }),
+        ]);
+        render(<SearchBar onSearchChange={onSearchChange} />);
+
+        await enterQuery("Verified");
+        fireEvent.mouseDown(screen.getByRole("option", { name: "Verified Medicine" }));
+
+        expect(onSearchChange).toHaveBeenCalledWith("Verified Medicine");
+        expect(screen.getByRole("combobox")).toHaveValue("Verified Medicine");
+    });
+
+    it("distinguishes a successful empty response from request failure", async () => {
+        createQueryBuilder([Promise.resolve({ data: [], error: null })]);
+        render(<SearchBar />);
+
+        await enterQuery("Unknown medicine");
+
+        expect(await screen.findByRole("status")).toHaveTextContent("No medicines found");
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("shows an offline state without querying or rendering fabricated suggestions", async () => {
+        Object.defineProperty(window.navigator, "onLine", { configurable: true, value: false });
+        render(<SearchBar />);
+
+        await enterQuery("Dolo");
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+            "Search is unavailable while offline."
+        );
+        expect(mockedFrom).not.toHaveBeenCalled();
+        expect(screen.queryByText("Dolo 650")).not.toBeInTheDocument();
+        expect(screen.getByRole("combobox")).toHaveValue("Dolo");
+    });
+
+    it("clears suggestions from a previous successful search when a later request fails", async () => {
+        createQueryBuilder([
+            Promise.resolve({
+                data: [{ brand_name: "First Genuine Result", batch_number: "REAL-1" }],
+                error: null,
+            }),
+            Promise.resolve({ data: null, error: { message: "Failed to fetch" } }),
+        ]);
+        render(<SearchBar />);
+
+        await enterQuery("First");
+        expect(screen.getByRole("option", { name: "First Genuine Result" })).toBeInTheDocument();
+
+        await enterQuery("Second");
+
+        expect(await screen.findByRole("alert")).toBeInTheDocument();
+        expect(
+            screen.queryByRole("option", { name: "First Genuine Result" })
+        ).not.toBeInTheDocument();
+    });
+
+    it("ignores an aborted older request and lets the newer request control the UI", async () => {
+        let resolveOlder: ((response: QueryResponse) => void) | undefined;
+        const olderResponse = new Promise<QueryResponse>((resolve) => {
+            resolveOlder = resolve;
+        });
+        const builder = createQueryBuilder([
+            olderResponse,
+            Promise.resolve({
+                data: [{ brand_name: "New Genuine Result", batch_number: "REAL-NEW" }],
+                error: null,
+            }),
+        ]);
+        render(<SearchBar />);
+
+        await enterQuery("Old");
+        await enterQuery("New");
+        expect((builder.abortSignal.mock.calls[0][0] as AbortSignal).aborted).toBe(true);
+        expect(screen.getByRole("option", { name: "New Genuine Result" })).toBeInTheDocument();
+
+        await act(async () => {
+            resolveOlder?.({
+                data: [{ brand_name: "Old Stale Result", batch_number: "REAL-OLD" }],
+                error: null,
+            });
+            await olderResponse;
+        });
+
+        expect(screen.getByRole("option", { name: "New Genuine Result" })).toBeInTheDocument();
+        expect(screen.queryByRole("option", { name: "Old Stale Result" })).not.toBeInTheDocument();
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3817**
- **Summary:**
  - Removed the production hardcoded medicine and batch fallback used after Supabase request failures.
  - Added distinct online-failure and offline states instead of displaying fabricated suggestions.
  - Cleared stale suggestions when a new search begins and prevented older requests from overwriting newer results.
  - Ignored intentionally aborted requests to avoid showing unnecessary error states.
  - Improved accessibility by adding appropriate status and alert roles for loading, empty, and error states.
  - Added regression tests covering network failures, offline behavior, stale results, aborted requests, out-of-order responses, and successful searches.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Tests Executed

```text
npm.cmd test -- --runInBand tests/SearchBar.test.tsx tests/SearchSuggestions.test.tsx
✓ 12 tests passed

Focused SearchBar regression tests
✓ 6 tests passed

npx.cmd tsc --noEmit
✓ Passed

npx.cmd eslint 'app/[locale]/components/SearchBar.tsx' components/SearchSuggestions.tsx tests/SearchBar.test.tsx
✓ Passed

npx.cmd prettier --check 'app/[locale]/components/SearchBar.tsx' components/SearchSuggestions.tsx tests/SearchBar.test.tsx
✓ Passed

git diff --check
✓ Passed
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3817`)
- [x] I have pulled the latest `main` and resolved any conflicts