### PR TITLE
fix(ml): mount /verify/compare route and use proper FastAPI responses

### DIFF
--- a/apps/ml/main.py
+++ b/apps/ml/main.py
@@ -21,7 +21,6 @@ RequestsInstrumentor().instrument()
 from services.telemetry import configure_telemetry_logging
 from services.router_loader import include_router_if_available
 from dependencies import verify_api_key
-from routers.verify import router as verify_router
 
 configure_telemetry_logging()
 logger = logging.getLogger(__name__)
@@ -110,30 +109,6 @@ if not tts_loaded:
         "TTS routes are disabled. Install google-cloud-texttospeech or configure Azure TTS."
     )
 include_router_if_available(app, "routers.voice_verify", required=True, dependencies=auth)
-
-# Directly attach the ML comparison computation layer to structural router
-@verify_router.post("/compare")
-async def compare_medicines(payload: dict):
-    medicine_a = payload.get("medicine_a", "")
-    medicine_b = payload.get("medicine_b", "")
-    
-    if not medicine_a or not medicine_b:
-        return {"error": "Both medicine names are required"}, 400
-        
-    from services.embedding import embed_query
-    from services.similarity import cosine_similarity
-    
-    emb_a = embed_query(medicine_a)
-    emb_b = embed_query(medicine_b)
-    
-    score = cosine_similarity(emb_a, emb_b)
-    
-    return {
-        "medicine_a": medicine_a,
-        "medicine_b": medicine_b,
-        "similarity_score": score,
-        "verdict": "highly_similar" if score >= 0.92 else "different"
-    }
 
 @app.get("/")
 @app.head("/")

--- a/apps/ml/routers/verify.py
+++ b/apps/ml/routers/verify.py
@@ -146,7 +146,7 @@ class CompareMedicinesResponse(BaseModel):
 
 
 @router.post("/compare", response_model=CompareMedicinesResponse)
-async def compare_medicines(payload: CompareMedicinesRequest) -> CompareMedicinesResponse:
+def compare_medicines(payload: CompareMedicinesRequest) -> CompareMedicinesResponse:
     if not payload.medicine_a.strip() or not payload.medicine_b.strip():
         raise HTTPException(
             status_code=400,

--- a/apps/ml/routers/verify.py
+++ b/apps/ml/routers/verify.py
@@ -133,6 +133,48 @@ class BatchVerifyResponse(BaseModel):
     source: str = "database"
 
 
+class CompareMedicinesRequest(BaseModel):
+    medicine_a: str
+    medicine_b: str
+
+
+class CompareMedicinesResponse(BaseModel):
+    medicine_a: str
+    medicine_b: str
+    similarity_score: float
+    verdict: str
+
+
+@router.post("/compare", response_model=CompareMedicinesResponse)
+async def compare_medicines(payload: CompareMedicinesRequest) -> CompareMedicinesResponse:
+    if not payload.medicine_a.strip() or not payload.medicine_b.strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Both medicine names are required",
+        )
+
+    from services.embedding import embed_query
+    from services.similarity import cosine_similarity
+
+    emb_a = embed_query(payload.medicine_a)
+    emb_b = embed_query(payload.medicine_b)
+
+    if emb_a is None or emb_b is None:
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to generate embeddings for one or both medicines",
+        )
+
+    score = cosine_similarity(emb_a, emb_b)
+
+    return CompareMedicinesResponse(
+        medicine_a=payload.medicine_a,
+        medicine_b=payload.medicine_b,
+        similarity_score=score,
+        verdict="highly_similar" if score >= 0.92 else "different",
+    )
+
+
 @router.post("/batch", response_model=BatchVerifyResponse)
 async def verify_batch(request: BatchVerifyRequest):
     if df.empty:

--- a/apps/ml/tests/test_verify_compare.py
+++ b/apps/ml/tests/test_verify_compare.py
@@ -1,5 +1,3 @@
-import os
-
 from dependencies import verify_api_key
 from fastapi.testclient import TestClient
 from main import app
@@ -7,9 +5,9 @@ from main import app
 client = TestClient(app)
 
 
-def test_compare_requires_api_key():
+def test_compare_requires_api_key(monkeypatch):
     app.dependency_overrides.pop(verify_api_key, None)
-    os.environ["ML_API_KEY"] = "test-secret-123"
+    monkeypatch.setenv("ML_API_KEY", "test-secret-123")
     try:
         res = client.post("/verify/compare", json={
             "medicine_a": "Dolo 650",
@@ -103,8 +101,10 @@ def test_compare_handles_embedding_failure(monkeypatch):
 
 
 def test_compare_no_mutation_of_vectors(monkeypatch):
+    vectors = {"A": [0.5, 0.5], "B": [0.25, 0.75]}
+
     def fake_embed_query(text: str):
-        return [0.5, 0.5]
+        return vectors[text]
 
     monkeypatch.setattr("services.embedding.embed_query", fake_embed_query)
 
@@ -113,3 +113,5 @@ def test_compare_no_mutation_of_vectors(monkeypatch):
         "medicine_b": "B",
     })
     assert res.status_code == 200
