### PR TITLE
fix: use AuthenticatedRequest type in scan submit route instead of as any

### DIFF
--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from "express";
+import type { AuthenticatedRequest } from "../middleware/auth";
 import { z } from "zod";
 import multer from "multer";
 import fs from "fs";
@@ -579,7 +580,7 @@ router.post(
     validateUploadSize,
     upload.fields([{ name: "image" }, { name: "voice" }]),
     idempotencyMiddleware,
-    async (req: Request, res: Response) => {
+    async (req: AuthenticatedRequest, res: Response) => {
         const idempotencyKey = (req as any).idempotencyKey;
         const submitSchema = z
             .object({
@@ -625,7 +626,7 @@ router.post(
 
         try {
             // Note: we require a user to be authenticated in a real app, assuming auth.uid() is available
-            const userId = (req as any).user?.id || (req as any).session?.user?.id;
+            const userId = req.user?.id || (req as any).session?.user?.id;
             if (!userId && process.env.NODE_ENV === "production") {
                 res.status(401).json({ error: "Authentication is required to submit scan data" });
                 return;


### PR DESCRIPTION
Replaces \(req as any).user?.id\ with \eq.user?.id\ by typing the handler as \AuthenticatedRequest\. This removes an unsafe \s any\ cast and enables proper TypeScript type checking.