### PR TITLE
fix: scope queued offline mutations to the user who created them

### DIFF
--- a/apps/web/lib/syncUserScoping.ts
+++ b/apps/web/lib/syncUserScoping.ts
@@ -1,0 +1,30 @@
+/**
+ * Client-side helpers for scoping the background-sync mutation queue to the
+ * signed-in user. The service worker replays queued mutations, so it must
+ * know who is currently signed in (and must never replay actions bound to a
+ * different user — see worker/index.js).
+ */
+
+export const SET_CURRENT_USER = "SET_CURRENT_USER";
+export const CLEAR_SYNC_QUEUE = "CLEAR_SYNC_QUEUE";
+
+async function postToServiceWorker(message: Record<string, unknown>): Promise<void> {
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return;
+    try {
+        const registration = await navigator.serviceWorker.ready;
+        registration.active?.postMessage(message);
+    } catch {
+        // No active service worker — nothing to notify.
+    }
+}
+
+/** Tell the service worker which user is signed in so queued mutations are scoped. */
+export function registerCurrentUser(userId: string | null): void {
+    void postToServiceWorker({ type: SET_CURRENT_USER, userId });
+}
+
+/** Called on sign-out: drop the queue and clear the registered user. */
+export function clearSyncQueueForLogout(): void {
+    void postToServiceWorker({ type: CLEAR_SYNC_QUEUE });
+    void postToServiceWorker({ type: SET_CURRENT_USER, userId: null });
+}

--- a/apps/web/src/components/AuthProvider.tsx
+++ b/apps/web/src/components/AuthProvider.tsx
@@ -4,6 +4,7 @@ import { createBrowserClient } from "@supabase/ssr";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
 import { createContext, useContext, useEffect, useState, useMemo, type ReactNode } from "react";
 import type { Session } from "@supabase/supabase-js";
+import { clearSyncQueueForLogout, registerCurrentUser } from "@/lib/syncUserScoping";
 
 interface AuthContextValue {
     session: Session | null;
@@ -37,6 +38,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             } else {
                 localStorage.removeItem("sb-access-token");
             }
+            syncServiceWorkerSession(s);
         });
 
         const {
@@ -48,6 +50,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             } else {
                 localStorage.removeItem("sb-access-token");
             }
+            syncServiceWorkerSession(session);
         });
 
         return () => subscription.unsubscribe();
@@ -58,4 +61,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             {children}
         </AuthContext.Provider>
     );
+}
+
+/**
+ * Keep the service worker's notion of the signed-in user in step with the
+ * auth session so queued offline mutations are scoped/bound to the user who
+ * created them. On sign-out the queue is cleared so an old offline action can
+ * never be submitted as a different user.
+ */
+function syncServiceWorkerSession(session: Session | null): void {
+    const userId = session?.user?.id ?? null;
+    if (userId) {
+        registerCurrentUser(userId);
+    } else {
+        clearSyncQueueForLogout();
+    }
 }