+    assert vectors["A"] == [0.5, 0.5]
+    assert vectors["B"] == [0.25, 0.75]

--- a/apps/ml/tests/test_verify_compare.py
+++ b/apps/ml/tests/test_verify_compare.py
@@ -1,0 +1,115 @@
+import os
+
+from dependencies import verify_api_key
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_compare_requires_api_key():
+    app.dependency_overrides.pop(verify_api_key, None)
+    os.environ["ML_API_KEY"] = "test-secret-123"
+    try:
+        res = client.post("/verify/compare", json={
+            "medicine_a": "Dolo 650",
+            "medicine_b": "Crocin",
+        })
+        assert res.status_code == 401
+    finally:
+        app.dependency_overrides[verify_api_key] = lambda: None
+
+
+def test_compare_route_registered_and_in_openapi():
+    paths = app.openapi()["paths"]
+    assert "/verify/compare" in paths
+    assert "post" in paths["/verify/compare"]
+
+
+def test_compare_returns_similarity_score(monkeypatch):
+    def fake_embed_query(text: str):
+        if text == "Dolo 650":
+            return [0.0, 1.0]
+        return [1.0, 0.0]
+
+    monkeypatch.setattr("services.embedding.embed_query", fake_embed_query)
+
+    res = client.post("/verify/compare", json={
+        "medicine_a": "Dolo 650",
+        "medicine_b": "Crocin",
+    })
+    assert res.status_code == 200
+    body = res.json()
+    assert body["medicine_a"] == "Dolo 650"
+    assert body["medicine_b"] == "Crocin"
+    assert body["similarity_score"] == 0.0
+    assert body["verdict"] == "different"
+
+
+def test_compare_highly_similar_verdict(monkeypatch):
+    def fake_embed_query(text: str):
+        return [0.6, 0.8]
+
+    monkeypatch.setattr("services.embedding.embed_query", fake_embed_query)
+    monkeypatch.setattr(
+        "services.similarity.cosine_similarity",
+        lambda a, b: 0.95,
+    )
+
+    res = client.post("/verify/compare", json={
+        "medicine_a": "Dolo 650",
+        "medicine_b": "Dolo 650",
+    })
+    assert res.status_code == 200
+    assert res.json()["similarity_score"] == 0.95
+    assert res.json()["verdict"] == "highly_similar"
+
+
+def test_compare_rejects_empty_medicine():
+    res = client.post("/verify/compare", json={
+        "medicine_a": "",
+        "medicine_b": "Crocin",
+    })
+    assert res.status_code == 400
+    assert res.json()["detail"] == "Both medicine names are required"
+
+
+def test_compare_rejects_missing_field():
+    res = client.post("/verify/compare", json={
+        "medicine_a": "Dolo 650",
+    })
+    assert res.status_code == 422
+
+
+def test_compare_rejects_non_string_field():
+    res = client.post("/verify/compare", json={
+        "medicine_a": "Dolo 650",
+        "medicine_b": 42,
+    })
+    assert res.status_code == 422
+
+
+def test_compare_handles_embedding_failure(monkeypatch):
+    def fake_embed_query(text: str):
+        return None
+
+    monkeypatch.setattr("services.embedding.embed_query", fake_embed_query)
+
+    res = client.post("/verify/compare", json={
+        "medicine_a": "Dolo 650",
+        "medicine_b": "Crocin",
+    })
+    assert res.status_code == 502
+
+
+def test_compare_no_mutation_of_vectors(monkeypatch):
+    def fake_embed_query(text: str):
+        return [0.5, 0.5]
+
+    monkeypatch.setattr("services.embedding.embed_query", fake_embed_query)
+
+    res = client.post("/verify/compare", json={
+        "medicine_a": "A",
+        "medicine_b": "B",
+    })
+    assert res.status_code == 200


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3999**
- **Summary:** `/verify/compare` always returned `404 Not Found` because the route was registered on `verify_router` *after* the router was already mounted via `include_router_if_available(app, "routers.verify", ...)`. FastAPI snapshots routes at `include_router()` time, so the `@verify_router.post("/compare")` decorator that ran later never reached the app route table. This PR moves the endpoint into `apps/ml/routers/verify.py` so it registers with the rest of the `/verify/*` routes, and fixes the incorrect `return {"error": ...}, 400` tuple response (which FastAPI serialized as `200 [dict, 400]`) by using `HTTPException` and typed Pydantic request/response models, matching project conventions.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_ N/A — ML backend change only.

### Test log (local run, `apps/ml`):

```
$ python -m pytest tests/test_api.py tests/test_verify.py tests/test_verify_compare.py -q
23 passed, 2 warnings

$ python -m pytest tests/ -q --timeout=120   # full ML suite
166 passed, 4 skipped, 5 warnings
3 failed (pre-existing test_asr_duration.py failures, reproduce on base branch)
```

New tests cover: route registered in OpenAPI (`/verify/compare` + `post`), valid request returns `similarity_score`/`verdict`, `highly_similar` verdict, empty name → 400, missing field → 422, non-string field → 422, embedding failure → 502, missing `x-api-key` → 401, and response shape.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #3999`)
- [x] I have pulled the latest `main` and resolved any conflicts
