### PR TITLE
fix(api): rate limit medicine safety requests

### DIFF
--- a/apps/web/app/api/medicine/safety/route.ts
+++ b/apps/web/app/api/medicine/safety/route.ts
@@ -15,6 +15,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { GoogleGenerativeAI, SchemaType, type Schema } from "@google/generative-ai";
 import Groq from "groq-sdk";
 import { createClient } from "@supabase/supabase-js";
+import { getClientIp } from "@/lib/getClientIp";
+import { rateLimit } from "@/lib/rateLimit";
+
+const MAX_QUERY_LENGTH = 100;
 
 // ── OpenFDA ───────────────────────────────────────────────────────────────────
 async function fetchOpenFdaContext(genericName: string): Promise<string> {
@@ -190,6 +194,14 @@ async function generateWithGroq(drug: string, rag: string): Promise<object> {
 
 // ── GET handler ───────────────────────────────────────────────────────────────
 export async function GET(request: NextRequest) {
+    const { success } = await rateLimit.limit(getClientIp(request));
+    if (!success) {
+        return NextResponse.json(
+            { error: "Too many requests. Please try again in a few moments." },
+            { status: 429 }
+        );
+    }
+
     // ── Supabase (server-side — uses service role key for cache writes) ────────────
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
     const supabaseKey =
@@ -207,6 +219,13 @@ export async function GET(request: NextRequest) {
     if (!q || q.length < 2) {
         return NextResponse.json(
             { error: "Query parameter 'q' is required (min 2 chars)." },
+            { status: 400 }
+        );
+    }
+
+    if (q.length > MAX_QUERY_LENGTH) {
+        return NextResponse.json(
+            { error: "Query parameter 'q' must be 100 characters or fewer." },
             { status: 400 }
         );
     }


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3868**
- **Summary:**
  - Added route-specific rate limiting to `GET /api/medicine/safety` using the project's existing Upstash-backed `rateLimit` helper.
  - Reused `getClientIp()` to enforce per-client throttling before any cache lookup or external LLM request.
  - Added a maximum query length validation (`100` characters) to reject excessively long inputs with a `400 Bad Request`.
  - Preserved the existing cache, OpenFDA, Gemini, and Groq request flow for valid requests while preventing abusive requests from triggering unnecessary upstream LLM calls.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Validation

- ✅ `npx eslint app/api/medicine/safety/route.ts`
- ✅ `npx prettier --check app/api/medicine/safety/route.ts`
- ✅ `git diff --check`

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3868`)
- [x] I have pulled the latest `main` and resolved any conflicts