### PR TITLE
fix: use Redis PING instead of isOpen for health check accuracy

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -218,8 +218,14 @@ app.get("/health", async (_req: Request, res: Response) => {
         const { error } = await supabase.from("medicines").select("id").limit(1);
         const uptime = process.uptime();
 
-        // Redis
-        const redisStatus = redisClient.isOpen ? "connected" : "disconnected";
+        // Redis — use PING instead of isOpen to detect half-open TCP connections
+        let redisStatus = "disconnected";
+        try {
+            await redisClient.ping();
+            redisStatus = "connected";
+        } catch {
+            redisStatus = "disconnected";
+        }
 
         // ML service — check config first, then do a lightweight reachability ping
         let mlStatus: string;


### PR DESCRIPTION
Replaces \edisClient.isOpen\ with an actual \edisClient.ping()\ call in the /health endpoint. \isOpen\ can return true even when the TCP connection is half-closed, leading to false-positive healthy status.