### PR TITLE
fix: redisClient.del array arg breaks cache invalidation, console.error bypasses structured logging

### DIFF
--- a/apps/api/src/controllers/admin.controller.ts
+++ b/apps/api/src/controllers/admin.controller.ts
@@ -84,7 +84,7 @@ export const getPendingReports = async (
             },
         });
     } catch (err) {
-        console.error(err);
+        logger.error(err instanceof Error ? err : String(err));
         res.status(500).json({ error: "Internal server error" });
     }
 };
@@ -236,7 +236,7 @@ export const updateReportStatus = async (
 
         res.json({ message: "Status updated", report: data });
     } catch (err) {
-        console.error(err);
+        logger.error(err instanceof Error ? err : String(err));
         res.status(500).json({ error: "Internal server error" });
     }
 };
@@ -276,7 +276,7 @@ export const getAllMedicines = async (req: AuthenticatedRequest, res: Response):
             },
         });
     } catch (err) {
-        console.error("Error in getAllMedicines:", err);
+        logger.error("Error in getAllMedicines:", err);
         res.status(500).json({ error: "Internal server error" });
     }
 };
@@ -301,7 +301,7 @@ export const getPendingPharmacies = async (
 
         res.json({ pharmacies: data ?? [] });
     } catch (err) {
-        console.error("Error in getPendingPharmacies:", err);
+        logger.error("Error in getPendingPharmacies:", err);
         res.status(500).json({ error: "Internal server error" });
     }
 };
@@ -351,7 +351,7 @@ export const updatePharmacyStatus = async (
 
         res.json({ message: "Pharmacy status updated", pharmacy: data });
     } catch (err) {
-        console.error("Error in updatePharmacyStatus:", err);
+        logger.error("Error in updatePharmacyStatus:", err);
         res.status(500).json({ error: "Internal server error" });
     }
 };
@@ -379,7 +379,7 @@ export const createMedicine = async (req: AuthenticatedRequest, res: Response): 
         await logAdminAction(req.user!.id, "CREATE_MEDICINE", "MEDICINE", data.id, parsed.data);
         res.status(201).json(data);
     } catch (err) {
-        console.error(err);
+        logger.error(err instanceof Error ? err : String(err));
         res.status(500).json({ error: "Internal server error" });
     }
 };
@@ -444,7 +444,7 @@ export const getAuditLogs = async (req: AuthenticatedRequest, res: Response): Pr
             },
         });
     } catch (err) {
-        console.error("Error in getAuditLogs:", err);
+        logger.error("Error in getAuditLogs:", err);
         res.status(500).json({ error: "Internal server error" });
     }
 };
@@ -488,7 +488,7 @@ export const getAllPharmacies = async (req: AuthenticatedRequest, res: Response)
             },
         });
     } catch (err) {
-        console.error("Error in getAllPharmacies:", err);
+        logger.error("Error in getAllPharmacies:", err);
         res.status(500).json({ error: "Internal server error" });
     }
 };
@@ -510,7 +510,7 @@ export const deletePharmacy = async (req: AuthenticatedRequest, res: Response): 
 
         res.json({ message: "Pharmacy soft-deleted successfully" });
     } catch (err) {
-        console.error("Error in deletePharmacy:", err);
+        logger.error("Error in deletePharmacy:", err);
         res.status(500).json({ error: "Internal server error" });
     }
 };
@@ -532,7 +532,7 @@ export const restorePharmacy = async (req: AuthenticatedRequest, res: Response):
 
         res.json({ message: "Pharmacy restored successfully" });
     } catch (err) {
-        console.error("Error in restorePharmacy:", err);
+        logger.error("Error in restorePharmacy:", err);
         res.status(500).json({ error: "Internal server error" });
     }
 };

--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -154,7 +154,7 @@ router.post(
                 // Chunked DEL — never fire one command with 500 keys
                 for (let i = 0; i < keys.length; i += CACHE_INVALIDATION_CHUNK_SIZE) {
                     const chunk = keys.slice(i, i + CACHE_INVALIDATION_CHUNK_SIZE);
-                    await redisClient.del(chunk);
+                    await redisClient.del(...chunk);
                 }
 
                 totalKeysInvalidated += keys.length;

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -200,9 +200,9 @@ alertsRouter.post("/ingest", requireApiKey, limiter, async (req: ApiKeyRequest, 
                 const keys = batchNumbersToInvalidate.map(
                     (batch) => `${KEY_PREFIXES.DRUG_CACHE}${batch}`
                 );
-                await redisClient.del(keys);
+                await redisClient.del(...keys);
             } catch (err) {
-                console.error("Failed to invalidate cache for alert batches:", err);
+                logger.error("Failed to invalidate cache for alert batches:", err);
             }
         }
 

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -240,7 +240,7 @@ reportsRouter.get("/mine", requireAuth, async (req: AuthenticatedRequest, res: R
             nextCursor,
         });
     } catch (err) {
-        console.error("Unexpected error in GET /api/reports/mine:", err);
+        logger.error("Unexpected error in GET /api/reports/mine:", err);
         res.status(500).json({ error: "An unexpected error occurred" });
     }
 });
