### PR TITLE
fix(web): handle session expiry without login loops

### DIFF
--- a/apps/web/app/[locale]/admin/analytics/page.tsx
+++ b/apps/web/app/[locale]/admin/analytics/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import React, { useState, useEffect, useCallback, useMemo } from "react";
-import { Link } from "@/i18n/routing";
+import { Link, usePathname } from "@/i18n/routing";
+import { useLocale } from "next-intl";
 import { supabase } from "@/lib/supabase";
 import { ADMIN_API_BASE } from "@/lib/adminApi";
+import { buildLoginPath } from "@/lib/authReturn";
 import {
     Pill,
     AlertTriangle,
@@ -95,6 +97,8 @@ function formatPercent(rate: number): string {
 
 export default function AnalyticsDashboard() {
     const { token, isLoading: authLoading } = useSession();
+    const locale = useLocale();
+    const pathname = usePathname();
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [timeframe, setTimeframe] = useState<"7d" | "30d" | "90d" | "all">("30d");
@@ -144,7 +148,11 @@ export default function AnalyticsDashboard() {
 
                 if (!pushAnalyticsRes.ok) {
                     if (pushAnalyticsRes.status === 401 && typeof window !== "undefined") {
-                        window.location.href = "/admin/login";
+                        // Session expired mid-flow: clear the stale auth state
+                        // (so the loop can't recur) and resume the intended
+                        // destination after re-authentication.
+                        void supabase.auth.signOut().catch(() => {});
+                        window.location.href = buildLoginPath(locale, pathname);
                         return;
                     }
                     const message =

--- a/apps/web/app/[locale]/history/page.tsx
+++ b/apps/web/app/[locale]/history/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import dynamic from "next/dynamic";
 
 import {
@@ -11,9 +11,12 @@ import {
     ScanHistoryEntry,
 } from "@/lib/db/scanHistory";
 import { CopyButton } from "@/components/ui/CopyButton";
-import { ClipboardList, Download, RefreshCw, Trash2 } from "lucide-react";
+import { ClipboardList, Download, LogIn, RefreshCw, Trash2 } from "lucide-react";
 import { syncScanHistoryWithCloud } from "@/lib/scanHistoryCloudSync";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { Link, usePathname } from "@/i18n/routing";
+import { useSession } from "@/src/components/AuthProvider";
+import { buildLoginPath } from "@/lib/authReturn";
 
 const ExportModal = dynamic(() => import("./ExportModal"));
 
@@ -33,6 +36,9 @@ export default function HistoryPage() {
     );
 
     const t = useTranslations("ScanHistory");
+    const locale = useLocale();
+    const pathname = usePathname();
+    const { session } = useSession();
     const [isExportModalOpen, setIsExportModalOpen] = useState(false);
 
     const loadHistory = useCallback(async () => {
@@ -265,6 +271,17 @@ export default function HistoryPage() {
                     </div>
                 )}
                 {syncMessage && <p className="mb-4 text-sm opacity-70">{syncMessage}</p>}
+                {syncStatus === "error" && !session && (
+                    <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm">
+                        <span className="text-amber-300">{t("sync_auth_title")}</span>
+                        <Link
+                            href={buildLoginPath(locale, pathname) as any}
+                            className="inline-flex items-center gap-2 rounded-lg bg-amber-500 px-4 py-2 font-semibold text-amber-950 transition hover:bg-amber-400"
+                        >
+                            <LogIn size={16} /> {t("sync_auth_action")}
+                        </Link>
+                    </div>
+                )}
                 <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-4">
                     <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
                         <p className="text-sm opacity-70">{t("stat_total")}</p>

--- a/apps/web/app/[locale]/login/page.tsx
+++ b/apps/web/app/[locale]/login/page.tsx
@@ -11,13 +11,14 @@ import {
     EyeOff,
 } from "lucide-react";
 import { FcGoogle } from "react-icons/fc";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useLocale, useTranslations } from "next-intl";
 import { Link, useRouter } from "@/i18n/routing";
 import { createBrowserClient } from "@supabase/ssr";
 import { LiveMessage } from "@/components/ui/LiveMessage";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
 import { FaGithub } from "react-icons/fa6";
+import { stripLocalePrefix, toLocalePath } from "@/lib/authReturn";
 export default function LoginPage() {
     const router = useRouter();
     const locale = useLocale();
@@ -54,6 +55,41 @@ export default function LoginPage() {
     const [error, setError] = useState("");
     const [showPassword, setShowPassword] = useState(false);
 
+    // Restore the intended destination after re-authentication (set by the
+    // middleware or admin pages when an expired session interrupts a flow).
+    const [queryParsed, setQueryParsed] = useState(false);
+    const [returnTo, setReturnTo] = useState<string | null>(null);
+
+    useEffect(() => {
+        const params = new URLSearchParams(window.location.search);
+        setReturnTo(params.get("returnTo"));
+        setQueryParsed(true);
+    }, []);
+
+    const targetPath = useMemo(
+        () => (returnTo ? stripLocalePrefix(returnTo, locale) : "/reports/me"),
+        [returnTo, locale]
+    );
+
+    // If a session already exists (e.g. a stale cookie was refreshed, or OAuth
+    // restored one), skip the form and resume the intended journey. This
+    // prevents the repeated login redirect loop for already-signed-in users.
+    useEffect(() => {
+        if (!queryParsed || isMissingEnvVars || !supabase) return;
+        let cancelled = false;
+        supabase.auth
+            .getSession()
+            .then(({ data }) => {
+                if (!cancelled && data.session) {
+                    router.push(targetPath);
+                }
+            })
+            .catch(() => {});
+        return () => {
+            cancelled = true;
+        };
+    }, [queryParsed, isMissingEnvVars, supabase, router, targetPath]);
+
     const getAuthErrorMessage = (message: string) => {
         return message === "Failed to fetch" ? t("errors.generic") : message;
     };
@@ -83,7 +119,7 @@ export default function LoginPage() {
             }
 
             if (data?.session?.access_token) {
-                router.push("/reports/me");
+                router.push(targetPath);
             }
         } catch {
             setError(t("errors.generic"));
@@ -106,7 +142,7 @@ export default function LoginPage() {
             const { error } = await supabase.auth.signInWithOAuth({
                 provider: "google",
                 options: {
-                    redirectTo: `${window.location.origin}/${locale}/reports/me`,
+                    redirectTo: `${window.location.origin}${toLocalePath(targetPath, locale)}`,
                 },
             });
 
@@ -133,7 +169,7 @@ export default function LoginPage() {
             const { error } = await supabase.auth.signInWithOAuth({
                 provider: "github",
                 options: {
-                    redirectTo: `${window.location.origin}/${locale}/reports/me`,
+                    redirectTo: `${window.location.origin}${toLocalePath(targetPath, locale)}`,
                 },
             });
 

--- a/apps/web/app/[locale]/profile/page.tsx
+++ b/apps/web/app/[locale]/profile/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { Link, useRouter } from "@/i18n/routing";
 import { User, ShieldCheck, Bell, ChevronRight, ArrowLeft, LogIn, LogOut } from "lucide-react";
 import ABHABadge from "@/components/ABHABadge";
 import { useSession } from "@/src/components/AuthProvider";
 import { clearReadCache } from "@/lib/offline/db";
+import { createBrowserClient } from "@supabase/ssr";
+import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
 
 const ACCESS_TOKEN_KEY = "sb-access-token";
 
@@ -89,6 +91,8 @@ export default function ProfilePage() {
     const { token, isLoading: authLoading } = useSession();
     const [session, setSession] = useState<ProfileSession>({ status: "checking" });
 
+    const supabase = useMemo(() => createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey()), []);
+
     const accountTitle =
         session.status === "authenticated"
             ? (session.displayName ?? t("signedInUser"))
@@ -132,6 +136,10 @@ export default function ProfilePage() {
     };
     const handleSignOut = () => {
         localStorage.removeItem(ACCESS_TOKEN_KEY);
+        // Clear the cookie-backed session too. Without this, the middleware
+        // keeps seeing a valid session while the app is signed out, which
+        // causes protected flows to bounce between login and the app.
+        void supabase.auth.signOut().catch(() => {});
         // Wipe cached schedules/summary (PHI) so the next person on a shared
         // device can't read them offline. Fire-and-forget — never block sign-out.
         void clearReadCache();

--- a/apps/web/lib/authReturn.ts
+++ b/apps/web/lib/authReturn.ts
@@ -1,0 +1,36 @@
+const FALLBACK_PATH = "/reports/me";
+
+export function stripLocalePrefix(path: string, locale: string): string {
+    const prefix = `/${locale}`;
+    if (path === prefix) return "/";
+    if (path.startsWith(`${prefix}/`)) return path.slice(prefix.length);
+    return path;
+}
+
+export function toLocalePath(path: string, locale: string): string {
+    const stripped = stripLocalePrefix(path, locale);
+    return stripped === "/" ? `/${locale}` : `/${locale}${stripped}`;
+}
+
+export function isSafeReturnTo(path: string | null | undefined): path is string {
+    return (
+        typeof path === "string" &&
+        path.startsWith("/") &&
+        !path.startsWith("//") &&
+        !path.includes("\\") &&
+        !path.includes("%0a") &&
+        !path.includes("%0d") &&
+        !path.includes("%0A") &&
+        !path.includes("%0D") &&
+        path !== "/" &&
+        // Never land the user back on the login screen (self-redirect loop).
+        !path.split("/").includes("login")
+    );
+}
+
+export function buildLoginPath(locale: string, returnTo?: string | null): string {
+    const target = isSafeReturnTo(returnTo) ? returnTo : null;
+    const login = `/${locale}/login`;
+    if (!target || target === FALLBACK_PATH) return login;
+    return `${login}?returnTo=${encodeURIComponent(target)}`;
+}

--- a/apps/web/messages/as.json
+++ b/apps/web/messages/as.json
@@ -1736,6 +1736,8 @@
         "no_search_results": "আপোনাৰ সন্ধানৰ সৈতে কোনো ঔষধৰ মিল নাই।",
         "item_status_label": "অৱস্থা:",
         "item_delete_button": "মচি পেলাওক",
+        "sync_auth_title": "আপোনাৰ ইতিহাস চিংক কৰিবলৈ চাইন ইন কৰক",
+        "sync_auth_action": "চাইন ইন",
         "item_copy_success": "ঔষধৰ নাম কপি কৰা হৈছে!"
     },
     "MyReports": {

--- a/apps/web/messages/bn.json
+++ b/apps/web/messages/bn.json
@@ -1736,6 +1736,8 @@
         "no_search_results": "আপনার অনুসন্ধানের সাথে মেলে এমন কোনো ওষুধ পাওয়া যায়নি।",
         "item_status_label": "স্থিতি: ",
         "item_delete_button": "মুছে ফেলুন",
+        "sync_auth_title": "আপনার ইতিহাস সিঙ্ক করতে সাইন ইন করুন",
+        "sync_auth_action": "সাইন ইন",
         "item_copy_success": "ওষুধের নাম কপি করা হয়েছে!"
     },
     "MyReports": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1424,6 +1424,8 @@
         "no_search_results": "No medicines match your search.",
         "item_status_label": "Status: ",
         "item_delete_button": "Delete",
+        "sync_auth_title": "Sign in to sync your history",
+        "sync_auth_action": "Sign in",
         "item_copy_success": "Medicine name copied!"
     },
     "MyReports": {

--- a/apps/web/messages/gu.json
+++ b/apps/web/messages/gu.json
@@ -1736,6 +1736,8 @@
         "no_search_results": "તમારી શોધ સાથે કોઈ દવાઓ મેળ ખાતી નથી.",
         "item_status_label": "સ્થિતિ:",
         "item_delete_button": "કાઢી નાખો",
+        "sync_auth_title": "તમારો ઇતિહાસ સિંક કરવા માટે સાઇન ઇન કરો",
+        "sync_auth_action": "સાઇન ઇન",
         "item_copy_success": "દવાના નામની નકલ કરી!"
     },
     "MyReports": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1431,6 +1431,8 @@
         "no_search_results": "आपकी खोज से मेल खाने वाली कोई दवा नहीं मिली।",
         "item_status_label": "स्थिति: ",
         "item_delete_button": "हटाएं",
+        "sync_auth_title": "अपना इतिहास सिंक करने के लिए साइन इन करें",
+        "sync_auth_action": "साइन इन",
         "item_copy_success": "दवा का नाम कॉपी हो गया!"
     },
     "MyReports": {

--- a/apps/web/messages/kn.json
+++ b/apps/web/messages/kn.json
@@ -1736,6 +1736,8 @@
         "no_search_results": "ನಿಮ್ಮ ಹುಡುಕಾಟಕ್ಕೆ ಯಾವುದೇ ಔಷಧಿಗಳು ಹೊಂದಿಕೆಯಾಗುವುದಿಲ್ಲ.",
         "item_status_label": "ಸ್ಥಿತಿ:",
         "item_delete_button": "ಅಳಿಸಿ",
+        "sync_auth_title": "ನಿಮ್ಮ ಇತಿಹಾಸವನ್ನು ಸಿಂಕ್ ಮಾಡಲು ಸೈನ್ ಇನ್ ಮಾಡಿ",
+        "sync_auth_action": "ಸೈನ್ ಇನ್",
         "item_copy_success": "ಔಷಧದ ಹೆಸರನ್ನು ನಕಲಿಸಲಾಗಿದೆ!"
     },
     "MyReports": {

--- a/apps/web/messages/kok.json
+++ b/apps/web/messages/kok.json
@@ -1225,6 +1225,8 @@
         "empty_description": "तुमचीं सत्यापीत केल्लीं वखदां हांगा दिसतलीं.",
         "item_status_label": "स्थिती: १.",
         "item_delete_button": "काडून उडोवप",
+        "sync_auth_title": "तुमचो इतिहास सिंक करपाक सायन इन करात",
+        "sync_auth_action": "सायन इन",
         "item_copy_success": "वखदाचें नांव नकल केलें!",
         "sync_status_synced": "सिंक केलें",
         "sync_status_offline": "ऑफलायन (सिंक प्रलंबित)",

--- a/apps/web/messages/ks.json
+++ b/apps/web/messages/ks.json
@@ -1681,6 +1681,8 @@
         "no_search_results": "کوئی دوا آپ کی تلاش سے مماثل نہیں ہے۔",
         "item_status_label": "حیثیت:",
         "item_delete_button": "حذف کریں۔",
+        "sync_auth_title": "سائن اِن کٔریو تاہِ ہیٚتھہٕچ ہسٹری سِنک کٔرِو",
+        "sync_auth_action": "سائن اِن",
         "item_copy_success": "دوا کا نام نقل کیا گیا!"
     },
     "MyReports": {

--- a/apps/web/messages/mai.json
+++ b/apps/web/messages/mai.json
@@ -1372,6 +1372,8 @@
         "no_search_results": "अहाँक खोजसँ मेल खायवला कोनो दवाइ नहि भेटल।",
         "item_status_label": "स्थिति: ",
         "item_delete_button": "मेटाऊ",
+        "sync_auth_title": "अपन इतिहास सिंक करबाक लेल साइन इन करू",
+        "sync_auth_action": "साइन इन",
         "item_copy_success": "दवाइक नाम कॉपी भेल!"
     },
     "MyReports": {

--- a/apps/web/messages/ml.json
+++ b/apps/web/messages/ml.json
@@ -1680,6 +1680,8 @@
         "no_search_results": "നിങ്ങളുടെ തിരയലുമായി പൊരുത്തപ്പെടുന്ന മരുന്നുകളൊന്നും ഇല്ല.",
         "item_status_label": "നില:",
         "item_delete_button": "ഇല്ലാതാക്കുക",
+        "sync_auth_title": "നിങ്ങളുടെ ചരിത്രം സിൻക് ചെയ്യാൻ സൈൻ ഇൻ ചെയ്യുക",
+        "sync_auth_action": "സൈൻ ഇൻ",
         "item_copy_success": "മരുന്നിൻ്റെ പേര് പകർത്തി!"
     },
     "MyReports": {

--- a/apps/web/messages/mni.json
+++ b/apps/web/messages/mni.json
@@ -1348,6 +1348,8 @@
         "no_search_results": "ꯅꯍꯥꯛꯅꯥ ꯊꯤꯕꯒꯥ ꯃꯥꯟꯅꯕꯥ ꯃꯦꯗꯤꯁꯤꯟ ꯑꯃꯠꯇꯥ ꯂꯩꯇ꯭ꯔꯤꏏ",
         "item_status_label": "ꯐꯤꯚꯝ (Status): ",
         "item_delete_button": "ꯃꯨꯠꯊꯠꯄꯥ",
+        "sync_auth_title": "ꯅꯍꯥꯛꯀꯤ ꯄꯨꯋꯥꯔꯤ ꯁꯤꯟꯛ ꯇꯧꯅꯕ ꯁꯥꯏꯟ ꯏꯟ ꯇꯧ",
+        "sync_auth_action": "ꯁꯥꯏꯟ ꯏꯟ",
         "item_copy_success": "ꯍꯤꯗꯥꯛꯀꯤ ꯃꯤꯡ ꯀꯣꯄꯤ ꯇꯧꯈ꯭ꯔꯦ!"
     },
     "MyReports": {

--- a/apps/web/messages/mr.json
+++ b/apps/web/messages/mr.json
@@ -1736,6 +1736,8 @@
         "no_search_results": "कोणतीही औषधे तुमच्��ा शोधाशी जुळत नाहीत.",
         "item_status_label": "स्थिती:",
         "item_delete_button": "हटवा",
+        "sync_auth_title": "तुमचा इतिहास सिंक करण्यासाठी साइन इन करा",
+        "sync_auth_action": "साइन इन",
         "item_copy_success": "औषधाचे नाव कॉपी केले!"
     },
     "MyReports": {

--- a/apps/web/messages/or.json
+++ b/apps/web/messages/or.json
@@ -1736,6 +1736,8 @@
         "no_search_results": "କ search ଣସି medicines ଷଧ ଆପଣଙ୍କ ସନ୍��ାନ ସହିତ ମେଳ ଖାଉ ନାହିଁ |",
         "item_status_label": "ସ୍ଥିତି:",
         "item_delete_button": "ବିଲୋପ କରନ୍ତୁ |",
+        "sync_auth_title": "ଆପଣଙ୍କ ଇତିହାସ ସିଙ୍କ କରିବାକୁ ସାଇନ ଇନ କରନ୍ତୁ",
+        "sync_auth_action": "ସାଇନ ଇନ",
         "item_copy_success": "Ic ଷଧ ନାମ କପି ହୋଇଛି!"
     },
     "MyReports": {

--- a/apps/web/messages/pa.json
+++ b/apps/web/messages/pa.json
@@ -1736,6 +1736,8 @@
         "no_search_results": "ਕੋਈ ਵੀ ਦਵਾਈ ਤੁਹਾਡੀ ਖੋਜ ਨਾਲ ਮੇਲ ਨਹੀਂ ਖਾਂਦੀ।",
         "item_status_label": "ਸਥਿਤੀ:",
         "item_delete_button": "ਮਿਟਾਓ",
+        "sync_auth_title": "ਆਪਣਾ ਇਤਿਹਾਸ ਸਿੰਕ ਕਰਨ ਲਈ ਸਾਈਨ ਇਨ ਕਰੋ",
+        "sync_auth_action": "ਸਾਈਨ ਇਨ",
         "item_copy_success": "ਦਵਾਈ ਦਾ ਨਾਮ ਕਾਪੀ ਕੀਤਾ ਗਿਆ!"
     },
     "MyReports": {

--- a/apps/web/messages/sa.json
+++ b/apps/web/messages/sa.json
@@ -1680,6 +1680,8 @@
         "no_search_results": "भवतः अन्वेषणेन सह कोऽपि औषधः न मेलति।",
         "item_status_label": "स्थितिः : १.",
         "item_delete_button": "विलोपयतु",
+        "sync_auth_title": "स्वस्य इतिहासं सिंक कर्तुं प्रवेशं कुरु",
+        "sync_auth_action": "प्रवेशं कुरु",
         "item_copy_success": "औषधस्य नाम प्रतिलिपिकृतम् !"
     },
     "MyReports": {

--- a/apps/web/messages/sd.json
+++ b/apps/web/messages/sd.json
@@ -1348,6 +1348,8 @@
         "no_search_results": "توهان جي ڳولا سان ميل کائيندڙ ڪا به دوا نه ملي.",
         "item_status_label": "اسٽيٽس: ",
         "item_delete_button": "ختم ڪريو",
+        "sync_auth_title": "پنھنجي تاريخ سنڪ ڪرڻ لاءِ سائن ان ڪريو",
+        "sync_auth_action": "سائن ان",
         "item_copy_success": "دوا جو نالو ڪاپي ٿي ويو!"
     },
     "MyReports": {

--- a/apps/web/messages/ta.json
+++ b/apps/web/messages/ta.json
@@ -1736,6 +1736,8 @@
         "no_search_results": "உங்கள் தேடலுக்கு எந்த மருந்தும் பொருந்தவில்லை.",
         "item_status_label": "நிலை:",
         "item_delete_button": "நீக்கு",
+        "sync_auth_title": "உங்கள் வரலாற்றை ஒத்திசைக்க உள்நுழைக",
+        "sync_auth_action": "உள்நுழை",
         "item_copy_success": "மருந்தின் பெயர் நகலெடுக்கப்பட்டது!"
     },
     "MyReports": {

--- a/apps/web/messages/te.json
+++ b/apps/web/messages/te.json
@@ -1736,6 +1736,8 @@
         "no_search_results": "మీ శోధనకు సరిపోలే మందులు లేవు.",
         "item_status_label": "స్థితి:",
         "item_delete_button": "తొలగించు",
+        "sync_auth_title": "మీ చరిత్రను సింక్ చేయడానికి సైన్ ఇన్ చేయండి",
+        "sync_auth_action": "సైన్ ఇన్",
         "item_copy_success": "ఔషధం పేరు కాపీ చేయబడింది!"
     },
     "MyReports": {

--- a/apps/web/messages/ur.json
+++ b/apps/web/messages/ur.json
@@ -1680,6 +1680,8 @@
         "no_search_results": "کوئی دوا آپ کی تلاش سے مماثل نہیں ہے۔",
         "item_status_label": "حیثیت:",
         "item_delete_button": "حذف کریں۔",
+        "sync_auth_title": "اپنی تاریخ سنک کرنے کے لیے سائن ان کریں",
+        "sync_auth_action": "سائن ان",
         "item_copy_success": "دوا کا نام نقل کیا گیا!"
     },
     "MyReports": {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -49,7 +49,7 @@ export default async function middleware(req: NextRequest) {
                 "https://overpass.kumi.systems",
                 "https://lz4.overpass-api.de",
                 "https://z.overpass-api.de",
-                "https://unpkg.com"
+                "https://unpkg.com",
             ].filter(Boolean)
         ),
     ].join(" ");
@@ -103,9 +103,10 @@ export default async function middleware(req: NextRequest) {
     if (/^\/[a-z]{2}\/admin\//.test(pathname) || /^\/[a-z]{2}\/admin$/.test(pathname)) {
         if (!session) {
             const locale = pathname.split("/")[1] ?? "en";
-            // Important: we need to redirect but also preserve the CSP headers?
-            // Actually NextResponse.redirect handles itself.
-            return NextResponse.redirect(new URL(`/${locale}/login`, req.url));
+            // Preserve the intended destination so the user is returned to it
+            // after re-authenticating instead of being dumped at the home page.
+            const returnTo = encodeURIComponent(pathname);
+            return NextResponse.redirect(new URL(`/${locale}/login?returnTo=${returnTo}`, req.url));
         }
     }
 

--- a/apps/web/src/components/AuthProvider.tsx
+++ b/apps/web/src/components/AuthProvider.tsx
@@ -42,7 +42,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 }
                 syncServiceWorkerSession(s);
             })
-            .catch((err) => console.error("[AuthProvider] Failed:", err));
+            .catch((err) => {
+                console.error("[AuthProvider] Failed:", err);
+                // Never leave consumers stuck in an infinite loading state:
+                // treat an unreadable session as signed-out so protected pages
+                // render their graceful re-authentication state.
+                setIsLoading(false);
+                localStorage.removeItem("sb-access-token");
+                syncServiceWorkerSession(null);
+            });
 
         const {
             data: { subscription },

--- a/apps/web/tests/authReturn.test.ts
+++ b/apps/web/tests/authReturn.test.ts
@@ -1,0 +1,78 @@
+import { buildLoginPath, isSafeReturnTo, stripLocalePrefix, toLocalePath } from "../lib/authReturn";
+
+describe("authReturn helpers", () => {
+    describe("stripLocalePrefix", () => {
+        it("removes the locale segment from a locale-prefixed path", () => {
+            expect(stripLocalePrefix("/en/admin/dashboard", "en")).toBe("/admin/dashboard");
+        });
+
+        it("returns the root for just the locale path", () => {
+            expect(stripLocalePrefix("/en", "en")).toBe("/");
+        });
+
+        it("leaves a non-prefixed path untouched", () => {
+            expect(stripLocalePrefix("/admin/dashboard", "en")).toBe("/admin/dashboard");
+        });
+
+        it("only strips when the locale is at the first segment", () => {
+            expect(stripLocalePrefix("/report/en/details", "en")).toBe("/report/en/details");
+        });
+    });
+
+    describe("toLocalePath", () => {
+        it("prefixes a bare path with the given locale", () => {
+            expect(toLocalePath("/admin", "en")).toBe("/en/admin");
+        });
+
+        it("returns the locale root for a root path", () => {
+            expect(toLocalePath("/", "ta")).toBe("/ta");
+        });
+
+        it("is idempotent for an already-prefixed path", () => {
+            expect(toLocalePath("/en/admin", "en")).toBe("/en/admin");
+        });
+    });
+
+    describe("isSafeReturnTo", () => {
+        it("accepts an internal path", () => {
+            expect(isSafeReturnTo("/en/admin/analytics")).toBe(true);
+        });
+
+        it("rejects external / protocol-relative URLs", () => {
+            expect(isSafeReturnTo("https://evil.example")).toBe(false);
+            expect(isSafeReturnTo("//evil.example")).toBe(false);
+        });
+
+        it("rejects the login route to avoid self-redirect", () => {
+            expect(isSafeReturnTo("/en/login")).toBe(false);
+            expect(isSafeReturnTo("/login")).toBe(false);
+        });
+
+        it("rejects path traversal and CR/LF injection", () => {
+            expect(isSafeReturnTo("/admin\\..")).toBe(false);
+            expect(isSafeReturnTo("/admin/%0aSet-Cookie:")).toBe(false);
+        });
+
+        it("rejects non-string values", () => {
+            expect(isSafeReturnTo(null)).toBe(false);
+            expect(isSafeReturnTo(undefined)).toBe(false);
+        });
+    });
+
+    describe("buildLoginPath", () => {
+        it("builds a locale-prefixed login path with a safe returnTo", () => {
+            expect(buildLoginPath("en", "/en/admin/analytics")).toBe(
+                "/en/login?returnTo=%2Fen%2Fadmin%2Fanalytics"
+            );
+        });
+
+        it("omits returnTo for the default destination", () => {
+            expect(buildLoginPath("ta")).toBe("/ta/login");
+        });
+
+        it("omits returnTo for an unsafe value", () => {
+            expect(buildLoginPath("en", "https://evil.example")).toBe("/en/login");
+            expect(buildLoginPath("en", "/en/login")).toBe("/en/login");
+        });
+    });
+});

--- a/apps/web/tests/login-page.test.tsx
+++ b/apps/web/tests/login-page.test.tsx
@@ -11,16 +11,19 @@ import {
 /**
  * @jest-environment jsdom
  */
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import LoginPage from "../app/[locale]/login/page";
 import { createBrowserClient } from "@supabase/ssr";
 
+const mockAuth = {
+    getSession: jest.fn(),
+    signInWithPassword: jest.fn(),
+    signInWithOAuth: jest.fn(),
+};
+
 jest.mock("@supabase/ssr", () => ({
     createBrowserClient: jest.fn(() => ({
-        auth: {
-            signInWithPassword: jest.fn(),
-            signInWithOAuth: jest.fn(),
-        },
+        auth: mockAuth,
     })),
 }));
 
@@ -34,18 +37,25 @@ jest.mock("next-intl", () => ({
     useTranslations: (namespace: string) => (key: string) => `${namespace}.${key}`,
 }));
 
+const mockRouter = { push: jest.fn() };
+
 jest.mock("@/i18n/routing", () => ({
     Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
         <a href={href}>{children}</a>
     ),
-    useRouter: () => ({
-        push: jest.fn(),
-    }),
+    useRouter: () => mockRouter,
 }));
 
 describe("LoginPage Supabase client creation", () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockAuth.getSession.mockResolvedValue({ data: { session: null } });
+        mockAuth.signInWithPassword.mockResolvedValue({
+            data: { session: { access_token: "token-123" } },
+            error: null,
+        });
+        // Reset URL so a fresh query string can be set per test.
+        window.history.replaceState({}, "", "/en/login");
     });
 
     it("should instantiate the Supabase client only once on initial render and reuse it across state updates", () => {
@@ -64,5 +74,49 @@ describe("LoginPage Supabase client creation", () => {
 
         // createBrowserClient should STILL have been called only once, demonstrating useMemo is successfully keeping it cached/singleton
         expect(createBrowserClient).toHaveBeenCalledTimes(1);
+    });
+
+    it("redirects to the stripped returnTo path after password login", async () => {
+        window.history.replaceState({}, "", "/en/login?returnTo=%2Fen%2Fadmin%2Fdashboard");
+
+        render(<LoginPage />);
+
+        fireEvent.change(screen.getByPlaceholderText("Login.emailPlaceholder"), {
+            target: { value: "test@example.com" },
+        });
+        fireEvent.change(screen.getByPlaceholderText("Login.passwordPlaceholder"), {
+            target: { value: "password123" },
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Login.signIn" }));
+
+        await waitFor(() => {
+            expect(mockRouter.push).toHaveBeenCalledWith("/admin/dashboard");
+        });
+    });
+
+    it("redirects away from the login page when a session already exists", async () => {
+        mockAuth.getSession.mockResolvedValue({
+            data: { session: { user: { id: "u1" } } },
+        });
+        window.history.replaceState({}, "", "/en/login?returnTo=%2Fen%2Fadmin%2Fapproval");
+
+        render(<LoginPage />);
+
+        await waitFor(() => {
+            expect(mockRouter.push).toHaveBeenCalledWith("/admin/approval");
+        });
+    });
+
+    it("falls back to My Reports when no returnTo is present", async () => {
+        mockAuth.getSession.mockResolvedValue({
+            data: { session: { user: { id: "u1" } } },
+        });
+
+        render(<LoginPage />);
+
+        await waitFor(() => {
+            expect(mockRouter.push).toHaveBeenCalledWith("/reports/me");
+        });
     });
 });


### PR DESCRIPTION



### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4116 **
- **Summary:**
What changed (437c707b, 28 files)
- proxy.ts — admin login redirect now appends ?returnTo=<pathname> so protected routes resume where the user left off.
- login/page.tsx — reads returnTo and restores it for both password and OAuth sign-in; redirects away when a session already exists (kills the stale-session loop); falls back to /reports/me.
- AuthProvider.tsx — clears isLoading on getSession failure so pages render a graceful state, not an infinite spinner.
- admin/analytics — replaced a dead /admin/login redirect (404 loop) with a locale-aware login carrying returnTo, plus clears stale auth on 401.
- profile — sign-out now calls supabase.auth.signOut() so the cookie session is cleared (fixes the cookie/localStorage drift loop).
- history — shows a "Sign in to sync" CTA when cloud sync fails due to no valid session.
- lib/authReturn.ts — new, unit-tested helpers (buildLoginPath, sanitizing returnTo against open-redirect/path-traversal/login self-loops).
- i18n — added ScanHistory.sync_auth_title/action to all 19 locales.
Verification
- Full web test suite: 104 suites / 598 passed (incl. new authReturn + 3 new login returnTo tests).
- tsc --noEmit, eslint, prettier, madge --circular all clean.
- Pre-push npm audit passed (0 vulnerabilities).



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4116 `)
- [x] I have pulled the latest `main` and resolved any conflicts
