### PR TITLE
fix(security): mask user_id in ws_registry logs (CodeQL #182)

### DIFF
--- a/apps/ml/utils/ws_registry.py
+++ b/apps/ml/utils/ws_registry.py
@@ -13,6 +13,7 @@ needs no locking.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 
@@ -27,6 +28,20 @@ WS_POLICY_VIOLATION_CODE = 1008
 
 # user_id -> set of live WebSocket connections owned by THIS worker process.
 _connections: dict[str, set[WebSocket]] = {}
+
+
+def _mask_user_id(user_id: str) -> str:
+    """Return a stable, non-reversible tag for a user_id for log correlation.
+
+    Revocation events must be traceable in logs (e.g. to confirm a user's
+    sockets were torn down) without writing the raw identifier — a sensitive,
+    user-identifying value — to log aggregators. A short SHA-256 prefix groups a
+    given user's events together and can be matched against a known id during an
+    incident, but cannot be reversed back to the user_id.
+    """
+    if not user_id:
+        return "unknown"
+    return hashlib.sha256(user_id.encode()).hexdigest()[:12]
 
 
 def register_connection(user_id: str, websocket: WebSocket) -> None:
@@ -57,7 +72,11 @@ async def close_user_connections(user_id: str, *, reason: str = "API Key Revoked
             await websocket.close(code=WS_POLICY_VIOLATION_CODE, reason=reason)
             closed += 1
         except Exception as error:  # already closing / disconnected — best effort
-            logger.warning("Failed to close revoked socket for user %s: %s", user_id, error)
+            logger.warning(
+                "Failed to close revoked socket for user %s: %s",
+                _mask_user_id(user_id),
+                error,
+            )
         finally:
             unregister_connection(user_id, websocket)
     return closed
@@ -97,7 +116,9 @@ async def listen_for_revocations(redis) -> None:
             closed = await close_user_connections(user_id)
             if closed:
                 logger.info(
-                    "Force-closed %d ML WebSocket(s) for revoked user %s.", closed, user_id
+                    "Force-closed %d ML WebSocket(s) for revoked user %s.",
+                    closed,
+                    _mask_user_id(user_id),
                 )
     except asyncio.CancelledError:
         raise


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3835
- **Summary:** `close_user_connections` and `listen_for_revocations` in `apps/ml/utils/ws_registry.py` logged the raw `user_id` of a just-revoked user in plaintext (CodeQL Alert #182 — clear-text logging of sensitive information), which could leak the identifier into log aggregators.
  - Added a `_mask_user_id()` helper that logs a short, stable SHA-256 prefix instead of the raw value, applied at both log sites (the alert's `info` at ~L99 and the `warning` at ~L60, same class of exposure).
  - The masked tag still groups a user's revocation events and can be matched against a known id during an incident, but cannot be reversed to the `user_id`.
  - Chose a one-way hash over truncating the raw value: CodeQL's taint tracking flows through string slicing, so a truncated substring can stay flagged, whereas hashing is recognised as a sanitiser — this reliably resolves the alert. (Both were offered as acceptable fixes in the issue.)
  - The revocation logic — registering, unregistering, closing sockets, and the listener control flow — is unchanged; only the logged value differs.
  - Scope: `apps/ml/utils/ws_registry.py` only.

## 📸 Proof of Work (Screenshots / Logs)

- `python -m py_compile apps/ml/utils/ws_registry.py` passes.
- Confirmed no `logger.*` call passes a raw `user_id` anymore; the `_mask_user_id` helper is stable, distinct per user, non-reversible (12-char hex), and maps empty → `"unknown"`.
- CodeQL should report Alert #182 as fixed on the next scan of `main`.

## 🏷️ PR Type

- [x] 🔒 `type: security`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3835`)
- [x] I have pulled the latest `main` and resolved any conflicts
