### PR TITLE
feat(api): add page/limit pagination to GET /api/wishlist

### DIFF
--- a/apps/api/tests/wishlist.test.ts
+++ b/apps/api/tests/wishlist.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import express from "express";
 import request, { Response as SuperTestResponse } from "supertest";
 import wishlistRouter, { mergeGuestWishlist } from "../src/routes/wishlist";
@@ -44,6 +43,157 @@ function expectUnavailableMerge(response: SuperTestResponse) {
         code: "WISHLIST_MERGE_UNAVAILABLE",
     });
 }
+
+describe("GET /api/v1/wishlist — pagination", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    function buildItems(n: number) {
+        return Array.from({ length: n }, (_, i) => ({
+            id: `item-${i + 1}`,
+            product_id: `product-${i + 1}`,
+            created_at: new Date().toISOString(),
+        }));
+    }
+
+    function mockWishlistPage(
+        items: object[],
+        totalCount: number,
+        error: object | null = null
+    ) {
+        const rangeMock = jest.fn().mockResolvedValue({
+            data: error ? null : items,
+            error,
+            count: error ? null : totalCount,
+        });
+        const orderMock = jest.fn().mockReturnValue({ range: rangeMock });
+        const eqMock = jest.fn().mockReturnValue({ order: orderMock });
+        const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+
+        mockedSupabase.from.mockImplementation((table: string) => {
+            if (table === "wishlists") {
+                return { select: selectMock } as never;
+            }
+            return {} as never;
+        });
+
+        return { rangeMock, orderMock, eqMock, selectMock };
+    }
+
+    it("returns the correct pagination schema on a populated page", async () => {
+        mockWishlistPage(buildItems(20), 45);
+
+        const res = await request(createTestApp()).get("/api/v1/wishlist?page=1&limit=20");
+
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({
+            page: 1,
+            limit: 20,
+            count: 45,
+            totalPages: 3,
+        });
+        expect(Array.isArray(res.body.items)).toBe(true);
+        expect(res.body.items).toHaveLength(20);
+    });
+
+    it("defaults to page=1 and limit=20 when no query params given", async () => {
+        mockWishlistPage(buildItems(20), 50);
+
+        const res = await request(createTestApp()).get("/api/v1/wishlist");
+
+        expect(res.status).toBe(200);
+        expect(res.body.page).toBe(1);
+        expect(res.body.limit).toBe(20);
+        expect(res.body.totalPages).toBe(3);
+    });
+
+    it("returns correct page when requesting page 2", async () => {
+        mockWishlistPage(buildItems(20), 45);
+
+        const res = await request(createTestApp()).get("/api/v1/wishlist?page=2&limit=20");
+
+        expect(res.status).toBe(200);
+        expect(res.body.page).toBe(2);
+    });
+
+    it("returns the remaining items on the last page", async () => {
+        mockWishlistPage(buildItems(5), 45);
+
+        const res = await request(createTestApp()).get("/api/v1/wishlist?page=3&limit=20");
+
+        expect(res.status).toBe(200);
+        expect(res.body.page).toBe(3);
+        expect(res.body.items).toHaveLength(5);
+        expect(res.body.totalPages).toBe(3);
+    });
+
+    it("falls back to page=1 when page param is invalid (string)", async () => {
+        mockWishlistPage(buildItems(20), 30);
+
+        const res = await request(createTestApp()).get("/api/v1/wishlist?page=abc&limit=20");
+
+        expect(res.status).toBe(200);
+        expect(res.body.page).toBe(1);
+    });
+
+    it("falls back to page=1 when page param is zero", async () => {
+        mockWishlistPage(buildItems(20), 30);
+
+        const res = await request(createTestApp()).get("/api/v1/wishlist?page=0&limit=20");
+
+        expect(res.status).toBe(200);
+        expect(res.body.page).toBe(1);
+    });
+
+    it("falls back to limit=20 when limit param is invalid", async () => {
+        mockWishlistPage(buildItems(20), 30);
+
+        const res = await request(createTestApp()).get("/api/v1/wishlist?page=1&limit=xyz");
+
+        expect(res.status).toBe(200);
+        expect(res.body.limit).toBe(20);
+    });
+
+    it("caps limit at 100 when limit param exceeds maximum", async () => {
+        mockWishlistPage(buildItems(100), 500);
+
+        const res = await request(createTestApp()).get("/api/v1/wishlist?page=1&limit=999");
+
+        expect(res.status).toBe(200);
+        expect(res.body.limit).toBe(100);
+        expect(res.body.totalPages).toBe(5);
+    });
+
+    it("returns empty items and zero counts when the wishlist is empty", async () => {
+        mockWishlistPage([], 0);
+
+        const res = await request(createTestApp()).get("/api/v1/wishlist?page=1&limit=20");
+
+        expect(res.status).toBe(200);
+        expect(res.body.items).toEqual([]);
+        expect(res.body.count).toBe(0);
+        expect(res.body.totalPages).toBe(0);
+    });
+
+    it("uses count from the full wishlist, not just the current page size", async () => {
+        mockWishlistPage(buildItems(5), 45);
+
+        const res = await request(createTestApp()).get("/api/v1/wishlist?page=3&limit=20");
+
+        expect(res.status).toBe(200);
+        expect(res.body.items).toHaveLength(5);
+        expect(res.body.count).toBe(45);
+    });
+
+    it("calls next(err) when the database returns an error", async () => {
+        mockWishlistPage([], 0, { message: "DB connection failed" });
+
+        const res = await request(createTestApp()).get("/api/v1/wishlist?page=1&limit=20");
+
+        expect(res.status).toBeGreaterThanOrEqual(500);
+    });
+});
 
 describe("mergeGuestWishlist", () => {
     beforeEach(() => {


### PR DESCRIPTION
**Closes #4048 **
- **Summary:** `GET /api/wishlist` previously fetched a user's entire wishlist in
  one unbounded query. This adds `page` (default 1) and `limit` (default 20,
  capped at 100) query params, applies `.range()` on the Supabase query the
  same way `alerts.ts` does, and returns `{ items, count, page, limit,
  totalPages }` instead of the old flat `{ success, count, items }` shape.
  `count` reflects the full wishlist size across all pages, not just the
  current page.

