### PR TITLE
feat: implement offline-first PWA sync queue using IndexedDB (#4019)

### DIFF
--- a/apps/web/components/OfflineBanner.tsx
+++ b/apps/web/components/OfflineBanner.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { WifiOff, Wifi, X } from "lucide-react";
 import { useOfflineStatus } from "@/hooks/useOfflineStatus";
+import { useSyncQueue } from "@/hooks/useSyncQueue";
 import { useTranslations } from "next-intl";
 
 /**
@@ -18,6 +19,7 @@ import { useTranslations } from "next-intl";
 export function OfflineBanner() {
     const t = useTranslations("offline");
     const { isOffline, isStatusDirty, isTestMode } = useOfflineStatus();
+    const { pendingCount } = useSyncQueue();
     const [isDismissed, setIsDismissed] = useState(false);
     const [isVisible, setIsVisible] = useState(false);
 
@@ -92,6 +94,11 @@ export function OfflineBanner() {
                                 {isCurrentlyOffline
                                     ? t("descriptionOffline") + (isTestMode ? " · Test mode" : "")
                                     : t("descriptionOnline")}
+                                {pendingCount > 0 && isCurrentlyOffline && (
+                                    <span className="ml-2 rounded bg-amber-700/50 px-2 py-0.5 font-semibold">
+                                        {pendingCount} action(s) pending sync
+                                    </span>
+                                )}
                             </p>
                         </div>
                     </div>

--- a/apps/web/hooks/useSyncQueue.ts
+++ b/apps/web/hooks/useSyncQueue.ts
@@ -1,0 +1,64 @@
+import { useState, useEffect } from 'react';
+import { useOfflineStatus } from './useOfflineStatus';
+
+export const useSyncQueue = () => {
+    const { isOffline } = useOfflineStatus();
+    const [pendingCount, setPendingCount] = useState(0);
+
+    const checkQueue = () => {
+        if (typeof window === 'undefined') return;
+        
+        const req = indexedDB.open('sahidawa-sync-db', 1);
+        req.onsuccess = (e: any) => {
+            const db = e.target.result;
+            if (!db.objectStoreNames.contains('requests')) {
+                setPendingCount(0);
+                db.close();
+                return;
+            }
+            try {
+                const tx = db.transaction('requests', 'readonly');
+                const store = tx.objectStore('requests');
+                const countReq = store.count();
+                countReq.onsuccess = () => {
+                    setPendingCount(countReq.result);
+                };
+                tx.oncomplete = () => db.close();
+            } catch (err) {
+                db.close();
+            }
+        };
+    };
+
+    useEffect(() => {
+        checkQueue();
+
+        const handleMessage = (event: MessageEvent) => {
+            if (event.data && event.data.type === 'SYNC_QUEUE_FLUSHED') {
+                checkQueue();
+            }
+        };
+
+        navigator.serviceWorker?.addEventListener('message', handleMessage);
+        
+        const interval = setInterval(() => {
+            checkQueue();
+        }, 5000);
+
+        return () => {
+            navigator.serviceWorker?.removeEventListener('message', handleMessage);
+            clearInterval(interval);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!isOffline && pendingCount > 0) {
+            const timer = setTimeout(() => {
+                checkQueue();
+            }, 3000);
+            return () => clearTimeout(timer);
+        }
+    }, [isOffline, pendingCount]);
+
+    return { pendingCount, isOffline };
+};

--- a/apps/web/hooks/useSyncQueue.ts
+++ b/apps/web/hooks/useSyncQueue.ts
@@ -1,30 +1,30 @@
-import { useState, useEffect } from 'react';
-import { useOfflineStatus } from './useOfflineStatus';
+import { useState, useEffect } from "react";
+import { useOfflineStatus } from "./useOfflineStatus";
 
 export const useSyncQueue = () => {
     const { isOffline } = useOfflineStatus();
     const [pendingCount, setPendingCount] = useState(0);
 
     const checkQueue = () => {
-        if (typeof window === 'undefined') return;
-        
-        const req = indexedDB.open('sahidawa-sync-db', 1);
+        if (typeof window === "undefined") return;
+
+        const req = indexedDB.open("sahidawa-sync-db", 1);
         req.onsuccess = (e: any) => {
             const db = e.target.result;
-            if (!db.objectStoreNames.contains('requests')) {
+            if (!db.objectStoreNames.contains("requests")) {
                 setPendingCount(0);
                 db.close();
                 return;
             }
             try {
-                const tx = db.transaction('requests', 'readonly');
-                const store = tx.objectStore('requests');
+                const tx = db.transaction("requests", "readonly");
+                const store = tx.objectStore("requests");
                 const countReq = store.count();
                 countReq.onsuccess = () => {
                     setPendingCount(countReq.result);
                 };
                 tx.oncomplete = () => db.close();
-            } catch (err) {
+            } catch {
                 db.close();
             }
         };
@@ -34,19 +34,19 @@ export const useSyncQueue = () => {
         checkQueue();
 
         const handleMessage = (event: MessageEvent) => {
-            if (event.data && event.data.type === 'SYNC_QUEUE_FLUSHED') {
+            if (event.data && event.data.type === "SYNC_QUEUE_FLUSHED") {
                 checkQueue();
             }
         };
 
-        navigator.serviceWorker?.addEventListener('message', handleMessage);
-        
+        navigator.serviceWorker?.addEventListener("message", handleMessage);
+
         const interval = setInterval(() => {
             checkQueue();
         }, 5000);
 
         return () => {
-            navigator.serviceWorker?.removeEventListener('message', handleMessage);
+            navigator.serviceWorker?.removeEventListener("message", handleMessage);
             clearInterval(interval);
         };
     }, []);

--- a/apps/web/worker/index.js
+++ b/apps/web/worker/index.js
@@ -370,9 +370,26 @@ async function handleApiRequest(request, url, cacheName) {
 }
 
 async function fetchWithoutCache(request) {
+    const clonedRequest = ['POST', 'PUT', 'DELETE', 'PATCH'].includes(request.method) ? request.clone() : null;
+
     try {
         return await fetchWithTimeout(request);
     } catch {
+        if (clonedRequest) {
+            await saveFailedRequest(clonedRequest);
+            if ('sync' in self.registration) {
+                try {
+                    await self.registration.sync.register('sahidawa-sync-mutations');
+                } catch (e) {
+                    console.warn('[SW] Sync registration failed', e);
+                }
+            }
+            return new Response(JSON.stringify({ 
+                error: "You are offline. Request queued for sync.", 
+                offline: true,
+                queued: true 
+            }), { status: 503, headers: { "Content-Type": "application/json" } });
+        }
         return createOfflineApiResponse();
     }
 }
@@ -701,6 +718,9 @@ self.addEventListener("sync", (event) => {
     if (event.tag === "sahidawa-sync-scans") {
         event.waitUntil(notifyClientsToFlush());
     }
+    if (event.tag === "sahidawa-sync-mutations") {
+        event.waitUntil(flushMutationsQueue());
+    }
 });
 
 async function notifyClientsToFlush() {
@@ -709,3 +729,94 @@ async function notifyClientsToFlush() {
         client.postMessage({ type: "FLUSH_SYNC_QUEUE" });
     }
 }
+
+// ---------------------------------------------------------------------------
+// SYNC QUEUE HELPERS FOR MUTATING REQUESTS
+// ---------------------------------------------------------------------------
+function openSyncDb() {
+    return new Promise((resolve, reject) => {
+        const req = indexedDB.open('sahidawa-sync-db', 1);
+        req.onupgradeneeded = (e) => {
+            const db = e.target.result;
+            if (!db.objectStoreNames.contains('requests')) {
+                db.createObjectStore('requests', { keyPath: 'id', autoIncrement: true });
+            }
+        };
+        req.onsuccess = (e) => resolve(e.target.result);
+        req.onerror = () => reject('Failed to open sync DB');
+    });
+}
+
+async function saveFailedRequest(request) {
+    try {
+        const db = await openSyncDb();
+        const headers = {};
+        for (const [key, value] of request.headers.entries()) {
+            headers[key] = value;
+        }
+        const bodyText = await request.text();
+        const serialized = {
+            url: request.url,
+            method: request.method,
+            headers,
+            body: bodyText,
+            timestamp: Date.now()
+        };
+        
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('requests', 'readwrite');
+            tx.objectStore('requests').add(serialized);
+            tx.oncomplete = () => { db.close(); resolve(); };
+            tx.onerror = () => { db.close(); reject(); };
+        });
+    } catch (e) {
+        console.error('[SW] Failed to save request to sync queue', e);
+    }
+}
+
+async function flushMutationsQueue() {
+    try {
+        const db = await openSyncDb();
+        const requests = await new Promise((resolve, reject) => {
+            const tx = db.transaction('requests', 'readonly');
+            const req = tx.objectStore('requests').getAll();
+            req.onsuccess = () => resolve(req.result);
+            req.onerror = () => reject();
+        });
+        
+        if (!requests || requests.length === 0) {
+            db.close();
+            return;
+        }
+        
+        for (const reqData of requests) {
+            try {
+                const response = await fetch(reqData.url, {
+                    method: reqData.method,
+                    headers: reqData.headers,
+                    body: reqData.method !== 'GET' && reqData.method !== 'HEAD' ? reqData.body : undefined
+                });
+                
+                if (response.ok || response.status >= 400) { 
+                    await new Promise((resolve) => {
+                        const tx = db.transaction('requests', 'readwrite');
+                        tx.objectStore('requests').delete(reqData.id);
+                        tx.oncomplete = resolve;
+                    });
+                }
+            } catch (e) {
+                console.warn('[SW] Sync flush fetch failed (still offline?)', e);
+                break;
+            }
+        }
+        db.close();
+        
+        const clients = await self.clients.matchAll({ type: "window" });
+        for (const client of clients) {
+            client.postMessage({ type: "SYNC_QUEUE_FLUSHED" });
+        }
+    } catch (e) {
+        console.error('[SW] Sync flush error', e);
+    }
+}
+


### PR DESCRIPTION
## Description
This PR resolves #4019 by implementing a robust Background Sync Queue for users with poor connectivity. 

### Changes Included:
- **Service Worker (`worker/index.js`)**: Implemented an IndexedDB wrapper (`sahidawa-sync-db`) to serialize and store failed mutating requests (`POST`, `PUT`, `DELETE`, `PATCH`).
- **Background Sync API**: The service worker intercepts failed mutations, caches them locally, and registers for a background sync (`sahidawa-sync-mutations`) to seamlessly flush the queue when network connectivity is restored.
- **UI Indicators**: Added a new custom hook (`useSyncQueue.ts`) which tracks the size of the IndexedDB pending request store.
- **Offline Banner**: Updated the `OfflineBanner.tsx` to dynamically display the number of pending sync actions while the user remains offline.

Closes #4019 

### Checklist
- [x] Tested in offline mode (Chrome DevTools).
- [x] Validated that forms submitted offline are pushed when reconnected.
- [x] No regressions to existing network-first cache routes.
