### PR TITLE
fix(consent): prevent privacy consent banner overlap on mobile

### DIFF
--- a/apps/web/app/[locale]/components/BackToTopButton.tsx
+++ b/apps/web/app/[locale]/components/BackToTopButton.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState, KeyboardEvent } from "react";
+import { usePrivacyConsent } from "@/components/PrivacyConsentProvider";
 
 /**
  * Scroll thresholds with hysteresis to prevent rapid show/hide flickering
@@ -13,9 +14,13 @@ const SHOW_THRESHOLD = 300;
 const HIDE_THRESHOLD = 200;
 
 export default function BackToTopButton() {
+    const { hasRespondedToConsent } = usePrivacyConsent();
+    const showConsent = !hasRespondedToConsent;
+
     const [isVisible, setIsVisible] = useState(false);
     const [isScrollingBack, setIsScrollingBack] = useState(false);
     const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
     const t = useTranslations("BackToTopButton");
     const label = t("label");
 
@@ -137,13 +142,15 @@ export default function BackToTopButton() {
     const baseClasses =
         "fixed bottom-[152px] right-4 z-50 flex h-12 w-12 items-center justify-center rounded-full transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-950 md:bottom-24 md:right-6 md:h-14 md:w-14";
 
-    const motionClasses = prefersReducedMotion
-        ? isVisible
-            ? "opacity-100 translate-y-0 scale-100 pointer-events-auto"
-            : "opacity-0 translate-y-0 scale-100 pointer-events-none"
-        : isVisible
-          ? "opacity-100 translate-y-0 scale-100 pointer-events-auto hover:scale-108 hover:-translate-y-0.5 active:scale-92"
-          : "opacity-0 translate-y-5 scale-90 pointer-events-none";
+    const motionClasses = showConsent
+        ? "opacity-0 pointer-events-none"
+        : prefersReducedMotion
+          ? isVisible
+              ? "opacity-100 translate-y-0 scale-100 pointer-events-auto"
+              : "opacity-0 translate-y-0 scale-100 pointer-events-none"
+          : isVisible
+            ? "opacity-100 translate-y-0 scale-100 pointer-events-auto hover:scale-108 hover:-translate-y-0.5 active:scale-92"
+            : "opacity-0 translate-y-5 scale-90 pointer-events-none";
 
     return (
         <>
@@ -160,8 +167,8 @@ export default function BackToTopButton() {
                 ref={buttonRef}
                 type="button"
                 aria-label={label}
-                aria-hidden={!isVisible}
-                tabIndex={isVisible ? 0 : -1}
+                aria-hidden={showConsent || !isVisible}
+                tabIndex={showConsent || !isVisible ? -1 : 0}
                 title={label}
                 onClick={handleScrollToTop}
                 onKeyDown={handleKeyDown}

--- a/apps/web/components/PrivacyConsentBanner.tsx
+++ b/apps/web/components/PrivacyConsentBanner.tsx
@@ -4,6 +4,10 @@ import React from "react";
 import { useTranslations } from "next-intl";
 import { usePrivacyConsent } from "@/components/PrivacyConsentProvider";
 
+// Keep in sync with your BottomNav's actual mobile height (h-16 = 64px here).
+// Adjust if your nav uses a different height class.
+const BOTTOM_NAV_OFFSET = "bottom-16 md:bottom-0";
+
 export default function PrivacyConsentBanner() {
     const t = useTranslations("PrivacyConsent");
     const { hasRespondedToConsent, acceptAll, denyAll } = usePrivacyConsent();
@@ -12,12 +16,19 @@ export default function PrivacyConsentBanner() {
 
     return (
         <div
-            className="animate-in fade-in slide-in-from-bottom-5 fixed right-0 bottom-0 left-0 z-50 border-t border-blue-200 bg-blue-50 p-4 shadow-xl transition-transform duration-300 md:p-6 dark:border-blue-800 dark:bg-slate-900"
+            className={`animate-in fade-in slide-in-from-bottom-5 fixed right-0 left-0 ${BOTTOM_NAV_OFFSET} z-[100] flex max-h-[90dvh] flex-col overflow-y-auto rounded-t-2xl border-t border-blue-200 bg-blue-50 p-4 shadow-xl transition-transform duration-300 md:rounded-none md:p-6 dark:border-blue-800 dark:bg-slate-900`}
+            style={{
+                paddingBottom: "max(1rem, env(safe-area-inset-bottom))",
+            }}
             role="dialog"
+            aria-modal="true"
             aria-labelledby="consent-title"
             aria-describedby="consent-desc"
         >
-            <div className="mx-auto flex max-w-7xl flex-col items-start justify-between gap-4 md:flex-row md:items-center">
+            {/* grab handle — signals "bottom sheet" on mobile only */}
+            <div className="mx-auto mb-2 h-1 w-10 shrink-0 rounded-full bg-slate-300 md:hidden dark:bg-slate-600" />
+
+            <div className="mx-auto flex w-full max-w-7xl flex-col items-start justify-between gap-4 md:flex-row md:items-center">
                 <div className="flex-1">
                     <h2
                         id="consent-title"
