### PR TITLE
fix(api): require user session to rotate API keys

### DIFF
--- a/apps/api/src/routes/apiKeys.ts
+++ b/apps/api/src/routes/apiKeys.ts
@@ -7,6 +7,9 @@ import { apiKeyLimiter } from "../middleware/rateLimit";
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
 import { redisClient } from "../utils/redis";
+import { sendNotificationToUser } from "../services/notifications";
+import { smsService } from "../services/sms-service";
+import { subscriberRepository } from "../repositories/subscriber.repository";
 
 const router = Router();
 const pbkdf2Async = promisify(pbkdf2);
@@ -23,70 +26,126 @@ const API_KEY_REVOKED_CHANNEL = "api_key_revoked_channel";
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
+ * Best-effort alert so the key owner can detect an unauthorized rotation.
+ * Delivery failures are logged but must never fail the rotation itself — the
+ * security fix that matters is the session requirement on the endpoint.
+ */
+async function notifyApiKeyRotation(userId: string, keyId: string): Promise<void> {
+    try {
+        const message =
+            "Your SahiDawa API key was rotated. If you did not do this, sign in and revoke the key immediately.";
+
+        await sendNotificationToUser(userId, {
+            title: "API key rotated",
+            body: message,
+            url: "/settings",
+        });
+
+        const subscriber = await subscriberRepository.findByUserId(userId);
+        if (subscriber?.phone && subscriber?.channels?.includes("sms")) {
+            await smsService.send(
+                subscriber.phone,
+                `SahiDawa alert: ${message}`,
+                subscriber.language || "en"
+            );
+        }
+    } catch (error) {
+        logger.error("Failed to notify user of API key rotation", { error, userId, keyId });
+    }
+}
+
+/**
  * @swagger
  * /api/keys/rotate:
  *   post:
  *     summary: Rotate API key
- *     description: Rotates the current API key by generating a new secret, updating the hash in the database, and returning the new secret. The existing key ID remains the same. Requires the current API key to be passed in the `x-api-secret` header.
+ *     description: Rotates the current API key by generating a new secret, updating the hash in the database, and returning the new secret. The existing key ID remains the same. Requires both the current API key in the `x-api-secret` header and a valid user session, so only the key's legitimate owner can rotate it — possession of the secret alone is not enough. The owner is notified (web push/SMS) of the rotation.
  *     security:
  *       - ApiKeyAuth: []
+ *         BearerAuth: []
  *     responses:
  *       200:
  *         description: Successfully rotated API key
  *       401:
  *         description: Unauthorized
+ *       403:
+ *         description: The authenticated user does not own the presented API key
  *       500:
  *         description: Internal server error
  */
