### PR TITLE
fix: prevent revoked auth tokens from being accepted via Redis cache

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -120,13 +120,12 @@ export const createAuthMiddleware =
         }
 
         const cacheKey = `auth:user:${crypto.createHash("sha256").update(token).digest("hex")}`;
+        let cachedUser: AuthenticatedUser | null = null;
         try {
             if (redisClient.isOpen) {
                 const cached = await redisClient.get(cacheKey);
                 if (cached) {
-                    req.user = JSON.parse(cached);
-                    next();
-                    return;
+                    cachedUser = JSON.parse(cached);
                 }
             }
         } catch (err) {
@@ -147,6 +146,11 @@ export const createAuthMiddleware =
                     error.message?.includes("refused");
 
                 if (isConnectionError) {
+                    if (cachedUser) {
+                        req.user = cachedUser;
+                        next();
+                        return;
+                    }
                     if (dbConfig) dbConfig.setOffline();
                     logger.warn({
                         message: "Supabase auth server returned connection error.",
@@ -159,11 +163,21 @@ export const createAuthMiddleware =
                     }
                 }
 
+                try {
+                    if (redisClient.isOpen) {
+                        await redisClient.del(cacheKey);
+                    }
+                } catch (_) {}
                 res.status(401).json({ error: "Unauthorized: Invalid or expired token" });
                 return;
             }
 
             if (!data.user) {
+                try {
+                    if (redisClient.isOpen) {
+                        await redisClient.del(cacheKey);
+                    }
+                } catch (_) {}
                 res.status(401).json({ error: "Unauthorized: Invalid or expired token" });
                 return;
             }
@@ -177,7 +191,7 @@ export const createAuthMiddleware =
 
             try {
                 if (redisClient.isOpen) {
-                    await redisClient.setEx(cacheKey, 300, JSON.stringify(req.user));
+                    await redisClient.setEx(cacheKey, 30, JSON.stringify(req.user));
                 }
             } catch (err) {
                 logger.warn({
@@ -232,13 +246,12 @@ export const createOptionalAuthMiddleware =
         }
 
         const cacheKey = `auth:user:${crypto.createHash("sha256").update(token).digest("hex")}`;
+        let cachedUser: AuthenticatedUser | null = null;
         try {
             if (redisClient.isOpen) {
                 const cached = await redisClient.get(cacheKey);
                 if (cached) {
-                    req.user = JSON.parse(cached);
-                    next();
-                    return;
+                    cachedUser = JSON.parse(cached);
                 }
             }
         } catch (err) {
@@ -259,6 +272,11 @@ export const createOptionalAuthMiddleware =
                     error.message?.includes("refused");
 
                 if (isConnectionError) {
+                    if (cachedUser) {
+                        req.user = cachedUser;
+                        next();
+                        return;
+                    }
                     if (dbConfig) dbConfig.setOffline();
                     logger.warn({
                         message: "Supabase auth server returned connection error.",
@@ -271,6 +289,11 @@ export const createOptionalAuthMiddleware =
                     return;
                 }
 
+                try {
+                    if (redisClient.isOpen) {
+                        await redisClient.del(cacheKey);
+                    }
+                } catch (_) {}
                 res.status(401).json({
                     error: "Unauthorized: Invalid or expired token",
                 });
@@ -278,6 +301,11 @@ export const createOptionalAuthMiddleware =
             }
 
             if (!data.user) {
+                try {
+                    if (redisClient.isOpen) {
+                        await redisClient.del(cacheKey);
+                    }
+                } catch (_) {}
                 res.status(401).json({
                     error: "Unauthorized: Invalid or expired token",
                 });
@@ -293,7 +321,7 @@ export const createOptionalAuthMiddleware =
 
             try {
                 if (redisClient.isOpen) {
-                    await redisClient.setEx(cacheKey, 300, JSON.stringify(req.user));
+                    await redisClient.setEx(cacheKey, 30, JSON.stringify(req.user));
                 }
             } catch (err) {
                 logger.warn({


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3917**
- **Summary:**
1. Cache no longer short-circuits token validation — Instead of next()-returning immediately on a Redis cache hit, the cached user object is stored locally and only used as a fallback when Supabase is unreachable (connection error). Every request now calls client.auth.getUser(token) to validate the token is still active, catching revocations instantly.
2. Stale cache entries are evicted on token rejection — When Supabase returns an auth error (invalid/expired/revoked token) or data.user is null, the cache key is deleted via redisClient.del() so stale entries don't linger or serve subsequent requests.
3. Cache TTL reduced from 300s to 30s — In edge cases where the cache is used as a Supabase-offline fallback, the window of vulnerability shrinks from 5 minutes to 30 seconds.



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3917`)
- [x] I have pulled the latest `main` and resolved any conflicts
