### PR TITLE
fix: use timing-safe comparison for OTP verification

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -14,6 +14,7 @@ import { escapeIlike } from "@sahidawa/shared";
 import logger from "../utils/logger";
 import { redisClient } from "../utils/redis";
 import { signGuestToken, verifyGuestPhone, isGuestTokenConfigured } from "../utils/guestToken";
+import { safeCompare } from "../utils/cryptoUtils";
 import {
     getMockRecallFeed,
     getVapidPublicKey,
@@ -591,7 +592,7 @@ router.post(
                 return;
             }
 
-            if (subscriber.verification_otp !== otp) {
+            if (!subscriber.verification_otp || !safeCompare(otp, subscriber.verification_otp)) {
                 await recordFailedOtpAttempt(formattedPhone);
                 res.status(400).json({ error: "Invalid OTP" });
                 return;


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #3844**
* **Summary:**

  * Replaced the direct OTP string comparison with the existing `safeCompare` utility to prevent timing attacks.
  * Added a null check for `subscriber.verification_otp` before performing the comparison.
  * Reused the project's existing constant-time comparison helper (`crypto.timingSafeEqual`) for secure OTP verification without changing the endpoint's behavior.

## 📸 Proof of Work (Screenshots / Logs)

Backend testing:

* OTP verification succeeds with a valid OTP.
* Invalid OTPs continue to return `400 Invalid OTP`.
* Verified that the comparison now uses `safeCompare` instead of a direct string comparison.
* No existing functionality was affected.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [x] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #3844`)
* [x] I have pulled the latest `main` and resolved any conflicts.
