### PR TITLE
fix(offline): sync queued scans deterministically without overwriting results

### DIFF
--- a/apps/web/hooks/useOfflineScanner.ts
+++ b/apps/web/hooks/useOfflineScanner.ts
@@ -18,32 +18,50 @@ export function useOfflineScanner() {
             // Determine API verification URL
             const mlUrl = process.env.NEXT_PUBLIC_ML_URL;
             const apiBase = process.env.NEXT_PUBLIC_API_URL || "http://localhost:4000";
-            const apiUrl = mlUrl 
-                ? `${mlUrl.replace(/\/+$/, "")}/verify/batch` 
+            const apiUrl = mlUrl
+                ? `${mlUrl.replace(/\/+$/, "")}/verify/batch`
                 : `${apiBase.replace(/\/+$/, "")}/api/verify`;
 
             // Collect device metadata
             const deviceMetadata = {
                 userAgent: typeof window !== "undefined" ? window.navigator.userAgent : "unknown",
-                platform: typeof window !== "undefined" ? (window.navigator as any).userAgentData?.platform || window.navigator.platform : "unknown",
+                platform:
+                    typeof window !== "undefined"
+                        ? (window.navigator as any).userAgentData?.platform ||
+                          window.navigator.platform
+                        : "unknown",
                 language: typeof window !== "undefined" ? window.navigator.language : "unknown",
             };
 
-            await addToSyncQueue(normalized, locale, apiUrl, deviceMetadata);
+            const item = await addToSyncQueue(normalized, locale, apiUrl, deviceMetadata);
+            // Use the queue item's id and timestamp for the PENDING history row so
+            // that when the scan is synced later, the result updates THIS row in
+            // place (transitioning PENDING -> VERIFIED/FAKE) instead of appending a
+            // duplicate with the sync-time timestamp. This keeps the correct result
+            // for each medicine and preserves the original scan time so an older
+            // scan can never overwrite a newer verification in history.
             await saveScanHistory({
-                id: crypto.randomUUID(),
-                timestamp: Date.now(),
+                id: item.id,
+                timestamp: item.timestamp,
                 medicineName: normalized,
                 status: "PENDING",
             });
 
             // Request Notification permissions if needed
-            if (typeof window !== "undefined" && "Notification" in window && Notification.permission === "default") {
+            if (
+                typeof window !== "undefined" &&
+                "Notification" in window &&
+                Notification.permission === "default"
+            ) {
                 void Notification.requestPermission();
             }
 
             // Register Background Sync if supported
-            if (typeof navigator !== "undefined" && "serviceWorker" in navigator && "SyncManager" in window) {
+            if (
+                typeof navigator !== "undefined" &&
+                "serviceWorker" in navigator &&
+                "SyncManager" in window
+            ) {
                 try {
                     const reg = await navigator.serviceWorker.ready;
                     await (reg as any).sync.register("sahidawa-sync-scans");

--- a/apps/web/lib/db/syncQueue.ts
+++ b/apps/web/lib/db/syncQueue.ts
@@ -65,7 +65,12 @@ export async function addToSyncQueue(
 export async function getSyncQueue(): Promise<QueuedScan[]> {
     if (!dbPromise) return [];
     const db = await dbPromise;
-    return db.getAll(STORE_NAME);
+    const items = (await db.getAll(STORE_NAME)) as QueuedScan[];
+    // IndexedDB getAll() returns rows in primary-key (random UUID) order, not
+    // chronological order. Sorting by timestamp ensures offline scans are synced
+    // deterministically (oldest first) and the pending list is shown in the order
+    // they were scanned, so results can never be processed out of order.
+    return items.sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0));
 }
 
 export async function removeFromSyncQueue(id: string): Promise<void> {

--- a/apps/web/lib/scanHistoryUtils.ts
+++ b/apps/web/lib/scanHistoryUtils.ts
@@ -29,3 +29,30 @@ export async function recordScanHistory(result: VerifyResult, fallbackBrandName?
         // Cloud sync is best-effort and must not block scan results.
     });
 }
+
+/**
+ * Records the verification result of an offline-queued scan that has just been
+ * synced, updating the linked PENDING history row in place.
+ *
+ * Uses the queue item's own id and original scan timestamp so the row keeps its
+ * chronological position. This prevents an older offline scan that happens to
+ * sync later from being stamped with the sync time and showing up as the newest
+ * verification (which would overwrite a newer result in history).
+ */
+export async function recordSyncScanHistory(
+    id: string,
+    timestamp: number,
+    result: VerifyResult,
+    fallbackBrandName?: string
+) {
+    await saveScanHistory({
+        id,
+        timestamp,
+        medicineName: getScanHistoryMedicineName(result, fallbackBrandName),
+        status: getScanHistoryStatus(result),
+    });
+
+    void syncScanHistoryWithCloud().catch(() => {
+        // Cloud sync is best-effort and must not block scan results.
+    });
+}

--- a/apps/web/lib/scanQueueSync.ts
+++ b/apps/web/lib/scanQueueSync.ts
@@ -1,6 +1,6 @@
 import { verifyMedicine } from "@/lib/api";
 import { getSyncQueue, removeFromSyncQueue } from "@/lib/db/syncQueue";
-import { recordScanHistory } from "@/lib/scanHistoryUtils";
+import { recordSyncScanHistory } from "@/lib/scanHistoryUtils";
 import { toast } from "sonner";
 
 export function isNetworkFailure(error: unknown): boolean {
@@ -18,64 +18,84 @@ export function isNetworkFailure(error: unknown): boolean {
 export async function syncPendingScans(onSynced?: (count: number) => void): Promise<number> {
     if (typeof window === "undefined" || !navigator.onLine) return 0;
 
-    const queue = await getSyncQueue();
-    if (queue.length === 0) return 0;
+    // Guard against overlapping flushes (e.g. the window's "online" event and the
+    // service worker's FLUSH_SYNC_QUEUE message firing at the same time). Two
+    // concurrent loops would verify and remove entries twice and race on the
+    // history rows. Only one sync may run at a time. The lock is claimed BEFORE
+    // any await so two calls racing on the same tick can't both acquire it.
+    if (syncInProgress) return 0;
+    syncInProgress = true;
 
     let synced = 0;
 
-    for (const item of queue) {
-        try {
-            const result = await verifyMedicine(item.barcode, undefined, item.apiUrl);
-            await recordScanHistory(result, item.barcode);
-            await removeFromSyncQueue(item.id);
-            synced++;
+    try {
+        const queue = await getSyncQueue();
+        if (queue.length === 0) return 0;
 
-            // Notify user of result
-            const medicineName = (result.verified && result.medicine.brand_name) || item.barcode;
-            let body = "";
-            let isCounterfeit = false;
+        // getSyncQueue() returns items sorted oldest-first by timestamp, so queued
+        // scans are processed deterministically in the order they were scanned.
+        for (const item of queue) {
+            try {
+                const result = await verifyMedicine(item.barcode, undefined, item.apiUrl);
+                // Update the linked PENDING history row in place, preserving the
+                // original scan timestamp, so an older scan can never overwrite a
+                // newer verification and each medicine keeps its correct result.
+                await recordSyncScanHistory(item.id, item.timestamp, result, item.barcode);
+                await removeFromSyncQueue(item.id);
+                synced++;
 
-            if (result.verified) {
-                isCounterfeit = result.medicine.is_counterfeit_alert;
-                if (isCounterfeit) {
-                    body = `Counterfeit Alert: "${medicineName}" (Batch: ${result.medicine.batch_number}) is flagged as counterfeit!`;
-                    toast.error(body, { duration: 6000 });
-                } else {
-                    body = `Verified: "${medicineName}" (Batch: ${result.medicine.batch_number}) is genuine.`;
-                    toast.success(body);
-                }
-            } else {
-                body = `Verification failed: Batch "${item.barcode}" could not be verified.`;
-                toast.error(body);
-            }
+                // Notify user of result
+                const medicineName =
+                    (result.verified && result.medicine.brand_name) || item.barcode;
+                let body = "";
+                let isCounterfeit = false;
 
-            // Web Notification if tab is hidden
-            if (
-                typeof window !== "undefined" &&
-                "Notification" in window &&
-                Notification.permission === "granted" &&
-                document.hidden
-            ) {
-                new Notification(
-                    isCounterfeit ? "⚠️ Counterfeit Alert!" : "✅ SahiDawa Verification",
-                    {
-                        body,
-                        icon: "/icons/icon-192.png",
+                if (result.verified) {
+                    isCounterfeit = result.medicine.is_counterfeit_alert;
+                    if (isCounterfeit) {
+                        body = `Counterfeit Alert: "${medicineName}" (Batch: ${result.medicine.batch_number}) is flagged as counterfeit!`;
+                        toast.error(body, { duration: 6000 });
+                    } else {
+                        body = `Verified: "${medicineName}" (Batch: ${result.medicine.batch_number}) is genuine.`;
+                        toast.success(body);
                     }
-                );
+                } else {
+                    body = `Verification failed: Batch "${item.barcode}" could not be verified.`;
+                    toast.error(body);
+                }
+
+                // Web Notification if tab is hidden
+                if (
+                    typeof window !== "undefined" &&
+                    "Notification" in window &&
+                    Notification.permission === "granted" &&
+                    document.hidden
+                ) {
+                    new Notification(
+                        isCounterfeit ? "⚠️ Counterfeit Alert!" : "✅ SahiDawa Verification",
+                        {
+                            body,
+                            icon: "/icons/icon-192.png",
+                        }
+                    );
+                }
+            } catch (error) {
+                if (!navigator.onLine || isNetworkFailure(error)) {
+                    break;
+                }
+                await removeFromSyncQueue(item.id);
             }
-        } catch (error) {
-            if (!navigator.onLine || isNetworkFailure(error)) {
-                break;
-            }
-            await removeFromSyncQueue(item.id);
         }
+    } finally {
+        // Always release the lock so subsequent online events can retry.
+        syncInProgress = false;
     }
 
     if (synced > 0 && onSynced) onSynced(synced);
     return synced;
 }
 
+let syncInProgress = false;
 let cleanupFn: (() => void) | null = null;
 
 export function initScanQueueSync(onSynced?: (count: number) => void, onQueueChange?: () => void) {

--- a/apps/web/tests/scanQueueSync.test.ts
+++ b/apps/web/tests/scanQueueSync.test.ts
@@ -46,6 +46,7 @@ jest.mock("../lib/api", () => ({
 
 jest.mock("../lib/scanHistoryUtils", () => ({
     recordScanHistory: jest.fn(),
+    recordSyncScanHistory: jest.fn(),
 }));
 
 import {
@@ -56,7 +57,7 @@ import {
 } from "../lib/db/syncQueue";
 import { syncPendingScans, isNetworkFailure } from "../lib/scanQueueSync";
 import { verifyMedicine } from "../lib/api";
-import { recordScanHistory } from "../lib/scanHistoryUtils";
+import { recordScanHistory, recordSyncScanHistory } from "../lib/scanHistoryUtils";
 
 describe("syncQueue", () => {
     beforeEach(async () => {
@@ -121,7 +122,7 @@ describe("scanQueueSync", () => {
             undefined,
             "https://queued.example/api/verify"
         );
-        expect(recordScanHistory).toHaveBeenCalled();
+        expect(recordSyncScanHistory).toHaveBeenCalled();
         expect(await getSyncQueue()).toHaveLength(0);
         expect(item.barcode).toBe("BATCH-789");
     });
@@ -152,5 +153,66 @@ describe("scanQueueSync", () => {
 
         expect(synced).toBe(0);
         expect(await getSyncQueue()).toHaveLength(1);
+    });
+
+    it("syncs queued scans deterministically in oldest-first order", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockResolvedValue({ verified: true, medicine: {} } as any);
+
+        // The queue store is keyed by random UUID, so IndexedDB order == insertion
+        // order, NOT scan order. Timestamps are deliberately out of insertion order
+        // to simulate scans made on a device and synced later.
+        const oldest = await addToSyncQueue("BATCH-OLD", "en", "https://x/api/verify");
+        const newest = await addToSyncQueue("BATCH-NEW", "en", "https://x/api/verify");
+        oldest.timestamp = 100;
+        newest.timestamp = 300;
+        queueStore.set(oldest.id, oldest);
+        queueStore.set(newest.id, newest);
+
+        await syncPendingScans();
+
+        // Oldest scan must be verified and recorded before the newest one.
+        expect(mockedVerify.mock.calls[0][0]).toBe("BATCH-OLD");
+        expect(mockedVerify.mock.calls[1][0]).toBe("BATCH-NEW");
+        expect((recordSyncScanHistory as jest.Mock).mock.calls[0][0]).toBe(oldest.id);
+        expect((recordSyncScanHistory as jest.Mock).mock.calls[1][0]).toBe(newest.id);
+    });
+
+    it("preserves the original scan timestamp for each synced medicine result", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockResolvedValue({ verified: true, medicine: {} } as any);
+
+        const item = await addToSyncQueue("BATCH-TS", "en", "https://x/api/verify");
+        item.timestamp = 123456789;
+        queueStore.set(item.id, item);
+
+        await syncPendingScans();
+
+        // The result must be written to the linked history row (same id) using the
+        // ORIGINAL scan timestamp, not the sync time — otherwise an older scan that
+        // syncs later would appear as the newest verification.
+        expect(recordSyncScanHistory).toHaveBeenCalledWith(
+            item.id,
+            123456789,
+            expect.anything(),
+            "BATCH-TS"
+        );
+    });
+
+    it("does not run concurrent flushes that would process entries twice", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockResolvedValue({ verified: true, medicine: {} } as any);
+
+        await addToSyncQueue("BATCH-CONCURRENT", "en", "https://x/api/verify");
+
+        // Fire two sync triggers on the same tick (e.g. "online" event + service
+        // worker flush). The lock is claimed before the first await, so only the
+        // first call may proceed; the second bails out and verifies nothing.
+        const [first, second] = await Promise.all([syncPendingScans(), syncPendingScans()]);
+
+        expect(first).toBe(1);
+        expect(second).toBe(0);
+        expect(mockedVerify).toHaveBeenCalledTimes(1);
+        expect(await getSyncQueue()).toHaveLength(0);
     });
 });


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4115**
- **Summary:**
- lib/db/syncQueue.ts — getSyncQueue() now sorts oldest-first by timestamp, making processing deterministic and the pending list chronological.
- lib/scanHistoryUtils.ts — new recordSyncScanHistory(id, timestamp, result, …) that writes the result into the linked history row using the original scan id/timestamp.
- lib/scanQueueSync.ts — syncPendingScans() uses the queue item's original id/timestamp (updates the PENDING row in place → no duplicate, no reordering), and a module-level lock (claimed before the first await) prevents concurrent flushes.
- hooks/useOfflineScanner.ts — the PENDING history row is now created with the queue item's id/timestamp so the sync can update it.
Verification
- tests/scanQueueSync.test.ts — 9/9 pass (incl. new tests: oldest-first ordering, original-timestamp preservation, concurrent-flush guard).
- offline-queue, searchQueue, PendingSearchQueue, usePendingSearchQueue suites — 14/14 pass.
- tsc --noEmit clean, prettier clean, pre-commit (madge circular) + pre-push (audit) hooks passed.



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4115 `)
- [x] I have pulled the latest `main` and resolved any conflicts
