### PR TITLE
fix(verify): never serve stale safety verdict from medicine cache

### DIFF
--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -15,6 +15,51 @@ function getBatchStatus(recallStatus: string | null | undefined): "safe" | "reca
     return "unknown";
 }
 
+// Safety-critical fields that must never be served stale. These drive the
+// "safe" vs "recalled"/"counterfeit" verdict shown to users.
+const SAFETY_OVERLAY_FIELDS = [
+    "cdsco_approval_status",
+    "is_counterfeit_alert",
+    "is_cdsco_verified",
+    "cdsco_match_score",
+    "matched_cdsco_product",
+    "matched_cdsco_manufacturer",
+    "product_match_score",
+    "manufacturer_match_score",
+];
+
+/**
+ * Overlays the latest safety-critical fields from the database onto the
+ * medicine record returned by lookupDrugByBatch().
+ *
+ * lookupDrugByBatch() may serve a cached medicine snapshot (TTL up to 24h) and
+ * cache invalidation depends on external webhooks that can be missed. Reading
+ * these fields live guarantees the verify endpoint always reflects the latest
+ * safety state (new recalls, counterfeit flags, CDSCO changes) instead of
+ * serving a stale "safe" result indefinitely. Falls back to the cached values
+ * if the live read fails so the endpoint degrades gracefully.
+ */
+async function refreshLiveSafety(data: any): Promise<void> {
+    const { data: live, error } = await supabase
+        .from("medicines")
+        .select(SAFETY_OVERLAY_FIELDS.join(", "))
+        .eq("id", data.id)
+        .maybeSingle();
+
+    if (error) {
+        logger.error("Failed to refresh live safety status", {
+            error,
+            medicineId: data.id,
+            route: "/api/verify",
+        });
+        return;
+    }
+
+    if (live) {
+        Object.assign(data, live);
+    }
+}
+
 function maskClientIp(ip: string | undefined): string | null {
     if (!ip) return null;
 
@@ -257,6 +302,11 @@ router.post(
                 });
                 return;
             }
+
+            // Always overlay the live safety-critical fields so a stale cache entry
+            // can never serve an outdated "safe" verdict after the CDSCO/database
+            // record has been updated (e.g. newly flagged recall or counterfeit alert).
+            await refreshLiveSafety(data);
 
             // Look up batch recall status from batches table
             const { data: batchData } = await supabase

--- a/apps/api/tests/verify.test.ts
+++ b/apps/api/tests/verify.test.ts
@@ -50,9 +50,23 @@ describe("POST /api/verify", () => {
                 },
                 error: null,
             })
-            // 2. batch recall check
+            // 2. live safety refresh
+            .mockResolvedValueOnce({
+                data: {
+                    cdsco_approval_status: "Approved",
+                    is_counterfeit_alert: false,
+                    is_cdsco_verified: true,
+                    cdsco_match_score: 98.4,
+                    matched_cdsco_product: "Test Brand",
+                    matched_cdsco_manufacturer: "Test Mfg",
+                    product_match_score: 97,
+                    manufacturer_match_score: 100,
+                },
+                error: null,
+            })
+            // 3. batch recall check
             .mockResolvedValueOnce({ data: { recall_status: "none" }, error: null })
-            // 3. scan counts RPC
+            // 4. scan counts RPC
             .mockResolvedValueOnce({ data: { count_24h: 0, count_7d: 0 }, error: null });
 
         const res = await request(app)
@@ -93,9 +107,23 @@ describe("POST /api/verify", () => {
                 },
                 error: null,
             })
-            // 2. batch recall check
+            // 2. live safety refresh
+            .mockResolvedValueOnce({
+                data: {
+                    cdsco_approval_status: "Approved",
+                    is_counterfeit_alert: false,
+                    is_cdsco_verified: false,
+                    cdsco_match_score: 42.1,
+                    matched_cdsco_product: null,
+                    matched_cdsco_manufacturer: null,
+                    product_match_score: 44,
+                    manufacturer_match_score: 38,
+                },
+                error: null,
+            })
+            // 3. batch recall check
             .mockResolvedValueOnce({ data: { recall_status: "none" }, error: null })
