### PR TITLE
fix(web): preserve local expiry-date boundaries

### DIFF
--- a/apps/web/app/[locale]/my-medicines/page.tsx
+++ b/apps/web/app/[locale]/my-medicines/page.tsx
@@ -9,6 +9,7 @@ import { RequestVerificationModal } from "@/components/RequestVerificationModal"
 import { API_BASE } from "@/lib/api";
 import { useTranslations } from "next-intl";
 import { useBookmarksStore } from "@/src/stores/useBookmarksStore";
+import { parseLocalDate } from "../expiry-tracker/components/dateUtils";
 
 interface TrackedMedicine {
     id: string;
@@ -17,8 +18,21 @@ interface TrackedMedicine {
     is_verified: boolean;
 }
 
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseExpiryDate(expiryDate: string): Date {
+    return DATE_ONLY_PATTERN.test(expiryDate) ? parseLocalDate(expiryDate) : new Date(expiryDate);
+}
+
 function getDaysUntilExpiry(expiryDate: string): number {
-    const diff = new Date(expiryDate).getTime() - new Date().getTime();
+    const expiry = parseExpiryDate(expiryDate);
+    const today = new Date();
+
+    if (DATE_ONLY_PATTERN.test(expiryDate)) {
+        today.setHours(0, 0, 0, 0);
+    }
+
+    const diff = expiry.getTime() - today.getTime();
     return Math.ceil(diff / (1000 * 3600 * 24));
 }
 
@@ -240,7 +254,9 @@ export default function MyMedicinesPage() {
                                                 </div>
                                                 <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
                                                     {t("table.expiry")}:{" "}
-                                                    {new Date(med.expiry_date).toLocaleDateString()}
+                                                    {parseExpiryDate(
+                                                        med.expiry_date
+                                                    ).toLocaleDateString()}
                                                 </p>
                                             </div>
                                         </div>


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3869**
- **Summary:**
  - Fixed date-only (`YYYY-MM-DD`) expiry parsing on the My Medicines page to preserve local calendar-day boundaries.
  - Reused the existing `parseLocalDate` utility from the expiry tracker for consistent date handling.
  - Added detection for date-only expiry values so they are parsed as local dates instead of UTC.
  - Preserved the existing behavior for full ISO datetime values.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Validation

- ✅ `npx eslint app/[locale]/my-medicines/page.tsx`
- ✅ `npx prettier --check app/[locale]/my-medicines/page.tsx`
- ✅ `git diff --check`

### Timezone Verification

Verified the fix using:

- ✅ Asia/Kolkata
- ✅ UTC
- ✅ America/New_York

Observed behavior:

- Date-only expiry values remain valid throughout the local expiry day.
- Days remaining is `0` on the expiry date.
- Days remaining becomes `-1` only after local midnight.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3869`)
- [x] I have pulled the latest `main` and resolved any conflicts