### PR TITLE
fix(districtAlertSync): retry and throw on stale alert deactivation failure

### DIFF
--- a/apps/api/src/cron/districtAlertSync.ts
+++ b/apps/api/src/cron/districtAlertSync.ts
@@ -134,10 +134,21 @@ export async function syncDistrictAlertTallies(): Promise<void> {
                 .in("id", staleIds);
 
             if (updateError) {
-                logger.error("District alert sync: bulk deactivate failed", {
+                logger.error("District alert sync: bulk deactivate failed, retrying", {
                     error: updateError.message,
                 });
-                errors += 1;
+                const { error: retryError } = await supabase
+                    .from("district_alerts")
+                    .update({ is_active: false, updated_at: timestamp })
+                    .in("id", staleIds);
+                if (retryError) {
+                    logger.error("District alert sync: bulk deactivate retry failed", {
+                        error: retryError.message,
+                    });
+                    throw new Error(
+                        `Failed to deactivate stale district alerts: ${retryError.message}`
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #4041

- Retry bulk deactivation once when it fails
- Throw error if retry also fails to prevent silent data corruption
- Ensures stale alerts are not left active in the database