### PR TITLE
fix: respect expiry digest notification frequencies

### DIFF
--- a/apps/api/src/cron/alert-broadcaster.ts
+++ b/apps/api/src/cron/alert-broadcaster.ts
@@ -19,27 +19,34 @@ export const broadcastConfig = {
 
 export type AlertFrequency = "immediate" | "daily" | "weekly" | "monthly";
 
+const FREQUENCIES: AlertFrequency[] = ["immediate", "daily", "weekly", "monthly"];
+
+// Daily digests are only attempted during this hour (server-local time), so a
+// daily subscriber receives at most one consolidated message per calendar day.
+const DAILY_DIGEST_HOUR = 8;
+
 /**
  * Returns true when the current broadcast run falls within the timeframe
  * that the subscriber's preferred frequency covers.
  *
  * - immediate: always matches (legacy behaviour, send on every run)
- * - daily:     matches once per calendar day  (script run hour = 0–23)
+ * - daily:     matches once per calendar day, during the daily digest hour
  * - weekly:    matches once per ISO week      (script run on Monday)
  * - monthly:   matches once per calendar month (script run on 1st)
  *
  * The broadcaster runs every 30 s, so for digest frequencies we rely on
  * the OS/cron scheduling the process at the right clock time rather than
- * implementing an internal counter — simple and robust.
+ * implementing an internal counter — simple and robust. Delivery cadence is
+ * additionally enforced by the expiry_digest_deliveries table, so a digest is
+ * never sent more than once per window even if the process restarts.
  */
 export function shouldSendForFrequency(frequency: AlertFrequency, now: Date = new Date()): boolean {
     switch (frequency) {
         case "immediate":
             return true;
         case "daily":
-            // Send once a day — caller is expected to invoke this during the
-            // daily digest window (e.g. a dedicated cron at 08:00).
-            return true;
+            // Send once a day during the configured digest hour (server-local time).
+            return now.getHours() === DAILY_DIGEST_HOUR;
         case "weekly":
             // Send on Monday (getDay() === 1)
             return now.getDay() === 1;
@@ -394,6 +401,243 @@ export async function broadcastDrugAlerts(): Promise<void> {
     }
 }
 
+interface ExpiringBatchRow {
+    id: string;
+    batch_number: string;
+    expiry_date: string;
+    medicine?: { brand_name: string } | null;
+}
+
+/**
+ * Start of the window that a digest delivery's sent_at must fall inside for a
+ * batch to count as already delivered at the given frequency. Only used for
+ * daily/weekly/monthly — immediate deliveries are tracked on
+ * batches.expiry_broadcasted. Aligned with shouldSendForFrequency() so a digest
+ * is delivered at most once per calendar day / ISO week / calendar month.
+ */
+function getDigestWindowStart(frequency: AlertFrequency, now: Date): Date {
+    const start = new Date(now);
+    switch (frequency) {
+        case "daily":
+            start.setHours(0, 0, 0, 0);
+            return start;
+        case "weekly": {
+            // Monday-aligned week start (getDay(): 0=Sun … 6=Sat)
+            const daysSinceMonday = (start.getDay() + 6) % 7;
+            start.setDate(start.getDate() - daysSinceMonday);
+            start.setHours(0, 0, 0, 0);
+            return start;
+        }
+        case "monthly":
+            start.setDate(1);
+            start.setHours(0, 0, 0, 0);
+            return start;
+        case "immediate":
+        default:
+            return new Date(0);
+    }
+}
+
+/**
+ * Fetches the batches that still need to be broadcast for the given frequency
+ * in this run. Immediate batches are those never delivered
+ * (expiry_broadcasted = false); digest batches are those with no delivery
+ * recorded inside the frequency's current window.
+ */
+async function fetchPendingExpiryBatches(
+    frequency: AlertFrequency,
+    now: Date,
+    todayStr: string,
+    thirtyDaysFromNow: string
+): Promise<ExpiringBatchRow[]> {
+    if (frequency === "immediate") {
+        const { data: expiringBatches, error } = await supabase
+            .from("batches")
+            .select("*, medicine:medicines(brand_name)")
+            .gte("expiry_date", todayStr)
+            .lte("expiry_date", thirtyDaysFromNow)
+            .eq("expiry_broadcasted", false);
+
+        if (error) {
+            logger.error({ message: "Failed to fetch expiring batches", error });
+            return [];
+        }
+        return (expiringBatches as ExpiringBatchRow[]) ?? [];
+    }
+
+    const windowStart = getDigestWindowStart(frequency, now).toISOString();
+
+    const { data: delivered, error: deliveredError } = await supabase
+        .from("expiry_digest_deliveries")
+        .select("batch_id")
+        .eq("frequency", frequency)
+        .gte("sent_at", windowStart);
+
+    if (deliveredError) {
+        logger.error({
+            message: "Failed to fetch already delivered expiry digest batches",
+            error: deliveredError,
+            frequency,
+        });
+        return [];
+    }
+
+    const deliveredIds = (delivered ?? []).map((row) => row.batch_id);
+
+    let query = supabase
+        .from("batches")
+        .select("*, medicine:medicines(brand_name)")
+        .gte("expiry_date", todayStr)
+        .lte("expiry_date", thirtyDaysFromNow);
+
+    if (deliveredIds.length > 0) {
+        query = query.not("id", "in", deliveredIds);
+    }
+
+    const { data: expiringBatches, error } = await query;
+
+    if (error) {
+        logger.error({ message: "Failed to fetch expiring batches", error });
+        return [];
+    }
+    return (expiringBatches as ExpiringBatchRow[]) ?? [];
+}
+
+async function subscriberExistsForFrequency(frequency: AlertFrequency): Promise<boolean> {
+    const { data, error } = await supabase
+        .from("notification_subscribers")
+        .select("id")
+        .eq("is_active", true)
+        .eq("preference_frequency", frequency)
+        .range(0, 0);
+
+    if (error) {
+        logger.error({
+            message: "Failed to check eligible subscribers",
+            error,
+            frequency,
+        });
+        return false;
+    }
+    return Boolean(data && data.length > 0);
+}
+
+async function markImmediateBatchesBroadcasted(batchIds: string[]): Promise<void> {
+    for (let i = 0; i < batchIds.length; i += broadcastConfig.MARK_BROADCASTED_CHUNK_SIZE) {
+        const chunk = batchIds.slice(i, i + broadcastConfig.MARK_BROADCASTED_CHUNK_SIZE);
+
+        const { error: markError } = await supabase
+            .from("batches")
+            .update({ expiry_broadcasted: true })
+            .in("id", chunk);
+
+        if (markError) {
+            logger.error({
+                message: "Failed to mark delivered expiry alert batches as broadcasted",
+                error: markError,
+                batchIds: chunk,
+            });
+        }
+    }
+}
+
+async function recordDigestDeliveries(
+    batchIds: string[],
+    frequency: AlertFrequency,
+    now: Date
+): Promise<void> {
+    const sentAt = now.toISOString();
+    for (let i = 0; i < batchIds.length; i += broadcastConfig.MARK_BROADCASTED_CHUNK_SIZE) {
+        const chunk = batchIds.slice(i, i + broadcastConfig.MARK_BROADCASTED_CHUNK_SIZE);
+        const rows = chunk.map((batchId) => ({ batch_id: batchId, frequency, sent_at: sentAt }));
+
+        const { error } = await supabase
+            .from("expiry_digest_deliveries")
+            .upsert(rows, { onConflict: "batch_id,frequency" });
+
+        if (error) {
+            logger.error({
+                message: "Failed to record expiry digest delivery",
+                error,
+                frequency,
+                batchIds: chunk,
+            });
+        }
+    }
+}
+
+async function broadcastExpiryToFrequency(
+    frequency: AlertFrequency,
+    pendingBatches: ExpiringBatchRow[],
+    now: Date
+): Promise<void> {
+    const batchSummaries: ExpiringBatchSummary[] = pendingBatches.map((batch) => ({
+        medicineName: batch.medicine?.brand_name || "Unknown Medicine",
+        batchNumber: batch.batch_number,
+        expiryDate: batch.expiry_date,
+    }));
+
+    let from = 0;
+    let to = PAGE_SIZE - 1;
+    let hasMore = true;
+    let hasSuccessfulDelivery = false;
+
+    while (hasMore) {
+        const { data: subscribers, error: subsError } = await supabase
+            .from("notification_subscribers")
+            .select("*")
+            .eq("is_active", true)
+            .eq("preference_frequency", frequency)
+            .range(from, to);
+
+        if (subsError) {
+            logger.error({
+                message: "Failed to fetch subscribers for expiry alerts",
+                error: subsError,
+                frequency,
+            });
+            return;
+        }
+
+        if (!subscribers || subscribers.length === 0) {
+            break;
+        }
+
+        for (let i = 0; i < subscribers.length; i += NOTIFICATION_CHUNK_SIZE) {
+            const chunk = subscribers.slice(i, i + NOTIFICATION_CHUNK_SIZE);
+            const notificationPromises = chunk.map((sub) =>
+                sendConsolidatedExpiryNotification(sub, batchSummaries)
+            );
+            const results = await Promise.allSettled(notificationPromises);
+            hasSuccessfulDelivery ||= results.some(
+                (result) => result.status === "fulfilled" && result.value
+            );
+        }
+
+        if (subscribers.length < PAGE_SIZE) {
+            hasMore = false;
+        } else {
+            from += PAGE_SIZE;
+            to += PAGE_SIZE;
+        }
+    }
+
+    if (!hasSuccessfulDelivery) {
+        logger.warn("Expiry alert delivery failed for every eligible subscriber; will retry.", {
+            frequency,
+            batchIds: pendingBatches.map((batch) => batch.id),
+        });
+        return;
+    }
+
+    const deliveredBatchIds = pendingBatches.map((batch) => batch.id);
+    if (frequency === "immediate") {
+        await markImmediateBatchesBroadcasted(deliveredBatchIds);
+    } else {
+        await recordDigestDeliveries(deliveredBatchIds, frequency, now);
+    }
+}
+
 export async function broadcastExpiryAlerts(now: Date = new Date()): Promise<void> {
     try {
         const todayStr = now.toISOString().split("T")[0];
@@ -401,131 +645,36 @@ export async function broadcastExpiryAlerts(now: Date = new Date()): Promise<voi
             .toISOString()
             .split("T")[0];
 
-        // Determine which frequency buckets are active for this run FIRST,
-        // before fetching batches — so we only fetch & mark batches that will
-        // actually be sent in this run.
-        const activeFrequencies = (
-            ["immediate", "daily", "weekly", "monthly"] as AlertFrequency[]
-        ).filter((freq) => shouldSendForFrequency(freq, now));
+        // Each frequency bucket is processed independently, so one subscriber
+        // receiving an alert never prevents another subscriber with a different
+        // configured frequency from receiving their scheduled digest.
+        const activeFrequencies = FREQUENCIES.filter((freq) => shouldSendForFrequency(freq, now));
 
-        const { data: expiringBatches, error: batchesError } = await supabase
-            .from("batches")
-            .select("*, medicine:medicines(brand_name)")
-            .gte("expiry_date", todayStr)
-            .lte("expiry_date", thirtyDaysFromNow)
-            .eq("expiry_broadcasted", false);
+        for (const frequency of activeFrequencies) {
+            const pendingBatches = await fetchPendingExpiryBatches(
+                frequency,
+                now,
+                todayStr,
+                thirtyDaysFromNow
+            );
 
-        if (batchesError) {
-            logger.error({ message: "Failed to fetch expiring batches", error: batchesError });
-            return;
-        }
+            if (pendingBatches.length === 0) continue;
 
-        if (!expiringBatches || expiringBatches.length === 0) return;
-
-        logger.info(`Broadcasting medicine expiry warnings for ${expiringBatches.length} batches`);
-
-        // Check whether any subscribers exist for the active frequencies
-        // before marking batches as broadcasted — so we only mark a batch
-        // as sent once it has actually been delivered per the user's schedule.
-        const { data: eligibleSubscribers, error: checkError } = await supabase
-            .from("notification_subscribers")
-            .select("id")
-            .eq("is_active", true)
-            .in("preference_frequency", activeFrequencies)
-            .range(0, 0);
-
-        if (checkError) {
-            logger.error({ message: "Failed to check eligible subscribers", error: checkError });
-            return;
-        }
-
-        // No subscribers match the current frequency window — skip marking
-        // batches as broadcasted so they remain available for the next
-        // scheduled digest run (e.g. weekly subscribers get it on Monday).
-        if (!eligibleSubscribers || eligibleSubscribers.length === 0) {
-            logger.info("No subscribers match active frequencies for this run — skipping.");
-            return;
-        }
-
-        const batchSummaries: ExpiringBatchSummary[] = expiringBatches.map((batch) => ({
-            medicineName: batch.medicine?.brand_name || "Unknown Medicine",
-            batchNumber: batch.batch_number,
-            expiryDate: batch.expiry_date,
-        }));
-
-        if (batchSummaries.length === 0) return;
-
-        let from = 0;
-        let to = PAGE_SIZE - 1;
-        let hasMore = true;
-        let hasSuccessfulDelivery = false;
-
-        while (hasMore) {
-            const { data: subscribers, error: subsError } = await supabase
-                .from("notification_subscribers")
-                .select("*")
-                .eq("is_active", true)
-                .in("preference_frequency", activeFrequencies)
-                .range(from, to);
-
-            if (subsError) {
-                logger.error({
-                    message: "Failed to fetch subscribers for expiry alerts",
-                    error: subsError,
-                });
-                break;
-            }
-
-            if (!subscribers || subscribers.length === 0) {
-                break;
-            }
-
-            for (let i = 0; i < subscribers.length; i += NOTIFICATION_CHUNK_SIZE) {
-                const chunk = subscribers.slice(i, i + NOTIFICATION_CHUNK_SIZE);
-                const notificationPromises = chunk.map((sub) =>
-                    sendConsolidatedExpiryNotification(sub, batchSummaries)
+            // Skip marking anything as delivered when no subscriber is eligible
+            // for this run's window, so the batches remain available for the
+            // next scheduled digest run (e.g. weekly subscribers get it Monday).
+            if (!(await subscriberExistsForFrequency(frequency))) {
+                logger.info(
+                    `No subscribers match frequency "${frequency}" for this run — skipping.`
                 );
-                const results = await Promise.allSettled(notificationPromises);
-                hasSuccessfulDelivery ||= results.some(
-                    (result) => result.status === "fulfilled" && result.value
-                );
+                continue;
             }
 
-            if (subscribers.length < PAGE_SIZE) {
-                hasMore = false;
-            } else {
-                from += PAGE_SIZE;
-                to += PAGE_SIZE;
-            }
-        }
+            logger.info(
+                `Broadcasting medicine expiry warnings for ${pendingBatches.length} batches (frequency: ${frequency})`
+            );
 
-        if (!hasSuccessfulDelivery) {
-            logger.warn("Expiry alert delivery failed for every eligible subscriber; will retry.", {
-                batchIds: expiringBatches.map((batch) => batch.id),
-            });
-            return;
-        }
-
-        for (
-            let i = 0;
-            i < expiringBatches.length;
-            i += broadcastConfig.MARK_BROADCASTED_CHUNK_SIZE
-        ) {
-            const chunk = expiringBatches.slice(i, i + broadcastConfig.MARK_BROADCASTED_CHUNK_SIZE);
-            const chunkIds = chunk.map((batch) => batch.id);
-
-            const { error: markError } = await supabase
-                .from("batches")
-                .update({ expiry_broadcasted: true })
-                .in("id", chunkIds);
-
-            if (markError) {
-                logger.error({
-                    message: "Failed to mark delivered expiry alert batches as broadcasted",
-                    error: markError,
-                    batchIds: chunkIds,
-                });
-            }
+            await broadcastExpiryToFrequency(frequency, pendingBatches, now);
         }
     } catch (err) {
         logger.error({ message: "Error in broadcastExpiryAlerts", error: err });

--- a/apps/api/tests/alertBroadcaster.test.ts
+++ b/apps/api/tests/alertBroadcaster.test.ts
@@ -59,8 +59,11 @@ describe("shouldSendForFrequency", () => {
         expect(shouldSendForFrequency("immediate", new Date("2026-06-25T10:00:00Z"))).toBe(true);
     });
 
-    it("always returns true for 'daily'", () => {
-        expect(shouldSendForFrequency("daily", new Date("2026-06-25T10:00:00Z"))).toBe(true);
+    it("returns true for 'daily' only during the daily digest hour", () => {
+        const atDigestHour = new Date(2026, 5, 25, 8, 0, 0); // local 08:00
+        const offHour = new Date(2026, 5, 25, 15, 0, 0); // local 15:00
+        expect(shouldSendForFrequency("daily", atDigestHour)).toBe(true);
+        expect(shouldSendForFrequency("daily", offHour)).toBe(false);
     });
 
     it("returns true for 'weekly' only on Monday", () => {
@@ -301,18 +304,44 @@ describe("broadcastExpiryAlerts", () => {
         jest.clearAllMocks();
     });
 
+    /**
+     * Mocks a `batches` query that supports the immediate chain
+     * (.select().gte().lte().eq("expiry_broadcasted", false)) and the digest
+     * chains (.select().gte().lte() with optional .not("id","in",delivered)).
+     * The terminal .lte() value is a thenable that also exposes .eq/.not so
+     * both query shapes resolve to the same "rows" result.
+     */
     function mockBatchesQuery(batches: any[], opts: { gte?: jest.Mock } = {}) {
         const gteSpy = opts.gte || jest.fn();
+        const result = (rows: any[]) => ({ data: rows, error: null });
+        const thenable = {
+            then: (resolve: (value: unknown) => void) => resolve(result(batches)),
+            eq: jest.fn().mockImplementation((col: string, value: boolean) => {
+                if (col === "expiry_broadcasted") {
+                    return Promise.resolve(
+                        result(
+                            value
+                                ? batches.filter((b) => b.expiry_broadcasted === true)
+                                : batches.filter((b) => b.expiry_broadcasted !== true)
+                        )
+                    );
+                }
+                return Promise.resolve(result(batches));
+            }),
+            not: jest
+                .fn()
+                .mockImplementation((_col: string, _op: string, ids: string[]) =>
+                    Promise.resolve(result(batches.filter((b) => !ids.includes(b.id))))
+                ),
+        };
         return {
-            in: jest.fn().mockResolvedValue({ data: batches, error: null }),
+            in: jest.fn().mockResolvedValue(result(batches)),
             select: jest.fn().mockReturnValue({
-                in: jest.fn().mockResolvedValue({ data: batches, error: null }),
-                gte: jest.fn().mockImplementation((...args) => {
+                in: jest.fn().mockResolvedValue(result(batches)),
+                gte: jest.fn().mockImplementation((...args: unknown[]) => {
                     gteSpy(...args);
                     return {
-                        lte: jest.fn().mockReturnValue({
-                            eq: jest.fn().mockResolvedValue({ data: batches, error: null }),
-                        }),
+                        lte: jest.fn().mockReturnValue(thenable),
                     };
                 }),
             }),
@@ -321,15 +350,49 @@ describe("broadcastExpiryAlerts", () => {
 
     /**
      * Build a notification_subscribers mock that supports the
-     * .eq("is_active", true).in("preference_frequency", [...]).range() chain.
+     * .eq("is_active", true).eq("preference_frequency", [...]).range() chain.
      */
     function mockSubscribersQuery(subscribers: any[]) {
         return {
             select: jest.fn().mockReturnValue({
                 eq: jest.fn().mockReturnValue({
-                    in: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockReturnValue({
                         range: jest.fn().mockResolvedValue({ data: subscribers, error: null }),
                     }),
+                }),
+            }),
+        };
+    }
+
+    /** Mocks expiry_digest_deliveries reads (and optionally the upsert). */
+    function mockDeliveredQuery(delivered: any[] = [], opts: { upsert?: jest.Mock } = {}) {
+        return {
+            select: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                    gte: jest.fn().mockResolvedValue({ data: delivered, error: null }),
+                }),
+            }),
+            upsert: opts.upsert || jest.fn().mockResolvedValue({ data: null, error: null }),
+        };
+    }
+
+    /**
+     * Subscriber mock that returns a different page per preference_frequency,
+     * mirroring the real query filter.
+     */
+    function mockSubscribersByFrequency(subscribersByFreq: Record<string, any[]>) {
+        return {
+            select: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                    eq: jest.fn().mockImplementation((col: string, value: string) => ({
+                        range: jest.fn().mockResolvedValue({
+                            data:
+                                col === "preference_frequency"
+                                    ? (subscribersByFreq[value] ?? [])
+                                    : [],
+                            error: null,
+                        }),
+                    })),
                 }),
             }),
         };
@@ -389,7 +452,8 @@ describe("broadcastExpiryAlerts", () => {
             return {};
         });
 
-        await broadcastExpiryAlerts();
+        // Non-Monday, non-1st, off the daily digest hour — only "immediate" active.
+        await broadcastExpiryAlerts(new Date(2026, 5, 25, 15, 0, 0));
 
         // 2 subscribers × 1 consolidated message each = 2 sends total,
         // not 2 subscribers × 3 batches = 6 sends.
@@ -428,7 +492,7 @@ describe("broadcastExpiryAlerts", () => {
                 return {
                     select: jest.fn().mockReturnValue({
                         eq: jest.fn().mockReturnValue({
-                            in: jest.fn().mockReturnValue({
+                            eq: jest.fn().mockReturnValue({
                                 range: jest.fn().mockImplementation((from: number, to: number) => {
                                     if (from === 0 && to === 0) {
                                         return Promise.resolve({
@@ -457,7 +521,8 @@ describe("broadcastExpiryAlerts", () => {
             return {};
         });
 
-        await broadcastExpiryAlerts();
+        // Non-Monday, non-1st, off the daily digest hour — only "immediate" active.
+        await broadcastExpiryAlerts(new Date(2026, 5, 25, 15, 0, 0));
 
         expect(callOrder).toEqual(["fetch_subscribers", "mark_batch_broadcasted"]);
     });
@@ -493,7 +558,8 @@ describe("broadcastExpiryAlerts", () => {
             return {};
         });
 
-        await broadcastExpiryAlerts();
+        // Non-Monday, non-1st, off the daily digest hour — only "immediate" active.
+        await broadcastExpiryAlerts(new Date(2026, 5, 25, 15, 0, 0));
 
         expect(smsService.send).toHaveBeenCalledTimes(1);
         expect(markBatchSpy).not.toHaveBeenCalled();
@@ -533,7 +599,8 @@ describe("broadcastExpiryAlerts", () => {
             return {};
         });
 
-        await broadcastExpiryAlerts();
+        // Non-Monday, non-1st, off the daily digest hour — only "immediate" active.
+        await broadcastExpiryAlerts(new Date(2026, 5, 25, 15, 0, 0));
 
         expect(smsService.send).toHaveBeenCalledTimes(1);
         expect(whatsappService.send).toHaveBeenCalledTimes(1);
@@ -548,7 +615,8 @@ describe("broadcastExpiryAlerts", () => {
             return {};
         });
 
-        await broadcastExpiryAlerts();
+        // Non-Monday, non-1st, off the daily digest hour — only "immediate" active.
+        await broadcastExpiryAlerts(new Date(2026, 5, 25, 15, 0, 0));
 
         expect(smsService.send).not.toHaveBeenCalled();
     });
@@ -563,7 +631,8 @@ describe("broadcastExpiryAlerts", () => {
             return {};
         });
 
-        await broadcastExpiryAlerts();
+        // Non-Monday, non-1st, off the daily digest hour — only "immediate" active.
+        await broadcastExpiryAlerts(new Date(2026, 5, 25, 15, 0, 0));
 
         expect(gteSpy).toHaveBeenCalledWith("expiry_date", expect.any(String));
         expect(smsService.send).not.toHaveBeenCalled();
@@ -619,7 +688,8 @@ describe("broadcastExpiryAlerts", () => {
 
         broadcastConfig.MARK_BROADCASTED_CHUNK_SIZE = 1;
         try {
-            await broadcastExpiryAlerts();
+            // Non-Monday, non-1st, off the daily digest hour — only "immediate" active.
+            await broadcastExpiryAlerts(new Date(2026, 5, 25, 15, 0, 0));
         } finally {
             broadcastConfig.MARK_BROADCASTED_CHUNK_SIZE = 500;
         }
@@ -634,10 +704,10 @@ describe("broadcastExpiryAlerts", () => {
     // preference_frequency filtering tests
     // -------------------------------------------------------------------------
 
-    it("only sends to 'immediate' subscribers when run on a non-Monday, non-1st day", async () => {
-        // Wednesday June 25 2026 — not Monday, not 1st
-        const wednesday = new Date("2026-06-25T08:00:00Z");
-        let capturedInArgs: string[] = [];
+    it("only processes 'immediate' subscribers when run outside every digest window", async () => {
+        // Thursday June 25 2026, 15:00 local — not Monday, not 1st, off digest hour
+        const thursday = new Date(2026, 5, 25, 15, 0, 0);
+        const capturedEqArgs: string[] = [];
 
         const batches = [
             {
@@ -657,12 +727,13 @@ describe("broadcastExpiryAlerts", () => {
                     }),
                 };
             }
+            if (table === "expiry_digest_deliveries") return mockDeliveredQuery([]);
             if (table === "notification_subscribers") {
                 return {
                     select: jest.fn().mockReturnValue({
                         eq: jest.fn().mockReturnValue({
-                            in: jest.fn().mockImplementation((_col: string, values: string[]) => {
-                                capturedInArgs = values;
+                            eq: jest.fn().mockImplementation((col: string, value: string) => {
+                                if (col === "preference_frequency") capturedEqArgs.push(value);
                                 return {
                                     range: jest.fn().mockResolvedValue({ data: [], error: null }),
                                 };
@@ -674,18 +745,15 @@ describe("broadcastExpiryAlerts", () => {
             return {};
         });
 
-        await broadcastExpiryAlerts(wednesday);
+        await broadcastExpiryAlerts(thursday);
 
-        // On a Wednesday only "immediate" and "daily" should be queried
-        expect(capturedInArgs).toContain("immediate");
-        expect(capturedInArgs).toContain("daily");
-        expect(capturedInArgs).not.toContain("weekly");
-        expect(capturedInArgs).not.toContain("monthly");
+        // Outside every digest window only "immediate" should be queried.
+        expect(capturedEqArgs).toEqual(["immediate"]);
     });
 
     it("includes 'weekly' subscribers when run on a Monday", async () => {
-        const monday = new Date("2026-06-22T08:00:00Z");
-        let capturedInArgs: string[] = [];
+        const monday = new Date(2026, 5, 22, 15, 0, 0); // Monday, off digest hour
+        const capturedEqArgs: string[] = [];
 
         const batches = [
             {
@@ -705,12 +773,13 @@ describe("broadcastExpiryAlerts", () => {
                     }),
                 };
             }
+            if (table === "expiry_digest_deliveries") return mockDeliveredQuery([]);
             if (table === "notification_subscribers") {
                 return {
                     select: jest.fn().mockReturnValue({
                         eq: jest.fn().mockReturnValue({
-                            in: jest.fn().mockImplementation((_col: string, values: string[]) => {
-                                capturedInArgs = values;
+                            eq: jest.fn().mockImplementation((col: string, value: string) => {
+                                if (col === "preference_frequency") capturedEqArgs.push(value);
                                 return {
                                     range: jest.fn().mockResolvedValue({ data: [], error: null }),
                                 };
@@ -724,12 +793,12 @@ describe("broadcastExpiryAlerts", () => {
 
         await broadcastExpiryAlerts(monday);
 
-        expect(capturedInArgs).toContain("weekly");
+        expect(capturedEqArgs).toContain("weekly");
     });
 
     it("includes 'monthly' subscribers when run on the 1st of a month", async () => {
-        const firstOfMonth = new Date("2026-07-01T08:00:00Z");
-        let capturedInArgs: string[] = [];
+        const firstOfMonth = new Date(2026, 6, 1, 15, 0, 0); // 1st, off digest hour
+        const capturedEqArgs: string[] = [];
 
         const batches = [
             {
@@ -749,12 +818,13 @@ describe("broadcastExpiryAlerts", () => {
                     }),
                 };
             }
+            if (table === "expiry_digest_deliveries") return mockDeliveredQuery([]);
             if (table === "notification_subscribers") {
                 return {
                     select: jest.fn().mockReturnValue({
                         eq: jest.fn().mockReturnValue({
-                            in: jest.fn().mockImplementation((_col: string, values: string[]) => {
-                                capturedInArgs = values;
+                            eq: jest.fn().mockImplementation((col: string, value: string) => {
+                                if (col === "preference_frequency") capturedEqArgs.push(value);
                                 return {
                                     range: jest.fn().mockResolvedValue({ data: [], error: null }),
                                 };
@@ -768,11 +838,11 @@ describe("broadcastExpiryAlerts", () => {
 
         await broadcastExpiryAlerts(firstOfMonth);
 
-        expect(capturedInArgs).toContain("monthly");
+        expect(capturedEqArgs).toContain("monthly");
     });
 
     it("does not send expiry alerts to 'weekly' subscribers on a non-Monday", async () => {
-        const thursday = new Date("2026-06-25T08:00:00Z");
+        const thursday = new Date(2026, 5, 25, 15, 0, 0);
 
         const batches = [
             {
@@ -792,6 +862,7 @@ describe("broadcastExpiryAlerts", () => {
                     }),
                 };
             }
+            if (table === "expiry_digest_deliveries") return mockDeliveredQuery([]);
             if (table === "notification_subscribers") {
                 return mockSubscribersQuery([]);
             }
@@ -807,7 +878,7 @@ describe("broadcastExpiryAlerts", () => {
         // If there are zero eligible subscribers for this run's frequency
         // window, the batch must stay unmarked so weekly/monthly subscribers
         // can still receive it on their scheduled day.
-        const tuesday = new Date("2026-06-23T08:00:00Z");
+        const tuesday = new Date(2026, 5, 23, 15, 0, 0);
         const markBatchSpy = jest.fn().mockReturnValue({
             eq: jest.fn().mockResolvedValue({ data: null, error: null }),
         });
@@ -828,6 +899,7 @@ describe("broadcastExpiryAlerts", () => {
                     update: markBatchSpy,
                 };
             }
+            if (table === "expiry_digest_deliveries") return mockDeliveredQuery([]);
             if (table === "notification_subscribers") {
                 // No subscribers match — empty result
                 return mockSubscribersQuery([]);
@@ -838,6 +910,122 @@ describe("broadcastExpiryAlerts", () => {
         await broadcastExpiryAlerts(tuesday);
 
         expect(markBatchSpy).not.toHaveBeenCalled();
+        expect(smsService.send).not.toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------------
+    // per-frequency independence tests
+    // -------------------------------------------------------------------------
+
+    it("sends to weekly subscribers on Monday even when the batch was already delivered immediately", async () => {
+        const monday = new Date(2026, 5, 22, 15, 0, 0); // Monday, off digest hour
+        const batches = [
+            {
+                id: "batch-1",
+                batch_number: "B1",
+                expiry_date: "2026-07-01",
+                expiry_broadcasted: true, // already delivered to immediate subscribers
+                medicine: { brand_name: "Aspirin" },
+            },
+        ];
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "batches") {
+                return {
+                    ...mockBatchesQuery(batches),
+                    update: jest.fn().mockReturnValue({
+                        in: jest.fn().mockResolvedValue({ data: null, error: null }),
+                    }),
+                };
+            }
+            if (table === "expiry_digest_deliveries") return mockDeliveredQuery([]);
+            if (table === "notification_subscribers") {
+                return mockSubscribersByFrequency({
+                    immediate: [],
+                    weekly: [
+                        {
+                            id: "sub-weekly",
+                            phone: "+910000000004",
+                            language: "en",
+                            channels: ["sms"],
+                            is_active: true,
+                            preference_frequency: "weekly",
+                        },
+                    ],
+                });
+            }
+            return {};
+        });
+
+        await broadcastExpiryAlerts(monday);
+
+        const sendMock = smsService.send as jest.Mock;
+        expect(sendMock).toHaveBeenCalledTimes(1);
+        expect(sendMock.mock.calls[0][0]).toBe("+910000000004");
+    });
+
+    it("sends a daily digest at most once per calendar day", async () => {
+        let deliveredRows: { batch_id: string }[] = [];
+        const upsertSpy = jest.fn().mockImplementation((rows: any[]) => {
+            deliveredRows = rows.map((r: any) => ({ batch_id: r.batch_id }));
+            return Promise.resolve({ data: null, error: null });
+        });
+
+        const batches = [
+            {
+                id: "batch-1",
+                batch_number: "B1",
+                expiry_date: "2026-07-01",
+                medicine: { brand_name: "Aspirin" },
+            },
+        ];
+        const digestTime = new Date(2026, 5, 25, 8, 0, 0); // local 08:00 (daily digest hour)
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "batches") {
+                return {
+                    ...mockBatchesQuery(batches),
+                    update: jest.fn().mockReturnValue({
+                        in: jest.fn().mockResolvedValue({ data: null, error: null }),
+                    }),
+                };
+            }
+            if (table === "expiry_digest_deliveries") {
+                return {
+                    select: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockReturnValue({
+                            gte: jest.fn().mockResolvedValue({ data: deliveredRows, error: null }),
+                        }),
+                    }),
+                    upsert: upsertSpy,
+                };
+            }
+            if (table === "notification_subscribers") {
+                return mockSubscribersByFrequency({
+                    immediate: [],
+                    daily: [
+                        {
+                            id: "sub-daily",
+                            phone: "+910000000003",
+                            language: "en",
+                            channels: ["sms"],
+                            is_active: true,
+                            preference_frequency: "daily",
+                        },
+                    ],
+                });
+            }
+            return {};
+        });
+
+        await broadcastExpiryAlerts(digestTime);
+        expect(smsService.send).toHaveBeenCalledTimes(1);
+        expect(upsertSpy).toHaveBeenCalledTimes(1);
+
+        (smsService.send as jest.Mock).mockClear();
+
+        // A second run inside the same day must not re-deliver the digest.
+        await broadcastExpiryAlerts(digestTime);
         expect(smsService.send).not.toHaveBeenCalled();
     });
 });

--- a/supabase/migrations/20260731000000_add_expiry_digest_deliveries.sql
+++ b/supabase/migrations/20260731000000_add_expiry_digest_deliveries.sql
@@ -1,0 +1,38 @@
+-- Migration: Add per-frequency expiry digest delivery tracking
+--
+-- Before this migration, batches.expiry_broadcasted was the only delivery
+-- state for expiry alerts. It is a single global boolean, so the first
+-- successful delivery (e.g. to an "immediate" subscriber) permanently removed
+-- the batch from every later run and "weekly"/"monthly" subscribers never
+-- received their scheduled digest.
+--
+-- This table records, per batch and per digest frequency, the last time the
+-- batch was included in a delivered expiry digest. It lets each frequency
+-- window advance independently: a batch is pending for a frequency when there
+-- is no row (or the row's sent_at falls before that frequency's current
+-- window). Immediate delivery state continues to live on
+-- batches.expiry_broadcasted, so no backfill is required.
+
+CREATE TABLE IF NOT EXISTS public.expiry_digest_deliveries (
+    batch_id UUID NOT NULL REFERENCES public.batches(id) ON DELETE CASCADE,
+    frequency TEXT NOT NULL CHECK (frequency IN ('daily', 'weekly', 'monthly')),
+    sent_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (batch_id, frequency)
+);
+
+-- Lookup used by the broadcaster: "which batches were already delivered for
+-- this frequency inside the current window?".
+CREATE INDEX IF NOT EXISTS idx_expiry_digest_deliveries_frequency_sent_at
+    ON public.expiry_digest_deliveries (frequency, sent_at DESC);
+
+COMMENT ON TABLE public.expiry_digest_deliveries IS
+  'Tracks the last delivery of each expiring batch per digest frequency so daily/weekly/monthly expiry digests operate independently. Immediate deliveries are tracked by batches.expiry_broadcasted.';
+
+ALTER TABLE public.expiry_digest_deliveries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "expiry_digest_deliveries_service_only"
+    ON public.expiry_digest_deliveries
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3967**
- **Summary:** Expiry digest frequency preferences (daily/weekly/monthly) were ignored after the first delivery. `batches.expiry_broadcasted` is a single global boolean, so the first successful delivery (e.g. to an `immediate` subscriber) permanently removed the batch from every later run, and digest subscribers never received their scheduled notification. This PR processes each frequency independently and introduces an `expiry_digest_deliveries` table keyed by `(batch_id, frequency)` to track per-frequency delivery state. Immediate behavior is unchanged (still uses `expiry_broadcasted`); daily/weekly/monthly digests are tracked in the new table. A new table was necessary because a single boolean cannot represent independent per-frequency delivery state without changing semantics.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_
>
> Backend change (no UI) — verification logs:
>
> ```
> $ npx jest --forceExit --silent tests/alertBroadcaster.test.ts
> Test Suites: 1 passed, 1 total
> Tests:       22 passed, 22 total
> ```
>
> ```
> $ npx tsc --noEmit -p tsconfig.json   (apps/api)
> (no output — clean)
> ```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
