### PR TITLE
feat: add phonetic fallback (Levenshtein/DoubleMetaphone) for LASA drug checks

### DIFF
--- a/apps/api/src/services/lasa.service.ts
+++ b/apps/api/src/services/lasa.service.ts
@@ -1,5 +1,7 @@
 import { supabase } from "../db/client";
 import type { LasaMatch, LasaMatchType } from "@sahidawa/types";
+import natural from "natural";
+import logger from "../utils/logger";
 
 // ── In-process TTL cache ────────────────────────────────────────────────────
 //
@@ -55,6 +57,64 @@ function setCached(key: string, value: LasaMatch[]): void {
     cache.set(key, { value, expiresAt: Date.now() + CACHE_TTL_MS });
 }
 
+// ── Local phonetic fallback vocabulary ──────────────────────────────────────
+// Used only when the primary Supabase RPC returns empty/errors (e.g. DB
+// connection pressure or network latency). Cached separately from match
+// results since the underlying medicine name list changes far less often.
+const VOCAB_TTL_MS = 30 * 60 * 1000;
+let vocabCache: { names: string[]; expiresAt: number } | null = null;
+
+async function getVocabulary(): Promise<string[]> {
+    if (vocabCache && Date.now() < vocabCache.expiresAt) {
+        return vocabCache.names;
+    }
+    const { data, error } = await supabase.from("medicines").select("brand_name, generic_name");
+
+    if (error || !data) {
+        // If we can't even load the vocabulary, fail safe with an empty list
+        // rather than throwing — the caller already knows the primary RPC failed.
+        return vocabCache?.names ?? [];
+    }
+
+    const names = new Set<string>();
+    for (const row of data as { brand_name: string | null; generic_name: string | null }[]) {
+        if (row.brand_name) names.add(row.brand_name);
+        if (row.generic_name) names.add(row.generic_name);
+    }
+
+    vocabCache = { names: [...names], expiresAt: Date.now() + VOCAB_TTL_MS };
+    return vocabCache.names;
+}
+
+const LEVENSHTEIN_THRESHOLD = 2;
+
+function phoneticFallback(targetName: string, vocabulary: string[]): LasaMatch[] {
+    const targetLower = targetName.toLowerCase();
+    const [targetPrimary, targetAlt] = natural.DoubleMetaphone.process(targetName);
+
+    const matches: LasaMatch[] = [];
+
+    for (const candidate of vocabulary) {
+        if (candidate.toLowerCase() === targetLower) continue;
+
+        const distance = natural.LevenshteinDistance(targetLower, candidate.toLowerCase());
+        const [candPrimary, candAlt] = natural.DoubleMetaphone.process(candidate);
+        const soundsAlike =
+            candPrimary === targetPrimary || candPrimary === targetAlt || candAlt === targetPrimary;
+
+        if (soundsAlike) {
+            matches.push({ name: candidate, type: "sound-alike", score: 1.0 });
+        } else if (distance <= LEVENSHTEIN_THRESHOLD) {
+            // Closer edit distance → higher score, capped at 0.85 to rank
+            // below true phonetic matches, matching the primary RPC's scoring.
+            const score = Math.max(0.5, 0.85 - distance * 0.15);
+            matches.push({ name: candidate, type: "look-alike", score });
+        }
+    }
+
+    return matches.sort((a, b) => b.score - a.score).slice(0, 5);
+}
+
 // ── Service ─────────────────────────────────────────────────────────────────
 
 export const detectLasaConflicts = async (medicineName: string): Promise<LasaMatch[]> => {
@@ -79,15 +139,24 @@ export const detectLasaConflicts = async (medicineName: string): Promise<LasaMat
                 target_name: targetName,
             });
 
-            if (error) {
-                throw new Error(`Failed to check LASA conflicts: ${error.message}`);
-            }
+            let result: LasaMatch[];
 
-            const result: LasaMatch[] = (data || []).map((row: LasaConflictRow) => ({
-                name: row.name,
-                type: row.match_type,
-                score: row.match_type === "sound-alike" ? 1.0 : 0.85,
-            }));
+            if (error) {
+                logger.warn("LASA RPC failed, using phonetic fallback", { error: error.message });
+                const vocabulary = await getVocabulary();
+                result = phoneticFallback(targetName, vocabulary);
+            } else {
+                result = (data || []).map((row: LasaConflictRow) => ({
+                    name: row.name,
+                    type: row.match_type,
+                    score: row.match_type === "sound-alike" ? 1.0 : 0.85,
+                }));
+
+                if (result.length === 0) {
+                    const vocabulary = await getVocabulary();
+                    result = phoneticFallback(targetName, vocabulary);
+                }
+            }
 
             setCached(cacheKey, result);
             return result;

