### PR TITLE
fix: sanitize error messages returned to clients to prevent info leakage

### DIFF
--- a/apps/api/src/middleware/errorHandler.ts
+++ b/apps/api/src/middleware/errorHandler.ts
@@ -1,9 +1,29 @@
 import { Request, Response, NextFunction } from "express";
 import logger from "../utils/logger";
-import { getDbErrorStatus } from "../utils/dbErrors";
+import { getDbErrorStatus, getDbErrorMessage } from "../utils/dbErrors";
 import { getRequestId } from "./requestId";
 
 import { sanitize } from "../utils/security/sanitize";
+
+const GENERIC_CLIENT_MESSAGES: Record<number, string> = {
+    400: "The request could not be processed. Please check your input.",
+    401: "Unauthorized. Please sign in to continue.",
+    403: "Forbidden. You do not have permission to perform this action.",
+    404: "The requested resource was not found.",
+    405: "Method not allowed.",
+    409: "A conflict occurred. Please try again.",
+    410: "The requested resource is no longer available.",
+    415: "Unsupported media type.",
+    422: "The request could not be processed due to invalid data.",
+    429: "Too many requests. Please try again later.",
+};
+
+function getClientMessage(err: Error & { code?: string }, statusCode: number): string {
+    if (statusCode >= 500) return "Internal Server Error";
+    const dbMessage = err.code ? getDbErrorMessage(err.code) : null;
+    if (dbMessage) return dbMessage;
+    return GENERIC_CLIENT_MESSAGES[statusCode] ?? "An unexpected error occurred.";
+}
 
 export function errorHandler(
     err: Error & { statusCode?: number; status?: number; code?: string },
@@ -36,7 +56,7 @@ export function errorHandler(
     });
 
     const isProduction = process.env.NODE_ENV === "production";
-    const clientMessage = statusCode >= 500 ? "Internal Server Error" : err.message;
+    const clientMessage = getClientMessage(err, statusCode);
 
     res.status(statusCode).json({
         success: false,

--- a/apps/api/src/utils/dbErrors.ts
+++ b/apps/api/src/utils/dbErrors.ts
@@ -1,13 +1,28 @@
 /**
- * Maps database error codes (like PostgreSQL/Supabase) to standard HTTP status codes.
+ * Maps database error codes (like PostgreSQL/Supabase) to standard HTTP status codes
+ * and user-safe messages that don't leak internal schema details.
  */
+
+interface DbErrorInfo {
+    status: number;
+    clientMessage: string;
+}
+
+const DB_ERROR_MAP: Record<string, DbErrorInfo> = {
+    "23505": {
+        status: 409,
+        clientMessage: "A record with the same value already exists.",
+    },
+    "23503": {
+        status: 422,
+        clientMessage: "The operation could not be completed due to a conflicting reference.",
+    },
+};
+
 export function getDbErrorStatus(code: string): number | null {
-  switch (code) {
-    case '23505':
-      return 409; // Conflict (Unique violation)
-    case '23503':
-      return 422; // Unprocessable Entity (Foreign key violation)
-    default:
-      return null;
-  }
+    return DB_ERROR_MAP[code]?.status ?? null;
+}
+
+export function getDbErrorMessage(code: string): string | null {
+    return DB_ERROR_MAP[code]?.clientMessage ?? null;
 }


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3919**
- **Sum:**
Replaces the raw err.message in client-facing error responses with generic, user-safe messages. Full error details continue to be logged server-side via the existing logger utility.

Changes:
1. dbErrors.ts: Refactored to a central DB_ERROR_MAP that maps PostgreSQL error codes to both HTTP status codes AND generic client-safe messages (e.g., code 23505 → 'A record with the same value already exists.'). Exported getDbErrorMessage().

2. errorHandler.ts: Introduced getClientMessage() which checks:
   - DB error codes first (generic message from dbErrors map)
   - Then the status code lookup table (GENERIC_CLIENT_MESSAGES)
   - Falls back to 'An unexpected error occurred.' All non-500 errors now return sanitized messages instead of raw err.message, preventing email enumeration via unique constraint errors and schema leakage via FK violation errors.mary



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3919 `)
- [x] I have pulled the latest `main` and resolved any conflicts
