### PR TITLE
fix(ci): clear all ESLint errors blocking the quality-check gate

### DIFF
--- a/apps/web/app/[locale]/components/Footer.tsx
+++ b/apps/web/app/[locale]/components/Footer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FaGithub, FaLinkedin, FaXTwitter } from "react-icons/fa6";
-import { Sparkles, Heart, Mail, ExternalLink, CalendarRange } from "lucide-react";
+import { Heart, Mail, ExternalLink, CalendarRange } from "lucide-react";
 import { Link } from "@/i18n/routing";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";

--- a/apps/web/app/[locale]/map/page.tsx
+++ b/apps/web/app/[locale]/map/page.tsx
@@ -18,7 +18,6 @@ import {
     WifiOff,
     MapPin,
 } from "lucide-react";
-import { PageHeader } from "../components/PageHeader";
 import PharmacyPanels, { calculateTrustBreakdown } from "./PharmacyPanels";
 
 const PharmacyMap = dynamic(() => import("./PharmacyMap"), {
@@ -438,7 +437,7 @@ export default function PharmacyMapPage() {
     const [locationSuggestions, setLocationSuggestions] = useState<
         Array<{ lat: number; lng: number; label: string }>
     >([]);
-    const [isSearchingLocation, setIsSearchingLocation] = useState(false);
+    const [, setIsSearchingLocation] = useState(false);
 
     // Live data state (PR #147 engine)
     const [pharmacies, setPharmacies] = useState<Pharmacy[]>([]);
@@ -446,7 +445,7 @@ export default function PharmacyMapPage() {
     const [isLoading, setIsLoading] = useState(false);
     const [fetchError, setFetchError] = useState<string | null>(null);
     const [showSearchArea, setShowSearchArea] = useState(false);
-    const [pharmacyCount, setPharmacyCount] = useState(0);
+    const [, setPharmacyCount] = useState(0);
     const [radiusKm, setRadiusKm] = useState<number>(10);
     const [heatmapMode, setHeatmapMode] = useState<HeatmapMode>("none");
     const [scanHotspots, setScanHotspots] = useState<RiskHotspot[]>([]);

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -184,8 +184,6 @@ function isErrorWithStatus(error: unknown): error is ErrorWithStatus {
 }
 
 async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
-    const maxRetries = 3;
-    let attempt = 0;
     while (true) {
         try {
             return await fn();

--- a/apps/web/app/api/overpass/route.ts
+++ b/apps/web/app/api/overpass/route.ts
@@ -53,8 +53,7 @@ export async function POST(req: NextRequest) {
             const cached = await redis.get(cacheKey);
             if (cached) {
                 try {
-                    const parsed =
-                        typeof cached === "string" ? JSON.parse(cached) : cached;
+                    const parsed = typeof cached === "string" ? JSON.parse(cached) : cached;
 
                     if (parsed && Array.isArray(parsed.elements)) {
                         return NextResponse.json(parsed, {
@@ -110,7 +109,9 @@ export async function POST(req: NextRequest) {
                 }
 
                 if (data.elements.length === 0) {
-                    throw new Error(`Mirror ${mirror} returned 0 elements, rejecting to wait for global mirrors`);
+                    throw new Error(
+                        `Mirror ${mirror} returned 0 elements, rejecting to wait for global mirrors`
+                    );
                 }
 
                 return data;
@@ -123,7 +124,7 @@ export async function POST(req: NextRequest) {
         let fastestData;
         try {
             fastestData = await Promise.any(fetchPromises);
-        } catch (err) {
+        } catch {
             // This catches both complete network failures AND cases where all mirrors returned 0 elements
             console.warn("[overpass] All mirrors rejected or returned 0 elements");
             fastestData = { elements: [] };
@@ -147,10 +148,10 @@ export async function POST(req: NextRequest) {
             headers: { "X-Cache": "MISS" },
         });
     } catch (err) {
-            console.error("[overpass] Uncaught error:", err);
-            return NextResponse.json(
-                { error: "All parallel Overpass mirrors failed" },
-                { status: 503 }
-            );
+        console.error("[overpass] Uncaught error:", err);
+        return NextResponse.json(
+            { error: "All parallel Overpass mirrors failed" },
+            { status: 503 }
+        );
     }
 }

--- a/apps/web/app/components/health/ChatUI.tsx
+++ b/apps/web/app/components/health/ChatUI.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import Link from "next/link";
-import { ThemeToggle } from "../../[locale]/components/ThemeToggle";
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
 import { ChatBubble, type Message } from "./components/ChatBubble";
 import { ActionCard } from "./components/ActionCard";
 import { TypingIndicator } from "./components/TypingIndicator";
-import { TrustBar } from "./components/TrustBar";
 import { Camera, Pill, MapPin, RotateCcw } from "lucide-react";
 import { isAbortError, readChatErrorMessage, readTextResponseStream } from "@/lib/chatStream";
 import { useTranslations } from "next-intl";

--- a/apps/web/worker/index.js
+++ b/apps/web/worker/index.js
@@ -527,12 +527,6 @@ async function navigateWithOfflineFallback(request) {
     }
 }
 
-function generateSecureFallbackUUID() {
-    return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
-        (c ^ (self.crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))).toString(16)
-    );
-}
-
 // ---------------------------------------------------------------------------
 // PUSH NOTIFICATIONS — medicine recall alerts
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #3831
- **Summary:** `npm run lint -w web` fails on every PR, blocking the required quality-check job. (Re-opens the fix after #3856 was closed on a merge conflict.) The original report named `Footer.tsx` and `worker/index.js`, but `main` has since accumulated more unused-var violations from other merged PRs, and the gate stays red until **all** are cleared — so this removes every current error (12 across 6 files), all the same trivial `no-unused-vars` / `prefer-const` class:
  - `Footer.tsx` — drop unused `Sparkles` import.
  - `[locale]/map/page.tsx` — drop unused `PageHeader` import; keep only the used setters for the never-read `isSearchingLocation` / `pharmacyCount` state (`const [, setX]`).
  - `api/chat/route.ts` — remove unused `maxRetries` / `attempt` locals in `withRetry` (dead scaffolding).
  - `api/overpass/route.ts` — drop unused `catch (err)` binding.
  - `components/health/ChatUI.tsx` — remove unused `Link` / `ThemeToggle` / `TrustBar` imports.
  - `worker/index.js` — remove dead `generateSecureFallbackUUID`.
  - All are dead-code / unused-binding cleanup with no behaviour change.

> **Scope note:** the issue's "Files to Touch" was a point-in-time snapshot of 2 files. The acceptance criterion is a green gate / zero lint errors, and the quality-check job lints the whole `web` workspace — so the other files had to be included, or the gate (and this PR's own CI) would stay red.

## 📸 Proof of Work (Screenshots / Logs)

Before: `✖ 12 problems (12 errors, 0 warnings)`. After:

web@0.1.0 lint
eslint .

(exit 0 — zero errors)


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] 🛠️ `type: devops`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3831`)
- [x] I have pulled the latest `main` and resolved any conflicts
