### PR TITLE
fix: restore Jest compatibility with TypeScript 7

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-    preset: "ts-jest",
     testEnvironment: "node",
     testTimeout: 30000,
     maxWorkers: 2,
@@ -18,17 +17,18 @@ module.exports = {
         "^@sahidawa/shared$": "<rootDir>/../../packages/shared/src",
         "^@sahidawa/validators$": "<rootDir>/../../packages/validators/src",
     },
+    // babel-jest replaces ts-jest here. It only strips TS syntax — it never
+    // calls into the TypeScript compiler API — so it's unaffected by which
+    // TypeScript major version (5.x, 7.x, ...) is installed anywhere in the
+    // monorepo. No babel.config.js needed: presets are passed inline below.
     transform: {
-        "^.+\\.tsx?$": [
-            "ts-jest",
+        "^.+\\.[tj]sx?$": [
+            "babel-jest",
             {
-                tsconfig: "<rootDir>/tsconfig.test.json",
-            },
-        ],
-        "^.+\\.jsx?$": [
-            "ts-jest",
-            {
-                tsconfig: "<rootDir>/tsconfig.test.json",
+                presets: [
+                    ["@babel/preset-env", { targets: { node: "current" } }],
+                    "@babel/preset-typescript",
+                ],
             },
         ],
     },

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,8 @@
         "start": "node dist/index.js",
         "dev": "ts-node-dev --respawn --transpile-only -r ./ws-setup.js src/index.ts",
         "build": "npm run build -w @sahidawa/types -w @sahidawa/validators -w @sahidawa/shared && tsc && cp -r assets dist/",
-        "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest --forceExit --silent"
+        "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest --forceExit --silent",
+        "test:types": "tsc --noEmit -p tsconfig.test.json"
     },
     "dependencies": {
         "@google/generative-ai": "^0.24.1",
@@ -50,6 +51,9 @@
         "zod": "^4.4.3"
     },
     "devDependencies": {
+        "@babel/core": "^7.26.0",
+        "@babel/preset-env": "^7.26.0",
+        "@babel/preset-typescript": "^7.26.0",
         "@types/compression": "^1.8.1",
         "@types/cookie-parser": "^1.4.10",
         "@types/cors": "^2.8.17",
@@ -66,9 +70,9 @@
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.8",
         "@types/web-push": "^3.6.4",
+        "babel-jest": "^29.7.0",
         "jest": "^29.7.0",
         "supertest": "^7.2.2",
-        "ts-jest": "^29.4.11",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.6.2"
     }


### PR DESCRIPTION
## Related Issue

Closes #3887

---

## Description

Fixed an issue where the API test suite failed to start because the current `ts-jest` setup was incompatible with **TypeScript 7.0.2**.

Previously, running the Jest test suite resulted in an initialization error indicating that the TypeScript compiler API was not available. This prevented both local development and CI pipelines from executing backend tests, blocking contributors from validating their changes.

This fix updates the test transformer configuration to use a TypeScript 7 compatible setup and aligns the Jest configuration and development dependencies accordingly. The changes ensure that the test suite initializes successfully while preserving the existing testing workflow.

---

## Changes Made

- Updated the Jest transformer configuration for TypeScript 7 compatibility.
- Updated/pinned the required testing dependencies in `package.json`.
- Adjusted `jest.config.js` to use the supported transformer configuration.
- Ensured the backend test suite starts successfully.
- Preserved existing test behavior and coverage.

---

## Steps to Test

1. Navigate to the API project:
   ```bash
   cd apps/api
   ```
2. Install dependencies:
   ```bash
   npm install
   ```
3. Run the test suite:
   ```bash
   npm test
   ```
4. Verify Jest starts successfully without TypeScript compiler API errors.
5. Confirm the test suite executes normally.
6. Verify the CI test job completes successfully.

---

## Expected Result

- Jest initializes successfully with TypeScript 7.
- No `ts-jest` compatibility errors occur during startup.
- Backend tests execute normally.
- CI test jobs pass without transformer-related failures.

---

## Files Changed

- `apps/api/jest.config.js`
- `apps/api/package.json`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update