--- a/apps/api/src/services/lasa.service.ts
+++ b/apps/api/src/services/lasa.service.ts
@@ -90,7 +90,7 @@ const LEVENSHTEIN_THRESHOLD = 2;
 
 function phoneticFallback(targetName: string, vocabulary: string[]): LasaMatch[] {
     const targetLower = targetName.toLowerCase();
-    const [targetPrimary, targetAlt] = natural.DoubleMetaphone.process(targetName);
+    const [targetPrimary, targetAlt] = (natural.DoubleMetaphone as any).process(targetName);
 
     const matches: LasaMatch[] = [];
 
@@ -98,7 +98,7 @@ function phoneticFallback(targetName: string, vocabulary: string[]): LasaMatch[]
         if (candidate.toLowerCase() === targetLower) continue;
 
         const distance = natural.LevenshteinDistance(targetLower, candidate.toLowerCase());
-        const [candPrimary, candAlt] = natural.DoubleMetaphone.process(candidate);
+        const [candPrimary, candAlt] = (natural.DoubleMetaphone as any).process(candidate);
         const soundsAlike =
             candPrimary === targetPrimary || candPrimary === targetAlt || candAlt === targetPrimary;
 

--- a/apps/api/tests/lasa-phonetic-fallback.test.ts
+++ b/apps/api/tests/lasa-phonetic-fallback.test.ts
@@ -1,0 +1,74 @@
+import { detectLasaConflicts, clearLasaCache } from "../src/services/lasa.service";
+
+jest.mock("../src/db/client", () => ({
+    supabase: {
+        rpc: jest.fn(),
+        from: jest.fn(),
+    },
+}));
+
+import { supabase } from "../src/db/client";
+
+describe("detectLasaConflicts - phonetic fallback", () => {
+    beforeEach(() => {
+        clearLasaCache();
+        jest.clearAllMocks();
+    });
+
+    it("falls back to local phonetic matching when RPC errors", async () => {
+        (supabase.rpc as jest.Mock).mockResolvedValue({
+            data: null,
+            error: { message: "connection pool exhausted" },
+        });
+
+        (supabase.from as jest.Mock).mockReturnValue({
+            select: jest.fn().mockResolvedValue({
+                data: [
+                    { brand_name: "Dopamine", generic_name: null },
+                    { brand_name: "Ibuprofen", generic_name: null },
+                ],
+                error: null,
+            }),
+        });
+
+        const result = await detectLasaConflicts("Dopamin");
+
+        expect(result.length).toBeGreaterThan(0);
+        expect(result.some((m) => m.name === "Dopamine")).toBe(true);
+    });
+
+    it("falls back when RPC returns zero results", async () => {
+        (supabase.rpc as jest.Mock).mockResolvedValue({ data: [], error: null });
+
+        (supabase.from as jest.Mock).mockReturnValue({
+            select: jest.fn().mockResolvedValue({
+                data: [{ brand_name: "Dopamine", generic_name: null }],
+                error: null,
+            }),
+        });
+
+        const result = await detectLasaConflicts("Dopamin");
+
+        expect(result.some((m) => m.name === "Dopamine")).toBe(true);
+    });
+
+    it("does not use fallback when RPC succeeds with results", async () => {
+        (supabase.rpc as jest.Mock).mockResolvedValue({
+            data: [{ name: "Dopamine", match_type: "sound-alike" }],
+            error: null,
+        });
+
+        const fromSpy = supabase.from as jest.Mock;
+
+        const result = await detectLasaConflicts("Dopamin");
+
+        expect(result).toEqual([{ name: "Dopamine", type: "sound-alike", score: 1.0 }]);
+        expect(fromSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns empty array for empty input without querying anything", async () => {
+        const result = await detectLasaConflicts("   ");
+        expect(result).toEqual([]);
+        expect(supabase.rpc).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #3893**
- **Summary:** Adds a local phonetic fallback (Levenshtein distance + Double Metaphone via the `natural` package) to `detectLasaConflicts` in `apps/api/src/services/lasa.service.ts`. The fallback triggers only when the primary Supabase `find_lasa_conflicts` RPC returns an error or zero results. A separate 30-minute-TTL cache holds the local vocabulary (brand/generic names from `medicines`), decoupled from the existing 5-minute LASA result cache. Sound-alike matches (Double Metaphone equality) score 1.0; look-alike matches (Levenshtein distance ≤ 2) score between 0.5–0.85, keeping the fallback's scoring consistent with the primary RPC's existing scale. `MAX_MEDICINE_NAME_LENGTH` (200 chars) is already enforced at the route layer in `lasa.ts`, satisfying that acceptance criterion.

## 📸 Proof of Work (Screenshots / Logs)
Backend-only change, no UI — no screenshots applicable. `tsc --noEmit` passes for this file (pre-existing unrelated errors in other files confirmed out of scope). Manual test pending — recommend adding unit tests in `apps/api/tests/lasa*.test.ts` (e.g. "Dopamin" → "Dopamine" typo match) before merge; see note below.

## 🏷️ PR Type
- [x] ✨ `type: feature`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #3893`)
- [x] I have pulled the latest `main` and resolved any conflicts