### PR TITLE
fix(web): lazy init supabase client in medicine safety route to prevent build crash

### DIFF
--- a/apps/web/app/api/medicine/safety/route.ts
+++ b/apps/web/app/api/medicine/safety/route.ts
@@ -16,12 +16,6 @@ import { GoogleGenerativeAI, SchemaType, type Schema } from "@google/generative-
 import Groq from "groq-sdk";
 import { createClient } from "@supabase/supabase-js";
 
-// ── Supabase (server-side — uses service role key for cache writes) ────────────
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseKey =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-const db = createClient(supabaseUrl, supabaseKey);
-
 // ── OpenFDA ───────────────────────────────────────────────────────────────────
 async function fetchOpenFdaContext(genericName: string): Promise<string> {
     try {
@@ -196,6 +190,19 @@ async function generateWithGroq(drug: string, rag: string): Promise<object> {
 
 // ── GET handler ───────────────────────────────────────────────────────────────
 export async function GET(request: NextRequest) {
+    // ── Supabase (server-side — uses service role key for cache writes) ────────────
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+    const supabaseKey =
+        process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+    if (!supabaseUrl || !supabaseKey) {
+        return NextResponse.json(
+            { error: "Server misconfiguration: Supabase credentials missing." },
+            { status: 500 }
+        );
+    }
+    const db = createClient(supabaseUrl, supabaseKey);
+
     const q = new URL(request.url).searchParams.get("q")?.trim();
     if (!q || q.length < 2) {
         return NextResponse.json(
@@ -261,16 +268,14 @@ export async function GET(request: NextRequest) {
 
     // ── 4. Persist to Supabase (best-effort) ──────────────────────────────────
     try {
-        await db
-            .from("medicine_safety_profiles")
-            .upsert(
-                {
-                    generic_name: genericName,
-                    profile_json: profile,
-                    updated_at: new Date().toISOString(),
-                },
-                { onConflict: "generic_name" }
-            );
+        await db.from("medicine_safety_profiles").upsert(
+            {
+                generic_name: genericName,
+                profile_json: profile,
+                updated_at: new Date().toISOString(),
+            },
+            { onConflict: "generic_name" }
+        );
     } catch {
         // non-fatal
     }


### PR DESCRIPTION
## 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3832** <!-- Replace with the issue number -->
- **Summary:**
  - Fixed the build-time crash in `apps/web/app/api/medicine/safety/route.ts`.
  - Moved the Supabase client initialization from module scope into the `GET` request handler to prevent Next.js from instantiating the client during `next build`.
  - Added a runtime safeguard that returns a `500 Internal Server Error` JSON response when the required Supabase environment variables are unavailable, instead of crashing the build process.

## 📸 Proof of Work (Screenshots / Logs)

### Commands Executed

```bash
clear
git checkout main
git pull origin main
clear
git checkout -b fix/lazy-init-supabase-medicine-safety-route

# Modified:
apps/web/app/api/medicine/safety/route.ts

NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 \
NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key \
npm run build -w web

npm install

NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 \
NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key \
npm run build -w web

npm run build

npm run build -w @sahidawa/types && \
NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 \
NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key \
npm run build -w web

git add apps/web/app/api/medicine/safety/route.ts
git commit -m "fix(web): lazy init supabase client in medicine safety route to prevent build crash"
```

### Verification

Previously, the following build command failed with:

```text
Error: supabaseUrl is required.
```

After this change, the build completes successfully:

```bash
NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321 \
NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key \
npm run build -w web
```

The `medicine/safety` API route now compiles successfully during `next build`, allowing the production build to complete without the previous build-time crash.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #`) <!-- Replace with the issue number -->
- [x] I have pulled the latest `main` and resolved any conflicts.