--- a/apps/web/tests/auth-provider-sync-scoping.test.tsx
+++ b/apps/web/tests/auth-provider-sync-scoping.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+/**
+ * @jest-environment jsdom
+ */
+import { act } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { AuthProvider } from "@/src/components/AuthProvider";
+import { createBrowserClient } from "@supabase/ssr";
+import { clearSyncQueueForLogout, registerCurrentUser } from "@/lib/syncUserScoping";
+
+jest.mock("@supabase/ssr", () => ({
+    createBrowserClient: jest.fn(),
+}));
+
+jest.mock("@/lib/env", () => ({
+    getSupabaseUrl: () => "https://example.supabase.co",
+    getSupabaseAnonKey: () => "anon-key-123",
+}));
+
+jest.mock("@/lib/syncUserScoping", () => ({
+    registerCurrentUser: jest.fn(),
+    clearSyncQueueForLogout: jest.fn(),
+}));
+
+const mockedCreateBrowserClient = createBrowserClient as jest.Mock;
+
+function setupAuth(options: { initialSession: Record<string, unknown> | null }) {
+    const authStateListeners: Array<(event: string, session: any) => void> = [];
+    const client = {
+        auth: {
+            getSession: jest.fn().mockResolvedValue({
+                data: { session: options.initialSession },
+                error: null,
+            }),
+            onAuthStateChange: jest.fn((listener: (event: string, session: any) => void) => {
+                authStateListeners.push(listener);
+                return { data: { subscription: { unsubscribe: jest.fn() } } };
+            }),
+        },
+    };
+    mockedCreateBrowserClient.mockReturnValue(client);
+    return { authStateListeners };
+}
+
+function sessionFor(userId: string): Record<string, unknown> {
+    return {
+        access_token: `token-${userId}`,
+        user: { id: userId, email: `${userId}@test.dev` },
+    };
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+});
+
+describe("AuthProvider sync queue user-scoping", () => {
+    it("registers the signed-in user with the service worker on mount", async () => {
+        setupAuth({ initialSession: sessionFor("user-A") });
+
+        await act(async () => {
+            render(
+                <AuthProvider>
+                    <div>app</div>
+                </AuthProvider>
+            );
+        });
+
+        expect(registerCurrentUser).toHaveBeenCalledWith("user-A");
+        expect(clearSyncQueueForLogout).not.toHaveBeenCalled();
+    });
+
+    it("clears the queue and unregisters the user when the session ends", async () => {
+        const { authStateListeners } = setupAuth({ initialSession: sessionFor("user-A") });
+
+        await act(async () => {
+            render(
+                <AuthProvider>
+                    <div>app</div>
+                </AuthProvider>
+            );
+        });
+        expect(registerCurrentUser).toHaveBeenCalledWith("user-A");
+
+        await act(async () => {
+            for (const listener of authStateListeners) listener("SIGNED_OUT", null);
+        });
+
+        expect(clearSyncQueueForLogout).toHaveBeenCalled();
+    });
+
+    it("registers a newly signed-in user via the auth state change", async () => {
+        const { authStateListeners } = setupAuth({ initialSession: null });
+
+        await act(async () => {
+            render(
+                <AuthProvider>
+                    <div>app</div>
+                </AuthProvider>
+            );
+        });
+        expect(clearSyncQueueForLogout).toHaveBeenCalled();
+
+        await act(async () => {
+            for (const listener of authStateListeners) listener("SIGNED_IN", sessionFor("user-B"));
+        });
+
+        expect(registerCurrentUser).toHaveBeenCalledWith("user-B");
+    });
+
+    it("re-registers the correct user when the session switches users", async () => {
+        const { authStateListeners } = setupAuth({ initialSession: null });
+
+        await act(async () => {
+            render(
+                <AuthProvider>
+                    <div>app</div>
+                </AuthProvider>
+            );
+        });
+
+        await act(async () => {
+            for (const listener of authStateListeners) listener("SIGNED_IN", sessionFor("user-A"));
+        });
+        expect(registerCurrentUser).toHaveBeenLastCalledWith("user-A");
+
+        await act(async () => {
+            for (const listener of authStateListeners) listener("SIGNED_OUT", null);
+            for (const listener of authStateListeners) listener("SIGNED_IN", sessionFor("user-B"));
+        });
+
+        expect(clearSyncQueueForLogout).toHaveBeenCalled();
+        expect(registerCurrentUser).toHaveBeenLastCalledWith("user-B");
+    });
+});

