### PR TITLE
fix: harden CORS origin defaults to fail closed in production

### DIFF
--- a/apps/api/src/utils/originCheck.ts
+++ b/apps/api/src/utils/originCheck.ts
@@ -2,13 +2,15 @@ import { Request } from "express";
 
 export const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
     ? process.env.ALLOWED_ORIGINS.split(",").map((s) => s.trim())
-    : [
-          "http://localhost:3000",
-          "http://localhost:5173",
-          "https://sahidawa.vercel.app",
-          "https://sahidawa-india.vercel.app",
-          "https://sahidawa.goswav.in",
-      ];
+    : process.env.NODE_ENV === "production"
+      ? []
+      : [
+            "http://localhost:3000",
+            "http://localhost:5173",
+            "https://sahidawa.vercel.app",
+            "https://sahidawa-india.vercel.app",
+            "https://sahidawa.goswav.in",
+        ];
 
 export function isAllowedOrigin(req: Request, requireOrigin = false): boolean {
     const origin = req.headers.origin;


### PR DESCRIPTION
In production, if ALLOWED_ORIGINS env var is not set, the origin check now fails closed (empty array) instead of accepting hardcoded fallback origins. This prevents accidental deployment with permissive CORS.