### PR TITLE
fix: reject additional reserved outbound IP ranges in backend URL validation

### DIFF
--- a/apps/api/src/config/mlService.ts
+++ b/apps/api/src/config/mlService.ts
@@ -1,23 +1,8 @@
 import logger from "../utils/logger";
+import { isBlockedOutboundHost } from "../utils/security/urlValidator";
 
 const MISSING_ML_SERVICE_URL_MESSAGE =
     "ML_SERVICE_URL is not configured. Set it to the ML service origin before using ML-backed routes.";
-
-// RFC-1918 private address ranges, loopback, and link-local prefixes that must
-// never be used as ML service endpoints. A misconfigured or injected value
-// pointing at these addresses would allow the API server to reach cloud instance
-// metadata services or internal network resources (SSRF).
-const BLOCKED_HOSTNAME_PATTERNS = [
-    /^localhost$/i,
-    /^127\./,
-    /^10\./,
-    /^172\.(1[6-9]|2\d|3[01])\./,
-    /^192\.168\./,
-    /^169\.254\./,
-    /^::1$/i,
-    /^fc00:/i,
-    /^fe80:/i,
-];
 
 /**
  * Extract the embedded IPv4 address from an IPv6-mapped IPv4 address.
@@ -34,10 +19,15 @@ function getMappedIpv4(hostname: string): string | null {
 /**
  * Returns true when the hostname is a safe external address, false for any
  * private, loopback, or link-local hostname.
+ *
+ * IPv6 literals arrive from `URL.hostname` with their brackets intact (e.g.
+ * "[fd00::1]"), so they are stripped before matching against the shared
+ * blocked-pattern list used by `validateOutboundUrl`.
  */
 function isAllowedHostname(hostname: string): boolean {
-    const mappedIpv4 = getMappedIpv4(hostname);
-    const normalizedHostname = mappedIpv4 ?? hostname;
+    const strippedHostname = hostname.replace(/^\[|\]$/g, "");
+    const mappedIpv4 = getMappedIpv4(strippedHostname);
+    const normalizedHostname = mappedIpv4 ?? strippedHostname;
 
     if (
         process.env.NODE_ENV !== "production" &&
@@ -46,7 +36,7 @@ function isAllowedHostname(hostname: string): boolean {
         return true;
     }
 
-    return !BLOCKED_HOSTNAME_PATTERNS.some((pattern) => pattern.test(normalizedHostname));
+    return !isBlockedOutboundHost(normalizedHostname);
 }
 
 /**

--- a/apps/api/src/routes/ml.ts
+++ b/apps/api/src/routes/ml.ts
@@ -11,6 +11,7 @@ import { requireAuth, AuthenticatedRequest } from "../middleware/auth";
 import logger from "../utils/logger";
 import { limiter } from "../middleware/rateLimit";
 import { redisClient } from "../utils/redis";
+import { isBlockedOutboundHost } from "../utils/security/urlValidator";
 
 const router = Router();
 
@@ -25,13 +26,7 @@ const analyzeResponseSchema = z.object({
     details: z.string(),
 });
 
-const PRIVATE_IP_RE =
-    /^(127\.\d{1,3}\.\d{1,3}\.\d{1,3}|10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|::1|::ffff:127\.\d{1,3}\.\d{1,3}\.\d{1,3}|0\.0\.0\.0)$/;
-
 const LINK_LOCAL_HOSTNAMES = [".local", ".internal", ".nip.io", ".localtest.me"];
-
-const PRIVATE_HOSTNAME_RE =
-    /^(localhost|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|::1|::ffff:127\.\d{1,3}\.\d{1,3}\.\d{1,3}|0\.0\.0\.0)$/;
 
 const ML_ANALYSIS_CACHE_TTL_SECONDS = 3600; // 1 hour
 const ML_ANALYSIS_TIMEOUT_MS = 8000;
@@ -41,18 +36,14 @@ function buildCacheKey(imageUrl: string): string {
     return `ml:analyze:${hash}`;
 }
 
-function isPrivateIp(ip: string): boolean {
-    return PRIVATE_IP_RE.test(ip);
-}
-
 async function isPrivateHostname(urlStr: string): Promise<boolean> {
     try {
-        const hostname = new URL(urlStr).hostname;
-        if (PRIVATE_HOSTNAME_RE.test(hostname)) return true;
+        const hostname = new URL(urlStr).hostname.replace(/^\[|\]$/g, "");
+        if (isBlockedOutboundHost(hostname)) return true;
         if (LINK_LOCAL_HOSTNAMES.some((s) => hostname.endsWith(s))) return true;
 
         const addresses = await dns.resolve4(hostname);
-        return addresses.some((addr) => isPrivateIp(addr));
+        return addresses.some((addr) => isBlockedOutboundHost(addr));
     } catch {
         return true;
     }

--- a/apps/api/src/utils/security/urlValidator.ts
+++ b/apps/api/src/utils/security/urlValidator.ts
@@ -8,20 +8,60 @@ import dns from "dns/promises";
  * attacker could otherwise supply a cloud-metadata address (169.254.169.254),
  * a loopback address, or an internal service URL that gets fetched by the
  * server (SSRF). These cover loopback, the RFC 1918 private ranges,
- * link-local, and their IPv6 equivalents.
+ * link-local, carrier-grade NAT (100.64.0.0/10), IPv6 ULA, IPv6 link-local,
+ * the unspecified address, and their IPv6-mapped equivalents.
  */
 export const BLOCKED_OUTBOUND_URL_PATTERNS = [
     /^localhost$/i,
+    /^0\./,
     /^127\./,
     /^10\./,
     /^172\.(1[6-9]|2\d|3[01])\./,
     /^192\.168\./,
     /^169\.254\./,
+    /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./,
+    /^::$/,
     /^::1$/,
-    /^fc00:/i,
-    /^fe80:/i,
+    /^f[cd][0-9a-f]{2}:/i,
+    /^fe[89ab][0-9a-f]:/i,
     /^::ffff:/i,
 ];
+
+/**
+ * Extract an embedded IPv4 address from the trailing 32 bits of an IPv6
+ * literal. Handles both IPv4-mapped (`::ffff:7f00:1`, `::ffff:127.0.0.1`) and
+ * deprecated IPv4-compatible (`::7f00:1`, `::127.0.0.1`) forms, in hex or
+ * dotted-decimal, so the embedded address can be re-checked against the IPv4
+ * blocked patterns.
+ *
+ * Returns `null` for anything that is not one of these IPv6-wrapped IPv4
+ * forms. The regex only matches `::`-prefixed literals, which always fall in
+ * the reserved `::/8` block, so no public IPv6 address can be misclassified.
+ */
+function getEmbeddedIpv4(host: string): string | null {
+    const match = host.match(/^::(?:ffff:)?([0-9a-f:]+)$/i);
+    if (!match) return null;
+
+    const groups = match[1].split(":").filter((group) => group !== "");
+    if (groups.length === 0 || groups.length > 4) return null;
+
+    const hex = groups.map((group) => group.padStart(4, "0")).join("");
+    if (!/^[0-9a-f]{8}$/i.test(hex)) return null;
+
+    const octets = hex.match(/[0-9a-f]{2}/gi)!.map((octet) => parseInt(octet, 16));
+    return octets.join(".");
+}
+
+export function isBlockedOutboundHost(host: string): boolean {
+    if (BLOCKED_OUTBOUND_URL_PATTERNS.some((pattern) => pattern.test(host))) return true;
+
+    const embeddedIpv4 = getEmbeddedIpv4(host);
+    if (embeddedIpv4 !== null) {
+        return BLOCKED_OUTBOUND_URL_PATTERNS.some((pattern) => pattern.test(embeddedIpv4));
+    }
+
+    return false;
+}
 
 /**
  * Hard cap on how long a DNS lookup is allowed to take. Without this a slow or
@@ -29,10 +69,6 @@ export const BLOCKED_OUTBOUND_URL_PATTERNS = [
  * via `DNS_LOOKUP_TIMEOUT_MS` so tests can shorten it.
  */
 const DNS_TIMEOUT_MS = parseInt(process.env.DNS_LOOKUP_TIMEOUT_MS ?? "3000", 10);
-
-function isBlockedHost(host: string): boolean {
-    return BLOCKED_OUTBOUND_URL_PATTERNS.some((pattern) => pattern.test(host));
-}
 
 /**
  * Validates that `rawUrl` is safe to fetch from the server.
@@ -51,7 +87,7 @@ export async function validateOutboundUrl(rawUrl: string): Promise<boolean> {
 
         // Strip the brackets around IPv6 literals (e.g. "[::1]" -> "::1").
         const normalizedHost = hostname.replace(/^\[|\]$/g, "");
-        if (isBlockedHost(normalizedHost)) return false;
+        if (isBlockedOutboundHost(normalizedHost)) return false;
 
         // Race the DNS lookup against a hard timeout so a slow resolver can't
         // hang the request.
@@ -65,7 +101,7 @@ export async function validateOutboundUrl(rawUrl: string): Promise<boolean> {
             }),
         ])) as { address: string };
 
-        if (isBlockedHost(address)) return false;
+        if (isBlockedOutboundHost(address)) return false;
 
         return true;
     } catch {

--- a/apps/api/tests/ml.test.ts
+++ b/apps/api/tests/ml.test.ts
@@ -24,7 +24,6 @@ jest.mock("node:dns", () => ({
 import { promises as dnsMock } from "node:dns";
 import { Request, Response, NextFunction } from "express";
 
-
 function buildApp() {
     const app = express();
     app.use(express.json());
@@ -163,6 +162,42 @@ describe("ml routes", () => {
             .post("/api/ml/analyze")
             .set("Authorization", VALID_TOKEN)
             .send({ imageUrl: "https://169.254.169.254/latest/meta-data/" });
+
+        assert.equal(response.status, 400);
+    });
+
+    it("rejects requests to 0.0.0.0 (SSRF protection)", async () => {
+        const response = await request(buildApp())
+            .post("/api/ml/analyze")
+            .set("Authorization", VALID_TOKEN)
+            .send({ imageUrl: "https://0.0.0.0/admin" });
+
+        assert.equal(response.status, 400);
+    });
+
+    it("rejects requests to carrier-grade NAT ranges (SSRF protection)", async () => {
+        const response = await request(buildApp())
+            .post("/api/ml/analyze")
+            .set("Authorization", VALID_TOKEN)
+            .send({ imageUrl: "https://100.64.0.1/internal" });
+
+        assert.equal(response.status, 400);
+    });
+
+    it("rejects requests to IPv6 ULA and unspecified addresses (SSRF protection)", async () => {
+        const response = await request(buildApp())
+            .post("/api/ml/analyze")
+            .set("Authorization", VALID_TOKEN)
+            .send({ imageUrl: "https://[fd00::1]/internal" });
+
+        assert.equal(response.status, 400);
+    });
+
+    it("rejects requests to IPv6-mapped IPv4 literals (SSRF protection)", async () => {
+        const response = await request(buildApp())
+            .post("/api/ml/analyze")
+            .set("Authorization", VALID_TOKEN)
+            .send({ imageUrl: "https://[::ffff:7f00:1]/internal" });
 
         assert.equal(response.status, 400);
     });

--- a/apps/api/tests/urlValidator.test.ts
+++ b/apps/api/tests/urlValidator.test.ts
@@ -4,6 +4,7 @@ import dns from "dns/promises";
 import {
     validateOutboundUrl,
     BLOCKED_OUTBOUND_URL_PATTERNS,
+    isBlockedOutboundHost,
 } from "../src/utils/security/urlValidator";
 
 jest.mock("dns/promises", () => ({
@@ -38,15 +39,43 @@ describe("validateOutboundUrl", () => {
 
     it.each([
         "http://localhost/x",
+        "http://0.0.0.0/x",
         "http://127.0.0.1/x",
         "http://10.0.0.5/x",
         "http://172.16.0.1/x",
         "http://192.168.1.1/x",
         "http://169.254.169.254/latest/meta-data",
+        "http://100.64.0.1/x",
+        "http://100.127.255.254/x",
+        "http://[::]/x",
         "http://[::1]/x",
+        "http://[::ffff:7f00:1]/x",
+        "http://[::ffff:127.0.0.1]/x",
+        "http://[::7f00:1]/x",
+        "http://[::127.0.0.1]/x",
+        "http://[fc00::1]/x",
+        "http://[fc01::1]/x",
+        "http://[fd00::1]/x",
+        "http://[fe80::1]/x",
+        "http://[fe81::1]/x",
+        "http://[fea0::1]/x",
+        "http://[febf::1]/x",
     ])("rejects blocked literal host %s before lookup", async (url) => {
         await expect(validateOutboundUrl(url)).resolves.toBe(false);
         expect(mockedLookup).not.toHaveBeenCalled();
+    });
+
+    it("rejects an IPv6 literal that embeds a private IPv4 (e.g. ::10.0.0.1)", async () => {
+        expect(isBlockedOutboundHost("::a00:1")).toBe(true);
+        expect(isBlockedOutboundHost("::ffff:7f00:1")).toBe(true);
+    });
+
+    it("accepts boundary addresses just outside the blocked ranges", async () => {
+        await expect(validateOutboundUrl("http://100.63.255.255/x")).resolves.toBe(true);
+        await expect(validateOutboundUrl("http://100.128.0.1/x")).resolves.toBe(true);
+        await expect(validateOutboundUrl("http://8.8.8.8/x")).resolves.toBe(true);
+        await expect(validateOutboundUrl("http://[2001:4860:4860::8888]/x")).resolves.toBe(true);
+        await expect(validateOutboundUrl("http://[fec0::1]/x")).resolves.toBe(true);
     });
 
     it("rejects a public hostname that resolves to a private address", async () => {
@@ -68,5 +97,10 @@ describe("validateOutboundUrl", () => {
     it("exposes the blocked-pattern list for reuse", () => {
         expect(BLOCKED_OUTBOUND_URL_PATTERNS.some((p) => p.test("127.0.0.1"))).toBe(true);
         expect(BLOCKED_OUTBOUND_URL_PATTERNS.some((p) => p.test("8.8.8.8"))).toBe(false);
+        expect(BLOCKED_OUTBOUND_URL_PATTERNS.some((p) => p.test("100.64.0.1"))).toBe(true);
+        expect(BLOCKED_OUTBOUND_URL_PATTERNS.some((p) => p.test("100.63.255.255"))).toBe(false);
+        expect(BLOCKED_OUTBOUND_URL_PATTERNS.some((p) => p.test("fd00::1"))).toBe(true);
+        expect(BLOCKED_OUTBOUND_URL_PATTERNS.some((p) => p.test("fe81::1"))).toBe(true);
+        expect(BLOCKED_OUTBOUND_URL_PATTERNS.some((p) => p.test("fec0::1"))).toBe(false);
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3969**
- **Summary:** Complete and consistency the SSRF blocklist in the backend's outbound URL validation. Empirically confirmed before the fix that `0.0.0.0`, `100.64.0.0/10`, IPv6 `::`, IPv6 ULA (`fc00::/7`) and non-`fe80` link-local ranges all passed `validateOutboundUrl`; only a subset (`127.0.0.1`, `::ffff:7f00:1`, `::1`, `fc00:`, `fe80:`) was blocked. This PR:

  - Adds the missing reserved ranges to `BLOCKED_OUTBOUND_URL_PATTERNS` in `apps/api/src/utils/security/urlValidator.ts`:
    - `0.0.0.0/8`
    - `100.64.0.0/10` (carrier-grade NAT, incl. boundary tests `100.63.255.255` vs `100.64.0.1` / `100.127.255.254`)
    - IPv6 unspecified `::`
    - full IPv6 ULA `fc00::/7` (`f[cd][0-9a-f]{2}:`, covers `fd00::1`)
    - full IPv6 link-local `fe80::/10` (`fe[89ab][0-9a-f]:`, covers `fe81::1`, `fea0::1`, `febf::1`)
  - Decodes IPv6-wrapped IPv4 literals (`::ffff:7f00:1`, `::7f00:1`, dotted or hex) and re-checks the embedded address against the IPv4 rules, closing loopback/private bypasses through IPv6 forms.
  - Centralizes the three duplicated pattern lists behind a single exported `isBlockedOutboundHost()` helper, reused by `validateOutboundUrl`, `config/mlService.ts`, and `routes/ml.ts` so all backend outbound-URL checks stay consistent. `routes/ml.ts` previously missed `100.64.0.0/10`, IPv6 ULA, `::`, and the hex-canonicalized `::ffff:` form.
  - Fixes the IPv6 bracket gap: `URL.hostname` keeps brackets (e.g. `[fd00::1]`), which previously let IPv6 literals through the API's ML-service validator.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

Backend change — test logs:

- `apps/api/tests/urlValidator.test.ts` → **32 passed** (includes all new blocked vectors, boundary-accept cases, and embedded-IPv4 checks).
- `apps/api/tests/ml.test.ts` → 17 passed incl. new SSRF cases (`0.0.0.0`, `100.64.0.1`, `[fd00::1]`, `[::ffff:7f00:1]`). The 2 remaining failures (`proxies valid Cloudinary URLs`, `allows domains whose DNS resolves to a public IP`) are **pre-existing on the base branch** — an ML-fetch mock/environment issue unrelated to this change (verified via `git stash`).
- `apps/api/tests/reports.test.ts` (only production caller of `validateOutboundUrl`) → **27 passed**.
- `tsc --noEmit -p apps/api/tsconfig.json` → clean. (`npm run test:types` fails on base for all test files — pre-existing `rootDir`/`include` mismatch.)

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3969`)
- [x] I have pulled the latest `main` and resolved any conflicts
