### PR TITLE
fix(scan): use queued endpoint during offline sync

### DIFF
--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -330,12 +330,18 @@ export async function fetchNearbyAshaWorkers(
 
 export async function verifyMedicine(
     batchNumber: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    endpoint?: string
 ): Promise<VerifyResult> {
-    const mlUrl = process.env.NEXT_PUBLIC_ML_URL;
+    const mlUrl = endpoint
+        ? /\/verify\/batch\/?$/.test(endpoint)
+            ? endpoint
+            : undefined
+        : process.env.NEXT_PUBLIC_ML_URL;
     if (mlUrl) {
         try {
-            const mlRes = await fetchWithRetry(`${mlUrl.replace(/\/+$/, "")}/verify/batch`, {
+            const mlEndpoint = endpoint ?? `${mlUrl.replace(/\/+$/, "")}/verify/batch`;
+            const mlRes = await fetchWithRetry(mlEndpoint, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
@@ -375,12 +381,18 @@ export async function verifyMedicine(
                     },
                 };
             }
-        } catch {
+            if (endpoint) {
+                throw new Error(
+                    "Stored ML verification endpoint returned an unsuccessful response"
+                );
+            }
+        } catch (error) {
+            if (endpoint) throw error;
             console.warn("ML service unavailable, falling back to Node API");
         }
     }
     return fetchWithCsrf<VerifyResult>(
-        `${API_BASE}/api/verify`,
+        endpoint ?? `${API_BASE}/api/verify`,
         {
             method: "POST",
             body: JSON.stringify({ batchNumber }),

--- a/apps/web/lib/db/syncQueue.ts
+++ b/apps/web/lib/db/syncQueue.ts
@@ -5,7 +5,7 @@ export interface QueuedScan {
     barcode: string;
     timestamp: number;
     locale: string;
-    apiUrl: string;
+    apiUrl?: string;
     deviceMetadata?: {
         userAgent: string;
         platform: string;
@@ -37,13 +37,18 @@ export async function addToSyncQueue(
     if (!dbPromise) throw new Error("IndexedDB not available");
     const db = await dbPromise;
 
-    const finalApiUrl = apiUrl || (() => {
-        const mlUrl = typeof process !== "undefined" ? process.env.NEXT_PUBLIC_ML_URL : undefined;
-        const apiBase = (typeof process !== "undefined" ? process.env.NEXT_PUBLIC_API_URL : undefined) || "http://localhost:4000";
-        return mlUrl 
-            ? `${mlUrl.replace(/\/+$/, "")}/verify/batch` 
-            : `${apiBase.replace(/\/+$/, "")}/api/verify`;
-    })();
+    const finalApiUrl =
+        apiUrl ||
+        (() => {
+            const mlUrl =
+                typeof process !== "undefined" ? process.env.NEXT_PUBLIC_ML_URL : undefined;
+            const apiBase =
+                (typeof process !== "undefined" ? process.env.NEXT_PUBLIC_API_URL : undefined) ||
+                "http://localhost:4000";
+            return mlUrl
+                ? `${mlUrl.replace(/\/+$/, "")}/verify/batch`
+                : `${apiBase.replace(/\/+$/, "")}/api/verify`;
+        })();
 
     const item: QueuedScan = {
         id: crypto.randomUUID(),

--- a/apps/web/lib/scanQueueSync.ts
+++ b/apps/web/lib/scanQueueSync.ts
@@ -25,7 +25,7 @@ export async function syncPendingScans(onSynced?: (count: number) => void): Prom
 
     for (const item of queue) {
         try {
-            const result = await verifyMedicine(item.barcode);
+            const result = await verifyMedicine(item.barcode, undefined, item.apiUrl);
             await recordScanHistory(result, item.barcode);
             await removeFromSyncQueue(item.id);
             synced++;

--- a/apps/web/tests/scanQueueSync.test.ts
+++ b/apps/web/tests/scanQueueSync.test.ts
@@ -112,13 +112,33 @@ describe("scanQueueSync", () => {
             },
         } as any);
 
-        const item = await addToSyncQueue("BATCH-789", "en");
+        const item = await addToSyncQueue("BATCH-789", "en", "https://queued.example/api/verify");
         const synced = await syncPendingScans();
 
         expect(synced).toBe(1);
+        expect(mockedVerify).toHaveBeenCalledWith(
+            "BATCH-789",
+            undefined,
+            "https://queued.example/api/verify"
+        );
         expect(recordScanHistory).toHaveBeenCalled();
         expect(await getSyncQueue()).toHaveLength(0);
         expect(item.barcode).toBe("BATCH-789");
+    });
+
+    it("uses the current endpoint for legacy queued scans without an apiUrl", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockResolvedValue({ verified: false, message: "Medicine not found" });
+
+        const item = await addToSyncQueue("BATCH-LEGACY", "en");
+        delete item.apiUrl;
+        queueStore.set(item.id, item);
+
+        const synced = await syncPendingScans();
+
+        expect(synced).toBe(1);
+        expect(mockedVerify).toHaveBeenCalledWith("BATCH-LEGACY", undefined, undefined);
+        expect(await getSyncQueue()).toHaveLength(0);
     });
 
     it("skips syncing while offline", async () => {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3884**
- **Summary:**
  - Fixes an issue where queued offline scans ignored their stored `apiUrl` during synchronization.
  - Updates the sync worker to use the endpoint captured with each queued scan.
  - Falls back to the current global configuration for legacy queue entries that do not contain `apiUrl`.
  - Adds regression tests covering both stored-endpoint and legacy queue scenarios.

## 📸 Proof of Work (Screenshots / Logs)

Backend/frontend logic change (no UI changes).

### Validation

- ✅ Added regression tests for queued endpoint synchronization.
- ✅ Focused test suite passed (6 tests).
- ✅ TypeScript passed.
- ✅ `prettier` passed.
- ✅ `git diff --check` passed.

### Notes

- Full ESLint execution is currently blocked by existing unrelated lint violations elsewhere in the repository. This PR does not introduce additional ESLint issues.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3884`)
- [x] I have pulled the latest `main` and resolved any conflicts