### PR TITLE
Fix #3824: Offload synchronous Whisper and ffmpeg calls to thread pool

### DIFF
--- a/apps/ml/routers/asr.py
+++ b/apps/ml/routers/asr.py
@@ -276,7 +276,7 @@ def _run_ner(transcript: str) -> dict:
 # Upload transcription
 # ---------------------------------------------------------------------------
 
-def transcribe_uploaded_bytes(
+async def transcribe_uploaded_bytes(
     contents: bytes,
     *,
     original_name: str,
@@ -299,7 +299,7 @@ def transcribe_uploaded_bytes(
     requested_language = normalize_requested_language(language)
     suffix = os.path.splitext(original_name)[-1].lower() or ".wav"
 
-    return _transcribe_audio_bytes(
+    return await _transcribe_audio_bytes(
         contents,
         original_name=original_name,
         suffix=suffix,
@@ -307,7 +307,7 @@ def transcribe_uploaded_bytes(
     )
 
 
-def _transcribe_audio_bytes(
+async def _transcribe_audio_bytes(
     contents: bytes,
     *,
     original_name: str,
@@ -325,19 +325,22 @@ def _transcribe_audio_bytes(
         normalized_path = tmp_path + "_norm.wav"
 
         try:
-            ffmpeg_result = subprocess.run(
-                [
-                    "ffmpeg", "-y",
-                    "-i", tmp_path,
-                    "-ar", "16000",
-                    "-ac", "1",
-                    "-f", "wav",
-                    normalized_path,
-                ],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                timeout=30,
-            )
+            def _run_ffmpeg():
+                return subprocess.run(
+                    [
+                        "ffmpeg", "-y",
+                        "-i", tmp_path,
+                        "-ar", "16000",
+                        "-ac", "1",
+                        "-f", "wav",
+                        normalized_path,
+                    ],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    timeout=30,
+                )
+
+            ffmpeg_result = await asyncio.to_thread(_run_ffmpeg)
         except FileNotFoundError:
             logger.error(
                 "ffmpeg not found. Install it on the ML host "
@@ -377,14 +380,18 @@ def _transcribe_audio_bytes(
         transcription_started_at = start_timer()
         memory_before_mb = get_memory_usage_mb()
 
-        segments, info = get_model().transcribe(
-            reduced_audio,
-            language=requested_language,
-            task="transcribe",
-            beam_size=WHISPER_BEAM_SIZE,
-            vad_filter=True,
-            vad_parameters=STREAM_VAD_PARAMETERS,
-        )
+        def _do_transcribe():
+            segs, inf = get_model().transcribe(
+                reduced_audio,
+                language=requested_language,
+                task="transcribe",
+                beam_size=WHISPER_BEAM_SIZE,
+                vad_filter=True,
+                vad_parameters=STREAM_VAD_PARAMETERS,
+            )
+            return list(segs), inf
+
+        segments, info = await asyncio.to_thread(_do_transcribe)
 
         transcript = " ".join(seg.text for seg in segments).strip()
 
@@ -907,7 +914,7 @@ async def transcribe_audio(
     """
     contents = await read_audio_upload_limited(file)
     original_name = file.filename or "upload"
-    return transcribe_uploaded_bytes(
+    return await transcribe_uploaded_bytes(
         contents,
         original_name=original_name,
         content_type=file.content_type,
@@ -996,14 +1003,15 @@ async def stream_transcription(websocket: WebSocket):
                     return
 
                 if message.get("bytes"):
-                    partial = session.append_and_maybe_transcribe(
+                    partial = await asyncio.to_thread(
+                        session.append_and_maybe_transcribe,
                         message["bytes"],
                         mime_type=mime_type,
                         language=language,
                     )
 
                     if session.total_audio_seconds > MAX_TRANSCRIPTION_DURATION_SECONDS:
-                        final = session.finalize(mime_type=mime_type, language=language)
+                        final = await asyncio.to_thread(session.finalize, mime_type=mime_type, language=language)
                         await websocket.send_json({
                             "type": "error",
                             "error": f"Streaming session exceeded maximum duration of {MAX_TRANSCRIPTION_DURATION_SECONDS}s.",
@@ -1034,7 +1042,7 @@ async def stream_transcription(websocket: WebSocket):
                         return
 
                     if text_payload.get("type") == "stop":
-                        final = session.finalize(mime_type=mime_type, language=language)
+                        final = await asyncio.to_thread(session.finalize, mime_type=mime_type, language=language)
                         await websocket.send_json({"type": "final", **final})
                         await websocket.close()
                         return

--- a/apps/ml/routers/voice_verify.py
+++ b/apps/ml/routers/voice_verify.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, UploadFile, File, HTTPException
 from fastapi.responses import JSONResponse
 import whisper
+import asyncio
 import tempfile
 import os
 from utils.audio_upload import read_audio_upload_limited
@@ -54,7 +55,7 @@ async def verify_medicine_voice(audio: UploadFile = File(...)):
 
     try:
         # Transcribe with Whisper (auto-detects language)
-        result = get_whisper_model().transcribe(tmp_path, task="transcribe")
+        result = await asyncio.to_thread(get_whisper_model().transcribe, tmp_path, task="transcribe")
         transcribed_text = result.get("text", "").strip()
         detected_lang = result.get("language", "en")
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3824**
- **Summary:** Offloaded blocking synchronous `Whisper` and `ffmpeg` calls directly to the event loop's default thread pool using `asyncio.to_thread`. This resolves the issue where the entire FastAPI service would freeze during voice verification or audio stream transcription, allowing other concurrent requests to be served normally.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

*(Backend fix. The event loop is no longer blocked by synchronous ASR inference. You can leave this blank or mention that it is a backend performance/bug fix.)*

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3824`)
- [x] I have pulled the latest `main` and resolved any conflicts