### PR TITLE
fix(scan): add request-scoped temp file cleanup to /submit endpoint

### DIFF
--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -80,6 +80,29 @@ const upload = multer({
     },
 });
 
+// ── Shared request-scoped temp-file cleanup ─────────────────────────────────
+// Deletes every path in the provided list exactly once.  Used by both /extract
+// and /submit via res.once("finish") / res.once("close") so that temp files
+// are removed the moment the response is done — regardless of success,
+// validation failure, processing error, or client disconnect.
+function cleanupTempFiles(filePaths: string[]): () => void {
+    let cleaned = false;
+    return () => {
+        if (cleaned) return;
+        cleaned = true;
+        for (const filePath of filePaths) {
+            if (fs.existsSync(filePath)) {
+                try {
+                    fs.unlinkSync(filePath);
+                    logger.info(`Cleaned up temp file: ${filePath}`);
+                } catch (err) {
+                    logger.error(`Failed to delete temp file ${filePath}:`, err);
+                }
+            }
+        }
+    };
+}
+
 /**
  * @openapi
  * /api/v1/scan/extract:
@@ -172,21 +195,11 @@ router.post("/extract", uploadRateLimiter, validateUploadSize, (req: Request, re
             ? path.join(UPLOAD_DIR, path.basename(file.filename))
             : undefined;
 
-        const cleanupTempFile = () => {
-            if (tempFilePath && fs.existsSync(tempFilePath)) {
-                try {
-                    fs.unlinkSync(tempFilePath);
-                    logger.info(`Cleaned up temp file: ${tempFilePath}`);
-                } catch (err) {
-                    logger.error(`Failed to delete temp file ${tempFilePath}:`, err);
-                }
-            }
-        };
-
         // Guarantees cleanup on every response outcome — success, thrown error,
         // or the client disconnecting before a response is ever sent.
-        res.on("finish", cleanupTempFile);
-        res.on("close", cleanupTempFile);
+        const cleanup = cleanupTempFiles(tempFilePath ? [tempFilePath] : []);
+        res.once("finish", cleanup);
+        res.once("close", cleanup);
 
         if (multerErr) {
             const msg = multerErr instanceof Error ? multerErr.message : "File upload error";
@@ -293,7 +306,9 @@ router.post("/extract", uploadRateLimiter, validateUploadSize, (req: Request, re
             const confidence = data.confidence ?? 0;
 
             if (rawText.trim().length === 0) {
-                logger.warn(`OCR returned empty text for "${file.originalname}" (confidence: ${confidence})`);
+                logger.warn(
+                    `OCR returned empty text for "${file.originalname}" (confidence: ${confidence})`
+                );
                 res.status(400).json({
                     error: "No text could be extracted from the image.",
                     code: "OCR_EMPTY_TEXT",
@@ -625,6 +640,22 @@ router.post(
     upload.fields([{ name: "image" }, { name: "voice" }]),
     idempotencyMiddleware,
     async (req: AuthenticatedRequest, res: Response) => {
+        // ── Request-scoped temp-file cleanup ────────────────────────────────
+        // Collect every temp file multer may have written for this request so
+        // they are removed the moment the response is finished — reusing the
+        // same cleanup helper as /extract (issue #4112).
+        const uploadedFiles: Express.Multer.File[] = [
+            ...((req.files as any)?.image ?? []),
+            ...((req.files as any)?.voice ?? []),
+        ];
+        const tempFilePaths = uploadedFiles
+            .filter((f): f is Express.Multer.File => !!f?.filename)
+            .map((f) => path.join(UPLOAD_DIR, path.basename(f.filename)));
+
+        const cleanup = cleanupTempFiles(tempFilePaths);
+        res.once("finish", cleanup);
+        res.once("close", cleanup);
+
         const idempotencyKey = (req as any).idempotencyKey;
         const submitSchema = z
             .object({

--- a/apps/api/tests/scanSubmitCleanup.test.ts
+++ b/apps/api/tests/scanSubmitCleanup.test.ts
@@ -1,0 +1,277 @@
+// @ts-nocheck
+import request from "supertest";
+import http from "http";
+import fs from "fs";
+import path from "path";
+import app from "../src/app";
+import { supabase } from "../src/db/client";
+import { redisClient } from "../src/utils/redis";
+
+// Regression coverage for the temp-file cleanup added in issue #4112.
+//
+// POST /api/v1/scan/submit stores image/voice uploads with multer disk storage,
+// then registers res.on("finish") AND res.on("close") -> cleanupTempFiles so the
+// temp files are always removed once the response is done, whether it finishes
+// normally or the client disconnects first.
+
+const SUBMIT_URL = "/api/v1/scan/submit";
+const UPLOAD_DIR = path.join(__dirname, "../temp-uploads");
+
+// Minimal buffers — multer's fileFilter only checks declared mimetype
+const JPEG_BUF = Buffer.from([0xff, 0xd8, 0xff]);
+const WEBM_BUF = Buffer.from("1a45dfa3010000000000001f", "hex");
+
+jest.mock("../src/utils/redis", () => ({
+    redisClient: {
+        isOpen: true,
+        get: jest.fn(),
+        set: jest.fn(),
+        on: jest.fn(),
+    },
+}));
+
+jest.mock("bullmq", () => ({
+    Queue: class {
+        on() {}
+        add() {}
+    },
+    Worker: class {
+        on() {}
+    },
+}));
+
+jest.mock("../src/db/client", () => {
+    const mockBuilder: any = {};
+    mockBuilder.from = jest.fn().mockReturnValue(mockBuilder);
+    mockBuilder.select = jest.fn().mockReturnValue(mockBuilder);
+    mockBuilder.eq = jest.fn().mockReturnValue(mockBuilder);
+    mockBuilder.insert = jest.fn().mockReturnValue(mockBuilder);
+    mockBuilder.update = jest.fn().mockReturnValue(mockBuilder);
+    mockBuilder.upsert = jest.fn().mockReturnValue(mockBuilder);
+    mockBuilder.delete = jest.fn().mockReturnValue(mockBuilder);
+    mockBuilder.maybeSingle = jest.fn();
+    mockBuilder.single = jest.fn();
+    return { supabase: mockBuilder };
+});
+
+// Poll for a condition instead of sleeping a fixed amount
+async function waitFor(cond: () => boolean, timeoutMs = 10000): Promise<void> {
+    const start = Date.now();
+    while (!cond()) {
+        if (Date.now() - start > timeoutMs) throw new Error("condition not met in time");
+        await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+}
+
+const cleanedTempPaths = (spy: jest.SpyInstance): string[] =>
+    spy.mock.calls.map((call) => String(call[0])).filter((p) => p.startsWith(UPLOAD_DIR));
+
+/**
+ * Set up the standard happy-path mocks for the idempotency middleware +
+ * resolveConflict + handler upsert chain.
+ */
+function setupHappyMocks() {
+    (redisClient.get as jest.Mock).mockResolvedValue(null);
+
+    // 1st insert call — idempotency reservation INSERT in the middleware
+    (supabase.insert as jest.Mock).mockReturnValueOnce(
+        Promise.resolve({ data: null, error: null })
+    );
+
+    // resolveConflict: existence check (no existing row)
+    (supabase.maybeSingle as jest.Mock).mockResolvedValueOnce({ data: null, error: null });
+    // resolveConflict: insert new row
+    (supabase.single as jest.Mock).mockResolvedValueOnce({
+        data: { id: "test-scan-id" },
+        error: null,
+    });
+
+    // resolveConflict: two .eq() calls for existence check, then terminal .eq() for update
+    (supabase.eq as jest.Mock)
+        .mockReturnValueOnce(supabase)
+        .mockReturnValueOnce(supabase)
+        .mockReturnValueOnce(Promise.resolve({ error: null }));
+    (supabase.update as jest.Mock).mockReturnValueOnce(supabase);
+}
+
+describe("POST /api/v1/scan/submit — temp file cleanup (#4112)", () => {
+    let server: http.Server;
+    let unlinkSpy: jest.SpyInstance;
+
+    beforeAll((done) => {
+        server = http.createServer(app);
+        server.listen(0, done);
+    });
+
+    afterAll((done) => {
+        server.closeAllConnections?.();
+        server.close(() => done());
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        unlinkSpy = jest.spyOn(fs, "unlinkSync");
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("deletes the temp files after a successful submission (200, finish)", async () => {
+        setupHappyMocks();
+
+        const res = await request(server)
+            .post(SUBMIT_URL)
+            .set("Idempotency-Key", "cleanup-success-key")
+            .field("deviceId", "device-1")
+            .field("clientUpdatedAt", Date.now().toString())
+            .field("metadata", JSON.stringify({ name: "Paracetamol" }))
+            .attach("image", JPEG_BUF, {
+                filename: "medicine.jpg",
+                contentType: "image/jpeg",
+            })
+            .attach("voice", WEBM_BUF, {
+                filename: "recording.webm",
+                contentType: "audio/webm",
+            });
+
+        expect(res.status).toBe(200);
+        await waitFor(() => cleanedTempPaths(unlinkSpy).length > 0);
+        const cleaned = cleanedTempPaths(unlinkSpy);
+        expect(cleaned.length).toBeGreaterThanOrEqual(2);
+        expect(cleaned.some((p) => p.endsWith(".jpg"))).toBe(true);
+        expect(cleaned.some((p) => p.endsWith(".webm"))).toBe(true);
+        for (const p of cleaned) {
+            expect(fs.existsSync(p)).toBe(false);
+        }
+    });
+
+    it("deletes the temp files when validation fails (400, finish)", async () => {
+        // No happy-path mocks needed — the request fails before resolveConflict.
+        // Multer still writes the file, but validation rejects the body.
+        const res = await request(server)
+            .post(SUBMIT_URL)
+            .set("Idempotency-Key", "cleanup-validation-key")
+            .field("deviceId", "device-1")
+            .field("metadata", JSON.stringify({ name: "Test" }))
+            // clientUpdatedAt intentionally missing — triggers 400
+            .attach("image", JPEG_BUF, {
+                filename: "medicine.jpg",
+                contentType: "image/jpeg",
+            });
+
+        expect(res.status).toBe(400);
+        await waitFor(() => cleanedTempPaths(unlinkSpy).length > 0);
+        expect(cleanedTempPaths(unlinkSpy).some((p) => p.endsWith(".jpg"))).toBe(true);
+    });
+
+    it("deletes the temp files when processing throws (500, finish)", async () => {
+        (redisClient.get as jest.Mock).mockResolvedValue(null);
+
+        // 1st insert call — idempotency reservation INSERT in the middleware
+        (supabase.insert as jest.Mock).mockReturnValueOnce(
+            Promise.resolve({ data: null, error: null })
+        );
+
+        // resolveConflict: existence check (no existing row)
+        (supabase.maybeSingle as jest.Mock).mockResolvedValueOnce({ data: null, error: null });
+        // resolveConflict: insert throws
+        (supabase.single as jest.Mock).mockRejectedValueOnce(new Error("DB connection lost"));
+
+        (supabase.eq as jest.Mock).mockReturnValueOnce(supabase).mockReturnValueOnce(supabase);
+
+        const res = await request(server)
+            .post(SUBMIT_URL)
+            .set("Idempotency-Key", "cleanup-error-key")
+            .field("deviceId", "device-1")
+            .field("clientUpdatedAt", Date.now().toString())
+            .attach("image", JPEG_BUF, {
+                filename: "medicine.jpg",
+                contentType: "image/jpeg",
+            });
+
+        expect(res.status).toBe(500);
+        await waitFor(() => cleanedTempPaths(unlinkSpy).length > 0);
+        expect(cleanedTempPaths(unlinkSpy).some((p) => p.endsWith(".jpg"))).toBe(true);
+    });
+
+    it("deletes image upload temp files (image-only cleanup works)", async () => {
+        setupHappyMocks();
+
+        const res = await request(server)
+            .post(SUBMIT_URL)
+            .set("Idempotency-Key", "cleanup-image-only-key")
+            .field("deviceId", "device-1")
+            .field("clientUpdatedAt", Date.now().toString())
+            .field("metadata", JSON.stringify({ name: "Aspirin" }))
+            .attach("image", JPEG_BUF, {
+                filename: "tablet.jpg",
+                contentType: "image/jpeg",
+            });
+
+        expect(res.status).toBe(200);
+        await waitFor(() => cleanedTempPaths(unlinkSpy).length > 0);
+        expect(cleanedTempPaths(unlinkSpy).some((p) => p.endsWith(".jpg"))).toBe(true);
+    });
+
+    it("deletes voice upload temp files (voice-only cleanup works)", async () => {
+        setupHappyMocks();
+
+        const res = await request(server)
+            .post(SUBMIT_URL)
+            .set("Idempotency-Key", "cleanup-voice-only-key")
+            .field("deviceId", "device-1")
+            .field("clientUpdatedAt", Date.now().toString())
+            .field("metadata", JSON.stringify({ name: "Ibuprofen" }))
+            .attach("voice", WEBM_BUF, {
+                filename: "dictation.webm",
+                contentType: "audio/webm",
+            });
+
+        expect(res.status).toBe(200);
+        await waitFor(() => cleanedTempPaths(unlinkSpy).length > 0);
+        expect(cleanedTempPaths(unlinkSpy).some((p) => p.endsWith(".webm"))).toBe(true);
+    });
+
+    it("does not crash when cleanup of an already-removed file is attempted", async () => {
+        setupHappyMocks();
+
+        const res = await request(server)
+            .post(SUBMIT_URL)
+            .set("Idempotency-Key", "cleanup-gone-key")
+            .field("deviceId", "device-1")
+            .field("clientUpdatedAt", Date.now().toString())
+            .attach("image", JPEG_BUF, {
+                filename: "gone.jpg",
+                contentType: "image/jpeg",
+            });
+
+        expect(res.status).toBe(200);
+        await waitFor(() => cleanedTempPaths(unlinkSpy).length > 0);
+        for (const call of unlinkSpy.mock.calls) {
+            const filePath = String(call[0]);
+            if (filePath.startsWith(UPLOAD_DIR)) {
+                expect(fs.existsSync(filePath)).toBe(false);
+            }
+        }
+    });
+
+    it("works when no files are attached (no cleanup needed, no error)", async () => {
+        setupHappyMocks();
+
+        const res = await request(server)
+            .post(SUBMIT_URL)
+            .set("Idempotency-Key", "cleanup-no-files-key")
+            .send({
+                deviceId: "device-1",
+                clientUpdatedAt: Date.now().toString(),
+                metadata: JSON.stringify({ name: "Paracetamol" }),
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.parts.image).toBe("skipped");
+        expect(res.body.parts.voice).toBe("skipped");
+        // No temp files were written, so no unlink calls for UPLOAD_DIR paths
+        expect(cleanedTempPaths(unlinkSpy).length).toBe(0);
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

---

## 📋 PR Summary & Link

- **Closes #4112**

### Summary

Fix request-scoped cleanup of temporary upload files for the offline scan submission endpoint.

`POST /api/v1/scan/submit` stores uploaded medicine images and voice recordings in `temp-uploads/` using the same multer storage as `/extract`, but it did not remove those files after the request completed. As a result, temporary files remained on disk until the scheduled cleanup job ran.

This PR extracts the existing cleanup logic into a shared helper and reuses it in both `/extract` and `/submit`, ensuring temporary uploads are deleted immediately after the response completes while preserving the existing API behavior.

---

## 📸 Proof of Work (Screenshots / Logs)

### Test Results

- ✅ 66 test suites passed
- ✅ 0 failed
- ✅ New regression tests added for request-scoped cleanup
- ✅ Existing behavior preserved
- ✅ No API contract changes

---

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

---

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4112`)
- [x] I have pulled the latest `main` and resolved any conflicts

---

## 🔧 Implementation Details

### Production changes

- Extracted a shared `cleanupTempFiles()` helper.
- Updated `/extract` to reuse the shared helper.
- Added identical request-scoped cleanup to `/api/v1/scan/submit`.
- Registered cleanup using `res.once("finish")` and `res.once("close")`.
- Added a guard flag to ensure cleanup executes only once even if both events occur.
- Cleanup failures are logged without affecting the API response.

### Tests

Added regression tests covering:

- Successful request cleanup
- Validation failure cleanup
- Exception during processing
- Image-only uploads
- Voice-only uploads
- Already-deleted files
- Requests without uploaded files

---

## 🔒 Impact

### Before

Temporary upload files created by `/api/v1/scan/submit` remained in `temp-uploads/` until the scheduled cleanup task removed them.

### After

Temporary upload files are deleted immediately after the request finishes (or the connection closes), matching the behavior already implemented by `/extract`.

---

## 🚀 Deployment Notes

- No database migrations
- No configuration changes
- No environment variable changes
- Fully backward compatible