@@ -32,7 +43,7 @@ export default function PrivacyConsentBanner() {
                         {t("description")} {t("locationPurpose")} {t("scanHistoryPurpose")}
                     </p>
                 </div>
-                <div className="flex w-full items-center justify-end gap-3 md:w-auto">
+                <div className="flex w-full shrink-0 items-center justify-end gap-3 md:w-auto">
                     <button
                         onClick={denyAll}
                         className="cursor-pointer rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 transition-colors hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-white dark:hover:bg-slate-700"

--- a/apps/web/tests/back-to-top-button.test.tsx
+++ b/apps/web/tests/back-to-top-button.test.tsx
@@ -17,6 +17,12 @@ jest.mock("next-intl", () => ({
     useTranslations: () => (key: string) => key,
 }));
 
+jest.mock("../components/PrivacyConsentProvider", () => ({
+    usePrivacyConsent: () => ({
+        hasRespondedToConsent: true,
+    }),
+}));
+
 describe("BackToTopButton", () => {
     it("keeps the mobile button high enough to stay visible above the chat launcher", () => {
         const markup = renderToStaticMarkup(<BackToTopButton />);


### PR DESCRIPTION
🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.
> [!WARNING]

- Closes Issue  #3700 

- Summary:
  - Convert the Privacy & Data Consent banner into a responsive bottom sheet.
  - Offset the banner above the mobile bottom navigation.
  - Ensure the consent banner appears above floating UI elements using appropriate z-index.
  - Hide the BackToTopButton while the consent banner is visible to prevent overlap.
  - Update the BackToTopButton test to account for the PrivacyConsentProvider dependency introduced by this change.

---

## 📸 Proof of Work (Screenshots / Logs)
<img width="1097" height="987" alt="Screenshot 2026-07-22 234530" src="https://github.com/user-attachments/assets/37de6c1f-08f9-426c-ba95-982053913030" />




### Before
- Consent banner overlapped page content.
- Bottom navigation remained visible behind the banner.
- Floating BackToTopButton overlapped the consent dialog.

### After
- Responsive bottom sheet displayed correctly.
- Banner stays above the mobile bottom navigation.
- Floating UI no longer overlaps the consent dialog.
- BackToTopButton remains hidden until the user responds to the consent banner.

> **Screenshots:** *(Attach mobile screenshots before/after here.)*
<img width="1920" height="1020" alt="Screenshot 2026-07-22 214857" src="https://github.com/user-attachments/assets/e859f794-4d70-4aa2-bbff-7d6217c1b182" />

-On Landscape view 
<img width="952" height="1007" alt="Screenshot 2026-07-22 214229" src="https://github.com/user-attachments/assets/7d23bab2-314b-46df-a582-69d1d03cde30" />


---

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] ♿ `type: accessibility`

---

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3700`)
- [x] I have pulled the latest `main` and resolved any conflicts 
- [x] I tested the changes on a mobile viewport.
- [x] I updated the affected test (`back-to-top-button.test.tsx`) for the new PrivacyConsentProvider dependency.

---

## 🤖 AI Assistance Disclosure

This PR was implemented with the assistance of ChatGPT. I reviewed, integrated, tested, and validated all changes before submitting.
