### PR TITLE
fix: hash OTPs with unique salt, store ephemerally in Redis, remove disk persistence

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -9,6 +9,7 @@ import { supabase, dbConfig } from "../db/client";
 import { smsService } from "../services/sms-service";
 import { whatsappService } from "../services/whatsapp-service";
 import { memorySubscriberStore, InMemorySubscriber } from "../services/memorySubscriberStore";
+import { otpStore } from "../services/otpStore";
 import { formatPhoneNumber } from "../utils/phone";
 import { escapeIlike } from "@sahidawa/shared";
 import logger from "../utils/logger";
@@ -199,7 +200,7 @@ const twilioWebhookSchema = z.object({
 });
 
 // The only subscriber fields any client is allowed to receive. Everything else on
-// a row is either a secret (verification_otp, otp_expires_at) or account-linkage
+// a row is either a secret (otp_store) or account-linkage
 // PII (user_id) and must never be serialized into a response. Returning the raw
 // row from /status let an unauthenticated caller read another subscriber's OTP and
 // Supabase user_id just by knowing their phone number, so every subscriber we hand
@@ -391,16 +392,18 @@ router.post(
                     existing.language = language;
                     existing.district = district;
                     existing.is_active = true;
-                    if (!isOwner) {
+                    if (!isOwner && otp && otpExpires) {
                         existing.status = "pending";
-                        existing.verification_otp = otp;
-                        existing.otp_expires_at = otpExpires;
+                        await otpStore.store(formattedPhone, otp, otpExpires);
                     } else {
                         existing.status = "active";
                     }
                     existing.updated_at = new Date().toISOString();
                     result = existing;
                 } else {
+                    if (!isOwner && otp && otpExpires) {
+                        await otpStore.store(formattedPhone, otp, otpExpires);
+                    }
                     result = {
                         id: `mem-${Date.now()}`,
                         user_id: req.user?.id || null,
@@ -410,8 +413,6 @@ router.post(
                         district,
                         is_active: true,
                         status: targetStatus,
-                        verification_otp: otp,
-                        otp_expires_at: otpExpires,
                         created_at: new Date().toISOString(),
                         updated_at: new Date().toISOString(),
                     };
@@ -426,10 +427,9 @@ router.post(
                         district,
                         is_active: true,
                     };
-                    if (!isOwner) {
+                    if (!isOwner && otp && otpExpires) {
                         updatePayload.status = "pending";
-                        updatePayload.verification_otp = otp;
-                        updatePayload.otp_expires_at = otpExpires;
+                        await otpStore.store(formattedPhone, otp, otpExpires);
                     } else {
                         updatePayload.status = "active";
                     }
@@ -451,6 +451,9 @@ router.post(
                     }
                     result = updated;
                 } else {
+                    if (!isOwner && otp && otpExpires) {
+                        await otpStore.store(formattedPhone, otp, otpExpires);
+                    }
                     const { data: created, error: insertError } = await supabase
                         .from("notification_subscribers")
                         .insert({
@@ -461,8 +464,6 @@ router.post(
                             district,
                             is_active: true,
                             status: targetStatus,
-                            verification_otp: otp,
-                            otp_expires_at: otpExpires,
                         })
                         .select()
                         .single();
@@ -591,23 +592,20 @@ router.post(
                 return;
             }
 
-            if (subscriber.verification_otp !== otp) {
+            const isValid = await otpStore.verify(formattedPhone, otp);
+            if (!isValid) {
                 await recordFailedOtpAttempt(formattedPhone);
-                res.status(400).json({ error: "Invalid OTP" });
-                return;
-            }
-
-            if (subscriber.otp_expires_at && new Date(subscriber.otp_expires_at) < new Date()) {
-                res.status(400).json({ error: "OTP expired" });
+                res.status(400).json({ error: "Invalid or expired OTP" });
                 return;
             }
 
             await clearOtpAttempts(formattedPhone);
+            await otpStore.clear(formattedPhone);
 
             if (!dbFailed) {
                 const { error: updateError } = await supabase
                     .from("notification_subscribers")
-                    .update({ status: "active", verification_otp: null, otp_expires_at: null })
+                    .update({ status: "active" })
                     .eq("id", subscriber.id);
 
                 if (updateError) {
@@ -617,8 +615,6 @@ router.post(
                 }
             } else {
                 subscriber.status = "active";
-                subscriber.verification_otp = null;
-                subscriber.otp_expires_at = null;
                 subscriber.updated_at = new Date().toISOString();
             }
 

--- a/apps/api/src/services/memorySubscriberStore.ts
+++ b/apps/api/src/services/memorySubscriberStore.ts
@@ -1,6 +1,3 @@
-import fs from "fs";
-import fsp from "fs/promises";
-import path from "path";
 import logger from "../utils/logger";
 import { supabase, dbConfig } from "../db/client";
 
@@ -13,91 +10,16 @@ export interface InMemorySubscriber {
     district: string;
     is_active: boolean;
     status: string;
-    verification_otp: string | null;
-    otp_expires_at: string | null;
     created_at: string;
     updated_at: string;
 }
 
-const DATA_FILE = path.resolve(process.cwd(), "data", "memory-subscribers.json");
-const SAVE_DEBOUNCE_MS = 2_000;
-
 class PersistedMemorySubscriberStore {
     private store = new Map<string, InMemorySubscriber>();
-    private saveTimer: ReturnType<typeof setTimeout> | null = null;
-    private dirty = false;
     private isReconciling = false;
 
     constructor() {
-        this.load();
-        this.startPeriodicSave();
         this.startReconciliation();
-    }
-
-    private load(): void {
-        try {
-            const filePath = DATA_FILE;
-            if (fs.existsSync(filePath)) {
-                const raw = fs.readFileSync(filePath, "utf-8");
-                const data: InMemorySubscriber[] = JSON.parse(raw);
-                for (const sub of data) {
-                    this.store.set(sub.phone, sub);
-                }
-                logger.info(`Loaded ${data.length} in-memory subscribers from ${filePath}`);
-            } else {
-                const dir = path.dirname(filePath);
-                if (!fs.existsSync(dir)) {
-                    fs.mkdirSync(dir, { recursive: true });
-                }
-                logger.info("No existing memory subscriber file found, starting fresh");
-            }
-        } catch (err) {
-            logger.error({
-                message: "Failed to load memory subscribers from file",
-                error: err,
-            });
-        }
-    }
-
-    private async save(): Promise<void> {
-        try {
-            const filePath = DATA_FILE;
-            const dir = path.dirname(filePath);
-            await fsp.mkdir(dir, { recursive: true });
-            const data = Array.from(this.store.values());
-            await fsp.writeFile(filePath, JSON.stringify(data, null, 2), "utf-8");
-        } catch (err) {
-            logger.error({
-                message: "Failed to save memory subscribers to file",
-                error: err,
-            });
-        }
-    }
-
-    private debouncedSave(): void {
-        this.dirty = true;
-        if (!this.saveTimer) {
-            this.saveTimer = setTimeout(() => {
-                this.saveTimer = null;
-                if (this.dirty) {
-                    this.dirty = false;
-                    this.save().catch((err) => {
-                        logger.error({ message: "Debounced save failed", error: err });
-                    });
-                }
-            }, SAVE_DEBOUNCE_MS);
-        }
-    }
-
-    private startPeriodicSave(): void {
-        setInterval(() => {
-            if (this.dirty) {
-                this.dirty = false;
-                this.save().catch((err) => {
-                    logger.error({ message: "Periodic save failed", error: err });
-                });
-            }
-        }, 30_000);
     }
 
     get(phone: string): InMemorySubscriber | undefined {
@@ -106,13 +28,10 @@ class PersistedMemorySubscriberStore {
 
     set(phone: string, subscriber: InMemorySubscriber): void {
         this.store.set(phone, subscriber);
-        this.debouncedSave();
     }
 
     delete(phone: string): boolean {
-        const result = this.store.delete(phone);
-        if (result) this.debouncedSave();
-        return result;
+        return this.store.delete(phone);
     }
 
     find(predicate: (sub: InMemorySubscriber) => boolean): InMemorySubscriber | undefined {
@@ -132,7 +51,6 @@ class PersistedMemorySubscriberStore {
 
     clear(): void {
         this.store.clear();
-        this.debouncedSave();
     }
 
     getAll(): InMemorySubscriber[] {
@@ -164,8 +82,6 @@ class PersistedMemorySubscriberStore {
                     district: sub.district,
                     is_active: sub.is_active,
                     status: sub.status,
-                    verification_otp: sub.verification_otp,
-                    otp_expires_at: sub.otp_expires_at,
                 };
 
                 let error;
@@ -202,8 +118,6 @@ class PersistedMemorySubscriberStore {
         }
 
         if (reconciled > 0) {
-            this.dirty = true;
-            await this.save();
             logger.info(`Reconciled ${reconciled} subscribers to Supabase, ${failed} failed`);
         }
     }
@@ -220,11 +134,6 @@ class PersistedMemorySubscriberStore {
                 }
             }
         }, 30_000);
-    }
-
-    async saveImmediate(): Promise<void> {
-        this.dirty = false;
-        await this.save();
     }
 }
 

--- a/apps/api/src/services/otpStore.ts
+++ b/apps/api/src/services/otpStore.ts
@@ -1,0 +1,76 @@
+import crypto from "node:crypto";
+import { redisClient } from "../utils/redis";
+
+interface StoredOtp {
+    hash: string;
+    salt: string;
+    expiresAt: string;
+}
+
+class OtpStore {
+    private fallbackStore = new Map<string, StoredOtp>();
+
+    private getRedisKey(phone: string): string {
+        return `otp:${phone}`;
+    }
+
+    async store(phone: string, otp: string, expiresAt: string): Promise<void> {
+        const salt = crypto.randomBytes(16).toString("hex");
+        const hash = crypto
+            .createHash("sha256")
+            .update(otp + salt)
+            .digest("hex");
+        const data: StoredOtp = { hash, salt, expiresAt };
+
+        if (redisClient.isOpen) {
+            const ttl = Math.max(
+                1,
+                Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000)
+            );
+            try {
+                await redisClient.setEx(this.getRedisKey(phone), ttl, JSON.stringify(data));
+            } catch {}
+        }
+
+        this.fallbackStore.set(phone, data);
+    }
+
+    async verify(phone: string, otp: string): Promise<boolean> {
+        let stored: StoredOtp | undefined;
+
+        if (redisClient.isOpen) {
+            try {
+                const raw = await redisClient.get(this.getRedisKey(phone));
+                if (raw) stored = JSON.parse(raw);
+            } catch {}
+        }
+
+        if (!stored) {
+            stored = this.fallbackStore.get(phone);
+        }
+
+        if (!stored) return false;
+
+        if (new Date(stored.expiresAt) < new Date()) {
+            await this.clear(phone);
+            return false;
+        }
+
+        const computedHash = crypto
+            .createHash("sha256")
+            .update(otp + stored.salt)
+            .digest("hex");
+        return computedHash === stored.hash;
+    }
+
+    async clear(phone: string): Promise<void> {
+        if (redisClient.isOpen) {
+            try {
+                await redisClient.del(this.getRedisKey(phone));
+            } catch {}
+        }
+        this.fallbackStore.delete(phone);
+    }
+}
+
+export const otpStore = new OtpStore();


### PR DESCRIPTION



Closes #3925

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3925 **
- **Summary:**

- Add OtpStore service that hashes OTPs with a unique random salt before storing (SHA-256). Stores in Redis with TTL matching OTP expiry, falling back to an in-memory Map (not persisted to disk).
- Remove verification_otp and otp_expires_at from InMemorySubscriber interface — OTPs are no longer part of subscriber data.
- Remove disk persistence (save/load/debouncedSave/periodicSave) from PersistedMemorySubscriberStore. The file system is no longer used as a fallback storage for subscriber data.
- Remove plaintext OTP sync from reconcileWithSupabase() — only subscriber preferences are synced to the notification_subscribers table.
- Update /register endpoint to store hashed OTPs via OtpStore instead of embedding plaintext OTPs in subscriber objects or Supabase INSERT/UPDATE payloads.
- Update /verify-otp endpoint to compare OTPs via OtpStore.verify() (hash comparison) instead of plaintext equality. Expiry is handled by the OTP store (Redis TTL + expiry check).
- Clean up OTP store on successful verification via OtpStore.clear().



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3925 `)
- [x] I have pulled the latest `main` and resolved any conflicts
