### PR TITLE
fix(api): exempt webhook endpoints from CSRF validation

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -145,7 +145,23 @@ const { doubleCsrfProtection, generateCsrfToken: generateToken } = doubleCsrf({
 // Registered in every environment so CodeQL sees CSRF middleware on every route
 // (resolves Alert 136) and development mirrors production, surfacing CSRF
 // integration issues locally instead of only after deploy.
-app.use(doubleCsrfProtection);
+//
+// Webhook endpoints are exempt from CSRF validation because external callers
+// (Supabase Database Webhooks, Twilio, ETL pipeline) cannot participate in the
+// CSRF token handshake — they authenticate via their own mechanisms (shared
+// HMAC secret, Twilio signature) which already prevent cross-site forgery.
+const WEBHOOK_EXEMPT_PREFIXES = ["/api/webhooks"];
+const WEBHOOK_EXEMPT_PATHS = ["/api/notifications/twilio-webhook"];
+
+app.use((req, res, next) => {
+    if (
+        WEBHOOK_EXEMPT_PREFIXES.some((p) => req.path.startsWith(p)) ||
+        WEBHOOK_EXEMPT_PATHS.includes(req.path)
+    ) {
+        return next();
+    }
+    return doubleCsrfProtection(req, res, next);
+});
 
 // ── CSRF token endpoint — frontend fetches this once on load ───────────────
 app.get("/api/csrf-token", (req: Request, res: Response) => {


### PR DESCRIPTION




### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3923**
- **Summary:**
The globally registered doubleCsrfProtection middleware was blocking all POST requests to webhook endpoints (/api/webhooks/* and /api/notifications/twilio-webhook) because external callers (Supabase Database Webhooks, Twilio, ETL pipeline) cannot participate in the CSRF token handshake — they authenticate via their own mechanisms (shared HMAC secret, Twilio signature).

This broke:
- All Supabase Database Webhook cache invalidation
- Twilio SMS/WhatsApp opt-out/in webhook
- ETL pipeline cache invalidation

Fix: replace global app.use(doubleCsrfProtection) with a conditional middleware that bypasses CSRF validation for known webhook paths while keeping it active for all browser-facing routes.



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3923`)
- [x] I have pulled the latest `main` and resolved any conflicts
