### PR TITLE
Fix: added structured API error message extraction

### DIFF
--- a/apps/web/lib/api/alternatives.ts
+++ b/apps/web/lib/api/alternatives.ts
@@ -40,6 +40,15 @@ export interface SchemeEligibilityResponse {
     eligible_schemes: EligibleScheme[];
 }
 
+type ApiErrorBody = { error?: string | { message?: string }; message?: string };
+
+function extractErrorMessage(body: ApiErrorBody, fallback: string): string {
+    if (typeof body.error === "string") return body.error;
+    if (body.error?.message) return body.error.message;
+    if (body.message) return body.message;
+    return fallback;
+}
+
 /**
  * Fetches generic alternatives for a medicine from the API.
  */
@@ -61,8 +70,8 @@ export async function fetchGenericAlternatives(
     });
 
     if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? "Failed to fetch generic alternatives.");
+        const body = (await res.json().catch(() => ({}))) as ApiErrorBody;
+        throw new Error(extractErrorMessage(body, "Failed to fetch generic alternatives."));
     }
 
     return res.json() as Promise<GenericAlternative>;
@@ -86,8 +95,8 @@ export async function checkSchemeEligibility(
     });
 
     if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? "Failed to check scheme eligibility.");
+        const body = (await res.json().catch(() => ({}))) as ApiErrorBody;
+        throw new Error(extractErrorMessage(body, "Failed to check scheme eligibility."));
     }
 
     return res.json() as Promise<SchemeEligibilityResponse>;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3875**
- **Summary:**
Fixes the bug where the eligibility form's error toast displayed [object Object] instead of the actual API error message.

- **Root Cause**
`checkSchemeEligibility` & `fetchGenericAlternatives` in `lib/api/alternatives.ts` assumed error responses had the shape `{ error: string }`. The actual API returns:
```
{ "success": false, "error": { "message": "invalid csrf token" }, "requestId": "..." }
```
Since error is an object `new Error(body.error ?? fallback)` coerced that object to a string producing "[object Object]". 

- **Changes:**
  - Added a shared `extractErrorMessage()` helper that handles both string and `{ message }` object shapes for error plus a top level message fallback.
  - Updated `checkSchemeEligibility` to use it when throwing on a failed response.
  - Updated `fetchGenericAlternatives` to use it as well since it had the same bug.

## 📸 Proof of Work (Screenshots / Logs)
<img width="425" height="855" alt="image" src="https://github.com/user-attachments/assets/c2238b99-1920-48a0-b8a3-0b6f41853a64" />

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3875`)
- [x] I have pulled the latest `main` and resolved any conflicts
