### PR TITLE
fix(cron): retry district and drug alerts on failed delivery

### DIFF
--- a/apps/api/src/cron/alert-broadcaster.ts
+++ b/apps/api/src/cron/alert-broadcaster.ts
@@ -164,7 +164,7 @@ async function sendNotificationToSubscriber(
     sub: NotificationSubscriber,
     type: "counterfeit" | "recall" | "expiry",
     data: NotificationAlertData
-): Promise<void> {
+): Promise<boolean> {
     const { title, body } = getLocalizedMessage(type, data, sub.language);
     const fullMessage = `${title}\n\n${body}`;
 
@@ -176,7 +176,10 @@ async function sendNotificationToSubscriber(
         sendPromises.push(whatsappService.send(sub.phone, fullMessage, sub.language));
     }
 
-    await Promise.all(sendPromises);
+    if (sendPromises.length === 0) return false;
+
+    const results = await Promise.allSettled(sendPromises);
+    return results.some((result) => result.status === "fulfilled" && result.value);
 }
 
 interface ExpiringBatchSummary {
@@ -248,24 +251,10 @@ export async function broadcastDistrictAlerts(): Promise<void> {
         for (const alert of alerts) {
             logger.info(`Broadcasting counterfeit alert for district: ${alert.district}`);
 
-            const { error: markError } = await supabase
-                .from("district_alerts")
-                .update({ broadcasted: true })
-                .eq("id", alert.id);
-
-            if (markError) {
-                logger.error({
-                    message:
-                        "Failed to mark district alert as broadcasted, skipping send to avoid duplicate delivery on next tick",
-                    error: markError,
-                    alertId: alert.id,
-                });
-                continue;
-            }
-
             let from = 0;
             let to = PAGE_SIZE - 1;
             let hasMore = true;
+            let hasSuccessfulDelivery = false;
 
             while (hasMore) {
                 const { data: subscribers, error: subsError } = await supabase
@@ -296,7 +285,10 @@ export async function broadcastDistrictAlerts(): Promise<void> {
                             district: alert.district,
                         })
                     );
-                    await Promise.allSettled(promises);
+                    const results = await Promise.allSettled(promises);
+                    hasSuccessfulDelivery ||= results.some(
+                        (result) => result.status === "fulfilled" && result.value
+                    );
                 }
 
                 if (subscribers.length < PAGE_SIZE) {
@@ -307,7 +299,26 @@ export async function broadcastDistrictAlerts(): Promise<void> {
                 }
             }
 
-            await supabase.from("district_alerts").update({ broadcasted: true }).eq("id", alert.id);
+            if (!hasSuccessfulDelivery) {
+                logger.warn(
+                    "District alert delivery failed for every eligible subscriber; will retry.",
+                    { alertId: alert.id, district: alert.district }
+                );
+                continue;
+            }
+
+            const { error: markError } = await supabase
+                .from("district_alerts")
+                .update({ broadcasted: true })
+                .eq("id", alert.id);
+
+            if (markError) {
+                logger.error({
+                    message: "Failed to mark district alert as broadcasted",
+                    error: markError,
+                    alertId: alert.id,
+                });
+            }
         }
     } catch (err) {
         logger.error({ message: "Error in broadcastDistrictAlerts", error: err });
@@ -334,25 +345,10 @@ export async function broadcastDrugAlerts(): Promise<void> {
         for (const alert of alerts) {
             logger.info(`Broadcasting CDSCO drug recall: ${alert.reported_brand_name}`);
 
-            // MARK AS BROADCASTED BEFORE SENDING
-            const { error: markError } = await supabase
-                .from("drug_alerts")
-                .update({ broadcasted: true })
-                .eq("id", alert.id);
-
-            if (markError) {
-                logger.error({
-                    message:
-                        "Failed to mark drug alert as broadcasted, skipping send to avoid duplicate delivery on next tick",
-                    error: markError,
-                    alertId: alert.id,
-                });
-                continue;
-            }
-
             let from = 0;
             let to = PAGE_SIZE - 1;
             let hasMore = true;
+            let hasSuccessfulDelivery = false;
 
             while (hasMore) {
                 let query = supabase
@@ -387,7 +383,10 @@ export async function broadcastDrugAlerts(): Promise<void> {
                             batchNumber: alert.batch_number,
                         })
                     );
-                    await Promise.allSettled(promises);
+                    const results = await Promise.allSettled(promises);
+                    hasSuccessfulDelivery ||= results.some(
+                        (result) => result.status === "fulfilled" && result.value
+                    );
                 }
 
                 if (subscribers.length < PAGE_SIZE) {
@@ -396,6 +395,27 @@ export async function broadcastDrugAlerts(): Promise<void> {
                     from += PAGE_SIZE;
                     to += PAGE_SIZE;
                 }
+            }
+
+            if (!hasSuccessfulDelivery) {
+                logger.warn(
+                    "Drug alert delivery failed for every eligible subscriber; will retry.",
+                    { alertId: alert.id, drug: alert.reported_brand_name }
+                );
+                continue;
+            }
+
+            const { error: markError } = await supabase
+                .from("drug_alerts")
+                .update({ broadcasted: true })
+                .eq("id", alert.id);
+
+            if (markError) {
+                logger.error({
+                    message: "Failed to mark drug alert as broadcasted",
+                    error: markError,
+                    alertId: alert.id,
+                });
             }
         }
     } catch (err) {

--- a/apps/api/tests/alertBroadcaster.test.ts
+++ b/apps/api/tests/alertBroadcaster.test.ts
@@ -252,21 +252,17 @@ describe("broadcastDistrictAlerts", () => {
         jest.clearAllMocks();
     });
 
-    it("marks the alert as broadcasted before paginating subscribers (not after)", async () => {
-        const callOrder: string[] = [];
-        const chain = getChain();
+    it("marks the alert as broadcasted only after at least one delivery succeeds", async () => {
+        const markSpy = jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+        });
+        (smsService.send as jest.Mock).mockResolvedValue(true);
 
-        chain.select.mockReturnThis();
-        chain.eq.mockReturnThis();
-        chain.ilike.mockReturnThis();
-
-        // First select(...).eq(...).eq(...) call: fetch unbroadcasted alerts
-        let selectCallCount = 0;
         (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
             if (table === "district_alerts") {
                 return {
-                    select: jest.fn().mockImplementation(() => ({
-                        eq: jest.fn().mockImplementation(() => ({
+                    select: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockReturnValue({
                             eq: jest.fn().mockResolvedValue({
                                 data: [
                                     {
@@ -280,32 +276,37 @@ describe("broadcastDistrictAlerts", () => {
                                 ],
                                 error: null,
                             }),
-                        })),
-                    })),
-                    update: jest.fn().mockImplementation(() => {
-                        callOrder.push("mark_broadcasted");
-                        return {
-                            eq: jest.fn().mockResolvedValue({ data: null, error: null }),
-                        };
+                        }),
                     }),
+                    update: markSpy,
                 };
             }
             if (table === "notification_subscribers") {
-                selectCallCount += 1;
-                return createSubscriberTable([], {
-                    onRange: () => callOrder.push("fetch_subscribers"),
-                });
+                return createSubscriberTable([
+                    {
+                        id: "sub-1",
+                        phone: "+911234567890",
+                        language: "en",
+                        channels: ["sms"],
+                        district: "Delhi",
+                        is_active: true,
+                        status: "active",
+                    },
+                ]);
             }
-            return chain;
+            return {};
         });
 
         await broadcastDistrictAlerts();
 
-        expect(callOrder[0]).toBe("mark_broadcasted");
-        expect(callOrder).toContain("fetch_subscribers");
+        expect(smsService.send).toHaveBeenCalledTimes(1);
+        expect(markSpy).toHaveBeenCalledWith({ broadcasted: true });
     });
 
-    it("does not send notifications when marking broadcasted=true fails", async () => {
+    it("keeps the alert eligible for retry when every delivery fails", async () => {
+        const markSpy = jest.fn();
+        (smsService.send as jest.Mock).mockResolvedValue(false);
+
         (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
             if (table === "district_alerts") {
                 return {
@@ -326,43 +327,29 @@ describe("broadcastDistrictAlerts", () => {
                             }),
                         }),
                     }),
-                    update: jest.fn().mockReturnValue({
-                        eq: jest.fn().mockResolvedValue({
-                            data: null,
-                            error: { message: "DB write failed" },
-                        }),
-                    }),
+                    update: markSpy,
                 };
             }
             if (table === "notification_subscribers") {
-                return {
-                    select: jest.fn().mockReturnValue({
-                        eq: jest.fn().mockReturnValue({
-                            ilike: jest.fn().mockReturnValue({
-                                range: jest.fn().mockResolvedValue({
-                                    data: [
-                                        {
-                                            id: "sub-1",
-                                            phone: "+911234567890",
-                                            language: "en",
-                                            channels: ["sms"],
-                                            district: "Mumbai",
-                                            is_active: true,
-                                        },
-                                    ],
-                                    error: null,
-                                }),
-                            }),
-                        }),
-                    }),
-                };
+                return createSubscriberTable([
+                    {
+                        id: "sub-1",
+                        phone: "+911234567890",
+                        language: "en",
+                        channels: ["sms"],
+                        district: "Mumbai",
+                        is_active: true,
+                        status: "active",
+                    },
+                ]);
             }
             return {};
         });
 
         await broadcastDistrictAlerts();
 
-        expect(smsService.send).not.toHaveBeenCalled();
+        expect(smsService.send).toHaveBeenCalledTimes(1);
+        expect(markSpy).not.toHaveBeenCalled();
     });
 
     it("does not re-notify already-broadcasted alerts on the next tick", async () => {
@@ -439,6 +426,110 @@ describe("broadcastDistrictAlerts", () => {
 
         expect(ilikeArgs).toEqual(["district", "Pune District"]);
         expect(smsService.send).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// broadcastDrugAlerts (retry semantics)
+// ---------------------------------------------------------------------------
+
+describe("broadcastDrugAlerts", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("marks the alert as broadcasted only after at least one delivery succeeds", async () => {
+        const markSpy = jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+        });
+        (smsService.send as jest.Mock).mockResolvedValue(true);
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "drug_alerts") {
+                return {
+                    select: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockResolvedValue({
+                            data: [
+                                {
+                                    id: "drug-alert-1",
+                                    district: "Delhi",
+                                    reported_brand_name: "Paracetamol",
+                                    batch_number: "B1",
+                                    broadcasted: false,
+                                },
+                            ],
+                            error: null,
+                        }),
+                    }),
+                    update: markSpy,
+                };
+            }
+            if (table === "notification_subscribers") {
+                return createSubscriberTable([
+                    {
+                        id: "sub-1",
+                        phone: "+911234567890",
+                        language: "en",
+                        channels: ["sms"],
+                        district: "Delhi",
+                        is_active: true,
+                        status: "active",
+                    },
+                ]);
+            }
+            return {};
+        });
+
+        await broadcastDrugAlerts();
+
+        expect(smsService.send).toHaveBeenCalledTimes(1);
+        expect(markSpy).toHaveBeenCalledWith({ broadcasted: true });
+    });
+
+    it("keeps the alert eligible for retry when every delivery fails", async () => {
+        const markSpy = jest.fn();
+        (smsService.send as jest.Mock).mockResolvedValue(false);
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "drug_alerts") {
+                return {
+                    select: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockResolvedValue({
+                            data: [
+                                {
+                                    id: "drug-alert-1",
+                                    district: "Mumbai",
+                                    reported_brand_name: "Ibuprofen",
+                                    batch_number: "B2",
+                                    broadcasted: false,
+                                },
+                            ],
+                            error: null,
+                        }),
+                    }),
+                    update: markSpy,
+                };
+            }
+            if (table === "notification_subscribers") {
+                return createSubscriberTable([
+                    {
+                        id: "sub-1",
+                        phone: "+911234567890",
+                        language: "en",
+                        channels: ["sms"],
+                        district: "Mumbai",
+                        is_active: true,
+                        status: "active",
+                    },
+                ]);
+            }
+            return {};
+        });
+
+        await broadcastDrugAlerts();
+
+        expect(smsService.send).toHaveBeenCalledTimes(1);
+        expect(markSpy).not.toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #3914**
- **Summary:** Fixes premature `broadcasted: true` marking in `broadcastDistrictAlerts` and `broadcastDrugAlerts`. Alerts are now only marked broadcasted after at least one successful delivery (mirroring `broadcastExpiryAlerts`), so dropped alerts are retried on the next tick while still preventing duplicates. `sendNotificationToSubscriber` now reports delivery success via `Promise.allSettled`.

## 📸 Proof of Work (Screenshots / Logs)

```
Tests:       30 passed, 30 total
Test Suites: 65 passed, 65 total
Tests:       1 skipped, 723 passed, 724 total
✔ No circular dependency found!
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #123`)
- [x] I have pulled the latest `main` and resolved any conflicts