@@ -308,7 +308,7 @@ reportsRouter.get("/", requireAuth, requireRole("admin"), async (req, res: Respo
             },
         });
     } catch (err) {
-        console.error("Unexpected error in GET /api/reports:", err);
+        logger.error("Unexpected error in GET /api/reports:", err);
         res.status(500).json({ error: "An unexpected error occurred" });
     }
 });
@@ -446,7 +446,7 @@ reportsRouter.patch(
 
             res.json({ report: data });
         } catch (err) {
-            console.error("Unexpected error in PATCH /api/reports/:id/status:", err);
+            logger.error("Unexpected error in PATCH /api/reports/:id/status:", err);
             res.status(500).json({ error: "An unexpected error occurred" });
         }
     }

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -62,7 +62,7 @@ router.post(
             } while (cursor !== 0);
 
             if (keysToDelete.length > 0) {
-                await redisClient.del(keysToDelete);
+                await redisClient.del(...keysToDelete);
                 logger.info(
                     `Health schemes cache invalidated — deleted ${keysToDelete.length} key(s)`,
                     { keys: keysToDelete }

--- a/apps/api/src/services/abha.service.ts
+++ b/apps/api/src/services/abha.service.ts
@@ -190,18 +190,28 @@ const requestAbdm = async <T>(
 };
 
 const encryptWithAbdmPublicKey = (value: string, publicKey: string): string => {
+    if (!publicKey || typeof publicKey !== "string" || publicKey.trim().length === 0) {
+        throw new Error("ABDM public key is empty or invalid");
+    }
+
     const normalizedPublicKey = publicKey.includes("BEGIN PUBLIC KEY")
         ? publicKey
         : `-----BEGIN PUBLIC KEY-----\n${publicKey.match(/.{1,64}/g)?.join("\n")}\n-----END PUBLIC KEY-----`;
 
-    return publicEncrypt(
-        {
-            key: normalizedPublicKey,
-            padding: constants.RSA_PKCS1_OAEP_PADDING,
-            oaepHash: "sha1",
-        },
-        Buffer.from(value, "utf8")
-    ).toString("base64");
+    try {
+        return publicEncrypt(
+            {
+                key: normalizedPublicKey,
+                padding: constants.RSA_PKCS1_OAEP_PADDING,
+                oaepHash: "sha1",
+            },
+            Buffer.from(value, "utf8")
+        ).toString("base64");
+    } catch (error) {
+        throw new Error(
+            `ABDM public key encryption failed: ${error instanceof Error ? error.message : "unknown error"}`
+        );
+    }
 };
 
 const isMappedAbdmError = (message: string): boolean =>

--- a/apps/api/src/services/cache.service.ts
+++ b/apps/api/src/services/cache.service.ts
@@ -249,7 +249,7 @@ export async function invalidateDrugCache(drugIds: string[]): Promise<string[]> 
                 // Chunk DEL to avoid blocking the Redis event loop
                 for (let i = 0; i < keysToDelete.length; i += CACHE_INVALIDATION_CHUNK_SIZE) {
                     const chunk = keysToDelete.slice(i, i + CACHE_INVALIDATION_CHUNK_SIZE);
-                    await redisClient.del(chunk);
+                    await redisClient.del(...chunk);
                 }
                 logger.info(
                     `Invalidated cache keys: ${keysToDelete.join(", ").replace(/[\r\n]/g, "")}`


### PR DESCRIPTION
### Bugs fixed

1. **redisClient.del(array) instead of redisClient.del(...array)** - ioredis `.del()` expects individual key arguments, not an array. Passing an array silently corrupts the cache key and prevents cache invalidation from working. Fixed in:
   - `services/cache.service.ts:252`
   - `routes/admin.routes.ts:157`
   - `routes/alerts.ts:203`
   - `routes/webhooks.ts:65`

2. **console.error instead of logger.error** - 10 occurrences in `controllers/admin.controller.ts` and 3 in `routes/reports.ts` and 1 in `routes/alerts.ts` bypassed the structured logging system, causing errors to be silently lost in production without proper context, timestamps, or routing.