### PR TITLE
fix(api): rename unused exception var to underscore prefix

### DIFF
--- a/apps/api/src/services/cache.service.ts
+++ b/apps/api/src/services/cache.service.ts
@@ -403,8 +403,8 @@ export async function getCacheStats(): Promise<{
         if (snapshotResult.status === "fulfilled" && snapshotResult.value) {
             try {
                 snapshot = JSON.parse(snapshotResult.value);
-            } catch (e) {
-                // Ignore parse errors
+            } catch (_e) {
+                // Ignore parse errors - snapshot will remain null
             }
         }
 


### PR DESCRIPTION
## Summary
Renames unused exception variable from 'e' to '_e' to indicate it's intentionally unused.

## Changes
- Renamed 'catch (e)' to 'catch (_e)' in cache.service.ts
- Updated comment to clarify behavior

## Why
- The underscore prefix convention indicates intentionally unused variables
- Improves code clarity for maintainers
- Follows common TypeScript/JavaScript conventions

Closes #4084