### PR TITLE
fix(web): harden Next.js client IP extraction for rate limiting (#4110)

### DIFF
--- a/apps/web/app/api/medicines/search/route.ts
+++ b/apps/web/app/api/medicines/search/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 import { redis } from "@/lib/redis";
 import { rateLimit } from "@/lib/rateLimit";
+import { getClientIp } from "@/lib/getClientIp";
 
 const CACHE_TTL = 24 * 60 * 60;
 const MAX_QUERY_LENGTH = 100;
@@ -13,14 +14,6 @@ function escapePostgrest(val: string) {
         .replace(/\\/g, "\\\\")
         .replace(/[%_]/g, "\\$&")
         .replace(/[,"'()]/g, "\\$&");
-}
-
-function getClientIp(request: NextRequest): string {
-    return (
-        request.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
-        request.headers.get("x-real-ip") ??
-        "anonymous"
-    );
 }
 
 export async function GET(request: NextRequest) {

--- a/apps/web/lib/getClientIp.ts
+++ b/apps/web/lib/getClientIp.ts
@@ -1,29 +1,138 @@
+/**
+ * Returns `true` when the process is running on Vercel.  Vercel sets
+ * `VERCEL=1` automatically on every deployment; the header
+ * `x-vercel-forwarded-for` is only trustworthy when this flag is present
+ * because Vercel overwrites it at the edge — it cannot be forged by
+ * end-users.  On a plain Node server the header is attacker-controlled.
+ *
+ * Mirrors the cloud-platform detection pattern in apps/api/src/utils/env.ts.
+ */
+function isVercel(): boolean {
+    return process.env.VERCEL === "1";
+}
+
+/**
+ * Returns `true` when the deployment explicitly opts into reading
+ * client IPs from forwarded-for headers (X-Forwarded-For, X-Real-IP).
+ *
+ * Defaults to **false** so that forged headers never influence rate
+ * limiting. Set `TRUST_PROXY_HEADERS=true` in production behind a
+ * reverse proxy (Nginx, Cloudflare, etc.).
+ *
+ * Mirrors the ML service's `TRUST_PROXY_HEADERS` env-var pattern.
+ * @see apps/ml/utils/rate_limiter.py
+ */
+function trustProxyHeaders(): boolean {
+    return process.env.TRUST_PROXY_HEADERS?.trim().toLowerCase() === "true";
+}
+
+/**
+ * How many trusted reverse-proxy hops sit between the internet and
+ * this application.  Used to pick the correct entry from a multi-hop
+ * `X-Forwarded-For` chain — reading from `[-hops]` (right side)
+ * rather than from the left, which is attacker-controlled.
+ *
+ * Defaults to 1 (single load balancer / Nginx).  Values < 1 are
+ * clamped to 1 so that proxy trust is never silently disabled.
+ *
+ * Mirrors the ML service's `TRUSTED_PROXY_HOPS` env-var pattern.
+ * @see apps/ml/utils/rate_limiter.py
+ */
+function trustedProxyHops(): number {
+    const raw = process.env.TRUSTED_PROXY_HOPS?.trim() ?? "1";
+    const hops = parseInt(raw, 10);
+    if (Number.isNaN(hops)) {
+        return 1;
+    }
+    return Math.max(hops, 1);
+}
+
+/**
+ * Quick validation that `value` looks like an IPv4 or IPv6 address.
+ * Rejects obviously spoofed or malformed values that should never
+ * be used as a rate-limit key.
+ */
+function isValidIp(value: string): boolean {
+    // IPv4: four dot-decimal octets 0-255
+    if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(value)) {
+        return value.split(".").every((octet) => {
+            const num = parseInt(octet, 10);
+            return num >= 0 && num <= 255;
+        });
+    }
+    // IPv6: contains at least one colon (sufficient for a safety check)
+    if (value.includes(":")) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Extract the client IP for rate-limiting.
+ *
+ * The function follows a safe-by-default strategy:
+ *
+ * 1. **Vercel** — `x-vercel-forwarded-for` is only trusted when the
+ *    `VERCEL` env-var is set (Vercel sets it automatically).  On a
+ *    plain Node server this header is attacker-controlled and is
+ *    therefore skipped.
+ *
+ * 2. **Self-hosted / Docker behind Nginx** — Forwarding headers
+ *    (`X-Forwarded-For`, `X-Real-IP`) are only consulted when the
+ *    operator explicitly sets `TRUST_PROXY_HEADERS=true`.  The IP
+ *    is then read from position `[-hops]` (the *right* side of the
+ *    chain), matching the ML service's secure pattern.
+ *
+ * 3. **Local development / no proxy** — The function returns
+ *    `"127.0.0.1"` because no forwarding header can be trusted.
+ *
+ * This prevents the rate-limit bypass described in Issue #4110:
+ * an attacker who forges `X-Forwarded-For: 203.0.113.N` on each
+ * request can no longer obtain a fresh rate-limit bucket.
+ */
 export function getClientIp(req: Request): string {
-    const vercelForwardedFor = req.headers.get("x-vercel-forwarded-for");
-    if (vercelForwardedFor) {
-        const ips = vercelForwardedFor
-            .split(",")
-            .map((ip) => ip.trim())
-            .filter(Boolean);
-        if (ips.length > 0) {
-            return ips[0]!;
+    // ── 1. Vercel edge — only when VERCEL env-var is set ─────────
+    if (isVercel()) {
+        const vercelForwardedFor = req.headers.get("x-vercel-forwarded-for");
+        if (vercelForwardedFor) {
+            const ips = vercelForwardedFor
+                .split(",")
+                .map((ip) => ip.trim())
+                .filter(Boolean);
+            if (ips.length > 0 && isValidIp(ips[0]!)) {
+                return ips[0]!;
+            }
         }
     }
 
-    const realIp = req.headers.get("x-real-ip");
-    if (realIp && realIp.trim()) {
-        return realIp.trim();
+    // ── 2. Non-Vercel — only trust headers when opted-in ────────
+    if (!trustProxyHeaders()) {
+        return "127.0.0.1";
     }
 
+    const hops = trustedProxyHops();
+
+    // Read from the RIGHT side of X-Forwarded-For (the position
+    // our trusted proxies wrote), not from the left (attacker-
+    // controlled).  This is the same strategy the ML service uses.
     const forwardedFor = req.headers.get("x-forwarded-for");
     if (forwardedFor) {
         const ips = forwardedFor
             .split(",")
             .map((ip) => ip.trim())
             .filter(Boolean);
-        if (ips.length > 0) {
-            return ips[0]!;
+        if (ips.length >= hops) {
+            const candidate = ips[ips.length - hops]!;
+            if (isValidIp(candidate)) {
+                return candidate;
+            }
         }
+    }
+
+    // X-Real-IP is only safe when explicitly trusted (see above).
+    const realIp = req.headers.get("x-real-ip");
+    if (realIp && isValidIp(realIp.trim())) {
+        return realIp.trim();
     }
 
     return "127.0.0.1";

--- a/apps/web/tests/getClientIp.test.ts
+++ b/apps/web/tests/getClientIp.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, beforeEach, afterAll } from "@jest/globals";
+/**
+ * @jest-environment node
+ */
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+    return new Request("http://localhost:3000/test", { headers });
+}
+
+describe("getClientIp", () => {
+    const ORIGINAL_ENV = process.env;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env = { ...ORIGINAL_ENV };
+        delete process.env.TRUST_PROXY_HEADERS;
+        delete process.env.TRUSTED_PROXY_HOPS;
+        delete process.env.VERCEL;
+    });
+
+    afterAll(() => {
+        process.env = ORIGINAL_ENV;
+    });
+
+    // ── Default behaviour (no env vars) ──────────────────────────
+
+    it("returns 127.0.0.1 when no headers are present", () => {
+        const { getClientIp } = require("@/lib/getClientIp");
+        expect(getClientIp(makeRequest())).toBe("127.0.0.1");
+    });
+
+    it("ignores forged X-Forwarded-For when TRUST_PROXY_HEADERS is not set", () => {
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-forwarded-for": "203.0.113.1" });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    it("ignores forged X-Real-IP when TRUST_PROXY_HEADERS is not set", () => {
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-real-ip": "203.0.113.2" });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    it("ignores multiple forged X-Forwarded-For entries", () => {
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-forwarded-for": "203.0.113.1, 203.0.113.2, 203.0.113.3",
+        });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    // ── Vercel (only when VERCEL env-var is set) ─────────────────
+
+    it("trusts x-vercel-forwarded-for when VERCEL=1", () => {
+        process.env.VERCEL = "1";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-vercel-forwarded-for": "198.51.100.7" });
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    it("takes the leftmost IP from x-vercel-forwarded-for", () => {
+        process.env.VERCEL = "1";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-vercel-forwarded-for": "198.51.100.7, 10.0.0.1",
+        });
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    it("falls through when x-vercel-forwarded-for contains invalid IP", () => {
+        process.env.VERCEL = "1";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-vercel-forwarded-for": "not-an-ip",
+            "x-forwarded-for": "10.0.0.1",
+        });
+        // x-forwarded-for ignored (TRUST_PROXY_HEADERS not set), x-real-ip absent
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    it("ignores x-vercel-forwarded-for when VERCEL is not set (non-Vercel server)", () => {
+        // VERCEL is explicitly deleted in beforeEach
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-vercel-forwarded-for": "198.51.100.7" });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    // ── Trusted proxy (TRUST_PROXY_HEADERS=true) ─────────────────
+
+    it("reads from X-Forwarded-For when TRUST_PROXY_HEADERS=true", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        // With hops=1, the rightmost entry is the real client
+        const req = makeRequest({
+            "x-forwarded-for": "203.0.113.1, 198.51.100.7",
+        });
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    it("returns the single entry from X-Forwarded-For with hops=1", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-forwarded-for": "198.51.100.7" });
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    it("prefers X-Forwarded-For over X-Real-IP when both are present", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-forwarded-for": "203.0.113.1, 198.51.100.7",
+            "x-real-ip": "10.0.0.99",
+        });
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    it("falls back to X-Real-IP when X-Forwarded-For is absent", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-real-ip": "198.51.100.7" });
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    it("returns 127.0.0.1 when TRUST_PROXY_HEADERS=true but no headers present", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        expect(getClientIp(makeRequest())).toBe("127.0.0.1");
+    });
+
+    // ── Forged headers bypass prevention ─────────────────────────
+
+    it("does not let attacker forge X-Forwarded-For with TRUST_PROXY_HEADERS unset", () => {
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req1 = makeRequest({ "x-forwarded-for": "203.0.113.1" });
+        const req2 = makeRequest({ "x-forwarded-for": "203.0.113.2" });
+        const req3 = makeRequest({ "x-forwarded-for": "203.0.113.3" });
+        // All return the same IP — attacker cannot get different buckets
+        expect(getClientIp(req1)).toBe("127.0.0.1");
+        expect(getClientIp(req2)).toBe("127.0.0.1");
+        expect(getClientIp(req3)).toBe("127.0.0.1");
+    });
+
+    it("does not let attacker forge X-Real-IP with TRUST_PROXY_HEADERS unset", () => {
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-real-ip": "203.0.113.99" });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    it("attacker cannot forge a different IP per request with TRUST_PROXY_HEADERS=true", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        process.env.TRUSTED_PROXY_HOPS = "1";
+        const { getClientIp } = require("@/lib/getClientIp");
+
+        // Nginx appends the real client IP (10.0.0.50) to the right.
+        // Anything to the left is attacker-controlled and ignored.
+        const req1 = makeRequest({
+            "x-forwarded-for": "203.0.113.1, 10.0.0.50",
+        });
+        const req2 = makeRequest({
+            "x-forwarded-for": "203.0.113.2, 10.0.0.50",
+        });
+        const req3 = makeRequest({
+            "x-forwarded-for": "203.0.113.3, 10.0.0.50",
+        });
+        // All return the same IP — the real client behind the proxy
+        expect(getClientIp(req1)).toBe("10.0.0.50");
+        expect(getClientIp(req2)).toBe("10.0.0.50");
+        expect(getClientIp(req3)).toBe("10.0.0.50");
+    });
+
+    // ── Multiple proxy hops ──────────────────────────────────────
+
+    it("reads from the correct hop position with TRUSTED_PROXY_HOPS=2", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        process.env.TRUSTED_PROXY_HOPS = "2";
+        const { getClientIp } = require("@/lib/getClientIp");
+        // 3 entries: attacker, CDN, Nginx → real client is 2 from right
+        const req = makeRequest({
+            "x-forwarded-for": "203.0.113.1, 192.0.2.50, 10.0.0.50",
+        });
+        expect(getClientIp(req)).toBe("192.0.2.50");
+    });
+
+    it("falls back to 127.0.0.1 when fewer entries than hops", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        process.env.TRUSTED_PROXY_HOPS = "3";
+        const { getClientIp } = require("@/lib/getClientIp");
+        // Only 2 entries but hops=3 → cannot determine trusted IP
+        const req = makeRequest({
+            "x-forwarded-for": "203.0.113.1, 192.0.2.50",
+        });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    // ── TRUSTED_PROXY_HOPS defaults and edge cases ───────────────
+
+    it("defaults hops to 1 when TRUSTED_PROXY_HOPS is not set", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-forwarded-for": "203.0.113.1, 198.51.100.7",
+        });
+        // hops=1 → rightmost entry
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    it("clamps TRUSTED_PROXY_HOPS to minimum 1 when set to 0", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        process.env.TRUSTED_PROXY_HOPS = "0";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-forwarded-for": "203.0.113.1, 198.51.100.7",
+        });
+        // hops clamped to 1 → rightmost entry
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    it("clamps TRUSTED_PROXY_HOPS to minimum 1 when set to negative", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        process.env.TRUSTED_PROXY_HOPS = "-5";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-forwarded-for": "203.0.113.1, 198.51.100.7",
+        });
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    it("defaults hops to 1 when TRUSTED_PROXY_HOPS is non-numeric", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        process.env.TRUSTED_PROXY_HOPS = "abc";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-forwarded-for": "203.0.113.1, 198.51.100.7",
+        });
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    // ── Case-insensitive env var parsing ──────────────────────────
+
+    it("accepts TRUST_PROXY_HEADERS=true in any case", () => {
+        process.env.TRUST_PROXY_HEADERS = "TRUE";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-forwarded-for": "198.51.100.7" });
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    it("accepts TRUST_PROXY_HEADERS with surrounding whitespace", () => {
+        process.env.TRUST_PROXY_HEADERS = "  true  ";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-forwarded-for": "198.51.100.7" });
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+
+    it("rejects TRUST_PROXY_HEADERS=1 (must be true/yes)", () => {
+        process.env.TRUST_PROXY_HEADERS = "1";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-forwarded-for": "198.51.100.7" });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    // ── IPv6 ─────────────────────────────────────────────────────
+
+    it("returns IPv6 address from x-vercel-forwarded-for", () => {
+        process.env.VERCEL = "1";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-vercel-forwarded-for": "2001:db8::1",
+        });
+        expect(getClientIp(req)).toBe("2001:db8::1");
+    });
+
+    it("returns IPv6 from X-Forwarded-For when trusted", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-forwarded-for": "203.0.113.1, 2001:db8::1",
+        });
+        expect(getClientIp(req)).toBe("2001:db8::1");
+    });
+
+    // ── Invalid/malformed values ─────────────────────────────────
+
+    it("rejects X-Real-IP with invalid octet > 255 when trusted", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-real-ip": "999.999.999.999",
+        });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    it("rejects X-Forwarded-For entry with invalid octet when trusted", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-forwarded-for": "999.999.999.999, 10.0.0.1",
+        });
+        // Rightmost (10.0.0.1) is valid
+        expect(getClientIp(req)).toBe("10.0.0.1");
+    });
+
+    it("falls back to 127.0.0.1 when X-Forwarded-For is empty string", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-forwarded-for": "" });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    it("falls back to 127.0.0.1 when X-Real-IP is empty string", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-real-ip": "" });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    it("handles whitespace-only X-Forwarded-For", () => {
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({ "x-forwarded-for": "  ,  ,  " });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    // ── Vercel precedence over TRUST_PROXY_HEADERS ───────────────
+
+    it("prefers x-vercel-forwarded-for over X-Forwarded-For when VERCEL=1", () => {
+        process.env.VERCEL = "1";
+        process.env.TRUST_PROXY_HEADERS = "true";
+        const { getClientIp } = require("@/lib/getClientIp");
+        const req = makeRequest({
+            "x-vercel-forwarded-for": "198.51.100.7",
+            "x-forwarded-for": "10.0.0.1, 10.0.0.2",
+        });
+        expect(getClientIp(req)).toBe("198.51.100.7");
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4110**
- **Summary:**
  - Hardened client IP extraction used by Next.js API rate limiting.
  - Trust `x-vercel-forwarded-for` only when running on Vercel (`VERCEL=1`).
  - Added configurable trusted proxy support using `TRUST_PROXY_HEADERS` and `TRUSTED_PROXY_HOPS`.
  - Switched `X-Forwarded-For` parsing to use trusted proxy hop extraction instead of the attacker-controlled leftmost entry.
  - Added IP validation before using extracted addresses as rate-limit keys.
  - Removed the duplicate `getClientIp()` implementation from `apps/web/app/api/medicines/search/route.ts` and replaced it with the shared helper.
  - Added comprehensive unit tests covering trusted and untrusted proxy scenarios, Vercel behavior, IPv4/IPv6 handling, malformed headers, trusted proxy hop extraction, and precedence rules.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.

### Test Results

```text
✓ Lint: Passed
✓ Typecheck: Passed
✓ Tests: 37/37 passing
```

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4110`)
- [x] I have pulled the latest `main` and resolved any conflicts