### PR TITLE
fix(compose): add missing healthchecks for production service dependencies (#4078)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,6 +64,12 @@ services:
       - .env
     networks:
       - frontend
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3000/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     deploy:
       resources:
         limits:
@@ -99,6 +105,12 @@ services:
         condition: service_healthy
       ml:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     deploy:
       resources:
         limits:
@@ -132,6 +144,12 @@ services:
           create_host_path: false
     networks:
       - backend
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     deploy:
       resources:
         limits:


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #4078**

### Summary

This PR adds explicit healthchecks for the `web`, `api`, and `ml` services in `docker-compose.prod.yml`.

Previously, these services were referenced using:

```yaml
depends_on:
  condition: service_healthy
```

but did not define Compose-level healthchecks, preventing the production stack from starting correctly.

### Changes

- Added a healthcheck for the `web` service using the existing root endpoint.
- Added a healthcheck for the `api` service using its existing root endpoint.
- Added a healthcheck for the `ml` service using the existing `/health` endpoint.
- Preserved the existing `service_healthy` dependency ordering.

The healthcheck commands and timing mirror the existing Dockerfile configuration and do not require any application code changes.

## 📸 Proof of Work (Screenshots / Logs)

### Before

Running:

```bash
docker compose -f docker-compose.prod.yml config
```

or

```bash
docker compose -f docker-compose.prod.yml up -d
```

failed because services referenced with `condition: service_healthy` did not define Compose-level healthchecks.

### After

- All services referenced by `service_healthy` now define healthchecks.
- The production Compose configuration validates successfully.
- Startup ordering is preserved.

> No UI changes. DevOps-only fix.

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [x] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4078`)
- [x] I have pulled the latest `main` and resolved any conflicts
