### PR TITLE
fix(api): authTargetLimiter keys on 'phone' so per-phone OTP throttling works

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -194,7 +194,9 @@ export const authTargetLimiter = createKeyLimiter({
     keyGenerator: (req: Request) => {
         // Look for common identity keys in the request body
         if (req.body?.abhaAddress) return `abha:${req.body.abhaAddress}`;
-        if (req.body?.phone_number) return `phone:${req.body.phone_number}`;
+        // The register and verify-otp routes send the phone as `phone`, not `phone_number`.
+        // Reading `phone_number` made per-target OTP throttling a no-op.
+        if (req.body?.phone) return `phone:${req.body.phone}`;
         // Fallback to IP if no explicit target is found
         return (req.ip || "unknown").replace(/:/g, "_");
     },


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3977**
- **Summary:** \uthTargetLimiter\\s keyGenerator read \eq.body.phone_number\, but the throttled routes — notifications \/register\ and \/verify-otp\ — send the target phone as \phone\ (per \egisterSchema\/\erifyOtpSchema\). As a result every request fell through to the IP fallback and per-phone OTP bombing protection was a no-op. The keyGenerator now keys on \phone\ (with the \bhaAddress\ branch unchanged, used by the ABHA link/verify-otp routes).

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_ N/A — backend change.

\\\
tsc --noEmit: clean (exit 0)
\\\

## 🏷️ PR Type

- [x] 🐛 \	ype: bug\
- [ ] ✨ \	ype: feature\
- [ ] 📖 \	ype: docs\
- [ ] 🧪 \	ype: testing\
- [ ] 🔒 \	ype: security\
- [ ] ⚡ \	ype: performance\
- [ ] 🎨 \	ype: design\
- [ ] ♻️ \	ype: refactor\
- [ ] 🛠️ \	ype: devops\
- [ ] ♿ \	ype: accessibility\

## ✅ Checklist

- [x] My PR has a linked issue (\Closes #123\)
- [x] I have pulled the latest \main\ and resolved any conflicts
