### PR TITLE
Fix: cache invalidation counterfeit alerts

### DIFF
--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -175,6 +175,9 @@ router.post(
                 let batchKeysInvalidated = 0;
 
                 for (const batch of batchNumbers) {
+                    // Use pattern-based invalidation (drug:batch:<batch>*) to delete both
+                    // batch-only and composite keys. This ensures stale counterfeit/recall
+                    // data is never served from cache after admin invalidation.
                     const deletedKeys = await invalidateCacheByPattern(
                         `${KEY_PREFIXES.DRUG_CACHE}${batch}*`
                     );

--- a/apps/api/src/routes/admin.routes.ts
+++ b/apps/api/src/routes/admin.routes.ts
@@ -21,6 +21,7 @@ import {
 import {
     invalidateDrugCache,
     flushInteractionCache,
+    invalidateCacheByPattern,
     KEY_PREFIXES,
 } from "../services/cache.service";
 import { redisClient } from "../utils/redis";
@@ -44,7 +45,6 @@ const validateIdParam = (req: Request, res: Response, next: NextFunction): void 
 router.use(limiter);
 
 router.get("/reports", requireAuth, requireRole("admin", "moderator"), getPendingReports);
-const CACHE_INVALIDATION_CHUNK_SIZE = 100;
 router.get("/medicines", requireAuth, requireRole("admin", "moderator"), getAllMedicines);
 router.get(
     "/pharmacies/pending",
@@ -172,15 +172,16 @@ router.post(
 
             // --- batchNumbers path ---
             if (batchNumbers.length > 0 && redisClient.isOpen) {
-                const keys = batchNumbers.map((batch) => `${KEY_PREFIXES.DRUG_CACHE}${batch}`);
+                let batchKeysInvalidated = 0;
 
-                // Chunked DEL — never fire one command with 500 keys
-                for (let i = 0; i < keys.length; i += CACHE_INVALIDATION_CHUNK_SIZE) {
-                    const chunk = keys.slice(i, i + CACHE_INVALIDATION_CHUNK_SIZE);
-                    await redisClient.del(chunk);
+                for (const batch of batchNumbers) {
+                    const deletedKeys = await invalidateCacheByPattern(
+                        `${KEY_PREFIXES.DRUG_CACHE}${batch}*`
+                    );
+                    batchKeysInvalidated += deletedKeys.length;
                 }
 
-                totalKeysInvalidated += keys.length;
+                totalKeysInvalidated += batchKeysInvalidated;
             }
 
             // --- Audit log ---

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -292,6 +292,9 @@ alertsRouter.post("/ingest", requireApiKey, limiter, async (req: ApiKeyRequest, 
         await Promise.all(batchUpdatePromises);
 
         // 3.5 Invalidate the cache for the updated batch numbers
+        // Use pattern-based invalidation (drug:batch:<batch>*) to delete both batch-only
+        // and composite keys (drug:batch:<batch>|<barcode>|<brand>). This prevents stale
+        // counterfeit/recall data from being served from cache after an alert is ingested.
         const batchNumbersToInvalidate = validatedAlerts
             .map((alert) => alert.batch_number)
             .filter(Boolean) as string[];

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -7,7 +7,7 @@ import { escapeIlike } from "../utils/db";
 import { requireApiKey, ApiKeyRequest } from "../middleware/apiKeyAuth";
 import logger from "../utils/logger";
 import { redisClient } from "../utils/redis";
-import { KEY_PREFIXES } from "../services/cache.service";
+import { KEY_PREFIXES, invalidateCacheByPattern } from "../services/cache.service";
 import { limiter, alertsReadLimiter } from "../middleware/rateLimit";
 import { requireAuth, requireRole } from "../middleware/auth";
 import { uuidSchema } from "../utils/validation";
@@ -298,10 +298,9 @@ alertsRouter.post("/ingest", requireApiKey, limiter, async (req: ApiKeyRequest, 
 
         if (batchNumbersToInvalidate.length > 0 && redisClient.isOpen) {
             try {
-                const keys = batchNumbersToInvalidate.map(
-                    (batch) => `${KEY_PREFIXES.DRUG_CACHE}${batch}`
-                );
-                await redisClient.del(keys);
+                for (const batch of batchNumbersToInvalidate) {
+                    await invalidateCacheByPattern(`${KEY_PREFIXES.DRUG_CACHE}${batch}*`);
+                }
             } catch (err) {
                 logger.error({
                     message: "Failed to invalidate cache for alert batches",

--- a/apps/api/src/services/cache.service.ts
+++ b/apps/api/src/services/cache.service.ts
@@ -225,7 +225,7 @@ export async function incrementMissCount(): Promise<number> {
 /**
  * Invalidates cache entries for specified drug IDs (resolves to batch numbers and deletes).
  * Supabase query is capped at 1000 rows as a safety limit.
- * Redis DEL commands are chunked at 100 keys each to avoid blocking the event loop.
+ * Uses SCAN with pattern matching to delete both batch-only and composite keys.
  * Returns the list of deleted cache keys for audit logging.
  */
 export async function invalidateDrugCache(drugIds: string[]): Promise<string[]> {
@@ -246,22 +246,25 @@ export async function invalidateDrugCache(drugIds: string[]): Promise<string[]> 
         }
 
         if (data && data.length > 0) {
-            const keysToDelete = data
+            const batchNumbers = data
                 .map((row: any) => row.batch_number)
-                .filter(Boolean)
-                .map((batch: string) => `${KEY_PREFIXES.DRUG_CACHE}${batch}`);
+                .filter(Boolean) as string[];
 
-            if (keysToDelete.length > 0) {
-                // Chunk DEL to avoid blocking the Redis event loop
-                for (let i = 0; i < keysToDelete.length; i += CACHE_INVALIDATION_CHUNK_SIZE) {
-                    const chunk = keysToDelete.slice(i, i + CACHE_INVALIDATION_CHUNK_SIZE);
-                    await redisClient.del(chunk);
-                }
-                logger.info(
-                    `Invalidated cache keys: ${keysToDelete.join(", ").replace(/[\r\n]/g, "")}`
-                );
-                return keysToDelete;
+            const allDeletedKeys: string[] = [];
+
+            // Use pattern-based invalidation to delete both batch-only and composite keys
+            for (const batch of batchNumbers) {
+                const pattern = `${KEY_PREFIXES.DRUG_CACHE}${batch}*`;
+                const deletedKeys = await invalidateCacheByPattern(pattern);
+                allDeletedKeys.push(...deletedKeys);
             }
+
+            if (allDeletedKeys.length > 0) {
+                logger.info(
+                    `Invalidated cache keys: ${allDeletedKeys.join(", ").replace(/[\r\n]/g, "")}`
+                );
+            }
+            return allDeletedKeys;
         }
         return [];
     } catch (err) {

--- a/apps/api/src/services/cache.service.ts
+++ b/apps/api/src/services/cache.service.ts
@@ -226,6 +226,11 @@ export async function incrementMissCount(): Promise<number> {
  * Invalidates cache entries for specified drug IDs (resolves to batch numbers and deletes).
  * Supabase query is capped at 1000 rows as a safety limit.
  * Uses SCAN with pattern matching to delete both batch-only and composite keys.
+ *
+ * IMPORTANT: This uses pattern-based deletion (drug:batch:<batch>*) instead of exact
+ * key deletion to ensure composite keys (drug:batch:<batch>|<barcode>|<brand>) are also
+ * invalidated. This fixes the bug where counterfeit/recall alerts would leave stale
+ * composite cache keys, causing the verification endpoint to serve pre-alert data.
  * Returns the list of deleted cache keys for audit logging.
  */
 export async function invalidateDrugCache(drugIds: string[]): Promise<string[]> {

--- a/apps/api/tests/cache.service.test.ts
+++ b/apps/api/tests/cache.service.test.ts
@@ -23,6 +23,7 @@ jest.mock("../src/utils/redis", () => ({
         expire: jest.fn().mockResolvedValue(true),
         connect: jest.fn().mockResolvedValue(true),
         on: jest.fn(),
+        scanIterator: jest.fn(),
     },
     connectRedis: jest.fn(),
 }));
@@ -182,18 +183,40 @@ describe("Redis Caching and Drug Lookup Services", () => {
     });
 
     describe("invalidateDrugCache", () => {
-        it("should resolve drug IDs to batch numbers and delete cache keys", async () => {
+        it("should resolve drug IDs to batch numbers and delete cache keys using pattern matching", async () => {
             const mockData = [{ batch_number: "BATCH-1" }, { batch_number: "BATCH-2" }];
 
             mockSupabase.in.mockReturnThis();
             mockSupabase.limit.mockResolvedValueOnce({ data: mockData, error: null });
 
-            await invalidateDrugCache(["med-1", "med-2"]);
+            // Mock scanIterator to return composite keys for each batch
+            mockRedis.scanIterator
+                .mockImplementationOnce(function* () {
+                    yield ["drug:batch:BATCH-1", "drug:batch:BATCH-1|barcode1|Brand1"];
+                })
+                .mockImplementationOnce(function* () {
+                    yield ["drug:batch:BATCH-2", "drug:batch:BATCH-2|barcode2|Brand2"];
+                });
+
+            const deletedKeys = await invalidateDrugCache(["med-1", "med-2"]);
 
             expect(mockSupabase.from).toHaveBeenCalledWith("medicines");
-            expect(mockRedis.del).toHaveBeenCalledWith([
+            // Verify scanIterator was called with correct patterns
+            expect(mockRedis.scanIterator).toHaveBeenCalledTimes(2);
+            expect(mockRedis.scanIterator).toHaveBeenNthCalledWith(1, {
+                MATCH: "drug:batch:BATCH-1*",
+                COUNT: 100,
+            });
+            expect(mockRedis.scanIterator).toHaveBeenNthCalledWith(2, {
+                MATCH: "drug:batch:BATCH-2*",
+                COUNT: 100,
+            });
+            // Verify all keys were deleted
+            expect(deletedKeys).toEqual([
                 "drug:batch:BATCH-1",
+                "drug:batch:BATCH-1|barcode1|Brand1",
                 "drug:batch:BATCH-2",
+                "drug:batch:BATCH-2|barcode2|Brand2",
             ]);
         });
     });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4007**
- **Summary:**
1. apps/api/src/services/cache.service.ts
- invalidateDrugCache() now uses pattern-based deletion (drug:batch:<batch>*) via invalidateCacheByPattern() to delete both batch-only and composite keys
2. apps/api/src/routes/alerts.ts
- Alert ingestion (POST /api/v1/alerts/ingest) now uses pattern-based invalidation for each affected batch number
3. apps/api/src/routes/admin.routes.ts
- Admin cache invalidation by batch numbers (POST /api/v1/admin/cache/invalidate) now uses pattern-based deletion
4. apps/api/tests/cache.service.test.ts
- Updated test to verify pattern-based invalidation works correctly with both batch-only and composite keys
Verification: All relevant tests pass (cache.service, alerts, admin, verify). The 3 failing tests are pre-existing issues unrelated to this fix (lasa.service mock issues and medicineSchedules syntax error).



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4007`)
- [x] I have pulled the latest `main` and resolved any conflicts
