### PR TITLE
fix(api): gate cron alert broadcasts on verified subscribers

### DIFF
--- a/apps/api/src/cron/alert-broadcaster.ts
+++ b/apps/api/src/cron/alert-broadcaster.ts
@@ -265,6 +265,7 @@ export async function broadcastDistrictAlerts(): Promise<void> {
                     .from("notification_subscribers")
                     .select("*")
                     .eq("is_active", true)
+                    .eq("status", "active")
                     .ilike("district", alert.district)
                     .range(from, to);
 
@@ -350,7 +351,8 @@ export async function broadcastDrugAlerts(): Promise<void> {
                 let query = supabase
                     .from("notification_subscribers")
                     .select("*")
-                    .eq("is_active", true);
+                    .eq("is_active", true)
+                    .eq("status", "active");
 
                 if (alert.district) {
                     query = query.ilike("district", alert.district);

--- a/apps/api/tests/alertBroadcaster.test.ts
+++ b/apps/api/tests/alertBroadcaster.test.ts
@@ -39,6 +39,7 @@ import { smsService } from "../src/services/sms-service";
 import { whatsappService } from "../src/services/whatsapp-service";
 import {
     broadcastDistrictAlerts,
+    broadcastDrugAlerts,
     broadcastExpiryAlerts,
     shouldSendForFrequency,
     broadcastConfig,
@@ -48,6 +49,65 @@ const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
 
 function getChain() {
     return mockedSupabase.from() as jest.Mocked<any>;
+}
+
+interface SubscriberTableHooks {
+    onIlike?: (...args: unknown[]) => void;
+    onRange?: () => void;
+}
+
+/**
+ * Stand-in for the notification_subscribers query builder that actually
+ * applies the filters to the seeded rows instead of only recording them.
+ * That way a test can seed a mix of rows and assert on who survives the
+ * query, rather than asserting that some particular .eq() was called.
+ */
+function createSubscriberTable(rows: Record<string, unknown>[], hooks: SubscriberTableHooks = {}) {
+    const select = () => {
+        const predicates: ((row: Record<string, unknown>) => boolean)[] = [];
+        const builder: Record<string, unknown> = {
+            eq: (column: string, value: unknown) => {
+                predicates.push((row) => row[column] === value);
+                return builder;
+            },
+            ilike: (column: string, value: string) => {
+                hooks.onIlike?.(column, value);
+                predicates.push(
+                    (row) => String(row[column] ?? "").toLowerCase() === value.toLowerCase()
+                );
+                return builder;
+            },
+            in: (column: string, values: unknown[]) => {
+                predicates.push((row) => values.includes(row[column]));
+                return builder;
+            },
+            range: (from: number, to: number) => {
+                hooks.onRange?.();
+                const matched = rows.filter((row) => predicates.every((match) => match(row)));
+                return Promise.resolve({ data: matched.slice(from, to + 1), error: null });
+            },
+        };
+        return builder;
+    };
+
+    return { select: jest.fn(select) };
+}
+
+/**
+ * district_alerts resolves its fetch after .eq().eq() and drug_alerts after a
+ * single .eq(), so the chain is made thenable to satisfy both without the
+ * test having to care how many filters the caller stacks.
+ */
+function createAlertTable(alerts: Record<string, unknown>[]) {
+    const chain: Record<string, unknown> = {
+        eq: jest.fn(() => chain),
+        then: (resolve: (value: unknown) => void) => resolve({ data: alerts, error: null }),
+    };
+
+    return {
+        select: jest.fn(() => chain),
+        update: jest.fn(() => ({ eq: jest.fn().mockResolvedValue({ data: null, error: null }) })),
+    };
 }
 
 // ---------------------------------------------------------------------------
@@ -127,18 +187,9 @@ describe("broadcastDistrictAlerts", () => {
             }
             if (table === "notification_subscribers") {
                 selectCallCount += 1;
-                return {
-                    select: jest.fn().mockReturnValue({
-                        eq: jest.fn().mockReturnValue({
-                            ilike: jest.fn().mockReturnValue({
-                                range: jest.fn().mockImplementation(() => {
-                                    callOrder.push("fetch_subscribers");
-                                    return Promise.resolve({ data: [], error: null });
-                                }),
-                            }),
-                        }),
-                    }),
-                };
+                return createSubscriberTable([], {
+                    onRange: () => callOrder.push("fetch_subscribers"),
+                });
             }
             return chain;
         });
@@ -257,30 +308,24 @@ describe("broadcastDistrictAlerts", () => {
                 };
             }
             if (table === "notification_subscribers") {
-                return {
-                    select: jest.fn().mockReturnValue({
-                        eq: jest.fn().mockReturnValue({
-                            ilike: jest.fn().mockImplementation((...args) => {
-                                ilikeArgs = args;
-                                return {
-                                    range: jest.fn().mockResolvedValue({
-                                        data: [
-                                            {
-                                                id: "sub-1",
-                                                phone: "+910000000001",
-                                                language: "en",
-                                                channels: ["sms"],
-                                                district: "Pune District",
-                                                is_active: true,
-                                            },
-                                        ],
-                                        error: null,
-                                    }),
-                                };
-                            }),
-                        }),
-                    }),
-                };
+                return createSubscriberTable(
+                    [
+                        {
+                            id: "sub-1",
+                            phone: "+910000000001",
+                            language: "en",
+                            channels: ["sms"],
+                            district: "Pune District",
+                            is_active: true,
+                            status: "active",
+                        },
+                    ],
+                    {
+                        onIlike: (...args) => {
+                            ilikeArgs = args;
+                        },
+                    }
+                );
             }
             return {};
         });
@@ -289,6 +334,109 @@ describe("broadcastDistrictAlerts", () => {
 
         expect(ilikeArgs).toEqual(["district", "Pune District"]);
         expect(smsService.send).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Verification gating (#3957)
+// ---------------------------------------------------------------------------
+
+describe("broadcast verification gating", () => {
+    const VERIFIED_PHONE = "+919000000001";
+    const UNVERIFIED_PHONE = "+919000000002";
+
+    const DISTRICT_ALERT = {
+        id: "alert-1",
+        district: "Delhi",
+        medicine_name: "Aspirin 500mg",
+        alert_level: "high",
+        is_active: true,
+        broadcasted: false,
+    };
+
+    const DRUG_ALERT = {
+        id: "drug-alert-1",
+        district: "Delhi",
+        reported_brand_name: "Paracetamol",
+        batch_number: "B1",
+        broadcasted: false,
+    };
+
+    /**
+     * Two subscribers in the same district: one that completed OTP
+     * verification and one that stopped at the pending step. The second
+     * row's status is what each test varies.
+     */
+    function seedSubscribers(secondStatus: "pending" | "active") {
+        return [
+            {
+                id: "sub-verified",
+                phone: VERIFIED_PHONE,
+                language: "en",
+                channels: ["sms"],
+                district: "Delhi",
+                is_active: true,
+                status: "active",
+            },
+            {
+                id: "sub-unverified",
+                phone: UNVERIFIED_PHONE,
+                language: "en",
+                channels: ["sms"],
+                district: "Delhi",
+                is_active: true,
+                status: secondStatus,
+            },
+        ];
+    }
+
+    function mockTables(alertTable: string, alerts: Record<string, unknown>[], subscribers: any[]) {
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === alertTable) return createAlertTable(alerts);
+            if (table === "notification_subscribers") return createSubscriberTable(subscribers);
+            return {};
+        });
+    }
+
+    function notifiedPhones() {
+        return (smsService.send as jest.Mock).mock.calls.map((call) => call[0]);
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (smsService.send as jest.Mock).mockResolvedValue(true);
+    });
+
+    it("skips pending subscribers when broadcasting a district alert", async () => {
+        mockTables("district_alerts", [DISTRICT_ALERT], seedSubscribers("pending"));
+
+        await broadcastDistrictAlerts();
+
+        expect(notifiedPhones()).toEqual([VERIFIED_PHONE]);
+    });
+
+    it("starts sending district alerts once a pending subscriber verifies", async () => {
+        mockTables("district_alerts", [DISTRICT_ALERT], seedSubscribers("active"));
+
+        await broadcastDistrictAlerts();
+
+        expect(notifiedPhones()).toEqual([VERIFIED_PHONE, UNVERIFIED_PHONE]);
+    });
+
+    it("skips pending subscribers when broadcasting a drug recall", async () => {
+        mockTables("drug_alerts", [DRUG_ALERT], seedSubscribers("pending"));
+
+        await broadcastDrugAlerts();
+
+        expect(notifiedPhones()).toEqual([VERIFIED_PHONE]);
+    });
+
+    it("starts sending drug recalls once a pending subscriber verifies", async () => {
+        mockTables("drug_alerts", [DRUG_ALERT], seedSubscribers("active"));
+
+        await broadcastDrugAlerts();
+
+        expect(notifiedPhones()).toEqual([VERIFIED_PHONE, UNVERIFIED_PHONE]);
     });
 });
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3957**
- **Summary:**