-router.post("/rotate", apiKeyLimiter, requireApiKey, async (req: ApiKeyRequest, res: Response) => {
-    try {
-        const keyId = req.apiKey?.keyId;
-        if (!keyId) {
-            res.status(401).json({ error: "Unauthorized" });
-            return;
-        }
+router.post(
+    "/rotate",
+    apiKeyLimiter,
+    requireAuth,
+    requireApiKey,
+    async (req: ApiKeyRequest & AuthenticatedRequest, res: Response) => {
+        try {
+            const keyId = req.apiKey?.keyId;
+            const keyOwnerId = req.apiKey?.userId;
+            const sessionUserId = req.user?.id;
 
-        // Generate a new secret and salt
-        const newSecret = crypto.randomBytes(32).toString("base64url");
-        const newSalt = crypto.randomBytes(16).toString("hex");
+            if (!keyId || !keyOwnerId || !sessionUserId) {
+                res.status(401).json({ error: "Unauthorized" });
+                return;
+            }
 
-        // Hash the new secret
-        const hashBuffer = await pbkdf2Async(newSecret, newSalt, 100000, 64, "sha512");
-        const newHash = hashBuffer.toString("hex");
+            // A valid API key proves only that the caller possesses the secret.
+            // Authenticating rotation with the key alone would let an attacker
+            // who stole the key rotate it into a secret only they know. The
+            // session must belong to the key's owner, mirroring the revoke
+            // endpoint's security model.
+            if (keyOwnerId !== sessionUserId) {
+                res.status(403).json({ error: "You do not own this API key" });
+                return;
+            }
 
-        // Calculate new expiry (30 days from now)
-        const expiresAt = new Date();
-        expiresAt.setDate(expiresAt.getDate() + 30);
+            // Generate a new secret and salt
+            const newSecret = crypto.randomBytes(32).toString("base64url");
+            const newSalt = crypto.randomBytes(16).toString("hex");
 
-        // Update the key in the database
-        const { error } = await supabase
-            .from("api_keys")
-            .update({
-                key_hash: newHash,
-                key_salt: newSalt,
-                expires_at: expiresAt.toISOString(),
-            })
-            .eq("id", keyId);
+            // Hash the new secret
+            const hashBuffer = await pbkdf2Async(newSecret, newSalt, 100000, 64, "sha512");
+            const newHash = hashBuffer.toString("hex");
 
-        if (error) {
-            logger.error("Failed to update API key during rotation", { error, keyId });
+            // Calculate new expiry (30 days from now)
+            const expiresAt = new Date();
+            expiresAt.setDate(expiresAt.getDate() + 30);
+
+            // Update the key in the database. The update is additionally scoped
+            // to the session owner so a stale or buggy key row can never be
+            // rotated across users.
+            const { error } = await supabase
+                .from("api_keys")
+                .update({
+                    key_hash: newHash,
+                    key_salt: newSalt,
+                    expires_at: expiresAt.toISOString(),
+                })
+                .eq("id", keyId)
+                .eq("user_id", sessionUserId);
+
+            if (error) {
+                logger.error("Failed to update API key during rotation", { error, keyId });
+                res.status(500).json({ error: "Internal server error" });
+                return;
+            }
+
+            logger.info("API key rotated successfully", { keyId, userId: sessionUserId });
+
+            await notifyApiKeyRotation(sessionUserId, keyId);
+
+            res.status(200).json({
+                message: "API key rotated successfully",
+                keyId: keyId,
+                newSecret: newSecret,
+                expiresAt: expiresAt.toISOString(),
+            });
+        } catch (error) {
+            logger.error("Unexpected error during API key rotation", { error });
             res.status(500).json({ error: "Internal server error" });
-            return;
         }
-
-        logger.info("API key rotated successfully", { keyId });
-
-        res.status(200).json({
-            message: "API key rotated successfully",
-            keyId: keyId,
-            newSecret: newSecret,
-            expiresAt: expiresAt.toISOString(),
-        });
-    } catch (error) {
-        logger.error("Unexpected error during API key rotation", { error });
-        res.status(500).json({ error: "Internal server error" });
     }
-});
+);
 
 /**
  * @swagger

--- a/apps/api/tests/apiKeys.test.ts
+++ b/apps/api/tests/apiKeys.test.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import request from "supertest";
+import crypto from "crypto";
 
 // ---------------------------------------------------------------------------
 // Chainable Supabase mock. from/select/update/delete/eq return the chain; the
@@ -10,6 +11,7 @@ import request from "supertest";
 const mockState = {
     orderResult: { data: [] as unknown, error: null as unknown },
     maybeSingleResult: { data: null as unknown, error: null as unknown },
+    updateResult: { data: null as unknown, error: null as unknown },
 };
 
 const mockSupabase = {
@@ -20,6 +22,12 @@ const mockSupabase = {
     eq: jest.fn(() => mockSupabase),
     order: jest.fn(() => Promise.resolve(mockState.orderResult)),
     maybeSingle: jest.fn(() => Promise.resolve(mockState.maybeSingleResult)),
+    // Thenable chain: `await supabase.from(...).update(...).eq(...)` in the
+    // rotate handler and the fire-and-forget last_used_at update in
+    // requireApiKey both await the chain itself.
+    then: jest.fn((resolve: (value: typeof mockState.updateResult) => void) =>
+        resolve(mockState.updateResult)
+    ),
 };
 
 jest.mock("../src/db/client", () => ({ supabase: mockSupabase }));
@@ -45,9 +53,37 @@ jest.mock("../src/utils/logger", () => ({
     default: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
 }));
 
-import apiKeysRouter from "../src/routes/apiKeys";
-import { requireApiKey, ApiKeyRequest } from "../src/middleware/apiKeyAuth";
+jest.mock("../src/services/notifications", () => ({
+    sendNotificationToUser: jest.fn().mockResolvedValue({
+        configured: false,
+        attempted: 0,
+        sent: 0,
+        failed: 0,
+    }),
+}));
+
+jest.mock("../src/services/sms-service", () => ({
+    smsService: { send: jest.fn().mockResolvedValue(true) },
+}));
+
+jest.mock("../src/repositories/subscriber.repository", () => ({
+    subscriberRepository: {
+        findByUserId: jest.fn().mockResolvedValue(null),
+    },
+}));
+
+// The mocked db/client module is required through apiKeysRouter and
+// requireApiKey. Use require() instead of ESM import: babel-jest hoists ESM
+// imports above the const declarations, so the jest.mock factory for db/client
+// would run while `mockSupabase` is still in its temporal dead zone. require()
+// stays in place and runs after the consts above are initialized.
+const apiKeysRouter = require("../src/routes/apiKeys").default;
+const { requireApiKey } = require("../src/middleware/apiKeyAuth");
+const { sendNotificationToUser } = require("../src/services/notifications");
+const { smsService } = require("../src/services/sms-service");
+const { subscriberRepository } = require("../src/repositories/subscriber.repository");
 import type { Response } from "express";
+import type { ApiKeyRequest } from "../src/middleware/apiKeyAuth";
 
 const app = express();
 app.use(express.json());
@@ -57,10 +93,21 @@ app.use("/api/keys", apiKeysRouter);
 // routes reject anything that isn't one before touching the database.
 const VALID_ID = "11111111-1111-1111-1111-111111111111";
 
+// A key whose hash/salt let the real requireApiKey middleware validate the
+// secret presented in the x-api-secret header (same scheme as the API key auth
+// middleware: `keyId.secret` with a pbkdf2-sha512 hash).
+const ROTATE_KEY_ID = VALID_ID;
+const ROTATE_SECRET = "rotate-test-secret";
+const ROTATE_SALT = "rotate-testsalt";
+const ROTATE_HASH = crypto
+    .pbkdf2Sync(ROTATE_SECRET, ROTATE_SALT, 100000, 64, "sha512")
+    .toString("hex");
+
 beforeEach(() => {
     jest.clearAllMocks();
     mockState.orderResult = { data: [], error: null };
     mockState.maybeSingleResult = { data: null, error: null };
+    mockState.updateResult = { data: null, error: null };
 });
 
 describe("GET /api/keys", () => {
@@ -147,6 +194,102 @@ describe("DELETE /api/keys/:id", () => {
 
         expect(res.status).toBe(404);
         expect(mockSupabase.delete).not.toHaveBeenCalled();
+    });
+});
+
+describe("POST /api/keys/rotate", () => {
+    const setValidKeyRow = () => {
+        mockState.maybeSingleResult = {
+            data: {
+                id: ROTATE_KEY_ID,
+                user_id: "user-1",
+                scopes: [],
+                expires_at: new Date(Date.now() + 60_000).toISOString(),
+                key_hash: ROTATE_HASH,
+                key_salt: ROTATE_SALT,
+                is_active: true,
+            },
+            error: null,
+        };
+    };
+
+    const rotationUpdateCalled = () =>
+        mockSupabase.update.mock.calls.some(
+            (call: unknown[]) =>
+                typeof call[0] === "object" &&
+                call[0] !== null &&
+                "key_hash" in (call[0] as Record<string, unknown>)
+        );
+
+    beforeEach(() => {
+        setValidKeyRow();
+    });
+
+    it("rotates the key when the session matches the key owner", async () => {
+        const res = await request(app)
+            .post("/api/keys/rotate")
+            .set("x-test-user", "user-1")
+            .set("x-api-secret", `${ROTATE_KEY_ID}.${ROTATE_SECRET}`);
+
+        expect(res.status).toBe(200);
+        expect(res.body.keyId).toBe(ROTATE_KEY_ID);
+        expect(typeof res.body.newSecret).toBe("string");
+        expect(res.body.newSecret.length).toBeGreaterThan(0);
+        // The rotation update must be scoped to the session owner.
+        expect(mockSupabase.eq).toHaveBeenCalledWith("user_id", "user-1");
+        // The owner is notified of the rotation.
+        expect(sendNotificationToUser).toHaveBeenCalledWith("user-1", expect.anything());
+    });
+
+    it("also sends an SMS when the owner has an SMS subscriber on file", async () => {
+        (subscriberRepository.findByUserId as jest.Mock).mockResolvedValue({
+            phone: "+919999999999",
+            channels: ["sms"],
+            language: "en",
+        });
+
+        await request(app)
+            .post("/api/keys/rotate")
+            .set("x-test-user", "user-1")
+            .set("x-api-secret", `${ROTATE_KEY_ID}.${ROTATE_SECRET}`);
+
+        expect(smsService.send).toHaveBeenCalledWith(
+            "+919999999999",
+            expect.stringContaining("API key was rotated"),
+            "en"
+        );
+    });
+
+    it("does not rotate a key the session user does not own", async () => {
+        const res = await request(app)
+            .post("/api/keys/rotate")
+            .set("x-test-user", "user-2")
+            .set("x-api-secret", `${ROTATE_KEY_ID}.${ROTATE_SECRET}`);
+
+        expect(res.status).toBe(403);
+        expect(rotationUpdateCalled()).toBe(false);
+        expect(sendNotificationToUser).not.toHaveBeenCalled();
+    });
+
+    it("rejects a request without a user session", async () => {
+        const res = await request(app)
+            .post("/api/keys/rotate")
+            .set("x-api-secret", `${ROTATE_KEY_ID}.${ROTATE_SECRET}`);
+
+        expect(res.status).toBe(401);
+        expect(rotationUpdateCalled()).toBe(false);
+        expect(sendNotificationToUser).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 when the database update fails", async () => {
+        mockState.updateResult = { data: null, error: { message: "DB error" } };
+
+        const res = await request(app)
+            .post("/api/keys/rotate")
+            .set("x-test-user", "user-1")
+            .set("x-api-secret", `${ROTATE_KEY_ID}.${ROTATE_SECRET}`);
+
+        expect(res.status).toBe(500);
     });
 });
 


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4005 **
- **Summary:**
POST /api/keys/rotate was protected only by requireApiKey, which authenticates using the very key being rotated. An attacker who obtained a user's API key (network interception, DB leak, supply chain) could call rotate with the stolen secret and immediately invalidate it, replacing it with a new secret only they know — locking out the legitimate owner.

Now requires both the current API key (requireApiKey) and a valid user session (requireAuth), and rejects rotation when the session user does not own the presented key. The DB update is also scoped to the session owner, and the owner is notified (web push + SMS) of the rotation as best-effort so an unauthorized rotation can be detected.

Adds tests covering success, ownership mismatch, missing session, SMS notification, and DB failure.
- Success when the session matches the key owner (asserts the update is scoped by user_id and the owner is notified)
- SMS is sent when the owner has an SMS subscriber on file
- 403 for a key the session user does not own (no rotation performed)
- 401 without a user session (no rotation performed)
- 500 when the DB update fails


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4005 `)
- [x] I have pulled the latest `main` and resolved any conflicts
