### PR TITLE
test: expand MedicinePhotoUpload component test coverage

### DIFF
--- a/apps/web/tests/medicine-photo-upload.test.tsx
+++ b/apps/web/tests/medicine-photo-upload.test.tsx
@@ -1,8 +1,29 @@
-import { renderToStaticMarkup } from "react-dom/server";
+import { render, screen, fireEvent } from "@testing-library/react";
 
+import { useUpload } from "../components/medicine/useUpload";
+
+import { renderToStaticMarkup } from "react-dom/server";
 import { MedicinePhotoUpload } from "../components/medicine/MedicinePhotoUpload";
 
+jest.mock("../components/medicine/useUpload");
+
+const mockUpload = jest.fn();
+const mockReset = jest.fn();
+const mockCancel = jest.fn();
+
+const mockedUseUpload = useUpload as jest.MockedFunction<typeof useUpload>;
+
 describe("MedicinePhotoUpload", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockedUseUpload.mockReturnValue({
+            state: { status: "idle" },
+            upload: mockUpload,
+            reset: mockReset,
+            cancel: mockCancel,
+        });
+    });
     it("renders the dropzone with file input constraints and accessibility attributes", () => {
         const markup = renderToStaticMarkup(
             <MedicinePhotoUpload onUploadComplete={() => undefined} label="Upload Medicine Photo" />
@@ -24,5 +45,153 @@ describe("MedicinePhotoUpload", () => {
 
         expect(markup).toContain('aria-disabled="true"');
         expect(markup).toContain("disabled");
+    });
+
+    it("calls upload when a valid file is selected", () => {
+        render(<MedicinePhotoUpload onUploadComplete={jest.fn()} />);
+
+        const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+        const file = new File(["abc"], "test.jpg", {
+            type: "image/jpeg",
+        });
+
+        fireEvent.change(input, {
+            target: {
+                files: [file],
+            },
+        });
+
+        expect(mockUpload).toHaveBeenCalledWith(file);
+    });
+
+    it("does not call upload when an invalid file type is selected", () => {
+        render(<MedicinePhotoUpload onUploadComplete={jest.fn()} />);
+
+        const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+        const file = new File(["abc"], "test.txt", {
+            type: "text/plain",
+        });
+
+        fireEvent.change(input, {
+            target: {
+                files: [file],
+            },
+        });
+
+        expect(mockUpload).not.toHaveBeenCalled();
+    });
+
+    it("renders upload progress while uploading", () => {
+        mockedUseUpload.mockReturnValue({
+            state: {
+                status: "uploading",
+                progress: 50,
+            },
+            upload: mockUpload,
+            reset: mockReset,
+            cancel: mockCancel,
+        });
+
+        render(<MedicinePhotoUpload onUploadComplete={jest.fn()} />);
+
+        expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "50");
+
+        expect(screen.getByText("50%")).toBeInTheDocument();
+    });
+
+    it("calls cancel when the cancel upload button is clicked", () => {
+        mockedUseUpload.mockReturnValue({
+            state: {
+                status: "uploading",
+                progress: 40,
+            },
+            upload: mockUpload,
+            reset: mockReset,
+            cancel: mockCancel,
+        });
+
+        render(<MedicinePhotoUpload onUploadComplete={jest.fn()} />);
+
+        fireEvent.click(
+            screen.getByRole("button", {
+                name: /cancel upload/i,
+            })
+        );
+
+        expect(mockCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders an error message when upload fails", () => {
+        mockedUseUpload.mockReturnValue({
+            state: {
+                status: "error",
+                message: "Upload failed",
+            },
+            upload: mockUpload,
+            reset: mockReset,
+            cancel: mockCancel,
+        });
+
+        render(<MedicinePhotoUpload onUploadComplete={jest.fn()} />);
+
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(screen.getByText("Upload failed")).toBeInTheDocument();
+    });
+
+    it("resets upload when try again is clicked", () => {
+        mockedUseUpload.mockReturnValue({
+            state: {
+                status: "error",
+                message: "Upload failed",
+            },
+            upload: mockUpload,
+            reset: mockReset,
+            cancel: mockCancel,
+        });
+
+        render(<MedicinePhotoUpload onUploadComplete={jest.fn()} />);
+
+        fireEvent.click(
+            screen.getByRole("button", {
+                name: /try uploading again/i,
+            })
+        );
+
+        expect(mockReset).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders uploaded medicine preview when upload is successful", () => {
+        mockedUseUpload.mockReturnValue({
+            state: { status: "success" },
+            upload: mockUpload,
+            reset: mockReset,
+            cancel: mockCancel,
+        });
+        render(<MedicinePhotoUpload onUploadComplete={jest.fn()} />);
+        expect(screen.getByAltText(/uploaded medicine preview/i)).toBeInTheDocument();
+    });
+
+    it("resets upload when remove button is clicked", () => {
+        mockedUseUpload.mockReturnValue({
+            state: {
+                status: "success",
+                secureUrl: "https://example.com/image.jpg",
+            },
+            upload: mockUpload,
+            reset: mockReset,
+            cancel: mockCancel,
+        });
+
+        render(<MedicinePhotoUpload onUploadComplete={jest.fn()} />);
+
+        fireEvent.click(
+            screen.getByRole("button", {
+                name: /remove uploaded photo/i,
+            })
+        );
+
+        expect(mockReset).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4017 
- **Summary:**
This PR expands the existing React Testing Library coverage for the `MedicinePhotoUpload` component.

### Added test coverage

- Upload callback is triggered for valid files.
- Invalid file types are rejected.
- Upload progress UI renders correctly.
- Cancel upload action invokes the cancel handler.
- Error state renders correctly.
- Retry action resets the upload state.
- Success state renders uploaded image preview.
- Remove / Re-upload resets the component state.

The existing accessibility and static rendering tests remain unchanged.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_
<img width="868" height="367" alt="Screenshot 2026-08-04 163425" src="https://github.com/user-attachments/assets/5126a571-7467-432f-926a-4804ff255720" />


## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
