### PR TITLE
fix(etl): import requests to prevent cache invalidation NameError

### DIFF
--- a/apps/etl/src/loaders/supabase_loader.py
+++ b/apps/etl/src/loaders/supabase_loader.py
@@ -29,6 +29,7 @@ from hashlib import sha256
 from pathlib import Path
 
 import pandas as pd
+import requests
 from dotenv import load_dotenv
 from supabase import Client, create_client
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4076**
- **Summary:**
  - Added the missing `requests` import in `apps/etl/src/loaders/supabase_loader.py`.
  - This fixes a `NameError` raised by `notify_cache_invalidation()` when invoking `requests.post(...)` and handling `requests.RequestException`.
  - Successful ETL runs are no longer incorrectly marked as failed during the cache invalidation step.

## 📸 Proof of Work (Screenshots / Logs)

### Before

```text
NameError: name 'requests' is not defined
```

The ETL pipeline completed successfully but failed during cache invalidation, causing the run to exit with a non-zero status and report a CRASHED state.

### After

- Added the missing `requests` import.
- `notify_cache_invalidation()` now executes without raising `NameError`.
- Existing exception handling for `requests.RequestException` remains unchanged.
- No ETL logic or webhook behavior was modified.

> No UI changes. This is a backend-only fix.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4076`)
- [x] I have pulled the latest `main` and resolved any conflicts