### PR TITLE
fix(voice): restore voice triage to /api/chat to resolve 404

### DIFF
--- a/apps/web/app/[locale]/voice/page.tsx
+++ b/apps/web/app/[locale]/voice/page.tsx
@@ -644,12 +644,13 @@ export default function VoiceTriagePage() {
         setError(null);
 
         try {
-            const response = await fetch("/api/triage", {
+            const response = await fetch("/api/chat", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
-                    transcript: nextTranscript,
-                    language: activeLanguageOption.responseLanguage,
+                    mode: "voice-triage",
+                    responseLanguage: activeLanguageOption.responseLanguage,
+                    messages: [{ text: nextTranscript }],
                 }),
             });
 


### PR DESCRIPTION
﻿### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

---

## 📋 PR Summary & Link

- **Closes #3998**

- **Summary:**
  - Restored the Voice Assistant to use the existing /api/chat voice-triage endpoint instead of the non-existent /api/triage endpoint.
  - Updated the request payload to match the supported oice-triage contract (mode, esponseLanguage, and messages).
  - Reused the existing chat route, preserving ML forwarding, authentication, rate limiting, Gemini/Groq fallbacks, and response handling.
  - No backend routes or API contracts were added or modified.

---

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

Please attach:

- Before: Network tab showing POST /api/triage → **404 Not Found**.
- After: Network tab showing successful POST /api/chat.
- Voice Assistant displaying the generated medical guidance after transcription.
- (Optional) Terminal output showing lint/typecheck/tests passing.

---

## 🏷️ PR Type

- [x] 🐛 	ype: bug
- [ ] ✨ 	ype: feature
- [ ] 📖 	ype: docs
- [ ] 🧪 	ype: testing
- [ ] 🔒 	ype: security
- [ ] ⚡ 	ype: performance
- [ ] 🎨 	ype: design
- [ ] ♻️ 	ype: refactor
- [ ] 🛠️ 	ype: devops
- [ ] ♿ 	ype: accessibility

---

## ✅ Checklist

- [x] My PR has a linked issue (Closes #3998)
- [x] I have pulled the latest main and resolved any conflicts.
