### PR TITLE
fix(api): prevent SSRF bypass via IPv6-mapped IPv4 addresses (#3829)

### DIFF
--- a/apps/api/src/config/mlService.ts
+++ b/apps/api/src/config/mlService.ts
@@ -14,20 +14,39 @@ const BLOCKED_HOSTNAME_PATTERNS = [
     /^172\.(1[6-9]|2\d|3[01])\./,
     /^192\.168\./,
     /^169\.254\./,
-    /^::1$/,
+    /^::1$/i,
     /^fc00:/i,
     /^fe80:/i,
 ];
+
+/**
+ * Extract the embedded IPv4 address from an IPv6-mapped IPv4 address.
+ *
+ * Example:
+ *   ::ffff:127.0.0.1   -> 127.0.0.1
+ *   ::FFFF:10.0.0.5    -> 10.0.0.5
+ */
+function getMappedIpv4(hostname: string): string | null {
+    const match = hostname.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i);
+    return match ? match[1] : null;
+}
 
 /**
  * Returns true when the hostname is a safe external address, false for any
  * private, loopback, or link-local hostname.
  */
 function isAllowedHostname(hostname: string): boolean {
-    if (process.env.NODE_ENV !== "production" && /^(localhost|127\.0\.0\.1)$/i.test(hostname)) {
+    const mappedIpv4 = getMappedIpv4(hostname);
+    const normalizedHostname = mappedIpv4 ?? hostname;
+
+    if (
+        process.env.NODE_ENV !== "production" &&
+        /^(localhost|127\.0\.0\.1)$/i.test(normalizedHostname)
+    ) {
         return true;
     }
-    return !BLOCKED_HOSTNAME_PATTERNS.some((pattern) => pattern.test(hostname));
+
+    return !BLOCKED_HOSTNAME_PATTERNS.some((pattern) => pattern.test(normalizedHostname));
 }
 
 /**


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

---

## 📋 PR Summary & Link

* **Closes #3829**
* **Summary:**

  * Added validation for IPv6-mapped IPv4 addresses in `apps/api/src/config/mlService.ts`.
  * Prevented SSRF validation bypass by detecting IPv6-mapped loopback and private IPv4 addresses (e.g. `::ffff:127.0.0.1`, `::ffff:10.0.0.1`) and applying the existing hostname validation rules.
  * Kept the change localized to the configuration file without affecting existing validation behavior for normal IPv4 and IPv6 addresses.

---

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> * **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> *Please drag & drop your screenshots/GIFs here.*

**Testing Performed:**

* Verified that valid external HTTP/HTTPS URLs continue to pass validation.
* Verified that IPv6-mapped IPv4 loopback and private addresses are rejected by the updated hostname validation logic.

---

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [x] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

---

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3829`)
* [x] I have pulled the latest `main` and resolved any conflicts
