### PR TITLE
fix(api): derive verify-brand verified status from medicine state (Closes #3997)

### DIFF
--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -21,6 +21,7 @@ import { supabase } from "../db/client";
 
 import { optionalAuth } from "../middleware/auth";
 import { escapeIlike, escapePostgrest, buildOrConditions } from "../utils/db";
+import { computeVerifiedStatus } from "../utils/verification";
 import { scanService } from "../services/scan.service";
 
 const router = Router();
@@ -559,7 +560,7 @@ router.post("/verify-brand", scanQueryLimiter, async (req: Request, res: Respons
         }
 
         const responseData = {
-            verified: true,
+            verified: computeVerifiedStatus(data),
             medicine: {
                 id: data.id,
                 brand_name: data.brand_name,

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -107,6 +107,7 @@ router.post(
 
             const payload = req.body;
             const record = payload.record || payload.old_record || {};
+            const oldRecord = payload.old_record || {};
             const batchNumber = record.batch_number;
             const brandName = record.brand_name;
             const genericName = record.generic_name;
@@ -128,7 +129,25 @@ router.post(
                 keysToDelete.push(`medicine:voice:${normalizedGeneric}`);
             }
 
-            // 3. Perform deletion if keys exist
+            // 3. Invalidate verify-brand cache for matching brand and generic names
+            if (brandName) {
+                keysToDelete.push(`brand_cache:${brandName.trim().toLowerCase()}`);
+            }
+            if (genericName) {
+                keysToDelete.push(`brand_cache:${genericName.trim().toLowerCase()}`);
+            }
+
+            // Counterfeit-flag transitions can stale verify-brand cache entries keyed
+            // by any user-supplied substring (e.g. "dolo"), which exact-name deletion
+            // above cannot enumerate — sweep the whole namespace on that rare event.
+            if (
+                oldRecord.is_counterfeit_alert !== undefined &&
+                Boolean(oldRecord.is_counterfeit_alert) !== Boolean(record.is_counterfeit_alert)
+            ) {
+                await invalidateCacheByPattern("brand_cache:*");
+            }
+
+            // 4. Perform deletion if keys exist
             const uniqueKeys = Array.from(new Set(keysToDelete));
             if (uniqueKeys.length > 0) {
                 await redisClient.del(uniqueKeys);

--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -111,6 +111,8 @@ router.post(
             const batchNumber = record.batch_number;
             const brandName = record.brand_name;
             const genericName = record.generic_name;
+            const oldBrandName = oldRecord.brand_name;
+            const oldGenericName = oldRecord.generic_name;
 
             const keysToDelete: string[] = [];
 
@@ -129,21 +131,24 @@ router.post(
                 keysToDelete.push(`medicine:voice:${normalizedGeneric}`);
             }
 
-            // 3. Invalidate verify-brand cache for matching brand and generic names
-            if (brandName) {
-                keysToDelete.push(`brand_cache:${brandName.trim().toLowerCase()}`);
+            // 3. Invalidate verify-brand cache for the old and new brand names and the
+            //    old and new generic names (renames leave old-name keys behind).
+            for (const name of [brandName, oldBrandName]) {
+                if (name) {
+                    keysToDelete.push(`brand_cache:${name.trim().toLowerCase()}`);
+                }
             }
-            if (genericName) {
-                keysToDelete.push(`brand_cache:${genericName.trim().toLowerCase()}`);
+            for (const name of [genericName, oldGenericName]) {
+                if (name) {
+                    keysToDelete.push(`brand_cache:${name.trim().toLowerCase()}`);
+                }
             }
 
-            // Counterfeit-flag transitions can stale verify-brand cache entries keyed
-            // by any user-supplied substring (e.g. "dolo"), which exact-name deletion
-            // above cannot enumerate — sweep the whole namespace on that rare event.
-            if (
-                oldRecord.is_counterfeit_alert !== undefined &&
-                Boolean(oldRecord.is_counterfeit_alert) !== Boolean(record.is_counterfeit_alert)
-            ) {
+            // Transitions in either field that feeds the computed `verified` verdict
+            // (is_cdsco_verified && !is_counterfeit_alert) can stale verify-brand cache
+            // entries keyed by any user-supplied substring (e.g. "dolo"), which exact-name
+            // deletion above cannot enumerate — sweep the whole namespace on that rare event.
+            if (verificationStatusChanged(oldRecord, record)) {
                 await invalidateCacheByPattern("brand_cache:*");
             }
 
@@ -169,6 +174,24 @@ router.post(
         }
     }
 );
+
+/**
+ * Whether the computed `verified` verdict could have changed between the old and
+ * new medicine records. The verdict derives from both `is_cdsco_verified` and
+ * `is_counterfeit_alert`, so a transition in either field can flip it for any
+ * user-supplied substring cache key that exact-name deletion cannot enumerate.
+ */
+function verificationStatusChanged(
+    oldRecord: Record<string, unknown>,
+    record: Record<string, unknown>
+): boolean {
+    const flipped = (before: unknown, after: unknown): boolean =>
+        before !== undefined && after !== undefined && Boolean(before) !== Boolean(after);
+    return (
+        flipped(oldRecord.is_counterfeit_alert, record.is_counterfeit_alert) ||
+        flipped(oldRecord.is_cdsco_verified, record.is_cdsco_verified)
+    );
+}
 
 /**
  * Helper to execute cache invalidation out-of-band/non-blocking

--- a/apps/api/src/services/scan.service.ts
+++ b/apps/api/src/services/scan.service.ts
@@ -1,6 +1,7 @@
 import { scanRepository } from "../repositories/scan.repository";
 import { redisRepository } from "../repositories/redis.repository";
 import { getMlAuthHeaders } from "../config/mlService";
+import { computeVerifiedStatus } from "../utils/verification";
 import logger from "../utils/logger";
 
 function calculateAdvancedMatchScore(ocrText: string, candidate: string): number {
@@ -318,7 +319,7 @@ export const scanService = {
         }
 
         const responseData = {
-            verified: true,
+            verified: computeVerifiedStatus(data),
             medicine: {
                 id: data.id,
                 brand_name: data.brand_name,

--- a/apps/api/src/utils/verification.ts
+++ b/apps/api/src/utils/verification.ts
@@ -1,0 +1,24 @@
+/**
+ * Medicine verification helpers.
+ *
+ * Centralizes the business rule that decides whether a medicine record is
+ * reported as "verified" to clients. Used by the verify-brand endpoints so the
+ * verdict is always derived from the actual medicine status instead of being
+ * hardcoded.
+ */
+
+export interface VerificationFields {
+    is_cdsco_verified?: boolean | null;
+    is_counterfeit_alert?: boolean | null;
+}
+
+/**
+ * Compute the top-level `verified` status for a medicine.
+ *
+ * A medicine is reported as verified only when its data has been matched
+ * against the CDSCO database (`is_cdsco_verified`) AND it has no active
+ * counterfeit alert (`is_counterfeit_alert`).
+ */
+export function computeVerifiedStatus(medicine: VerificationFields): boolean {
+    return medicine.is_cdsco_verified === true && medicine.is_counterfeit_alert !== true;
+}

--- a/apps/api/tests/routes/webhooks.test.ts
+++ b/apps/api/tests/routes/webhooks.test.ts
@@ -172,6 +172,58 @@ describe("Webhooks Routes", () => {
             expect(deletedKeys).toContain("brand_cache:aspirin");
         });
 
+        it("deletes the old brand cache key when the brand is renamed", async () => {
+            (invalidateCacheByPattern as jest.Mock).mockResolvedValue([]);
+
+            const res = await request(app)
+                .post("/api/webhooks/supabase/medicines")
+                .set("Authorization", "Bearer test-secret")
+                .send({
+                    record: {
+                        batch_number: "B123",
+                        brand_name: "New Brand",
+                        generic_name: "Aspirin",
+                    },
+                    old_record: {
+                        batch_number: "B123",
+                        brand_name: "Old Brand",
+                        generic_name: "Aspirin",
+                    },
+                });
+
+            expect(res.status).toBe(200);
+
+            const deletedKeys = (redisClient.del as jest.Mock).mock.calls[0][0];
+            expect(deletedKeys).toContain("brand_cache:old brand");
+            expect(deletedKeys).toContain("brand_cache:new brand");
+        });
+
+        it("deletes the old generic cache key when the generic is renamed", async () => {
+            (invalidateCacheByPattern as jest.Mock).mockResolvedValue([]);
+
+            const res = await request(app)
+                .post("/api/webhooks/supabase/medicines")
+                .set("Authorization", "Bearer test-secret")
+                .send({
+                    record: {
+                        batch_number: "B123",
+                        brand_name: "Aspirin Plus",
+                        generic_name: "New Generic",
+                    },
+                    old_record: {
+                        batch_number: "B123",
+                        brand_name: "Aspirin Plus",
+                        generic_name: "Old Generic",
+                    },
+                });
+
+            expect(res.status).toBe(200);
+
+            const deletedKeys = (redisClient.del as jest.Mock).mock.calls[0][0];
+            expect(deletedKeys).toContain("brand_cache:old generic");
+            expect(deletedKeys).toContain("brand_cache:new generic");
+        });
+
         it("sweeps all verify-brand cache keys when the counterfeit alert flag changes", async () => {
             (invalidateCacheByPattern as jest.Mock).mockResolvedValue([]);
 
@@ -195,6 +247,31 @@ describe("Webhooks Routes", () => {
             expect(invalidateCacheByPattern).toHaveBeenCalledWith("brand_cache:*");
         });
 
+        it("sweeps all verify-brand cache keys when the CDSCO verification flag changes", async () => {
+            (invalidateCacheByPattern as jest.Mock).mockResolvedValue([]);
+
+            const res = await request(app)
+                .post("/api/webhooks/supabase/medicines")
+                .set("Authorization", "Bearer test-secret")
+                .send({
+                    record: {
+                        batch_number: "B123",
+                        brand_name: "Aspirin Plus",
+                        is_cdsco_verified: true,
+                        is_counterfeit_alert: false,
+                    },
+                    old_record: {
+                        batch_number: "B123",
+                        brand_name: "Aspirin Plus",
+                        is_cdsco_verified: false,
+                        is_counterfeit_alert: false,
+                    },
+                });
+
+            expect(res.status).toBe(200);
+            expect(invalidateCacheByPattern).toHaveBeenCalledWith("brand_cache:*");
+        });
+
         it("does not sweep brand cache when the counterfeit alert flag is unchanged", async () => {
             (invalidateCacheByPattern as jest.Mock).mockResolvedValue([]);
 
@@ -210,6 +287,31 @@ describe("Webhooks Routes", () => {
                     old_record: {
                         batch_number: "B123",
                         brand_name: "Aspirin Plus",
+                        is_counterfeit_alert: false,
+                    },
+                });
+
+            expect(res.status).toBe(200);
+            expect(invalidateCacheByPattern).not.toHaveBeenCalledWith("brand_cache:*");
+        });
+
+        it("does not sweep brand cache when verification-related fields are unchanged", async () => {
+            (invalidateCacheByPattern as jest.Mock).mockResolvedValue([]);
+
+            const res = await request(app)
+                .post("/api/webhooks/supabase/medicines")
+                .set("Authorization", "Bearer test-secret")
+                .send({
+                    record: {
+                        batch_number: "B456",
+                        brand_name: "Aspirin Plus",
+                        is_cdsco_verified: true,
+                        is_counterfeit_alert: false,
+                    },
+                    old_record: {
+                        batch_number: "B123",
+                        brand_name: "Aspirin Plus",
+                        is_cdsco_verified: true,
                         is_counterfeit_alert: false,
                     },
                 });

--- a/apps/api/tests/routes/webhooks.test.ts
+++ b/apps/api/tests/routes/webhooks.test.ts
@@ -150,6 +150,73 @@ describe("Webhooks Routes", () => {
             expect(deletedKeys).toContain("medicine:voice:aspirin");
             expect(deletedKeys).not.toContain("drug:batch:B123:data");
         });
+
+        it("invalidates verify-brand cache for brand and generic names", async () => {
+            (invalidateCacheByPattern as jest.Mock).mockResolvedValue([]);
+
+            const res = await request(app)
+                .post("/api/webhooks/supabase/medicines")
+                .set("Authorization", "Bearer test-secret")
+                .send({
+                    record: {
+                        batch_number: "B123",
+                        brand_name: "Aspirin Plus",
+                        generic_name: "Aspirin",
+                    },
+                });
+
+            expect(res.status).toBe(200);
+
+            const deletedKeys = (redisClient.del as jest.Mock).mock.calls[0][0];
+            expect(deletedKeys).toContain("brand_cache:aspirin plus");
+            expect(deletedKeys).toContain("brand_cache:aspirin");
+        });
+
+        it("sweeps all verify-brand cache keys when the counterfeit alert flag changes", async () => {
+            (invalidateCacheByPattern as jest.Mock).mockResolvedValue([]);
+
+            const res = await request(app)
+                .post("/api/webhooks/supabase/medicines")
+                .set("Authorization", "Bearer test-secret")
+                .send({
+                    record: {
+                        batch_number: "B123",
+                        brand_name: "Aspirin Plus",
+                        is_counterfeit_alert: true,
+                    },
+                    old_record: {
+                        batch_number: "B123",
+                        brand_name: "Aspirin Plus",
+                        is_counterfeit_alert: false,
+                    },
+                });
+
+            expect(res.status).toBe(200);
+            expect(invalidateCacheByPattern).toHaveBeenCalledWith("brand_cache:*");
+        });
+
+        it("does not sweep brand cache when the counterfeit alert flag is unchanged", async () => {
+            (invalidateCacheByPattern as jest.Mock).mockResolvedValue([]);
+
+            const res = await request(app)
+                .post("/api/webhooks/supabase/medicines")
+                .set("Authorization", "Bearer test-secret")
+                .send({
+                    record: {
+                        batch_number: "B123",
+                        brand_name: "Aspirin Plus",
+                        is_counterfeit_alert: false,
+                    },
+                    old_record: {
+                        batch_number: "B123",
+                        brand_name: "Aspirin Plus",
+                        is_counterfeit_alert: false,
+                    },
+                });
+
+            expect(res.status).toBe(200);
+            expect(invalidateCacheByPattern).not.toHaveBeenCalledWith("brand_cache:*");
+        });
     });
 
     describe("POST /api/webhooks/supabase/pharmacies (Async Invalidation)", () => {

--- a/apps/api/tests/scanVerifyBrand.test.ts
+++ b/apps/api/tests/scanVerifyBrand.test.ts
@@ -1,0 +1,154 @@
+import request from "supertest";
+import app from "../src/app";
+
+jest.mock("../src/db/client", () => {
+    const mock = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        ilike: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn(),
+    };
+
+    return { supabase: mock };
+});
+
+jest.mock("../src/utils/redis", () => ({
+    redisClient: {
+        isOpen: false,
+        get: jest.fn(),
+        set: jest.fn(),
+    },
+}));
+
+import { supabase } from "../src/db/client";
+import { redisClient } from "../src/utils/redis";
+
+const medicineFixture = (overrides: Record<string, unknown> = {}) => ({
+    id: "11111111-1111-1111-1111-111111111111",
+    brand_name: "Dolo 650",
+    generic_name: "Paracetamol",
+    manufacturer: "Micro Labs Ltd",
+    batch_number: "BN2024001",
+    expiry_date: "2026-12-31",
+    cdsco_approval_status: "approved",
+    is_counterfeit_alert: false,
+    is_cdsco_verified: true,
+    cdsco_match_score: 98.4,
+    matched_cdsco_product: "Dolo 650",
+    matched_cdsco_manufacturer: "Micro Labs Ltd",
+    product_match_score: 97,
+    manufacturer_match_score: 100,
+    ...overrides,
+});
+
+describe("POST /api/v1/scan/verify-brand", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (redisClient as any).isOpen = false;
+        ((redisClient as any).get as jest.Mock).mockResolvedValue(null);
+        ((supabase as any).maybeSingle as jest.Mock).mockResolvedValue({
+            data: medicineFixture(),
+            error: null,
+        });
+    });
+
+    it("reports verified when the medicine is CDSCO verified and not flagged counterfeit", async () => {
+        ((supabase as any).maybeSingle as jest.Mock).mockResolvedValue({
+            data: medicineFixture({ is_cdsco_verified: true, is_counterfeit_alert: false }),
+            error: null,
+        });
+
+        const res = await request(app)
+            .post("/api/v1/scan/verify-brand")
+            .send({ brandName: "Dolo 650" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.verified).toBe(true);
+        expect(res.body.medicine.brand_name).toBe("Dolo 650");
+    });
+
+    it("reports unverified when the medicine is flagged as counterfeit", async () => {
+        ((supabase as any).maybeSingle as jest.Mock).mockResolvedValue({
+            data: medicineFixture({ is_cdsco_verified: true, is_counterfeit_alert: true }),
+            error: null,
+        });
+
+        const res = await request(app)
+            .post("/api/v1/scan/verify-brand")
+            .send({ brandName: "Dolo 650" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.verified).toBe(false);
+        expect(res.body.medicine.is_counterfeit_alert).toBe(true);
+    });
+
+    it("reports unverified when the medicine is not CDSCO verified", async () => {
+        ((supabase as any).maybeSingle as jest.Mock).mockResolvedValue({
+            data: medicineFixture({ is_cdsco_verified: false, is_counterfeit_alert: false }),
+            error: null,
+        });
+
+        const res = await request(app)
+            .post("/api/v1/scan/verify-brand")
+            .send({ brandName: "Dolo 650" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.verified).toBe(false);
+    });
+
+    it("stores the correctly computed verification status in the Redis cache", async () => {
+        (redisClient as any).isOpen = true;
+        ((redisClient as any).get as jest.Mock).mockResolvedValue(null);
+        ((supabase as any).maybeSingle as jest.Mock).mockResolvedValue({
+            data: medicineFixture({ is_cdsco_verified: true, is_counterfeit_alert: true }),
+            error: null,
+        });
+
+        const res = await request(app)
+            .post("/api/v1/scan/verify-brand")
+            .send({ brandName: "Dolo 650" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.verified).toBe(false);
+
+        const setMock = (redisClient as any).set as jest.Mock;
+        expect(setMock).toHaveBeenCalledWith("brand_cache:dolo 650", expect.any(String), {
+            EX: 86400,
+        });
+        const cachedPayload = JSON.parse(setMock.mock.calls[0][1]);
+        expect(cachedPayload.verified).toBe(false);
+        expect(cachedPayload.medicine.is_counterfeit_alert).toBe(true);
+    });
+
+    it("returns the cached response (with correct computed status) on a cache hit", async () => {
+        (redisClient as any).isOpen = true;
+        ((redisClient as any).get as jest.Mock).mockResolvedValue(
+            JSON.stringify({
+                verified: false,
+                medicine: medicineFixture({ is_cdsco_verified: true, is_counterfeit_alert: true }),
+            })
+        );
+
+        const res = await request(app)
+            .post("/api/v1/scan/verify-brand")
+            .send({ brandName: "Dolo 650" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.verified).toBe(false);
+        expect((supabase as any).from).not.toHaveBeenCalled();
+    });
+
+    it("serves unverified for a medicine not found in the database", async () => {
+        ((supabase as any).maybeSingle as jest.Mock)
+            .mockResolvedValueOnce({ data: null, error: null })
+            .mockResolvedValueOnce({ data: null, error: null });
+
+        const res = await request(app)
+            .post("/api/v1/scan/verify-brand")
+            .send({ brandName: "Unknown Medicine" });
+
+        expect(res.status).toBe(404);
+        expect(res.body.verified).toBe(false);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3997**
- **Summary:** `POST /api/v1/scan/verify-brand` returned `verified: true` unconditionally (hardcoded) and cached the stale payload in Redis for 24h. This PR derives `verified` from the actual medicine state (`is_cdsco_verified && !is_counterfeit_alert`) via a shared helper, computes the correct value before caching, and invalidates `brand_cache:*` on medicines changes (including a full sweep when the counterfeit-alert flag transitions, so substring-alias keys can't serve stale verdicts).

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_

**API test output** (affects API backend only — no UI changes):

```
PASS tests/scanVerifyBrand.test.ts
PASS tests/routes/webhooks.test.ts
Tests:       17 passed, 17 total

> tsc --noEmit   (clean)
> prettier --check (all modified files pass)
```

New tests cover all five scenarios:
1. CDSCO verified + no counterfeit alert → `verified: true`
2. CDSCO verified + counterfeit alert → `verified: false`
3. Not CDSCO verified → `verified: false`
4. Redis cache stores the correctly computed status (and cache hits return it)
5. Medicine status changes → `brand_cache` invalidated via the medicines webhook (exact keys + namespace sweep on counterfeit-flag transitions)

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3997`)
- [x] I have pulled the latest `main` and resolved any conflicts
