### PR TITLE
refactor(devops): introduce DISCORD_APP_ALERTS_WEBHOOK_URL for app-level alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,12 @@ GOOGLE_APPLICATION_CREDENTIALS=apps/ml/google-credentials.json
 # --- Caching (Redis/Upstash) ---
 REDIS_URL=your_redis_url
 
+# --- Discord Webhooks ---
+# Used for backend application-level failure alerts (e.g. Redis cache stats failures)
+DISCORD_APP_ALERTS_WEBHOOK_URL=your_discord_app_alerts_webhook_url
+# Used exclusively for pg_cron job monitoring alerts
+PG_CRON_MONITOR_WEBHOOK_URL=your_pg_cron_monitor_webhook_url
+
 # --- Web Push Notifications ---
 # Generate with: npx web-push generate-vapid-keys
 VAPID_PUBLIC_KEY=your_vapid_public_key

--- a/apps/api/src/services/cache.service.ts
+++ b/apps/api/src/services/cache.service.ts
@@ -324,7 +324,7 @@ let lastDiscordAlertTime = 0;
 const DISCORD_ALERT_DEBOUNCE_MS = 15 * 60 * 1000; // 15 minutes
 
 async function sendCacheAlertDiscord(): Promise<void> {
-    const WEBHOOK_URL = process.env.PG_CRON_MONITOR_WEBHOOK_URL;
+    const WEBHOOK_URL = process.env.DISCORD_APP_ALERTS_WEBHOOK_URL;
     if (!WEBHOOK_URL) return;
 
     const now = Date.now();

--- a/apps/api/src/services/cache.test.ts
+++ b/apps/api/src/services/cache.test.ts
@@ -152,7 +152,7 @@ describe("cache.service", () => {
 
         beforeEach(() => {
             mockFetch.mockClear();
-            process.env.PG_CRON_MONITOR_WEBHOOK_URL = "http://mock-webhook";
+            process.env.DISCORD_APP_ALERTS_WEBHOOK_URL = "http://mock-webhook";
         });
 
         it("should return live stats and save snapshot on success", async () => {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3604**
- **Summary:** Introduces a dedicated `DISCORD_APP_ALERTS_WEBHOOK_URL` for backend application-level alerts (Redis cache stats failures) in `cache.service.ts`, instead of reusing the `PG_CRON_MONITOR_WEBHOOK_URL` cron-monitor webhook. `pgCronMonitor.ts` still uses `PG_CRON_MONITOR_WEBHOOK_URL`. Both vars documented in `.env.example`.

## 📸 Proof of Work (Screenshots / Logs)

```
Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
```

## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
