### PR TITLE
fix(alerts): retry expiry notifications after delivery failures

### DIFF
--- a/apps/api/src/cron/alert-broadcaster.ts
+++ b/apps/api/src/cron/alert-broadcaster.ts
@@ -204,7 +204,7 @@ function buildConsolidatedExpiryMessage(
 async function sendConsolidatedExpiryNotification(
     sub: NotificationSubscriber,
     batchSummaries: ExpiringBatchSummary[]
-): Promise<void> {
+): Promise<boolean> {
     const { title, body } = buildConsolidatedExpiryMessage(batchSummaries, sub.language);
     const fullMessage = `${title}\n\n${body}`;
 
@@ -216,7 +216,8 @@ async function sendConsolidatedExpiryNotification(
         sendPromises.push(whatsappService.send(sub.phone, fullMessage, sub.language));
     }
 
-    await Promise.all(sendPromises);
+    const results = await Promise.allSettled(sendPromises);
+    return results.some((result) => result.status === "fulfilled" && result.value);
 }
 
 export async function broadcastDistrictAlerts(): Promise<void> {
@@ -458,7 +459,7 @@ export async function broadcastExpiryAlerts(now: Date = new Date()): Promise<voi
 
             const { error: markError } = await supabase
                 .from("batches")
-                .update({ expiry_broadcasted: true })
+                .select("id")
                 .in("id", chunkIds);
 
             if (markError) {
@@ -490,6 +491,7 @@ export async function broadcastExpiryAlerts(now: Date = new Date()): Promise<voi
         let from = 0;
         let to = PAGE_SIZE - 1;
         let hasMore = true;
+        let hasSuccessfulDelivery = false;
 
         while (hasMore) {
             const { data: subscribers, error: subsError } = await supabase
@@ -516,7 +518,10 @@ export async function broadcastExpiryAlerts(now: Date = new Date()): Promise<voi
                 const notificationPromises = chunk.map((sub) =>
                     sendConsolidatedExpiryNotification(sub, batchSummaries)
                 );
-                await Promise.allSettled(notificationPromises);
+                const results = await Promise.allSettled(notificationPromises);
+                hasSuccessfulDelivery ||= results.some(
+                    (result) => result.status === "fulfilled" && result.value
+                );
             }
 
             if (subscribers.length < PAGE_SIZE) {
@@ -524,6 +529,35 @@ export async function broadcastExpiryAlerts(now: Date = new Date()): Promise<voi
             } else {
                 from += PAGE_SIZE;
                 to += PAGE_SIZE;
+            }
+        }
+
+        if (!hasSuccessfulDelivery) {
+            logger.warn("Expiry alert delivery failed for every eligible subscriber; will retry.", {
+                batchIds: expiringBatches.map((batch) => batch.id),
+            });
+            return;
+        }
+
+        for (
+            let i = 0;
+            i < expiringBatches.length;
+            i += broadcastConfig.MARK_BROADCASTED_CHUNK_SIZE
+        ) {
+            const chunk = expiringBatches.slice(i, i + broadcastConfig.MARK_BROADCASTED_CHUNK_SIZE);
+            const chunkIds = chunk.map((batch) => batch.id);
+
+            const { error: markError } = await supabase
+                .from("batches")
+                .update({ expiry_broadcasted: true })
+                .in("id", chunkIds);
+
+            if (markError) {
+                logger.error({
+                    message: "Failed to mark delivered expiry alert batches as broadcasted",
+                    error: markError,
+                    batchIds: chunkIds,
+                });
             }
         }
     } catch (err) {

--- a/apps/api/tests/alertBroadcaster.test.ts
+++ b/apps/api/tests/alertBroadcaster.test.ts
@@ -36,6 +36,7 @@ jest.mock("../src/db/client", () => {
 
 import { supabase } from "../src/db/client";
 import { smsService } from "../src/services/sms-service";
+import { whatsappService } from "../src/services/whatsapp-service";
 import {
     broadcastDistrictAlerts,
     broadcastExpiryAlerts,
@@ -303,7 +304,9 @@ describe("broadcastExpiryAlerts", () => {
     function mockBatchesQuery(batches: any[], opts: { gte?: jest.Mock } = {}) {
         const gteSpy = opts.gte || jest.fn();
         return {
+            in: jest.fn().mockResolvedValue({ data: batches, error: null }),
             select: jest.fn().mockReturnValue({
+                in: jest.fn().mockResolvedValue({ data: batches, error: null }),
                 gte: jest.fn().mockImplementation((...args) => {
                     gteSpy(...args);
                     return {
@@ -398,7 +401,7 @@ describe("broadcastExpiryAlerts", () => {
         expect(fullMessage).toContain("B3");
     });
 
-    it("marks each batch as expiry_broadcasted=true before any notification is sent", async () => {
+    it("marks batches as broadcasted after successful expiry notification delivery", async () => {
         const callOrder: string[] = [];
         const batches = [
             {
@@ -416,7 +419,7 @@ describe("broadcastExpiryAlerts", () => {
                     update: jest.fn().mockImplementation(() => {
                         callOrder.push("mark_batch_broadcasted");
                         return {
-                            eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+                            in: jest.fn().mockResolvedValue({ data: null, error: null }),
                         };
                     }),
                 };
@@ -434,7 +437,17 @@ describe("broadcastExpiryAlerts", () => {
                                         });
                                     }
                                     callOrder.push("fetch_subscribers");
-                                    return Promise.resolve({ data: [], error: null });
+                                    return Promise.resolve({
+                                        data: [
+                                            {
+                                                id: "sub-1",
+                                                phone: "+910000000001",
+                                                language: "en",
+                                                channels: ["sms"],
+                                            },
+                                        ],
+                                        error: null,
+                                    });
                                 }),
                             }),
                         }),
@@ -446,7 +459,85 @@ describe("broadcastExpiryAlerts", () => {
 
         await broadcastExpiryAlerts();
 
-        expect(callOrder[0]).toBe("mark_batch_broadcasted");
+        expect(callOrder).toEqual(["fetch_subscribers", "mark_batch_broadcasted"]);
+    });
+
+    it("keeps batches eligible for retry when every expiry delivery fails", async () => {
+        const markBatchSpy = jest.fn();
+        (smsService.send as jest.Mock).mockResolvedValue(false);
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "batches") {
+                return {
+                    ...mockBatchesQuery([
+                        {
+                            id: "batch-1",
+                            batch_number: "B1",
+                            expiry_date: "2026-07-01",
+                            medicine: { brand_name: "Aspirin" },
+                        },
+                    ]),
+                    update: markBatchSpy,
+                };
+            }
+            if (table === "notification_subscribers") {
+                return mockSubscribersQuery([
+                    {
+                        id: "sub-1",
+                        phone: "+910000000001",
+                        language: "en",
+                        channels: ["sms"],
+                    },
+                ]);
+            }
+            return {};
+        });
+
+        await broadcastExpiryAlerts();
+
+        expect(smsService.send).toHaveBeenCalledTimes(1);
+        expect(markBatchSpy).not.toHaveBeenCalled();
+    });
+
+    it("marks batches as broadcasted after a partial expiry delivery success", async () => {
+        const markBatchSpy = jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({ data: null, error: null }),
+        });
+        (smsService.send as jest.Mock).mockResolvedValue(true);
+        (whatsappService.send as jest.Mock).mockResolvedValue(false);
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "batches") {
+                return {
+                    ...mockBatchesQuery([
+                        {
+                            id: "batch-1",
+                            batch_number: "B1",
+                            expiry_date: "2026-07-01",
+                            medicine: { brand_name: "Aspirin" },
+                        },
+                    ]),
+                    update: markBatchSpy,
+                };
+            }
+            if (table === "notification_subscribers") {
+                return mockSubscribersQuery([
+                    {
+                        id: "sub-1",
+                        phone: "+910000000001",
+                        language: "en",
+                        channels: ["sms", "whatsapp"],
+                    },
+                ]);
+            }
+            return {};
+        });
+
+        await broadcastExpiryAlerts();
+
+        expect(smsService.send).toHaveBeenCalledTimes(1);
+        expect(whatsappService.send).toHaveBeenCalledTimes(1);
+        expect(markBatchSpy).toHaveBeenCalledWith({ expiry_broadcasted: true });
     });
 
     it("does not re-send to a batch already marked expiry_broadcasted=true", async () => {
@@ -478,7 +569,7 @@ describe("broadcastExpiryAlerts", () => {
         expect(smsService.send).not.toHaveBeenCalled();
     });
 
-    it("skips a batch and excludes it from the consolidated message if marking it broadcasted fails", async () => {
+    it("keeps delivery behavior when marking broadcasted batches fails", async () => {
         const batches = [
             {
                 id: "batch-1",
@@ -535,7 +626,7 @@ describe("broadcastExpiryAlerts", () => {
 
         expect(smsService.send).toHaveBeenCalledTimes(1);
         const [, fullMessage] = (smsService.send as jest.Mock).mock.calls[0];
-        expect(fullMessage).not.toContain("B1");
+        expect(fullMessage).toContain("B1");
         expect(fullMessage).toContain("B2");
     });
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3883**
- **Summary:**
  - Fixes an issue where expiry batches were marked as broadcasted before any notification delivery succeeded.
  - Updates the broadcaster to mark batches as `expiry_broadcasted = true` only after at least one successful notification delivery.
  - Keeps batches retryable when all delivery attempts fail.
  - Preserves the existing behavior for partial success to avoid duplicate notifications.
  - Adds regression tests covering successful, failed, and partial delivery scenarios.

## 📸 Proof of Work (Screenshots / Logs)

Backend logic change (no UI changes).

### Validation

- ✅ Added regression tests covering:
  - all deliveries succeed
  - all deliveries fail
  - partial SMS/WhatsApp success
- ✅ Focused test suite passed (`20/20`).
- ✅ `prettier` passed.

### Notes

- Full TypeScript checking is currently blocked by the repository's existing missing `jsonwebtoken` dependency.
- ESLint could not be executed directly because `apps/api` does not contain a standalone ESLint flat configuration.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3883`)
- [x] I have pulled the latest `main` and resolved any conflicts