### PR TITLE
fix(api): propagate guest wishlist merge failures

### DIFF
--- a/apps/api/src/routes/wishlist.ts
+++ b/apps/api/src/routes/wishlist.ts
@@ -30,6 +30,13 @@ interface WishlistItem {
     created_at: string;
 }
 
+class WishlistMergeUnavailableError extends Error {
+    constructor() {
+        super("Wishlist sync is temporarily unavailable. Please try again.");
+        this.name = "WishlistMergeUnavailableError";
+    }
+}
+
 export async function mergeGuestWishlist(
     userId: string,
     guestProductIds: string[]
@@ -46,7 +53,7 @@ export async function mergeGuestWishlist(
 
         if (fetchError) {
             logger.error("Failed to fetch existing wishlist", { error: fetchError });
-            return [];
+            throw new WishlistMergeUnavailableError();
         }
 
         const existingProductIds = new Set(
@@ -58,10 +65,17 @@ export async function mergeGuestWishlist(
         if (newProductIds.length === 0) {
             return [];
         }
-        const { data: existingMedicines } = await supabase
+        const { data: existingMedicines, error: medicineLookupError } = await supabase
             .from("medicines")
             .select("id")
             .in("id", newProductIds);
+
+        if (medicineLookupError) {
+            logger.error("Failed to validate guest wishlist medicines", {
+                error: medicineLookupError,
+            });
+            throw new WishlistMergeUnavailableError();
+        }
 
         const verifiedProductIds = new Set(
             (existingMedicines || []).map((m: { id: string }) => m.id)
@@ -84,13 +98,14 @@ export async function mergeGuestWishlist(
 
         if (insertError) {
             logger.error("Failed to merge guest wishlist", { error: insertError });
-            return [];
+            throw new WishlistMergeUnavailableError();
         }
 
         return (inserted || []).map((item: Pick<WishlistItem, "product_id">) => item.product_id);
     } catch (err) {
-        logger.error("Error merging guest wishlist", { error: err });
-        return [];
+        if (err instanceof WishlistMergeUnavailableError) throw err;
+        logger.error("Unexpected error merging guest wishlist", { error: err });
+        throw new WishlistMergeUnavailableError();
     }
 }
 
@@ -271,6 +286,14 @@ router.post(
                 merged_items: mergedIds,
             });
         } catch (err) {
+            if (err instanceof WishlistMergeUnavailableError) {
+                res.status(503).json({
+                    success: false,
+                    error: err.message,
+                    code: "WISHLIST_MERGE_UNAVAILABLE",
+                });
+                return;
+            }
             next(err);
         }
     }

--- a/apps/api/tests/wishlist.test.ts
+++ b/apps/api/tests/wishlist.test.ts
@@ -1,4 +1,21 @@
-import { mergeGuestWishlist } from "../src/routes/wishlist";
+import express from "express";
+import request, { Response as SuperTestResponse } from "supertest";
+import wishlistRouter, { mergeGuestWishlist } from "../src/routes/wishlist";
+
+jest.mock("../src/middleware/auth", () => ({
+    requireAuth: (
+        req: { user?: { id: string; role: string } },
+        _res: unknown,
+        next: () => void
+    ) => {
+        req.user = { id: "user-1", role: "user" };
+        next();
+    },
+}));
+
+jest.mock("../src/middleware/rateLimit", () => ({
+    limiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
 
 jest.mock("../src/db/client", () => {
     const mockSupabase = {
@@ -10,6 +27,22 @@ jest.mock("../src/db/client", () => {
 import { supabase } from "../src/db/client";
 
 const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
+
+function createTestApp() {
+    const app = express();
+    app.use(express.json());
+    app.use("/api/v1/wishlist", wishlistRouter);
+    return app;
+}
+
+function expectUnavailableMerge(response: SuperTestResponse) {
+    expect(response.status).toBe(503);
+    expect(response.body).toEqual({
+        success: false,
+        error: "Wishlist sync is temporarily unavailable. Please try again.",
+        code: "WISHLIST_MERGE_UNAVAILABLE",
+    });
+}
 
 describe("mergeGuestWishlist", () => {
     beforeEach(() => {
@@ -90,5 +123,110 @@ describe("mergeGuestWishlist", () => {
         expect(result).toEqual([]);
         expect(wishlistsSelectEqMock).toHaveBeenCalledWith("user_id", userId);
         expect(medicinesInMock).toHaveBeenCalledWith("id", [invalidId]);
+    });
+
+    it("returns an empty array when every guest item is already wishlisted", async () => {
+        const productId = "44444444-4444-4444-8444-444444444444";
+        const wishlistsSelectEqMock = jest.fn().mockResolvedValue({
+            data: [{ product_id: productId }],
+            error: null,
+        });
+        mockedSupabase.from.mockReturnValue({
+            select: jest.fn().mockReturnValue({ eq: wishlistsSelectEqMock }),
+        } as never);
+
+        await expect(mergeGuestWishlist("user-1", [productId])).resolves.toEqual([]);
+        expect(mockedSupabase.from).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns 503 when fetching the existing wishlist fails", async () => {
+        const fetchError = { message: "database unavailable" };
+        const productIds = ["55555555-5555-4555-8555-555555555555"];
+        mockedSupabase.from.mockReturnValue({
+            select: jest.fn().mockReturnValue({
+                eq: jest.fn().mockResolvedValue({ data: null, error: fetchError }),
+            }),
+        } as never);
+
+        const response = await request(createTestApp())
+            .post("/api/v1/wishlist/merge-guest")
+            .send({ product_ids: productIds });
+
+        expectUnavailableMerge(response);
+        expect(response.text).not.toContain("database unavailable");
+    });
+
+    it("returns 503 when medicine lookup fails", async () => {
+        const productId = "66666666-6666-4666-8666-666666666666";
+        mockedSupabase.from.mockImplementation((table: string) => {
+            if (table === "wishlists") {
+                return {
+                    select: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockResolvedValue({ data: [], error: null }),
+                    }),
+                };
+            }
+            return {
+                select: jest.fn().mockReturnValue({
+                    in: jest.fn().mockResolvedValue({
+                        data: null,
+                        error: { message: "medicine lookup failed" },
+                    }),
+                }),
+            };
+        });
+
+        const response = await request(createTestApp())
+            .post("/api/v1/wishlist/merge-guest")
+            .send({ product_ids: [productId] });
+
+        expectUnavailableMerge(response);
+    });
+
+    it("returns 503 when wishlist insertion fails", async () => {
+        const productId = "77777777-7777-4777-8777-777777777777";
+        mockedSupabase.from.mockImplementation((table: string) => {
+            if (table === "medicines") {
+                return {
+                    select: jest.fn().mockReturnValue({
+                        in: jest.fn().mockResolvedValue({
+                            data: [{ id: productId }],
+                            error: null,
+                        }),
+                    }),
+                };
+            }
+            return {
+                select: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockResolvedValue({ data: [], error: null }),
+                }),
+                insert: jest.fn().mockReturnValue({
+                    select: jest.fn().mockResolvedValue({
+                        data: null,
+                        error: { message: "insert failed" },
+                    }),
+                }),
+            };
+        });
+
+        const response = await request(createTestApp())
+            .post("/api/v1/wishlist/merge-guest")
+            .send({ product_ids: [productId] });
+
+        expectUnavailableMerge(response);
+    });
+
+    it("returns 503 for an unexpected merge exception", async () => {
+        const productId = "88888888-8888-4888-8888-888888888888";
+        mockedSupabase.from.mockImplementation(() => {
+            throw new Error("unexpected internal details");
+        });
+
+        const response = await request(createTestApp())
+            .post("/api/v1/wishlist/merge-guest")
+            .send({ product_ids: [productId] });
+
+        expectUnavailableMerge(response);
+        expect(response.text).not.toContain("unexpected internal details");
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3818**
- **Summary:**
  - Prevented database and unexpected failures from being reported as successful zero-item guest wishlist merges.
  - Added a sanitized `503 Service Unavailable` response with `success: false` and `WISHLIST_MERGE_UNAVAILABLE` for temporary merge failures.
  - Preserved existing behavior for successful merges, legitimate zero-item merges, missing medicine IDs, and request validation.
  - Propagated existing wishlist fetch, medicine lookup, and insertion failures instead of converting them into empty results.
  - Added regression tests covering fetch, lookup, insertion, unexpected exceptions, and HTTP response behavior.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Tests Executed

```text
node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --config jest.config.js --forceExit --silent --runInBand tests/wishlist.test.ts
✓ 7 tests passed

npx.cmd tsc --noEmit
✓ Passed

npx.cmd prettier --check src/routes/wishlist.ts tests/wishlist.test.ts
✓ Passed

git diff --check
✓ Passed
```

**Note:** `apps/api` does not currently include an ESLint flat configuration (`eslint.config.js`), so standalone ESLint validation could not be executed for this package.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3818`)
- [x] I have pulled the latest `main` and resolved any conflicts