`broadcastDistrictAlerts` and `broadcastDrugAlerts` picked their recipients on `is_active` alone. `POST /api/notifications/register` is unauthenticated and inserts with `is_active: true` and `status: "pending"` before any OTP is confirmed, so a row that never got past the OTP step still matched the cron's query and got real SMS and WhatsApp on the next tick. The admin broadcast handler at `routes/notifications.ts:893` already gates on `.eq("status", "active")`. The cron is the path that runs unattended, and it was the one missing the filter.

Both subscriber queries now carry `.eq("status", "active")`, the same filter the admin handler uses. `status` defaults to `'active'` in the migration that added it (`20260625120000_add_notification_verification.sql`), so nobody who is already subscribed loses anything. Only rows explicitly parked at `pending` drop out, and they start receiving again as soon as they verify.

Two things I raised in the issue thread and deliberately left alone:

- Both subscriber queries in `broadcastExpiryAlerts`, the eligibility probe and the paging loop, have the same gap. That path messages people about medicines they tracked themselves rather than a district-wide alert, so the consent argument is not quite the same one, and I would rather a maintainer make that call than fold it in quietly. Happy to add it here if you want it.
- The filter now lives in three places. A shared "verified subscribers" query helper would stop a fourth copy drifting off, but that is a refactor across two files and I did not want it riding along with a fix.