-            // 3. scan counts RPC
+            // 4. scan counts RPC
             .mockResolvedValueOnce({ data: { count_24h: 2, count_7d: 5 }, error: null });
 
         const res = await request(app)
@@ -108,6 +136,64 @@ describe("POST /api/verify", () => {
         expect(res.body.scanMeta.suspicious).toBe(true);
         expect(res.body.scanMeta.suspicionReasons.length).toBeGreaterThan(0);
         expect(res.body.medicine.is_cdsco_verified).toBe(false);
+    });
+
+    it("should reflect the latest safety state even when the cached medicine record is stale", async () => {
+        // Cached/lookup record is stale: says the medicine is NOT counterfeit and
+        // IS CDSCO verified (i.e. "safe"). The live safety refresh must override
+        // this so users never see a stale "safe" result after it has been flagged.
+        ((supabase as any).insert as jest.Mock).mockResolvedValue({ data: null, error: null });
+        ((supabase as any).maybeSingle as jest.Mock)
+            // 1. lookupDrugByBatch (stale snapshot)
+            .mockResolvedValueOnce({
+                data: {
+                    id: "11111111-1111-1111-1111-111111111111",
+                    brand_name: "Test Brand",
+                    generic_name: "Test Generic",
+                    manufacturer: "Test Mfg",
+                    batch_number: "AUG625D",
+                    cdsco_approval_status: "Approved",
+                    is_counterfeit_alert: false,
+                    is_cdsco_verified: true,
+                    cdsco_match_score: 98.4,
+                    matched_cdsco_product: "Test Brand",
+                    matched_cdsco_manufacturer: "Test Mfg",
+                    product_match_score: 97,
+                    manufacturer_match_score: 100,
+                },
+                error: null,
+            })
+            // 2. live safety refresh (recalled / counterfeit + not CDSCO verified)
+            .mockResolvedValueOnce({
+                data: {
+                    cdsco_approval_status: "recalled",
+                    is_counterfeit_alert: true,
+                    is_cdsco_verified: false,
+                    cdsco_match_score: 98.4,
+                    matched_cdsco_product: "Test Brand",
+                    matched_cdsco_manufacturer: "Test Mfg",
+                    product_match_score: 97,
+                    manufacturer_match_score: 100,
+                },
+                error: null,
+            })
+            // 3. batch recall check
+            .mockResolvedValueOnce({ data: { recall_status: "none" }, error: null })
+            // 4. scan counts RPC
+            .mockResolvedValueOnce({ data: { count_24h: 0, count_7d: 0 }, error: null });
+
+        const res = await request(app)
+            .post("/api/verify")
+            .send({ batchNumber: "AUG625D", brandName: "Augmentin" });
+
+        expect(res.status).toBe(200);
+        // The stale cached flags must be replaced by the live safety state.
+        expect(res.body.medicine.is_counterfeit_alert).toBe(true);
+        expect(res.body.medicine.is_cdsco_verified).toBe(false);
+        expect(res.body.medicine.cdsco_approval_status).toBe("recalled");
+        // Suspicious logic must also use the live counterfeit flag.
+        expect(res.body.scanMeta.suspicious).toBe(true);
+        expect(res.body.scanMeta.suspicionReasons.length).toBeGreaterThan(0);
     });
 
     it("should return 404 for an unknown batch number", async () => {


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4114**
- **Summary:**
Added refreshLiveSafety(), which re-reads the safety-critical fields live from the medicines table by id and overlays them onto the cached record before building the response. The route already did a live batches.recall_status read, but not the counterfeit/CDSCO flags — this closes that gap. On a live-read failure it degrades gracefully to the cached values.
This keeps caching (performance) while guaranteeing the safety verdict always reflects the latest DB state.
Verification
- tests/verify.test.ts — 7/7 pass, incl. new regression test proving a stale "safe" cache entry is overridden by a recalled/counterfeit live row.
- drugLookup, cache, scanVerifyBrand suites — 39/39 pass.
- Prettier + circular-dependency + pre-push audit hooks passed.
- Only pre-existing, unrelated typecheck error (csurf missing file: dep, present on base too).



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4114 `)
- [x] I have pulled the latest `main` and resolved any conflicts
