### PR TITLE
fix: fail notification delivery when providers are unavailable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,16 @@ VAPID_PUBLIC_KEY=your_vapid_public_key
 VAPID_PRIVATE_KEY=your_vapid_private_key
 VAPID_SUBJECT=mailto:security@sahidawa.local
 
+# --- SMS & WhatsApp Alerts ---
+# When these are not set, SMS/WhatsApp deliveries FAIL in production so alerts
+# are never falsely marked as delivered. Deliveries are only mocked in local
+# development (NODE_ENV=development).
+TWILIO_ACCOUNT_SID=your_twilio_account_sid
+TWILIO_AUTH_TOKEN=your_twilio_auth_token
+TWILIO_PHONE_NUMBER=your_twilio_phone_number
+GUPSHUP_API_KEY=your_gupshup_api_key
+GUPSHUP_SOURCE_NUMBER=your_gupshup_source_number
+
 # --- Cloudinary (Medicine Photo Storage) ---
 # Server-side keys (Used by secure backend upload route at /api/upload)
 CLOUDINARY_CLOUD_NAME=your_cloud_name

--- a/apps/api/src/services/sms-service.ts
+++ b/apps/api/src/services/sms-service.ts
@@ -1,5 +1,6 @@
 import logger from "../utils/logger";
 import { smsQueue } from "../queues/smsQueue";