## 📸 Proof of Work (Screenshots / Logs)

Backend only, no UI to screenshot.

Test first, in `apps/api/tests/alertBroadcaster.test.ts`. Two subscribers seeded in the same district, both `is_active: true`, one at `status: "active"` and one at `status: "pending"`. The subscriber mock applies the filters to the seeded rows rather than only recording the calls, so the assertion lands on who actually received a message rather than on which builder methods fired.

Failing on `main`, with the unverified number `+919000000002` in the recipient list:

```
$ cd apps/api && npx jest tests/alertBroadcaster.test.ts

  ● broadcast verification gating › skips pending subscribers when broadcasting a district alert

    expect(received).toEqual(expected) // deep equality

    - Expected  - 0
    + Received  + 1

      Array [
        "+919000000001",
    +   "+919000000002",
      ]

    > 418 |         expect(notifiedPhones()).toEqual([VERIFIED_PHONE]);
          |                                  ^

  ● broadcast verification gating › skips pending subscribers when broadcasting a drug recall

    expect(received).toEqual(expected) // deep equality

    - Expected  - 0
    + Received  + 1

      Array [
        "+919000000001",
    +   "+919000000002",
      ]

    > 434 |         expect(notifiedPhones()).toEqual([VERIFIED_PHONE]);
          |                                  ^

Test Suites: 1 failed, 1 total
Tests:       2 failed, 22 passed, 24 total
```

Passing with the fix applied:

```
$ cd apps/api && npx jest tests/alertBroadcaster.test.ts

PASS tests/alertBroadcaster.test.ts
  shouldSendForFrequency
    ✓ always returns true for 'immediate' (4 ms)
    ✓ always returns true for 'daily' (2 ms)
    ✓ returns true for 'weekly' only on Monday (1 ms)
    ✓ returns true for 'monthly' only on the 1st of the month (1 ms)
  broadcastDistrictAlerts
    ✓ marks the alert as broadcasted before paginating subscribers (not after) (9 ms)
    ✓ does not send notifications when marking broadcasted=true fails (5 ms)
    ✓ does not re-notify already-broadcasted alerts on the next tick (1 ms)
    ✓ matches subscribers via .ilike('district', ...) when the alert is keyed on a real administrative district (#2307) (4 ms)
  broadcast verification gating
    ✓ skips pending subscribers when broadcasting a district alert (4 ms)
    ✓ starts sending district alerts once a pending subscriber verifies (3 ms)
    ✓ skips pending subscribers when broadcasting a drug recall (4 ms)
    ✓ starts sending drug recalls once a pending subscriber verifies (3 ms)
  broadcastExpiryAlerts
    ✓ sends exactly one consolidated notification per subscriber, not one per batch (6 ms)
    ✓ marks batches as broadcasted after successful expiry notification delivery (3 ms)
    ✓ keeps batches eligible for retry when every expiry delivery fails (24 ms)
    ✓ marks batches as broadcasted after a partial expiry delivery success (4 ms)
    ✓ does not re-send to a batch already marked expiry_broadcasted=true (1 ms)
    ✓ excludes already-expired batches via the lower-bound date filter (2 ms)
    ✓ keeps delivery behavior when marking broadcasted batches fails (5 ms)
    ✓ only sends to 'immediate' subscribers when run on a non-Monday, non-1st day (5 ms)
    ✓ includes 'weekly' subscribers when run on a Monday (5 ms)
    ✓ includes 'monthly' subscribers when run on the 1st of a month (4 ms)
    ✓ does not send expiry alerts to 'weekly' subscribers on a non-Monday (4 ms)
    ✓ does NOT mark batches as expiry_broadcasted when no subscribers match the active frequency (4 ms)

Test Suites: 1 passed, 1 total
Tests:       24 passed, 24 total
```

The two "starts sending once a pending subscriber verifies" cases pass either way. They are there to catch the opposite mistake, a filter that locks verified people out.

Type check is clean:

```
$ cd apps/api && npx tsc --noEmit
$ echo $?
0
```

Two existing tests needed their mocks widened, because adding a filter changes the builder chain shape they hard-coded. They assert the same things as before.

Note on ordering: #3914 is assigned and rewrites the `broadcasted: true` sequencing in these same two functions. No PR is open for it yet, so there was nothing to rebase onto. My change is one line per query and should merge either way round.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
