### PR TITLE
fix(e2e): enable offline sync test and add proper test documentation

### DIFF
--- a/apps/web/tests/e2e/offline.spec.ts
+++ b/apps/web/tests/e2e/offline.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "@playwright/test";
 
+/**
+ * E2E test for offline scanner sync queue functionality.
+ * Tests that barcode scans are queued when offline and synced when back online.
+ *
+ * Related issue: #4052 - Offline Sync Test is Skipped - Critical PWA Feature Untested
+ */
 test.describe("Offline Scanner and Sync Queue", () => {
     const testBarcode = "OFFLINE-TEST-BATCH-001";
 
@@ -18,7 +24,7 @@ test.describe("Offline Scanner and Sync Queue", () => {
         await page.reload();
     });
 
-    test.skip("intercepts scan when offline, queues it in IndexedDB, and flushes on reconnect", async ({
+    test("intercepts scan when offline, queues it in IndexedDB, and flushes on reconnect", async ({
         page,
         context,
     }) => {


### PR DESCRIPTION
## Summary

This PR enables the offline sync queue E2E test that was previously skipped, providing critical test coverage for the PWA's offline functionality.

## Changes

- Removed `test.skip()` to enable the offline sync queue E2E test
- Added JSDoc comment documenting the test purpose and related issue
- Test verifies that barcode scans are queued when offline and synced when back online

## Why This Matters

- **Offline-first is a core PWA feature** - Users in rural India often have intermittent connectivity
- **Critical medicine verification workflow** - A failed sync could mean a verified medicine is not recorded
- **Data integrity risk** - Queued mutations could be lost during sync failures

## Testing

```bash
cd apps/web
npx playwright test tests/e2e/offline.spec.ts
```

## Checklist

- [x] I have self-reviewed my changes
- [x] I have tested my changes
- [x] I have linked the related issue (closes #4052)
- [x] I have followed the PR template structure

Closes #4052