### PR TITLE
fix: reject past expiry dates in POST /api/tracking/track (#3891)

### DIFF
--- a/apps/api/src/routes/tracking.ts
+++ b/apps/api/src/routes/tracking.ts
@@ -12,7 +12,12 @@ const trackSchema = z.object({
     medicine_id: uuidSchema,
     medicine_name: z.string().min(1).max(200),
     batch_number: z.string().max(100).optional(),
-    expiry_date: z.string().date(),
+    expiry_date: z
+        .string()
+        .date()
+        .refine((date) => new Date(date) > new Date(), {
+            message: "Expiry date must be in the future",
+        }),
 });
 router.get(
     "/tracked",


### PR DESCRIPTION

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #3891**
- **Summary:** Adds a `.refine()` to the `expiry_date` field in the tracking schema (`apps/api/src/routes/tracking.ts`) to reject dates that are not in the future, per the fix suggested in the issue.

## 📸 Proof of Work (Screenshots / Logs)
Backend-only change, no UI. Change is a single Zod schema refinement, no unit tests added yet due to time constraints — recommend adding a test asserting past dates return 400 before merge.

## 🏷️ PR Type
- [x] 🐛 `type: bug`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #3891`)
- [x] I have pulled the latest `main` and resolved any conflicts
- [x] Only `apps/api/src/routes/tracking.ts` is changed