### PR TITLE
fix(api): require OTP verification for notification phone changes

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -247,6 +247,75 @@ function getGuestToken(req: AuthenticatedRequest): string | undefined {
     return typeof header === "string" ? header : undefined;
 }
 
+// ── Pending phone-change state (authenticated users) ───────────────────────────
+// When an authenticated user requests a phone number change, we don't write it
+// immediately. Instead we generate an OTP, send it to the new number, and store
+// the pending change in Redis.  Only after the user presents a valid OTP through
+// POST /verify-otp do we apply the change.
+const PENDING_PHONE_CHANGE_PREFIX = "pending_phone_change:";
+const PENDING_PHONE_CHANGE_TTL_SECONDS = 10 * 60; // 10 minutes
+
+interface PendingPhoneChange {
+    userId: string;
+    oldPhone: string;
+    newPhone: string;
+    expiresAt: string;
+}
+
+function getPendingPhoneChangeKey(userId: string): string {
+    return `${PENDING_PHONE_CHANGE_PREFIX}${userId}`;
+}
+
+async function storePendingPhoneChange(
+    userId: string,
+    oldPhone: string,
+    newPhone: string
+): Promise<void> {
+    const data: PendingPhoneChange = {
+        userId,
+        oldPhone,
+        newPhone,
+        expiresAt: new Date(Date.now() + PENDING_PHONE_CHANGE_TTL_SECONDS * 1000).toISOString(),
+    };
+    if (redisClient.isOpen) {
+        try {
+            await redisClient.setEx(
+                getPendingPhoneChangeKey(userId),
+                PENDING_PHONE_CHANGE_TTL_SECONDS,
+                JSON.stringify(data)
+            );
+        } catch (err) {
+            logger.warn({
+                message: "Redis error storing pending phone change",
+                error: String(err),
+            });
+        }
+    }
+}
+
+async function getPendingPhoneChange(userId: string): Promise<PendingPhoneChange | null> {
+    if (!redisClient.isOpen) return null;
+    try {
+        const raw = await redisClient.get(getPendingPhoneChangeKey(userId));
+        if (!raw) return null;
+        const data: PendingPhoneChange = JSON.parse(raw);
+        if (new Date(data.expiresAt) < new Date()) {
+            await clearPendingPhoneChange(userId);
+            return null;
+        }
+        return data;
+    } catch {
+        return null;
+    }
+}
+
+async function clearPendingPhoneChange(userId: string): Promise<void> {
+    if (!redisClient.isOpen) return;
+    try {
+        await redisClient.del(getPendingPhoneChangeKey(userId));
+    } catch {}
+}
+
 router.get("/status", limiter, optionalAuth, async (req: AuthenticatedRequest, res) => {
     try {
         // Guests have no account, so they prove ownership of the number with a
@@ -682,6 +751,42 @@ router.post(
             await clearOtpAttempts(formattedPhone);
             await otpStore.clear(formattedPhone);
 
+            // Check if this OTP verification is for a pending phone change
+            // (authenticated user changing their notification phone number).
+            if (req.user) {
+                const pendingChange = await getPendingPhoneChange(req.user.id);
+                if (pendingChange && pendingChange.newPhone === formattedPhone) {
+                    await clearPendingPhoneChange(req.user.id);
+
+                    if (!dbFailed) {
+                        const { error: updateError } = await supabase
+                            .from("notification_subscribers")
+                            .update({ phone: formattedPhone })
+                            .eq("user_id", req.user.id);
+
+                        if (updateError) {
+                            logger.error({
+                                message: "Failed to update phone number",
+                                error: updateError,
+                            });
+                            res.status(500).json({ error: "Database error" });
+                            return;
+                        }
+                    } else {
+                        const sub = memorySubscriberStore.find((s) => s.user_id === req.user!.id);
+                        if (sub) {
+                            memorySubscriberStore.delete(sub.phone);
+                            sub.phone = formattedPhone;
+                            memorySubscriberStore.set(formattedPhone, sub);
+                            sub.updated_at = new Date().toISOString();
+                        }
+                    }
+
+                    res.json({ success: true, message: "Phone number changed successfully" });
+                    return;
+                }
+            }
+
             if (!dbFailed) {
                 const { error: updateError } = await supabase
                     .from("notification_subscribers")
@@ -752,9 +857,9 @@ router.patch(
 
         // Resolve who is making the change: a signed-in user (scoped by user_id)
         // or a guest who proved ownership of their number with a token (scoped by
-        // that number). Guests may not move their subscription to a different
-        // number here — changing the number means re-verifying it through
-        // register + OTP, so the new number's owner still has to consent.
+        // that number). Neither guests nor authenticated users may move their
+        // subscription to a different number without proving ownership of the
+        // new number via OTP.
         let guestPhone: string | undefined;
         if (!req.user) {
             const verified = verifyGuestPhone(getGuestToken(req));
@@ -773,11 +878,85 @@ router.patch(
             guestPhone = verified;
         }
 
+        // Authenticated users who want to change their phone number must verify
+        // ownership of the new number via OTP. Generate the OTP, send it, store
+        // the pending change, and return the current subscriber state. The actual
+        // phone update happens only after the user presents the OTP through
+        // POST /verify-otp. The response is 200 (not 202) to preserve backward
+        // compatibility with existing clients that expect subscriber in the body.
+        if (req.user && formattedNewPhone) {
+            let currentSubscriber = null;
+            if (!dbConfig?.isSupabaseOffline) {
+                try {
+                    const { data } = await supabase
+                        .from("notification_subscribers")
+                        .select("phone, channels, language, district, is_active")
+                        .eq("user_id", req.user.id)
+                        .maybeSingle();
+                    currentSubscriber = data;
+                } catch {}
+            }
+            if (!currentSubscriber) {
+                currentSubscriber = memorySubscriberStore.find((s) => s.user_id === req.user!.id);
+            }
+
+            if (!currentSubscriber) {
+                res.status(404).json({ error: "Subscriber not found" });
+                return;
+            }
+
+            if (formattedNewPhone === currentSubscriber.phone) {
+                res.status(400).json({ error: "New phone number is the same as the current one." });
+                return;
+            }
+
+            const otp = randomInt(100000, 1000000).toString();
+            const otpExpires = new Date(
+                Date.now() + PENDING_PHONE_CHANGE_TTL_SECONDS * 1000
+            ).toISOString();
+
+            await otpStore.store(formattedNewPhone, otp, otpExpires);
+            await storePendingPhoneChange(req.user.id, currentSubscriber.phone, formattedNewPhone);
+
+            const sends: Promise<unknown>[] = [];
+            const channelsForOtp =
+                channels ?? (currentSubscriber.channels as ("sms" | "whatsapp")[]);
+            if (channelsForOtp.includes("sms")) {
+                sends.push(
+                    smsService
+                        .sendOtp(
+                            formattedNewPhone,
+                            otp,
+                            language ?? (currentSubscriber.language as string)
+                        )
+                        .catch((e) => logger.error("SMS OTP failed", e))
+                );
+            }
+            if (channelsForOtp.includes("whatsapp")) {
+                sends.push(
+                    whatsappService
+                        .sendOtp(
+                            formattedNewPhone,
+                            otp,
+                            language ?? (currentSubscriber.language as string)
+                        )
+                        .catch((e) => logger.error("WhatsApp OTP failed", e))
+                );
+            }
+            await Promise.allSettled(sends);
+
+            res.json({
+                success: true,
+                verificationRequired: true,
+                subscriber: toPublicSubscriber(currentSubscriber),
+            });
+            return;
+        }
+
         // Build the set of columns to change up front. With nothing to change the
         // request is a no-op, and issuing an empty PostgREST UPDATE is undefined
         // behaviour, so reject it before touching the database.
         const updateData: Record<string, unknown> = {};
-        if (formattedNewPhone !== undefined) updateData.phone = formattedNewPhone;
         if (channels !== undefined) updateData.channels = channels;
         if (language !== undefined) updateData.language = language;
         if (district !== undefined) updateData.district = district;
@@ -832,11 +1011,6 @@ router.patch(
                     : memorySubscriberStore.get(guestPhone!);
 
                 if (sub) {
-                    if (formattedNewPhone) {
-                        memorySubscriberStore.delete(sub.phone);
-                        sub.phone = formattedNewPhone;
-                        memorySubscriberStore.set(formattedNewPhone, sub);
-                    }
                     if (channels) sub.channels = channels;
                     if (language) sub.language = language;
                     if (district) sub.district = district;

--- a/apps/api/tests/notifications.test.ts
+++ b/apps/api/tests/notifications.test.ts
@@ -127,6 +127,26 @@ jest.mock("../src/services/otpStore", () => ({
     },
 }));
 
+// In-memory store to simulate Redis for pending phone changes in tests
+const mockPendingPhoneChanges = new Map<string, string>();
+
+jest.mock("../src/utils/redis", () => ({
+    redisClient: {
+        get isOpen() {
+            return true;
+        },
+        get: jest.fn().mockImplementation(async (key: string) => {
+            return mockPendingPhoneChanges.get(key) ?? null;
+        }),
+        setEx: jest.fn().mockImplementation(async (key: string, _ttl: number, value: string) => {
+            mockPendingPhoneChanges.set(key, value);
+        }),
+        del: jest.fn().mockImplementation(async (key: string) => {
+            mockPendingPhoneChanges.delete(key);
+        }),
+    },
+}));
+
 import express from "express";
 import request from "supertest";
 import notificationsRouter from "../src/routes/notifications";
@@ -134,8 +154,12 @@ import { computeTwilioSignature } from "../src/middleware/twilioSignature";
 import { signGuestToken, verifyGuestPhone } from "../src/utils/guestToken";
 import { Request, Response, NextFunction } from "express";
 import { otpStore } from "../src/services/otpStore";
+import { smsService } from "../src/services/sms-service";
+import { whatsappService } from "../src/services/whatsapp-service";
 
 const mockOtpStore = otpStore as any;
+const smsServiceMock = smsService as any;
+const whatsappServiceMock = whatsappService as any;
 
 describe("notifications routes", () => {
     let app: express.Express;
@@ -725,6 +749,239 @@ describe("notifications routes", () => {
 
             expect(response.status).toBe(401);
             expect(mockQueryBuilder.eq).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("authenticated phone change via OTP verification", () => {
+        beforeEach(() => {
+            mockPendingPhoneChanges.clear();
+            // Default: subscriber exists with phone +919876543210
+            mockQueryBuilder.maybeSingle.mockResolvedValueOnce({
+                data: { ...mockSubscriber, phone: "+919876543210" },
+                error: null,
+            });
+        });
+
+        it("returns 200 with verificationRequired and current subscriber when phone change requested", async () => {
+            const response = await request(app)
+                .patch("/api/notifications/phone")
+                .send({ phone: "9876543210", newPhone: "9123456789" });
+
+            expect(response.status).toBe(200);
+            expect(response.body.success).toBe(true);
+            expect(response.body.verificationRequired).toBe(true);
+            expect(response.body.subscriber).toBeDefined();
+            // Returns the CURRENT phone, not the new one (not yet verified)
+            expect(response.body.subscriber.phone).toBe("+919876543210");
+            // Must NOT update the DB directly
+            expect(mockQueryBuilder.update).not.toHaveBeenCalled();
+        });
+
+        it("sends OTP to the new phone number via sms and whatsapp", async () => {
+            const response = await request(app)
+                .patch("/api/notifications/phone")
+                .send({ phone: "9876543210", newPhone: "9123456789" });
+
+            expect(response.status).toBe(200);
+            expect(smsServiceMock.sendOtp).toHaveBeenCalledWith(
+                "+919123456789",
+                expect.any(String),
+                "en"
+            );
+            expect(whatsappServiceMock.sendOtp).toHaveBeenCalledWith(
+                "+919123456789",
+                expect.any(String),
+                "en"
+            );
+        });
+
+        it("stores the OTP in otpStore for the new phone", async () => {
+            await request(app)
+                .patch("/api/notifications/phone")
+                .send({ phone: "9876543210", newPhone: "9123456789" });
+
+            expect(mockOtpStore.store).toHaveBeenCalledWith(
+                "+919123456789",
+                expect.stringMatching(/^\d{6}$/),
+                expect.any(String)
+            );
+        });
+
+        it("returns 400 when changing to the same phone number", async () => {
+            const response = await request(app)
+                .patch("/api/notifications/phone")
+                .send({ phone: "9876543210", newPhone: "9876543210" });
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe("New phone number is the same as the current one.");
+        });
+
+        it("returns 404 when authenticated user has no subscriber", async () => {
+            mockQueryBuilder.maybeSingle.mockReset();
+            // First call: phone change lookup returns no subscriber
+            mockQueryBuilder.maybeSingle.mockResolvedValueOnce({ data: null, error: null });
+
+            const response = await request(app)
+                .patch("/api/notifications/phone")
+                .send({ phone: "9876543210", newPhone: "9123456789" });
+
+            expect(response.status).toBe(404);
+            expect(response.body.error).toBe("Subscriber not found");
+        });
+
+        it("completes phone change when OTP is valid", async () => {
+            // Request phone change first
+            mockQueryBuilder.maybeSingle.mockReset();
+            mockQueryBuilder.maybeSingle.mockResolvedValueOnce({
+                data: { ...mockSubscriber, phone: "+919876543210" },
+                error: null,
+            });
+            await request(app)
+                .patch("/api/notifications/phone")
+                .send({ phone: "9876543210", newPhone: "9123456789" });
+
+            // Now verify OTP
+            mockQueryBuilder.maybeSingle.mockReset();
+            mockQueryBuilder.maybeSingle.mockResolvedValueOnce({
+                data: { ...mockSubscriber, phone: "+919123456789", status: "pending" },
+                error: null,
+            });
+            mockOtpStore.hasPending.mockResolvedValueOnce(true);
+            mockOtpStore.verify.mockResolvedValueOnce(true);
+
+            const response = await request(app)
+                .post("/api/notifications/verify-otp")
+                .send({ phone: "9123456789", otp: "123456" });
+
+            expect(response.status).toBe(200);
+            expect(response.body.success).toBe(true);
+            expect(response.body.message).toBe("Phone number changed successfully");
+            // The DB should have been updated with the new phone
+            expect(mockQueryBuilder.update).toHaveBeenCalledWith({ phone: "+919123456789" });
+            expect(mockQueryBuilder.eq).toHaveBeenCalledWith("user_id", "test-user-uuid");
+        });
+
+        it("does not complete phone change with invalid OTP", async () => {
+            // Request phone change first
+            mockQueryBuilder.maybeSingle.mockReset();
+            mockQueryBuilder.maybeSingle.mockResolvedValueOnce({
+                data: { ...mockSubscriber, phone: "+919876543210" },
+                error: null,
+            });
+            await request(app)
+                .patch("/api/notifications/phone")
+                .send({ phone: "9876543210", newPhone: "9123456789" });
+
+            // Verify OTP with wrong code
+            mockQueryBuilder.maybeSingle.mockReset();
+            mockQueryBuilder.maybeSingle.mockResolvedValueOnce({
+                data: { ...mockSubscriber, phone: "+919123456789", status: "pending" },
+                error: null,
+            });
+            mockOtpStore.hasPending.mockResolvedValueOnce(true);
+            mockOtpStore.verify.mockResolvedValueOnce(false);
+
+            const response = await request(app)
+                .post("/api/notifications/verify-otp")
+                .send({ phone: "9123456789", otp: "000000" });
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe("Invalid or expired OTP");
+            // Phone should NOT have been updated
+            expect(mockQueryBuilder.update).not.toHaveBeenCalledWith(
+                expect.objectContaining({ phone: expect.anything() })
+            );
+        });
+
+        it("allows updating other fields without triggering OTP flow", async () => {
+            mockQueryBuilder.maybeSingle.mockReset();
+
+            const response = await request(app)
+                .patch("/api/notifications/phone")
+                .send({ phone: "9876543210", district: "New District", channels: ["sms"] });
+
+            expect(response.status).toBe(200);
+            expect(response.body.success).toBe(true);
+            expect(mockQueryBuilder.update).toHaveBeenCalledWith({
+                district: "New District",
+                channels: ["sms"],
+            });
+        });
+
+        it("guest phone change is still blocked", async () => {
+            mockAuthenticatedUser = null;
+            const token = signGuestToken("+919876543210");
+
+            const response = await request(app)
+                .patch("/api/notifications/phone")
+                .set("X-Guest-Token", token)
+                .send({ phone: "9876543210", newPhone: "9123456789" });
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe(
+                "Changing your number requires verifying the new number first."
+            );
+        });
+
+        it("scopes pending phone change to the authenticated user (not the phone number)", async () => {
+            // User A requests phone change
+            mockAuthenticatedUser = {
+                id: "user-a-uuid",
+                role: "user",
+                email: "a@example.com",
+            };
+            mockQueryBuilder.maybeSingle.mockReset();
+            mockQueryBuilder.maybeSingle.mockResolvedValueOnce({
+                data: { ...mockSubscriber, user_id: "user-a-uuid", phone: "+919876543210" },
+                error: null,
+            });
+            await request(app)
+                .patch("/api/notifications/phone")
+                .send({ phone: "9876543210", newPhone: "9123456789" });
+
+            // User B also requests change to same newPhone
+            mockAuthenticatedUser = {
+                id: "user-b-uuid",
+                role: "user",
+                email: "b@example.com",
+            };
+            mockQueryBuilder.maybeSingle.mockReset();
+            mockQueryBuilder.maybeSingle.mockResolvedValueOnce({
+                data: { ...mockSubscriber, user_id: "user-b-uuid", phone: "+919876543211" },
+                error: null,
+            });
+            await request(app)
+                .patch("/api/notifications/phone")
+                .send({ phone: "9876543211", newPhone: "9123456789" });
+
+            // Now verify OTP as User A — should succeed (pending change is under user-a-uuid)
+            mockAuthenticatedUser = {
+                id: "user-a-uuid",
+                role: "user",
+                email: "a@example.com",
+            };
+            mockQueryBuilder.maybeSingle.mockReset();
+            mockQueryBuilder.maybeSingle.mockResolvedValueOnce({
+                data: {
+                    ...mockSubscriber,
+                    user_id: "user-a-uuid",
+                    phone: "+919123456789",
+                    status: "pending",
+                },
+                error: null,
+            });
+            mockOtpStore.hasPending.mockResolvedValueOnce(true);
+            mockOtpStore.verify.mockResolvedValueOnce(true);
+
+            const response = await request(app)
+                .post("/api/notifications/verify-otp")
+                .send({ phone: "9123456789", otp: "123456" });
+
+            expect(response.status).toBe(200);
+            expect(response.body.message).toBe("Phone number changed successfully");
+            // DB update is scoped to User A
+            expect(mockQueryBuilder.update).toHaveBeenCalledWith({ phone: "+919123456789" });
+            expect(mockQueryBuilder.eq).toHaveBeenCalledWith("user_id", "user-a-uuid");
         });
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #4111**
* **Summary:**
  This PR fixes an authorization gap in the notification phone update flow by requiring OTP verification before an authenticated user can change their subscribed phone number.

  Previously, authenticated users could update `newPhone` directly without proving ownership of the new number. While the endpoint correctly scoped updates to the authenticated user's subscriber record, it did not verify ownership of the replacement phone number.

  This implementation introduces a secure two-step verification flow:

  * Generates and sends an OTP to the new phone number.
  * Stores the pending phone change in Redis with a 10-minute TTL, scoped by authenticated user ID.
  * Returns `200 OK` with `verificationRequired: true` while preserving the current subscriber state for backward compatibility.
  * Applies the phone number update only after successful OTP verification through the existing `/api/notifications/verify-otp` endpoint.
  * Existing updates to channels, language, district, and notification status continue to work immediately without additional verification.

## 📸 Proof of Work (Screenshots / Logs)

> **Testing completed**
>
> * ✅ TypeScript compilation passes (`npx tsc --noEmit`)
> * ✅ All tests passing (`45/45`)
> * ✅ No database migrations required
> * ✅ Existing registration flow remains unchanged

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [x] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #4111`)
* [x] I have pulled the latest `main` and resolved any conflicts

## 🔐 Security Impact

**Before**

* Authenticated users could change their notification phone number to any arbitrary value without proving ownership of the new number.

**After**

* Phone number changes require successful OTP verification before the subscriber record is updated.
* Pending phone changes are scoped to the authenticated user and automatically expire after 10 minutes.
* Existing non-phone preference updates remain unaffected.

## 🧪 Testing

Added 10 new tests covering:

* Authenticated phone change returns `verificationRequired`
* OTP delivery via SMS and WhatsApp
* OTP storage for the new phone number
* Same-phone update rejection
* Missing subscriber handling
* Successful phone update after valid OTP verification
* Invalid OTP rejection
* Non-phone preference updates remain unchanged
* Guest phone change restriction remains intact
* Pending phone changes are isolated per authenticated user

**Results**

* ✅ 45/45 tests passing
* ✅ TypeScript compilation clean
* ✅ No unrelated files modified

## 📝 Notes

* No immediate frontend changes are required for compatibility. Existing clients continue to function, and clients may optionally inspect `verificationRequired` to provide an OTP verification flow.
* Existing clients that do not inspect `verificationRequired` will continue displaying a generic success message until frontend support for the verification flow is added.
* The existing `otpStore` remains keyed by phone number, which is an existing repository limitation and is **not introduced by this PR**.