### PR TITLE
fix(api): gracefully handle Redis unavailability in compare route (#4077)

### DIFF
--- a/apps/api/src/routes/compare.ts
+++ b/apps/api/src/routes/compare.ts
@@ -38,15 +38,21 @@ router.post(
             const { medicine_a, medicine_b } = parsed.data;
             const cacheKey = getCacheKey(medicine_a, medicine_b);
 
-            // 1. Check Redis Cache for pre-computed similarity
-            if (redisClient) {
-                const cachedResult = await redisClient.get(cacheKey);
-                if (cachedResult) {
-                    logger.info(
-                        `Cache hit for medicine comparison: ${medicine_a} vs ${medicine_b}`
+            // 1. Check Redis Cache for pre-computed similarity (skip when Redis unavailable)
+            if (redisClient.isOpen) {
+                try {
+                    const cachedResult = await redisClient.get(cacheKey);
+                    if (cachedResult) {
+                        logger.info(
+                            `Cache hit for medicine comparison: ${medicine_a} vs ${medicine_b}`
+                        );
+                        res.status(200).json(JSON.parse(cachedResult));
+                        return;
+                    }
+                } catch (cacheErr) {
+                    logger.warn(
+                        `Redis cache read error in compare route: ${cacheErr instanceof Error ? cacheErr.message : cacheErr}`
                     );
-                    res.status(200).json(JSON.parse(cachedResult));
-                    return;
                 }
             }
 
@@ -65,10 +71,16 @@ router.post(
                 const resultData = mlResponse.data;
 
                 // 3. Save result to Redis with 24 hours TTL (86400 seconds)
-                if (redisClient) {
-                    await redisClient.set(cacheKey, JSON.stringify(resultData), {
-                        EX: 86400,
-                    });
+                if (redisClient.isOpen) {
+                    try {
+                        await redisClient.set(cacheKey, JSON.stringify(resultData), {
+                            EX: 86400,
+                        });
+                    } catch (cacheErr) {
+                        logger.warn(
+                            `Redis cache write error in compare route: ${cacheErr instanceof Error ? cacheErr.message : cacheErr}`
+                        );
+                    }
                 }
 
                 res.status(200).json(resultData);


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## PR Summary & Link

- **Closes #4077**

### Summary

This PR updates the /api/compare route to gracefully handle Redis unavailability.

#### Changes

- Guard Redis cache reads with edisClient.isOpen.
- Guard Redis cache writes with edisClient.isOpen.
- Wrap Redis get() operations in 	ry/catch.
- Wrap Redis set() operations in 	ry/catch.
- Log Redis cache failures without interrupting request processing.

This matches the behavior already implemented in other cache-backed routes.

## Proof of Work (Screenshots / Logs)

### Before

- Valid comparison requests returned **HTTP 500** when Redis was unavailable because cache operations threw errors that propagated to the global error handler.

### After

- Requests continue to the ML service when Redis is unavailable.
- Cache operations are skipped or logged if they fail.
- Valid comparison requests complete successfully without returning an unexpected HTTP 500.

> No UI changes. Backend-only fix.

## PR Type

- [x] bug (type: bug)
- [ ] feature
- [ ] docs
- [ ] testing
- [ ] security
- [ ] performance
- [ ] design
- [ ] refactor
- [ ] devops
- [ ] accessibility

## Checklist

- [x] My PR has a linked issue (Closes #4077)
- [x] I have pulled the latest main and resolved any conflicts
