### PR TITLE
fix(api): key authTargetLimiter on the phone field the OTP routes actually send

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -3,6 +3,7 @@ import { Request, Response } from "express";
 import { RedisStore } from "rate-limit-redis";
 import { redisClient } from "../utils/redis";
 import logger from "../utils/logger";
+import { formatPhoneNumber } from "../utils/phone";
 interface LimiterOptions {
     windowMs: number;
     max: number;
@@ -185,19 +186,47 @@ export const authLimiter = createLimiter({
     prefix: "auth",
 });
 
+/**
+ * Builds the bucket key for {@link authTargetLimiter}.
+ *
+ * Exported so the key derivation can be unit-tested on its own - a mismatch
+ * here silently degrades the limiter to per-IP instead of failing loudly.
+ *
+ * Both target values are normalised before they reach the key. Two spellings of
+ * one number ("9876543210" and "+91 98765 43210") or one ABHA address
+ * ("Ravi@sbx" and "ravi@sbx") would otherwise land in separate buckets and hand
+ * the caller a multiple of the cap.
+ */
+export const authTargetKeyGenerator = (req: Request): string => {
+    // Look for common identity keys in the request body
+    const abhaAddress = req.body?.abhaAddress;
+    if (typeof abhaAddress === "string" && abhaAddress.trim()) {
+        // ABHA addresses are case-insensitive (ABDM lowercases them on issue).
+        return `abha:${abhaAddress.trim().toLowerCase()}`;
+    }
+
+    // The notification routes send `phone`; `phone_number` is kept for any
+    // caller still using the field this limiter originally shipped with.
+    const phone = req.body?.phone ?? req.body?.phone_number;
+    if (typeof phone === "string") {
+        const formatted = formatPhoneNumber(phone);
+        // An unparseable number is rejected by the route before any OTP goes
+        // out, so there is no target to throttle - and keying on the raw value
+        // would let junk input mint a fresh bucket on every request.
+        if (formatted) return `phone:${formatted}`;
+    }
+
+    // Fallback to IP if no explicit target is found
+    return (req.ip || "unknown").replace(/:/g, "_");
+};
+
 /** Target-based limiter to prevent OTP bombing against a specific user/target irrespective of IP */
 export const authTargetLimiter = createKeyLimiter({
     windowMs: 10 * 60 * 1000, // 10 minutes
     max: 5, // Max 5 requests per 10 minutes per target
     message: "Too many requests for this target. Please try again later.",
     prefix: "auth_target",
-    keyGenerator: (req: Request) => {
-        // Look for common identity keys in the request body
-        if (req.body?.abhaAddress) return `abha:${req.body.abhaAddress}`;
-        if (req.body?.phone_number) return `phone:${req.body.phone_number}`;
-        // Fallback to IP if no explicit target is found
-        return (req.ip || "unknown").replace(/:/g, "_");
-    },
+    keyGenerator: authTargetKeyGenerator,
 });
 
 // ── Notification registration limiter ──────────────────────────────────────────

--- a/apps/api/tests/authTargetLimiter.test.ts
+++ b/apps/api/tests/authTargetLimiter.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "@jest/globals";
+import { Request } from "express";
+import { authTargetKeyGenerator } from "../src/middleware/rateLimit";
+
+/**
+ * Unit tests for the authTargetLimiter key generator.
+ *
+ * The limiter caps how many OTPs one target can be sent regardless of the
+ * source IP. It only does that if the key it builds actually names the target,
+ * so these tests assert the key string directly rather than driving requests
+ * through the limiter - a key that quietly falls through to the IP branch still
+ * returns 200s and looks healthy from the outside.
+ *
+ * Related: Issue #3958 - per-target OTP limiter never matched the notification
+ * routes, which send `phone`, not `phone_number`.
+ */
+
+const makeReq = (body: unknown, ip = "203.0.113.7"): Request => ({ body, ip }) as Request;
+
+describe("authTargetKeyGenerator", () => {
+    describe("phone targets", () => {
+        it("keys on `phone`, the field the notification routes send", () => {
+            expect(authTargetKeyGenerator(makeReq({ phone: "9876543210" }))).toBe(
+                "phone:+919876543210"
+            );
+        });
+
+        it("still keys on `phone_number` for callers using the older field", () => {
+            expect(authTargetKeyGenerator(makeReq({ phone_number: "9876543210" }))).toBe(
+                "phone:+919876543210"
+            );
+        });
+
+        it("gives one bucket to national and E.164 spellings of the same number", () => {
+            const national = authTargetKeyGenerator(makeReq({ phone: "9876543210" }));
+            const e164 = authTargetKeyGenerator(makeReq({ phone: "+919876543210" }));
+            const spaced = authTargetKeyGenerator(makeReq({ phone: "+91 98765 43210" }));
+
+            expect(national).toBe(e164);
+            expect(spaced).toBe(e164);
+        });
+
+        it("does not let the two field names split one number across buckets", () => {
+            expect(authTargetKeyGenerator(makeReq({ phone: "+919876543210" }))).toBe(
+                authTargetKeyGenerator(makeReq({ phone_number: "9876543210" }))
+            );
+        });
+
+        it("falls back to IP when the number cannot be parsed", () => {
+            // The routes reject these with 400 before any OTP is sent, so there
+            // is no target to throttle - and an unparseable value must not mint
+            // a fresh bucket on every request.
+            expect(authTargetKeyGenerator(makeReq({ phone: "not-a-number" }))).toBe("203.0.113.7");
+        });
+    });
+
+    describe("ABHA targets", () => {
+        it("keys on abhaAddress", () => {
+            expect(authTargetKeyGenerator(makeReq({ abhaAddress: "ravi.kumar@sbx" }))).toBe(
+                "abha:ravi.kumar@sbx"
+            );
+        });
+
+        it("gives one bucket to differently-cased spellings of one address", () => {
+            expect(authTargetKeyGenerator(makeReq({ abhaAddress: "Ravi.Kumar@SBX" }))).toBe(
+                authTargetKeyGenerator(makeReq({ abhaAddress: "ravi.kumar@sbx" }))
+            );
+        });
+
+        it("ignores surrounding whitespace", () => {
+            expect(authTargetKeyGenerator(makeReq({ abhaAddress: "  ravi.kumar@sbx  " }))).toBe(
+                "abha:ravi.kumar@sbx"
+            );
+        });
+
+        it("takes precedence over a phone in the same body", () => {
+            expect(
+                authTargetKeyGenerator(
+                    makeReq({ abhaAddress: "ravi.kumar@sbx", phone: "9876543210" })
+                )
+            ).toBe("abha:ravi.kumar@sbx");
+        });
+    });
+
+    describe("IP fallback", () => {
+        it("falls back to IP for an empty body", () => {
+            expect(authTargetKeyGenerator(makeReq({}))).toBe("203.0.113.7");
+        });
+
+        it("falls back to IP when the body is absent", () => {
+            expect(authTargetKeyGenerator(makeReq(undefined))).toBe("203.0.113.7");
+        });
+
+        it("escapes colons so IPv6 addresses stay valid Redis key segments", () => {
+            expect(authTargetKeyGenerator(makeReq({}, "2001:db8::1"))).toBe("2001_db8__1");
+        });
+
+        it("uses `unknown` when express reports no IP", () => {
+            expect(authTargetKeyGenerator({ body: {} } as Request)).toBe("unknown");
+        });
+
+        it("ignores non-string target values", () => {
+            expect(authTargetKeyGenerator(makeReq({ phone: 9876543210 }))).toBe("203.0.113.7");
+            expect(authTargetKeyGenerator(makeReq({ abhaAddress: { id: 1 } }))).toBe("203.0.113.7");
+        });
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3958**
- **Summary:**

`authTargetLimiter` is the limiter that caps how many OTPs a single target can be sent no matter which IP asks. Its `keyGenerator` read `req.body.abhaAddress`, then `req.body.phone_number`, then fell back to IP. The two notification routes that mount it send `phone`, not `phone_number`, and both schemas are `.strict()`, so `phone_number` can't get through even if a client sent it. Nothing ever matched the phone branch, every request landed on the IP fallback, and `POST /register` and `POST /verify-otp` had no per-target cap at all.

What changed in `apps/api/src/middleware/rateLimit.ts`:

- The key generator also reads `phone`. `phone_number` stays in, so nothing that already sends it breaks.
- The value goes through `formatPhoneNumber` from `utils/phone` before the key is built. Without that, `9876543210` and `+919876543210` are two buckets for one number and the cap quietly doubles.
- `abhaAddress` had the same split, since it went into the key raw: `Ravi@sbx` and `ravi@sbx` counted separately. It is now trimmed and lowercased. ABDM issues ABHA addresses lowercase and treats them case-insensitively.
- A number `formatPhoneNumber` can't parse now falls back to IP instead of keying on the raw string. The routes reject those with 400 before any OTP is sent, there's no target to throttle, and keying on junk would hand out a fresh bucket every request.
- `abhaAddress` still takes priority over phone, and the IP fallback for a body with no target is unchanged.

The generator is now a named export, `authTargetKeyGenerator`, so the key can be asserted directly in a test. That matters here. The bug threw nothing and failed no request, the limiter just kept returning 200s while counting nothing, which is how it lasted from #3605 until now. A test that drove requests through the limiter would have passed too.

On the two nearby issues, in case this looks like a dupe: #3605 asked for `phone_number` by name, so the original implementation did match its own issue. #3918 saw the symptom and added the per-phone OTP lockout in `otpLockout.service.ts`, which stops OTP guessing but doesn't limit how many OTPs get sent to one number.

#3953 plans a broader `rateLimit.ts` refactor. If you'd rather this be folded into that, say so on the issue and I'll move it there.

## 📸 Proof of Work (Screenshots / Logs)

Backend only, no UI. New test file: `apps/api/tests/authTargetLimiter.test.ts`.

**Before the fix**, with the key generator extracted but its behaviour untouched. `cd apps/api && npx jest tests/authTargetLimiter.test.ts`:

```
FAIL tests/authTargetLimiter.test.ts
      ✕ keys on `phone`, the field the notification routes send
      ✕ still keys on `phone_number` for callers using the older field
      ✓ gives one bucket to national and E.164 spellings of the same number
      ✕ does not let the two field names split one number across buckets
      ✓ falls back to IP when the number cannot be parsed
      ✓ keys on abhaAddress
      ✕ gives one bucket to differently-cased spellings of one address
      ✕ ignores surrounding whitespace
      ✓ takes precedence over a phone in the same body
      ✓ falls back to IP for an empty body
      ✓ falls back to IP when the body is absent
      ✓ escapes colons so IPv6 addresses stay valid Redis key segments
      ✓ uses `unknown` when express reports no IP
      ✕ ignores non-string target values

Test Suites: 1 failed, 1 total
Tests:       6 failed, 8 passed, 14 total
```

The first failure is the whole bug in one line:

```
● authTargetKeyGenerator › phone targets › keys on `phone`, the field the notification routes send

  Expected: "phone:+919876543210"
  Received: "203.0.113.7"
```

**After the fix**, same command:

```
PASS tests/authTargetLimiter.test.ts
      ✓ keys on `phone`, the field the notification routes send (8 ms)
      ✓ still keys on `phone_number` for callers using the older field (3 ms)
      ✓ gives one bucket to national and E.164 spellings of the same number (2 ms)
      ✓ does not let the two field names split one number across buckets (2 ms)
      ✓ falls back to IP when the number cannot be parsed (1 ms)
      ✓ keys on abhaAddress (1 ms)
      ✓ gives one bucket to differently-cased spellings of one address (1 ms)
      ✓ ignores surrounding whitespace (2 ms)
      ✓ takes precedence over a phone in the same body (1 ms)
      ✓ falls back to IP for an empty body (1 ms)
      ✓ falls back to IP when the body is absent (1 ms)
      ✓ escapes colons so IPv6 addresses stay valid Redis key segments (1 ms)
      ✓ uses `unknown` when express reports no IP (1 ms)
      ✓ ignores non-string target values (1 ms)

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
```

Also run:

- `npx tsc --noEmit -p tsconfig.json` in `apps/api`, clean.
- `npx prettier --check` on both changed files, clean.
- `npx jest tests/barcodeLimiter.test.ts tests/twilioWebhookSignature.test.ts`, 23 passed.

Two suites that touch these routes, `tests/notifications.test.ts` and `tests/abha.routes.test.ts`, fail to load on this branch. Both fail the same way on `main` with this branch's source reverted, so neither is down to this change. notifications dies on `TypeError: argument handler must be a function` from a `cacheMiddleware` mock, and abha.routes on `ReferenceError: Cannot access 'mockGetAuthorizationUrl' before initialization`, a `jest.mock` hoisting problem inside the test file itself. Happy to file those separately if they aren't tracked already.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3958`)
- [x] I have pulled the latest `main` and resolved any conflicts
