### PR TITLE
fix: add error handling for loadFromDatabase() to prevent crash on startup

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -65,7 +65,11 @@ if (process.env.NODE_ENV !== "test") {
         await warmCache();
 
         // Load dynamic OCR synonyms
-        await medicineNameNormalizer.loadFromDatabase();
+        try {
+            await medicineNameNormalizer.loadFromDatabase();
+        } catch (err) {
+            logger.error("Failed to load OCR synonyms from database, continuing without normalizer", err);
+        }
 
         // Start cron jobs only after Redis is ready
         jobScheduler.start();


### PR DESCRIPTION
Wraps \medicineNameNormalizer.loadFromDatabase()\ in try/catch so the server doesn't crash on startup if the database is unreachable. Logs the error and continues without the normalizer.