### PR TITLE
test: expand TensorFlow Lite inference test coverage

### DIFF
--- a/apps/ml/tests/test_tflite_inference.py
+++ b/apps/ml/tests/test_tflite_inference.py
@@ -1,7 +1,15 @@
 import pytest
-import numpy as np
 from PIL import Image
 from services.tflite_inference import TFLiteModelRunner
+
+def test_runner_attributes():
+    runner = TFLiteModelRunner("does_not_exist.tflite")
+
+    assert runner.model_path.name == "does_not_exist.tflite"
+    assert runner.interpreter is None
+    assert runner.input_details is None
+    assert runner.output_details is None
+    assert runner.is_loaded is False
 
 def test_tflite_runner_initialization(tmp_path):
     # Test with non-existent model
@@ -17,3 +25,16 @@ def test_tflite_predict_unloaded_model():
 # If tflite_runtime is available, we could test a dummy model,
 # but it requires creating a valid flatbuffer which is complex.
 # This test suite ensures the robust error handling works.
+
+def test_predict_with_grayscale_image():
+    runner = TFLiteModelRunner("does_not_exist.tflite")
+    image = Image.new("L", (224, 224))
+
+    assert runner.predict(image) is None
+
+@pytest.mark.parametrize("size", [(32, 32), (224, 224), (640, 480)])
+def test_predict_handles_various_image_sizes(size):
+    runner = TFLiteModelRunner("does_not_exist.tflite")
+    image = Image.new("RGB", size)
+
+    assert runner.predict(image) is None


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #3685**
- **Summary:** Expanded test coverage for the TFLite inference service (`services/tflite_inference.py`). Added tests for runner attribute initialization on a missing model path, prediction behavior with grayscale images, and prediction handling across multiple image sizes (32x32, 224x224, 640x480) — all verifying that `predict()` safely returns `None` when the model is not loaded, without raising errors.

## 📸 Proof of Work (Screenshots / Logs)
_Please drag & drop your test run output/logs here (e.g. `pytest apps/ml/tests/test_tflite_inference.py -v` output showing all tests passing)._

## 🏷️ PR Type
- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [x] 🧪 `type: testing`
- [ ] 📖 `type: docs`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #3685`)
- [x] I have pulled the latest `main` and resolved any conflicts