--- a/apps/web/tests/sync-user-scoping.test.ts
+++ b/apps/web/tests/sync-user-scoping.test.ts
@@ -1,0 +1,355 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import vm from "vm";
+
+const workerSource = readFileSync(join(process.cwd(), "worker/index.js"), "utf8");
+
+type WorkerHandler = (event: any) => void;
+
+const MUTATION_URL = "https://sahidawa.test/api/v1/reports";
+const QUEUE_DB = "sahidawa-sync-db";
+
+function base64Url(input: string): string {
+    return Buffer.from(input, "utf8")
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+}
+
+/** Minimal Supabase-style JWT with a `sub` claim identifying the user. */
+function bearerTokenFor(userId: string): string {
+    const header = base64Url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+    const payload = base64Url(JSON.stringify({ sub: userId, role: "authenticated" }));
+    return `${header}.${payload}.signature`;
+}
+
+async function deleteQueueDb(): Promise<void> {
+    await new Promise<void>((resolve) => {
+        const req = indexedDB.deleteDatabase(QUEUE_DB);
+        req.onsuccess = () => resolve();
+        req.onerror = () => resolve();
+        req.onblocked = () => resolve();
+    });
+}
+
+async function openQueueDb(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+        const req = indexedDB.open(QUEUE_DB, 2);
+        req.onupgradeneeded = () => {
+            const db = req.result;
+            if (!db.objectStoreNames.contains("requests")) {
+                db.createObjectStore("requests", { keyPath: "id", autoIncrement: true });
+            }
+            if (!db.objectStoreNames.contains("meta")) {
+                db.createObjectStore("meta", { keyPath: "key" });
+            }
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+    });
+}
+
+async function seedQueue(entries: Array<Record<string, unknown>>): Promise<void> {
+    const db = await openQueueDb();
+    await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction("requests", "readwrite");
+        for (const entry of entries) tx.objectStore("requests").add(entry);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+}
+
+async function setRegisteredUser(userId: string | null): Promise<void> {
+    const db = await openQueueDb();
+    await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction("meta", "readwrite");
+        tx.objectStore("meta").put({ key: "current-user-id", value: userId });
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+}
+
+async function readCurrentUserId(): Promise<string | null> {
+    const db = await openQueueDb();
+    const result = await new Promise<string | null>((resolve, reject) => {
+        const tx = db.transaction("meta", "readonly");
+        const req = tx.objectStore("meta").get("current-user-id");
+        req.onsuccess = () => resolve(req.result ? (req.result.value as string) : null);
+        req.onerror = () => reject(req.error);
+    });
+    db.close();
+    return result;
+}
+
+async function readQueue(): Promise<Array<Record<string, unknown> & { id: number }>> {
+    const db = await openQueueDb();
+    const result = await new Promise<any[]>((resolve, reject) => {
+        const tx = db.transaction("requests", "readonly");
+        const req = tx.objectStore("requests").getAll();
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+    });
+    db.close();
+    return result;
+}
+
+interface Harness {
+    sync: (tag: string) => Promise<void>;
+    dispatch: (event: any) => void;
+    fetchMock: jest.Mock;
+    client: { postMessage: jest.Mock };
+    handlers: Map<string, WorkerHandler>;
+}
+
+function createHarness(): Harness {
+    const handlers = new Map<string, WorkerHandler>();
+    const client = { postMessage: jest.fn() };
+    const fetchMock = jest.fn();
+
+    const self = {
+        location: new URL("https://sahidawa.test"),
+        addEventListener: jest.fn((type: string, handler: WorkerHandler) => {
+            handlers.set(type, handler);
+        }),
+        skipWaiting: jest.fn(),
+        clients: {
+            claim: jest.fn(),
+            matchAll: jest.fn().mockResolvedValue([client]),
+        },
+        crypto: globalThis.crypto,
+        registration: { sync: { register: jest.fn().mockResolvedValue(undefined) } },
+    };
+
+    vm.runInNewContext(workerSource, {
+        self,
+        caches: {
+            open: jest.fn(),
+            keys: jest.fn().mockResolvedValue([]),
+            delete: jest.fn().mockResolvedValue(true),
+        },
+        fetch: fetchMock,
+        Request,
+        Response,
+        Headers,
+        URL,
+        AbortController,
+        setTimeout,
+        clearTimeout,
+        console,
+        indexedDB,
+        Promise,
+        JSON,
+        Date,
+        atob: (s: string) => Buffer.from(s, "base64").toString("binary"),
+        Uint8Array,
+    });
+
+    async function sync(tag: string): Promise<void> {
+        const syncHandler = handlers.get("sync");
+        if (!syncHandler) throw new Error("Service worker sync handler was not registered");
+        let done: Promise<unknown> | undefined;
+        syncHandler({
+            tag,
+            waitUntil(promise: Promise<unknown>) {
+                done = promise;
+            },
+        });
+        if (!done) throw new Error("Sync handler did not register work");
+        await done;
+    }
+
+    function dispatch(event: any): void {
+        const kind = event.type ?? "message";
+        const handler = handlers.get(kind);
+        if (!handler) throw new Error(`No handler registered for event ${kind}`);
+        handler(event);
+    }
+
+    return { sync, dispatch, fetchMock, client, handlers };
+}
+
+function mutationEntry(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+        url: MUTATION_URL,
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ brand: "counterfeit", report: true }),
+        timestamp: Date.now(),
+        userId: null,
+        ...overrides,
+    };
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+    return new Response(typeof body === "string" ? body : JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+async function dispatchFetchSave(harness: Harness, request: Request): Promise<void> {
+    const fetchHandler = harness.handlers.get("fetch");
+    if (!fetchHandler) throw new Error("fetch handler not registered");
+    const respondWith = jest.fn((p: Promise<unknown>) => p);
+    fetchHandler({ request, respondWith, waitUntil: jest.fn() });
+    await respondWith.mock.calls[0][0];
+}
+beforeEach(async () => {
+    await deleteQueueDb();
+});
+
+afterAll(async () => {
+    await deleteQueueDb();
+});
+
+describe("service worker queue user-scoping", () => {
+    describe("saveFailedRequest()", () => {
+        it("stamps the userId derived from the Authorization bearer token", async () => {
+            const harness = createHarness();
+            harness.fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+            const request = new Request(MUTATION_URL, {
+                method: "POST",
+                headers: { authorization: `Bearer ${bearerTokenFor("user-A")}` },
+                body: "{}",
+            });
+            await dispatchFetchSave(harness, request);
+
+            const queue = await readQueue();
+            expect(queue).toHaveLength(1);
+            expect(queue[0].userId).toBe("user-A");
+        });
+
+        it("falls back to the registered current user when no Authorization header is present", async () => {
+            const harness = createHarness();
+            harness.fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+            await setRegisteredUser("user-A");
+
+            await dispatchFetchSave(
+                harness,
+                new Request(MUTATION_URL, { method: "POST", body: "{}" })
+            );
+
+            const queue = await readQueue();
+            expect(queue).toHaveLength(1);
+            expect(queue[0].userId).toBe("user-A");
+        });
+
+        it("leaves the entry unbound (null user) when no identity is available", async () => {
+            const harness = createHarness();
+            harness.fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+            await dispatchFetchSave(
+                harness,
+                new Request(MUTATION_URL, { method: "POST", body: "{}" })
+            );
+
+            const queue = await readQueue();
+            expect(queue).toHaveLength(1);
+            expect(queue[0].userId).toBeNull();
+        });
+    });
+
+    describe("SET_CURRENT_USER / CLEAR_SYNC_QUEUE messages", () => {
+        it("persists the registered current user and clears the scoping meta", async () => {
+            const harness = createHarness();
+            harness.dispatch({
+                data: { type: "SET_CURRENT_USER", userId: "user-A" },
+                waitUntil: jest.fn(),
+            });
+            // waitUntil is async; give the IDB write a tick.
+            await new Promise((r) => setTimeout(r, 0));
+            expect(await readCurrentUserId()).toBe("user-A");
+
+            harness.dispatch({
+                data: { type: "SET_CURRENT_USER", userId: null },
+                waitUntil: jest.fn(),
+            });
+            await new Promise((r) => setTimeout(r, 0));
+            expect(await readCurrentUserId()).toBeNull();
+        });
+
+        it("drops all queued mutations on CLEAR_SYNC_QUEUE", async () => {
+            const harness = createHarness();
+            await seedQueue([
+                mutationEntry({ userId: "user-A" }),
+                mutationEntry({ userId: "user-A" }),
+            ]);
+            expect(await readQueue()).toHaveLength(2);
+
+            harness.dispatch({ data: { type: "CLEAR_SYNC_QUEUE" }, waitUntil: jest.fn() });
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(await readQueue()).toHaveLength(0);
+        });
+    });
+
+    describe("flushMutationsQueue() replay guard", () => {
+        it("replays and deletes a queued mutation when the owner matches the current user", async () => {
+            const harness = createHarness();
+            await seedQueue([mutationEntry({ userId: "user-A" })]);
+            await setRegisteredUser("user-A");
+            harness.fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }));
+
+            await harness.sync("sahidawa-sync-mutations");
+
+            expect(await readQueue()).toHaveLength(0);
+            expect(harness.fetchMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("refuses to replay a mutation owned by a different user", async () => {
+            const harness = createHarness();
+            await seedQueue([mutationEntry({ userId: "user-A" })]);
+            await setRegisteredUser("user-B");
+            harness.fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }));
+
+            await harness.sync("sahidawa-sync-mutations");
+
+            expect(await readQueue()).toHaveLength(1);
+            expect(harness.fetchMock).not.toHaveBeenCalled();
+        });
+
+        it("refuses to replay a mutation when no current user is registered", async () => {
+            const harness = createHarness();
+            await seedQueue([mutationEntry({ userId: "user-A" })]);
+            harness.fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }));
+
+            await harness.sync("sahidawa-sync-mutations");
+
+            expect(await readQueue()).toHaveLength(1);
+            expect(harness.fetchMock).not.toHaveBeenCalled();
+        });
+
+        it("only replays the subset owned by the current user in a mixed queue", async () => {
+            const harness = createHarness();
+            await seedQueue([
+                mutationEntry({ userId: "user-A", url: `${MUTATION_URL}/a` }),
+                mutationEntry({ userId: "user-B", url: `${MUTATION_URL}/b` }),
+            ]);
+            await setRegisteredUser("user-A");
+            harness.fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }));
+
+            await harness.sync("sahidawa-sync-mutations");
+
+            const remaining = await readQueue();
+            expect(remaining).toHaveLength(1);
+            expect(remaining[0].userId).toBe("user-B");
+            expect(harness.fetchMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("replays legacy unbound (null-user) entries under any signed-in user", async () => {
+            const harness = createHarness();
+            await seedQueue([mutationEntry({ userId: null })]);
+            await setRegisteredUser("user-B");
+            harness.fetchMock.mockResolvedValue(jsonResponse(200, { ok: true }));
+
+            await harness.sync("sahidawa-sync-mutations");
+
+            expect(await readQueue()).toHaveLength(0);
+            expect(harness.fetchMock).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/apps/web/tests/syncUserScoping.test.ts
+++ b/apps/web/tests/syncUserScoping.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+/**
+ * @jest-environment jsdom
+ */
+import { clearSyncQueueForLogout, registerCurrentUser } from "@/lib/syncUserScoping";
+
+describe("lib/syncUserScoping", () => {
+    const postMessage = jest.fn();
+
+    beforeEach(() => {
+        postMessage.mockClear();
+        Object.defineProperty(navigator, "serviceWorker", {
+            configurable: true,
+            value: {
+                ready: Promise.resolve({ active: { postMessage } }),
+            },
+        });
+    });
+
+    afterEach(() => {
+        Object.defineProperty(navigator, "serviceWorker", {
+            configurable: true,
+            value: undefined,
+        });
+    });
+
+    it("registers the current user with the active service worker", async () => {
+        registerCurrentUser("user-A");
+        await Promise.resolve();
+        expect(postMessage).toHaveBeenCalledWith({ type: "SET_CURRENT_USER", userId: "user-A" });
+    });
+
+    it("clears the queue and unregisters the user on logout", async () => {
+        clearSyncQueueForLogout();
+        await Promise.resolve();
+        expect(postMessage).toHaveBeenCalledWith({ type: "CLEAR_SYNC_QUEUE" });
+        expect(postMessage).toHaveBeenCalledWith({ type: "SET_CURRENT_USER", userId: null });
+    });
+
+    it("is a no-op when service worker is unavailable", async () => {
+        Object.defineProperty(navigator, "serviceWorker", {
+            configurable: true,
+            value: undefined,
+        });
+        registerCurrentUser("user-A");
+        clearSyncQueueForLogout();
+        await Promise.resolve();
+        expect(postMessage).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/worker/index.js
+++ b/apps/web/worker/index.js
@@ -703,11 +703,20 @@ function checkExpiryAndNotify() {
 }
 
 // ---------------------------------------------------------------------------
-// MESSAGE — allow pages to communicate with the SW (e.g. skip waiting)
+// MESSAGE — allow pages to communicate with the SW
+//   - SKIP_WAITING: activate a newly installed worker immediately
+//   - SET_CURRENT_USER: record which user is signed in (for queue scoping)
+//   - CLEAR_SYNC_QUEUE: drop queued mutations (on sign-out)
 // ---------------------------------------------------------------------------
 self.addEventListener("message", (event) => {
     if (event.data?.type === "SKIP_WAITING") {
         self.skipWaiting();
+    }
+    if (event.data?.type === "SET_CURRENT_USER") {
+        event.waitUntil?.(setMetaValue("current-user-id", event.data.userId ?? null));
+    }
+    if (event.data?.type === "CLEAR_SYNC_QUEUE") {
+        event.waitUntil?.(clearQueuedRequests());
     }
 });
 
@@ -735,16 +744,94 @@ async function notifyClientsToFlush() {
 // ---------------------------------------------------------------------------
 function openSyncDb() {
     return new Promise((resolve, reject) => {
-        const req = indexedDB.open('sahidawa-sync-db', 1);
+        const req = indexedDB.open("sahidawa-sync-db", 2);
         req.onupgradeneeded = (e) => {
             const db = e.target.result;
-            if (!db.objectStoreNames.contains('requests')) {
-                db.createObjectStore('requests', { keyPath: 'id', autoIncrement: true });
+            if (!db.objectStoreNames.contains("requests")) {
+                db.createObjectStore("requests", { keyPath: "id", autoIncrement: true });
+            }
+            if (!db.objectStoreNames.contains("meta")) {
+                db.createObjectStore("meta", { keyPath: "key" });
             }
         };
         req.onsuccess = (e) => resolve(e.target.result);
-        req.onerror = () => reject('Failed to open sync DB');
+        req.onerror = () => reject("Failed to open sync DB");
     });
+}
+
+function setMetaValue(key, value) {
+    return openSyncDb()
+        .then((db) => {
+            return new Promise((resolve, reject) => {
+                if (!db.objectStoreNames.contains("meta")) {
+                    db.close();
+                    return resolve();
+                }
+                const tx = db.transaction("meta", "readwrite");
+                tx.objectStore("meta").put({ key, value });
+                tx.oncomplete = () => {
+                    db.close();
+                    resolve();
+                };
+                tx.onerror = () => {
+                    db.close();
+                    reject("Failed to write sync DB meta");
+                };
+            });
+        })
+        .catch((e) => console.error("[SW] Failed to write sync DB meta", e));
+}
+
+function getMetaValue(key) {
+    return openSyncDb()
+        .then((db) => {
+            return new Promise((resolve, reject) => {
+                if (!db.objectStoreNames.contains("meta")) {
+                    db.close();
+                    return resolve(null);
+                }
+                const tx = db.transaction("meta", "readonly");
+                const req = tx.objectStore("meta").get(key);
+                req.onsuccess = () => {
+                    db.close();
+                    resolve(req.result ? req.result.value : null);
+                };
+                req.onerror = () => {
+                    db.close();
+                    reject("Failed to read sync DB meta");
+                };
+            });
+        })
+        .catch(() => null);
+}
+
+/** The user id the page has most recently told us is signed in (or null). */
+function getCurrentUserId() {
+    return getMetaValue("current-user-id");
+}
+
+/**
+ * Derive the owning user id for a queued mutation from its Authorization
+ * bearer token (a Supabase JWT whose `sub` claim is the user id). When we
+ * later replay the stored headers verbatim, we must only do so while the same
+ * user is signed in — replaying with a stored token under a different session
+ * would submit an action as the wrong user.
+ */
+function extractUserIdFromRequest(request) {
+    const authHeader = request.headers.get("authorization");
+    if (!authHeader) return null;
+    const match = /^Bearer\s+(.+)$/i.exec(authHeader);
+    if (!match) return null;
+    try {
+        const encodedPayload = match[1].split(".")[1];
+        if (!encodedPayload) return null;
+        const base64 = encodedPayload.replace(/-/g, "+").replace(/_/g, "/");
+        const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+        const payload = JSON.parse(atob(padded));
+        return payload?.sub || payload?.user_id || payload?.user?.id || null;
+    } catch {
+        return null;
+    }
 }
 
 async function saveFailedRequest(request) {
@@ -760,17 +847,27 @@ async function saveFailedRequest(request) {
             method: request.method,
             headers,
             body: bodyText,
-            timestamp: Date.now()
+            timestamp: Date.now(),
+            // Bind this entry to the user who created it so it is never
+            // replayed under a different session. Prefer the explicit token in
+            // the request; fall back to the currently registered session user.
+            userId: extractUserIdFromRequest(request) || (await getCurrentUserId()) || null,
         };
-        
+
         return new Promise((resolve, reject) => {
-            const tx = db.transaction('requests', 'readwrite');
-            tx.objectStore('requests').add(serialized);
-            tx.oncomplete = () => { db.close(); resolve(); };
-            tx.onerror = () => { db.close(); reject(); };
+            const tx = db.transaction("requests", "readwrite");
+            tx.objectStore("requests").add(serialized);
+            tx.oncomplete = () => {
+                db.close();
+                resolve();
+            };
+            tx.onerror = () => {
+                db.close();
+                reject();
+            };
         });
     } catch (e) {
-        console.error('[SW] Failed to save request to sync queue', e);
+        console.error("[SW] Failed to save request to sync queue", e);
     }
 }
 
@@ -778,45 +875,80 @@ async function flushMutationsQueue() {
     try {
         const db = await openSyncDb();
         const requests = await new Promise((resolve, reject) => {
-            const tx = db.transaction('requests', 'readonly');
-            const req = tx.objectStore('requests').getAll();
+            const tx = db.transaction("requests", "readonly");
+            const req = tx.objectStore("requests").getAll();
             req.onsuccess = () => resolve(req.result);
             req.onerror = () => reject();
         });
-        
+
         if (!requests || requests.length === 0) {
             db.close();
             return;
         }
-        
+
+        // User-scoping guard: a mutation bound to a specific user must only be
+        // replayed while that same user is authenticated. Never replay queued
+        // actions under a different session (or under login as another user),
+        // because the stored headers carry credentials for the original owner.
+        const currentUserId = await getCurrentUserId();
+
         for (const reqData of requests) {
+            if (reqData.userId && currentUserId !== reqData.userId) {
+                console.warn(
+                    "[SW] Skipping queued mutation owned by a different user (current session mismatch)"
+                );
+                continue;
+            }
             try {
                 const response = await fetch(reqData.url, {
                     method: reqData.method,
                     headers: reqData.headers,
-                    body: reqData.method !== 'GET' && reqData.method !== 'HEAD' ? reqData.body : undefined
+                    body:
+                        reqData.method !== "GET" && reqData.method !== "HEAD"
+                            ? reqData.body
+                            : undefined,
                 });
-                
-                if (response.ok || response.status >= 400) { 
+
+                if (response.ok || response.status >= 400) {
                     await new Promise((resolve) => {
-                        const tx = db.transaction('requests', 'readwrite');
-                        tx.objectStore('requests').delete(reqData.id);
+                        const tx = db.transaction("requests", "readwrite");
+                        tx.objectStore("requests").delete(reqData.id);
                         tx.oncomplete = resolve;
                     });
                 }
             } catch (e) {
-                console.warn('[SW] Sync flush fetch failed (still offline?)', e);
+                console.warn("[SW] Sync flush fetch failed (still offline?)", e);
                 break;
             }
         }
         db.close();
-        
+
         const clients = await self.clients.matchAll({ type: "window" });
         for (const client of clients) {
             client.postMessage({ type: "SYNC_QUEUE_FLUSHED" });
         }
     } catch (e) {
-        console.error('[SW] Sync flush error', e);
+        console.error("[SW] Sync flush error", e);
     }
 }
 
+/** Drop every queued mutation (used when the user signs out). */
+async function clearQueuedRequests() {
+    try {
+        const db = await openSyncDb();
+        if (!db.objectStoreNames.contains("requests")) {
+            db.close();
+            return;
+        }
+        await new Promise((resolve) => {
+            const tx = db.transaction("requests", "readwrite");
+            tx.objectStore("requests").clear();
+            tx.oncomplete = resolve;
+            tx.onerror = resolve;
+        });
+        db.close();
+        console.log("[SW] Cleared queued mutations after sign-out");
+    } catch (e) {
+        console.error("[SW] Failed to clear queued mutations", e);
+    }
+}


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4070**
- **Summary:**
The service worker replays queued mutations with their stored Authorization headers. If a user signs out and another signs in before the queue flushes, those headers would be replayed under the new session, submitting actions as the wrong user.

- Bump sahidawa-sync-db to v2 and add a meta store
- saveFailedRequest stamps each queued entry with the userId derived from the request's bearer token (Supabase JWT sub), falling back to the currently registered session user
- flushMutationsQueue refuses to replay entries whose owner differs from the current signed-in user (and never replays when no user is registered)
- Add SET_CURRENT_USER / CLEAR_SYNC_QUEUE messages; AuthProvider registers the signed-in user and drops the queue on sign-out
- Add worker + client tests



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4070`)
- [x] I have pulled the latest `main` and resolved any conflicts
