### PR TITLE
fix(api): align alert upsert with unique constraint

### DIFF
--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -22,6 +22,7 @@ const AlertSchema = z
         district: z.string().optional(),
         reported_at: z.string().optional(),
         proof_image_url: z.string().optional().nullable(),
+        source_url: z.string().optional().nullable(),
     })
     .passthrough();
 
@@ -186,7 +187,7 @@ alertsRouter.post("/ingest", requireApiKey, limiter, async (req: ApiKeyRequest, 
         const { data: insertedAlerts, error: insertError } = await supabase
             .from("drug_alerts")
             .upsert(validatedAlerts, {
-                onConflict: "batch_number,manufacturer,reported_brand_name",
+                onConflict: "batch_number,source_url",
                 ignoreDuplicates: true,
             })
             .select();


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required files.

## 📋 PR Summary & Link

- **Closes #3682**
- **Summary:**
  - Added `source_url` to the alert ingestion `AlertSchema`.
  - Updated the Supabase `.upsert()` conflict target from `batch_number,manufacturer,reported_brand_name` to `batch_number,source_url`.
  - Aligned the API with the existing `unique_drug_alert` database constraint to ensure duplicate CDSCO alerts are handled correctly.

## 📸 Proof of Work (Screenshots / Logs)

### Verification
- Verified that `source_url` is now accepted by the ingestion schema.
- Verified that the `onConflict` target matches the existing database unique constraint (`batch_number,source_url`).

> Note: `npm run lint` currently fails due to pre-existing unrelated lint errors in:
> - `apps/web/app/[locale]/components/Footer.tsx`
> - `apps/web/worker/index.js`
>
> No new lint errors were introduced by this PR.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3682`)
- [x] I have pulled the latest `main` and resolved any conflicts