### PR TITLE
fix(ci): resolve ESLint errors blocking the quality-check gate

### DIFF
--- a/apps/web/app/[locale]/components/Footer.tsx
+++ b/apps/web/app/[locale]/components/Footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FaGithub, FaLinkedin, FaXTwitter } from "react-icons/fa6";
-import { Sparkles, Heart, Mail, ExternalLink, CalendarRange } from "lucide-react";
+import { Heart, Mail, ExternalLink, CalendarRange } from "lucide-react";
 import { Link } from "@/i18n/routing";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";

--- a/apps/web/worker/index.js
+++ b/apps/web/worker/index.js
@@ -64,6 +64,7 @@ const PUBLIC_API_ROUTES = [
 function isPublicCacheableApiRequest(request, url) {
     if (request.method !== "GET" || request.credentials === "include") return false;
 
+    const authenticationHeaders = [
         "authorization",
         "proxy-authorization",
         // "cookie", // Forbidden header; not readable in service workers.
@@ -525,12 +526,6 @@ async function navigateWithOfflineFallback(request) {
             { status: 503, headers: { "Content-Type": "text/html; charset=utf-8" } }
         );
     }
-}
-
-function generateSecureFallbackUUID() {
-    return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
-        (c ^ (self.crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
-    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #** 3831
- **Summary:** `npm run lint -w web` failed on every PR, blocking the required quality-check CI job.
  - **Footer.tsx:** removed the unused `Sparkles` lucide-react import.
  - **worker/index.js:** restored the missing `const authenticationHeaders = [` declaration — the array literal in `isPublicCacheableApiRequest` had no owning variable (a parse error). Header-checking behavior is unchanged.
  - **worker/index.js:** also removed the dead `generateSecureFallbackUUID` function (defined but never called). **Note:** this unused-var error was *masked* by the parse error above — ESLint stops at a syntax error, so it only surfaced once the file parsed. It had to be removed for `npm run lint -w web` to reach **zero** errors (the acceptance criterion); it's dead code, so behavior is unaffected.
  - Scope: the two files listed in the issue.

## 📸 Proof of Work (Screenshots / Logs)

Before: `✖ 2 problems` (then a 3rd surfaced once the parse error was fixed).
After:

web@0.1.0 lint
eslint .

(exit 0 — zero errors) 

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] 🛠️ `type: devops`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3831`)
- [x] I have pulled the latest `main` and resolved any conflicts
