### PR TITLE
fix: prevent PostgREST filter injection via string interpolation 

### DIFF
--- a/apps/api/src/routes/alternatives.ts
+++ b/apps/api/src/routes/alternatives.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from "express";
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
-import { escapePostgrest } from "../utils/db";
+
 import { barcodeLimiter } from "../middleware/rateLimit";
 import { cacheMiddleware } from "../middleware/cache";
 import { redisClient } from "../utils/redis";
@@ -141,25 +141,43 @@ router.get(
             let alternative: GenericAlternative | null = null;
 
             if (medicine) {
-                const { data } = await supabase
+                let { data } = await supabase
                     .from("generic_alternatives")
                     .select("*")
-                    .or(
-                        `brand_medicine_id.eq.${medicine.id},brand_name.ilike."%${escapePostgrest(String(medicine.brand_name))}%"`
-                    )
+                    .eq("brand_medicine_id", medicine.id)
                     .limit(1)
                     .maybeSingle();
+
+                if (!data && medicine.brand_name) {
+                    const result = await supabase
+                        .from("generic_alternatives")
+                        .select("*")
+                        .ilike("brand_name", `%${medicine.brand_name}%`)
+                        .limit(1)
+                        .maybeSingle();
+                    data = result.data;
+                }
+
                 alternative = data;
             } else {
                 // Try lookup directly in generic_alternatives by brand name or generic name matching medicine_id
-                const { data } = await supabase
+                let { data } = await supabase
                     .from("generic_alternatives")
                     .select("*")
-                    .or(
-                        `brand_name.ilike."%${escapePostgrest(String(medicine_id))}%",generic_name.ilike."%${escapePostgrest(medicine_id)}%"`
-                    )
+                    .ilike("brand_name", `%${medicine_id}%`)
                     .limit(1)
                     .maybeSingle();
+
+                if (!data) {
+                    const result = await supabase
+                        .from("generic_alternatives")
+                        .select("*")
+                        .ilike("generic_name", `%${medicine_id}%`)
+                        .limit(1)
+                        .maybeSingle();
+                    data = result.data;
+                }
+
                 alternative = data;
             }
 

--- a/apps/api/src/routes/interactions.ts
+++ b/apps/api/src/routes/interactions.ts
@@ -461,26 +461,52 @@ async function resolveMedicinesToGenerics(
 
     if (!dbFailed && cleanInputs.length > 0) {
         try {
-            // Build a single massive OR query combining all the resolution filters
-            const orQuery = cleanInputs.map(buildMedicineResolutionFilter).join(",");
-            const { data, error } = await supabase
-                .from("medicines")
-                .select("brand_name, generic_name")
-                .or(orQuery);
+            // Query each input individually using parameterized PostgREST
+            // filter methods instead of string interpolation in .or().
+            for (const input of cleanInputs) {
+                const lowerInput = input.toLowerCase();
 
-            if (error) {
-                dbFailed = true;
-                if (
-                    error.message?.includes("fetch failed") ||
-                    error.message?.includes("refused") ||
-                    error.message?.includes("timeout")
-                ) {
-                    if (dbConfig) dbConfig.isSupabaseOffline = true;
+                let { data, error } = await supabase
+                    .from("medicines")
+                    .select("brand_name, generic_name")
+                    .ilike("brand_name", `%${input}%`)
+                    .limit(5);
+
+                if (error) {
+                    dbFailed = true;
+                    if (
+                        error.message?.includes("fetch failed") ||
+                        error.message?.includes("refused") ||
+                        error.message?.includes("timeout")
+                    ) {
+                        if (dbConfig) dbConfig.isSupabaseOffline = true;
+                    }
+                    break;
                 }
-            } else if (data) {
-                // Match the returned DB rows back to the inputs
-                for (const input of cleanInputs) {
-                    const lowerInput = input.toLowerCase();
+
+                if (!data || data.length === 0) {
+                    const result = await supabase
+                        .from("medicines")
+                        .select("brand_name, generic_name")
+                        .ilike("generic_name", `%${input}%`)
+                        .limit(5);
+                    data = result.data;
+                    error = result.error;
+
+                    if (error) {
+                        dbFailed = true;
+                        if (
+                            error.message?.includes("fetch failed") ||
+                            error.message?.includes("refused") ||
+                            error.message?.includes("timeout")
+                        ) {
+                            if (dbConfig) dbConfig.isSupabaseOffline = true;
+                        }
+                        break;
+                    }
+                }
+
+                if (data && data.length > 0) {
                     const match = data.find(
                         (d) =>
                             d.brand_name?.toLowerCase().includes(lowerInput) ||

--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -504,14 +504,12 @@ router.post("/verify-brand", scanQueryLimiter, async (req: Request, res: Respons
     }
 
     try {
-        const { data, error } = await supabase
+        let { data, error } = await supabase
             .from("medicines")
             .select(
                 "id, brand_name, generic_name, manufacturer, batch_number, expiry_date, cdsco_approval_status, is_counterfeit_alert, is_cdsco_verified, cdsco_match_score, matched_cdsco_product, matched_cdsco_manufacturer, product_match_score, manufacturer_match_score"
             )
-            .or(
-                `brand_name.ilike."%${escapePostgrest(brandName)}%",generic_name.ilike."%${escapePostgrest(brandName)}%"`
-            )
+            .ilike("brand_name", `%${brandName}%`)
             .limit(1)
             .maybeSingle();
 
@@ -522,6 +520,28 @@ router.post("/verify-brand", scanQueryLimiter, async (req: Request, res: Respons
                 message: "Database lookup failed",
             });
             return;
+        }
+
+        if (!data) {
+            const result = await supabase
+                .from("medicines")
+                .select(
+                    "id, brand_name, generic_name, manufacturer, batch_number, expiry_date, cdsco_approval_status, is_counterfeit_alert, is_cdsco_verified, cdsco_match_score, matched_cdsco_product, matched_cdsco_manufacturer, product_match_score, manufacturer_match_score"
+                )
+                .ilike("generic_name", `%${brandName}%`)
+                .limit(1)
+                .maybeSingle();
+
+            if (result.error) {
+                logger.error(`Database lookup error for verify-brand: ${result.error.message}`);
+                res.status(500).json({
+                    verified: false,
+                    message: "Database lookup failed",
+                });
+                return;
+            }
+
+            data = result.data;
         }
 
         if (!data) {

--- a/apps/api/src/utils/db.ts
+++ b/apps/api/src/utils/db.ts
@@ -9,10 +9,19 @@ export function escapeIlike(word: string): string {
 }
 /**
  * Escapes a value for safe use in PostgREST .or() filters.
- * Prevents comma injection by escaping special characters.
+ * Prevents filter injection by escaping all characters with special
+ * meaning in PostgREST filter syntax.
  */
 export function escapePostgrest(val: string): string {
-    return val.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_").replace(/"/g, '""');
+    return val
+        .replace(/\\/g, "\\\\")
+        .replace(/"/g, '""')
+        .replace(/%/g, "\\%")
+        .replace(/_/g, "\\_")
+        .replace(/,/g, "\\,")
+        .replace(/\(/g, "\\(")
+        .replace(/\)/g, "\\)")
+        .replace(/\./g, "\\.");
 }
 
 export function buildOrConditions(fields: string[], words: string[]): string {


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3924**
- **Summary:**
- scan/verify-brand: replace .or() string interpolation with .ilike()
- interactions/resolveMedicinesToGenerics: replace .or() with individual .ilike() queries
- alternatives: replace .or() string interpolation with .eq()/.ilike() chaining
- escapePostgrest: add defense-in-depth escaping for , . ( ) characters

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3924 `)
- [x] I have pulled the latest `main` and resolved any conflicts