+import { isLocalDevelopment } from "../utils/env";
 export interface SMSProvider {
     send(phone: string, message: string, language: string): Promise<boolean>;
     sendOtp(phone: string, otp: string, language: string): Promise<boolean>;
@@ -8,6 +9,21 @@ export interface SMSProvider {
 export class TwilioSMSService implements SMSProvider {
     async send(phone: string, message: string, language: string): Promise<boolean> {
         logger.info(`[SMS][${language}] Queueing SMS for ${phone}`);
+
+        // Never treat a queued job as delivered when Twilio is not configured:
+        // the worker would have no credentials to deliver it, so the alert must
+        // remain pending instead of being reported as sent. Local development
+        // still enqueues, where the SMS worker mocks the delivery.
+        const hasTwilioCredentials = Boolean(
+            process.env.TWILIO_ACCOUNT_SID &&
+            process.env.TWILIO_AUTH_TOKEN &&
+            process.env.TWILIO_PHONE_NUMBER
+        );
+
+        if (!hasTwilioCredentials && !isLocalDevelopment()) {
+            logger.error(`Twilio credentials missing. SMS delivery to ${phone} failed.`);
+            return false;
+        }
 
         try {
             await smsQueue.add(

--- a/apps/api/src/services/whatsapp-service.ts
+++ b/apps/api/src/services/whatsapp-service.ts
@@ -1,4 +1,5 @@
 import logger from "../utils/logger";
+import { isLocalDevelopment } from "../utils/env";
 
 export interface WhatsAppProvider {
     send(phone: string, message: string, language: string): Promise<boolean>;
@@ -13,8 +14,12 @@ export class GupshupWhatsAppService implements WhatsAppProvider {
         logger.info(`[WhatsApp][${language}] Preparing to send to ${phone}: "${message}"`);
 
         if (!this.apiKey || !this.sourceNumber) {
-            logger.warn(`Gupshup credentials missing. MOCKING WhatsApp delivery to ${phone}.`);
-            return true;
+            if (isLocalDevelopment()) {
+                logger.warn(`Gupshup credentials missing. MOCKING WhatsApp delivery to ${phone}.`);
+                return true;
+            }
+            logger.error(`Gupshup credentials missing. WhatsApp delivery to ${phone} failed.`);
+            return false;
         }
 
         try {

--- a/apps/api/src/utils/env.ts
+++ b/apps/api/src/utils/env.ts
@@ -1,0 +1,31 @@
+/**
+ * Cloud-platform env vars that are always present once the app is deployed,
+ * regardless of how NODE_ENV was configured for that deploy. Mirrors the guard
+ * in src/index.ts: NODE_ENV alone is not a reliable signal that the process is
+ * running on a developer's machine, because it is trivially set to
+ * "development" in cloud/staging environments.
+ */
+const CLOUD_PLATFORM_ENV_VARS = [
+    "RAILWAY_ENVIRONMENT_NAME",
+    "VERCEL",
+    "RENDER",
+    "FLY_APP_NAME",
+    "AWS_EXECUTION_ENV",
+    "KUBERNETES_SERVICE_HOST",
+    "DYNO", // Heroku
+];
+
+/**
+ * True only on a genuine local development machine.
+ *
+ * Used to decide whether SMS/WhatsApp deliveries may be mocked when provider
+ * credentials are missing. Mocks must never run in production — a mocked
+ * delivery would otherwise be reported as successful even though no message
+ * reaches the recipient.
+ */
+export function isLocalDevelopment(): boolean {
+    return (
+        process.env.NODE_ENV === "development" &&
+        !CLOUD_PLATFORM_ENV_VARS.some((key) => Boolean(process.env[key]))
+    );
+}

--- a/apps/api/src/workers/smsWorker.ts
+++ b/apps/api/src/workers/smsWorker.ts
@@ -1,54 +1,70 @@
 import IORedis from "ioredis";
 import { Worker, Job } from "bullmq";
 import logger from "../utils/logger";
+import { isLocalDevelopment } from "../utils/env";
+
+/**
+ * Process a single "send-sms" job.
+ *
+ * Throws on any failure (missing credentials outside local development, rate
+ * limit, provider error) so BullMQ retries the job with its configured
+ * exponential backoff. Resolving without a real delivery is only allowed in
+ * local development, where missing credentials are mocked.
+ */
+export async function processSmsJob(job: Job): Promise<void> {
+    const { phone, message, language } = job.data;
+
+    logger.info(`[SMS][${language}] Processing job for ${phone}`);
+
+    const accountSid = process.env.TWILIO_ACCOUNT_SID;
+    const authToken = process.env.TWILIO_AUTH_TOKEN;
+    const fromNumber = process.env.TWILIO_PHONE_NUMBER;
+
+    if (!accountSid || !authToken || !fromNumber) {
+        if (isLocalDevelopment()) {
+            logger.warn(`Twilio credentials missing. MOCKING SMS delivery to ${phone}.`);
+            return;
+        }
+        throw new Error(`Twilio credentials missing. SMS delivery to ${phone} failed.`);
+    }
+
+    const endpoint = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
+
+    const credentials = Buffer.from(`${accountSid}:${authToken}`).toString("base64");
+
+    const params = new URLSearchParams();
+    params.append("To", phone);
+    params.append("From", fromNumber);
+    params.append("Body", message);
+
+    const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+            Authorization: `Basic ${credentials}`,
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: params.toString(),
+    });
+
+    if (response.ok) {
+        logger.info(`Twilio SMS sent successfully to ${phone}`);
+        return;
+    }
+
+    if (response.status === 429) {
+        throw new Error("Twilio rate limited");
+    }
+
+    const errText = await response.text();
+    throw new Error(`Twilio SMS API error: ${response.status} ${errText}`);
+}
 
 const connection = new IORedis(process.env.REDIS_URL as string, { maxRetriesPerRequest: null });
 
 new Worker(
     "sms-queue",
     async (job: Job) => {
-        const { phone, message, language } = job.data;
-
-        logger.info(`[SMS][${language}] Processing job for ${phone}`);
-
-        const accountSid = process.env.TWILIO_ACCOUNT_SID;
-        const authToken = process.env.TWILIO_AUTH_TOKEN;
-        const fromNumber = process.env.TWILIO_PHONE_NUMBER;
-
-        if (!accountSid || !authToken || !fromNumber) {
-            logger.warn(`Twilio credentials missing. MOCKING SMS delivery to ${phone}.`);
-            return;
-        }
-
-        const endpoint = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`;
-
-        const credentials = Buffer.from(`${accountSid}:${authToken}`).toString("base64");
-
-        const params = new URLSearchParams();
-        params.append("To", phone);
-        params.append("From", fromNumber);
-        params.append("Body", message);
-
-        const response = await fetch(endpoint, {
-            method: "POST",
-            headers: {
-                Authorization: `Basic ${credentials}`,
-                "Content-Type": "application/x-www-form-urlencoded",
-            },
-            body: params.toString(),
-        });
-
-        if (response.ok) {
-            logger.info(`Twilio SMS sent successfully to ${phone}`);
-            return;
-        }
-
-        if (response.status === 429) {
-            throw new Error("Twilio rate limited");
-        }
-
-        const errText = await response.text();
-        throw new Error(`Twilio SMS API error: ${response.status} ${errText}`);
+        await processSmsJob(job);
     },
     {
         connection: connection as any,

--- a/apps/api/tests/notificationProviders.test.ts
+++ b/apps/api/tests/notificationProviders.test.ts
@@ -1,0 +1,188 @@
+jest.mock("../src/queues/smsQueue", () => ({
+    smsQueue: { add: jest.fn().mockResolvedValue(undefined), on: jest.fn() },
+}));
+
+jest.mock("../src/utils/logger", () => ({
+    __esModule: true,
+    default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { GupshupWhatsAppService } from "../src/services/whatsapp-service";
+import { TwilioSMSService } from "../src/services/sms-service";
+import { smsQueue } from "../src/queues/smsQueue";
+import { isLocalDevelopment } from "../src/utils/env";
+
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_FETCH = global.fetch;
+
+const CLOUD_PLATFORM_ENV_VARS = [
+    "RAILWAY_ENVIRONMENT_NAME",
+    "VERCEL",
+    "RENDER",
+    "FLY_APP_NAME",
+    "AWS_EXECUTION_ENV",
+    "KUBERNETES_SERVICE_HOST",
+    "DYNO",
+];
+
+function clearProviderEnv() {
+    delete process.env.TWILIO_ACCOUNT_SID;
+    delete process.env.TWILIO_AUTH_TOKEN;
+    delete process.env.TWILIO_PHONE_NUMBER;
+    delete process.env.GUPSHUP_API_KEY;
+    delete process.env.GUPSHUP_SOURCE_NUMBER;
+    for (const key of CLOUD_PLATFORM_ENV_VARS) {
+        delete process.env[key];
+    }
+}
+
+afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    global.fetch = ORIGINAL_FETCH;
+    jest.clearAllMocks();
+});
+
+describe("isLocalDevelopment", () => {
+    it("returns true for NODE_ENV=development without cloud platform vars", () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "development";
+        expect(isLocalDevelopment()).toBe(true);
+    });
+
+    it("returns false for NODE_ENV=production", () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        expect(isLocalDevelopment()).toBe(false);
+    });
+
+    it("returns false when NODE_ENV is unset", () => {
+        clearProviderEnv();
+        delete process.env.NODE_ENV;
+        expect(isLocalDevelopment()).toBe(false);
+    });
+
+    it("returns false on a cloud platform even with NODE_ENV=development", () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "development";
+        process.env.RAILWAY_ENVIRONMENT_NAME = "production";
+        expect(isLocalDevelopment()).toBe(false);
+    });
+});
+
+describe("GupshupWhatsAppService", () => {
+    it("mocks a successful delivery in development when credentials are missing", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "development";
+        const service = new GupshupWhatsAppService();
+        await expect(service.send("+919876543210", "hello", "en")).resolves.toBe(true);
+    });
+
+    it("fails delivery in production when credentials are missing", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        const service = new GupshupWhatsAppService();
+        await expect(service.send("+919876543210", "hello", "en")).resolves.toBe(false);
+    });
+
+    it("fails delivery on a cloud platform even with NODE_ENV=development", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "development";
+        process.env.RAILWAY_ENVIRONMENT_NAME = "production";
+        const service = new GupshupWhatsAppService();
+        await expect(service.send("+919876543210", "hello", "en")).resolves.toBe(false);
+    });
+
+    it("sends successfully when credentials are present and the API responds ok", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        process.env.GUPSHUP_API_KEY = "test-api-key";
+        process.env.GUPSHUP_SOURCE_NUMBER = "+15551234567";
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            text: async () => "ok",
+        } as unknown as Response);
+
+        const service = new GupshupWhatsAppService();
+        await expect(service.send("+919876543210", "hello", "en")).resolves.toBe(true);
+    });
+
+    it("fails delivery when the Gupshup API returns an error", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        process.env.GUPSHUP_API_KEY = "test-api-key";
+        process.env.GUPSHUP_SOURCE_NUMBER = "+15551234567";
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            text: async () => "boom",
+        } as unknown as Response);
+
+        const service = new GupshupWhatsAppService();
+        await expect(service.send("+919876543210", "hello", "en")).resolves.toBe(false);
+    });
+
+    it("delegates sendOtp to send", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        const service = new GupshupWhatsAppService();
+        await expect(service.sendOtp("+919876543210", "123456", "en")).resolves.toBe(false);
+    });
+});
+
+describe("TwilioSMSService", () => {
+    it("fails delivery in production when credentials are missing and does not enqueue", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        const service = new TwilioSMSService();
+        await expect(service.send("+919876543210", "hello", "en")).resolves.toBe(false);
+        expect(smsQueue.add).not.toHaveBeenCalled();
+    });
+
+    it("enqueues (reports queued) in development when credentials are missing", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "development";
+        const service = new TwilioSMSService();
+        await expect(service.send("+919876543210", "hello", "en")).resolves.toBe(true);
+        expect(smsQueue.add).toHaveBeenCalledTimes(1);
+    });
+
+    it("fails delivery on a cloud platform even with NODE_ENV=development", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "development";
+        process.env.RAILWAY_ENVIRONMENT_NAME = "production";
+        const service = new TwilioSMSService();
+        await expect(service.send("+919876543210", "hello", "en")).resolves.toBe(false);
+        expect(smsQueue.add).not.toHaveBeenCalled();
+    });
+
+    it("enqueues when credentials are present", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        process.env.TWILIO_ACCOUNT_SID = "test-sid";
+        process.env.TWILIO_AUTH_TOKEN = "test-token";
+        process.env.TWILIO_PHONE_NUMBER = "+15551234567";
+        const service = new TwilioSMSService();
+        await expect(service.send("+919876543210", "hello", "en")).resolves.toBe(true);
+        expect(smsQueue.add).toHaveBeenCalledTimes(1);
+    });
+
+    it("fails delivery when enqueuing throws", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        process.env.TWILIO_ACCOUNT_SID = "test-sid";
+        process.env.TWILIO_AUTH_TOKEN = "test-token";
+        process.env.TWILIO_PHONE_NUMBER = "+15551234567";
+        (smsQueue.add as jest.Mock).mockRejectedValueOnce(new Error("Redis down"));
+        const service = new TwilioSMSService();
+        await expect(service.send("+919876543210", "hello", "en")).resolves.toBe(false);
+    });
+
+    it("delegates sendOtp to send", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        const service = new TwilioSMSService();
+        await expect(service.sendOtp("+919876543210", "123456", "en")).resolves.toBe(false);
+        expect(smsQueue.add).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/tests/smsWorker.test.ts
+++ b/apps/api/tests/smsWorker.test.ts
@@ -1,0 +1,112 @@
+// The SMS worker creates a real BullMQ Worker + IORedis connection at module
+// load, so both are mocked here and the processor is tested in isolation.
+jest.mock("ioredis", () => jest.fn().mockImplementation(() => ({})));
+
+jest.mock("bullmq", () => ({
+    Worker: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock("../src/utils/logger", () => ({
+    __esModule: true,
+    default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { processSmsJob } from "../src/workers/smsWorker";
+
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_FETCH = global.fetch;
+
+const CLOUD_PLATFORM_ENV_VARS = [
+    "RAILWAY_ENVIRONMENT_NAME",
+    "VERCEL",
+    "RENDER",
+    "FLY_APP_NAME",
+    "AWS_EXECUTION_ENV",
+    "KUBERNETES_SERVICE_HOST",
+    "DYNO",
+];
+
+function clearProviderEnv() {
+    delete process.env.TWILIO_ACCOUNT_SID;
+    delete process.env.TWILIO_AUTH_TOKEN;
+    delete process.env.TWILIO_PHONE_NUMBER;
+    for (const key of CLOUD_PLATFORM_ENV_VARS) {
+        delete process.env[key];
+    }
+}
+
+afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    global.fetch = ORIGINAL_FETCH;
+    jest.clearAllMocks();
+});
+
+const job = {
+    data: { phone: "+919876543210", message: "SahiDawa alert", language: "en" },
+};
+
+describe("processSmsJob", () => {
+    it("throws when Twilio credentials are missing in production (BullMQ retries)", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        await expect(processSmsJob(job as any)).rejects.toThrow(/Twilio credentials missing/i);
+    });
+
+    it("mocks (resolves) when Twilio credentials are missing in development", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "development";
+        await expect(processSmsJob(job as any)).resolves.toBeUndefined();
+    });
+
+    it("throws on a cloud platform even with NODE_ENV=development", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "development";
+        process.env.RAILWAY_ENVIRONMENT_NAME = "production";
+        await expect(processSmsJob(job as any)).rejects.toThrow(/Twilio credentials missing/i);
+    });
+
+    it("resolves when Twilio responds ok", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        process.env.TWILIO_ACCOUNT_SID = "test-sid";
+        process.env.TWILIO_AUTH_TOKEN = "test-token";
+        process.env.TWILIO_PHONE_NUMBER = "+15551234567";
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            text: async () => "ok",
+        } as unknown as Response);
+
+        await expect(processSmsJob(job as any)).resolves.toBeUndefined();
+    });
+
+    it("throws a rate-limit error on HTTP 429 (BullMQ retries)", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        process.env.TWILIO_ACCOUNT_SID = "test-sid";
+        process.env.TWILIO_AUTH_TOKEN = "test-token";
+        process.env.TWILIO_PHONE_NUMBER = "+15551234567";
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: false,
+            status: 429,
+            text: async () => "",
+        } as unknown as Response);
+
+        await expect(processSmsJob(job as any)).rejects.toThrow("Twilio rate limited");
+    });
+
+    it("throws a provider error on other non-OK responses", async () => {
+        clearProviderEnv();
+        process.env.NODE_ENV = "production";
+        process.env.TWILIO_ACCOUNT_SID = "test-sid";
+        process.env.TWILIO_AUTH_TOKEN = "test-token";
+        process.env.TWILIO_PHONE_NUMBER = "+15551234567";
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            text: async () => "boom",
+        } as unknown as Response);
+
+        await expect(processSmsJob(job as any)).rejects.toThrow(/Twilio SMS API error: 500/);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3968**
- **Summary:** SMS and WhatsApp alerts no longer report success when the underlying providers (Twilio / Gupshup) are unavailable. Missing credentials previously caused both send paths to log a "MOCKING" message and return success, so alert batches were marked broadcasted/delivered even though no message was ever sent in production. This PR makes delivery fail honestly outside local development: SMS jobs are retried by BullMQ, and alert batches stay pending for the next tick instead of being marked delivered.

### Changes

- **`apps/api/src/utils/env.ts` (new):** `isLocalDevelopment()` — returns true only when `NODE_ENV === "development"` and no cloud-platform env vars are present (Railway, Vercel, Render, Fly.io, AWS, Kubernetes, Heroku). Mirrors the existing production guard in `src/index.ts`.
- **`apps/api/src/services/whatsapp-service.ts`:** Missing Gupshup credentials now `return false` (with an error log) outside local development instead of returning `true` ("MOCKING"). Local dev still mocks.
- **`apps/api/src/services/sms-service.ts`:** When Twilio credentials are missing and not in local development, the enqueue is rejected up front (`return false`) so a queued job is never treated as delivered.
- **`apps/api/src/workers/smsWorker.ts`:** Processing logic extracted to an exported `processSmsJob(job)`. Missing credentials now `throw` outside local development so BullMQ retries with the configured exponential backoff instead of resolving as success. Local dev still mocks.
- **`.env.example`:** Documents the new `TWILIO_*` / `GUPSHUP_*` variables with a note that missing credentials fail in production.
- **Tests:** New `tests/notificationProviders.test.ts` (16 tests) and `tests/smsWorker.test.ts` (6 tests) covering development and production behavior.

## 📸 Proof of Work (Screenshots / Logs)

```
Test Suites: 4 passed, 4 total
Tests:       49 passed, 49 total
  PASS tests/twilioWebhookSignature.test.ts
  PASS tests/alertBroadcaster.test.ts
  PASS tests/notificationProviders.test.ts
  PASS tests/smsWorker.test.ts

$ npx tsc --noEmit -p tsconfig.json   # src typecheck: no errors

$ npm run lint:circular              # no circular dependencies
✔ No circular dependency found!
```

- New functionality is covered by dedicated tests (22 new tests).
- Existing related suites (`alertBroadcaster`, `twilioWebhookSignature`) still pass.
- Source type-check passes (`tsc --noEmit -p tsconfig.json`).

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3968`)
- [x] I have pulled the latest `main` and resolved any conflicts

## Notes for reviewers

- Pre-existing unrelated test failures (e.g. `notifications`, `medicineSchedules`, `districtAlertSync`, `cache.service`, `apiKeys`, `abha*`) were **verified to be present on the base branch** by stashing this PR's changes and re-running — they are not introduced by this PR.
- `npm run test:types` fails for **all** test files with a pre-existing `TS6059 rootDir` config conflict (`rootDir: ./src` vs `tests/**/*.ts` include in `tsconfig.test.json`); it is unrelated technical debt and intentionally out of scope.
- The pre-push `npm audit` hook fails on pre-existing high-severity dependency advisories (Next.js, OpenTelemetry, brace-expansion); no dependencies were added by this PR.
