### PR TITLE
fix(db): lock down public.users role/points/badges self-writes

### DIFF
--- a/supabase/migrations/20260806100000_protect_users_privileged_columns.sql
+++ b/supabase/migrations/20260806100000_protect_users_privileged_columns.sql
@@ -1,0 +1,62 @@
+-- Prevent authenticated clients from escalating role / points / badges on
+-- public.users. Profile self-updates may still change display fields only;
+-- privileged columns are owned by service_role / SECURITY DEFINER RPCs.
+
+CREATE OR REPLACE FUNCTION public.protect_users_privileged_columns()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    -- Only clamp browser/client roles. service_role, postgres, and migrations
+    -- may mint points or promote roles intentionally.
+    IF coalesce(auth.role(), '') NOT IN ('authenticated', 'anon') THEN
+        RETURN NEW;
+    END IF;
+
+    IF TG_OP = 'INSERT' THEN
+        NEW.role := 'user';
+        NEW.points := 0;
+        NEW.badges := '{}'::text[];
+        RETURN NEW;
+    END IF;
+
+    -- UPDATE: always preserve privileged columns from the existing row.
+    NEW.role := OLD.role;
+    NEW.points := OLD.points;
+    NEW.badges := OLD.badges;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS protect_users_privileged_columns ON public.users;
+
+CREATE TRIGGER protect_users_privileged_columns
+    BEFORE INSERT OR UPDATE ON public.users
+    FOR EACH ROW
+    EXECUTE FUNCTION public.protect_users_privileged_columns();
+
+-- Tighten INSERT so a crafted row cannot satisfy RLS with elevated values
+-- even before the trigger runs (defense in depth).
+DROP POLICY IF EXISTS "Users can insert their own profile" ON public.users;
+
+CREATE POLICY "Users can insert their own profile"
+    ON public.users
+    FOR INSERT
+    WITH CHECK (
+        auth.uid() = id
+        AND role = 'user'
+        AND points = 0
+        AND coalesce(badges, '{}'::text[]) = '{}'::text[]
+    );
+
+-- Explicit service_role write access for API award/promotion paths.
+DROP POLICY IF EXISTS "Service role can manage users" ON public.users;
+
+CREATE POLICY "Service role can manage users"
+    ON public.users
+    FOR ALL
+    TO service_role
+    USING (true)
+    WITH CHECK (true);

--- a/supabase/tests/rls/users_privileged_columns.test.sql
+++ b/supabase/tests/rls/users_privileged_columns.test.sql
@@ -1,0 +1,121 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap;
+
+SELECT plan(5);
+
+-- --------------------------------------------------------------------
+-- Create test user
+-- --------------------------------------------------------------------
+
+DELETE FROM public.users
+WHERE id = 'cccccccc-0000-4000-8000-000000000003';
+
+DELETE FROM auth.users
+WHERE id = 'cccccccc-0000-4000-8000-000000000003';
+
+INSERT INTO auth.users (
+    instance_id,
+    id,
+    aud,
+    role,
+    email,
+    encrypted_password,
+    email_confirmed_at,
+    confirmation_token,
+    recovery_token,
+    email_change_token_new,
+    email_change,
+    raw_app_meta_data,
+    raw_user_meta_data,
+    created_at,
+    updated_at
+)
+VALUES
+(
+    '00000000-0000-0000-0000-000000000000',
+    'cccccccc-0000-4000-8000-000000000003',
+    'authenticated',
+    'authenticated',
+    'pgtap-users-priv@test.local',
+    '',
+    now(),
+    '',
+    '',
+    '',
+    '',
+    '{"provider":"email","providers":["email"]}',
+    '{}',
+    now(),
+    now()
+);
+
+SELECT set_config(
+    'request.jwt.claims',
+    json_build_object(
+        'sub',
+        'cccccccc-0000-4000-8000-000000000003',
+        'role',
+        'authenticated'
+    )::text,
+    true
+);
+
+SET LOCAL ROLE authenticated;
+
+-- Insert with attempted privilege escalation must land as default user/0 pts
+SELECT lives_ok(
+    $$
+    INSERT INTO public.users (id, full_name, role, points, badges)
+    VALUES (
+        'cccccccc-0000-4000-8000-000000000003',
+        'Escalation Attempt',
+        'admin',
+        9999,
+        ARRAY['god_mode']
+    );
+    $$,
+    'Authenticated user can insert own profile row'
+);
+
+SELECT is(
+    (SELECT role FROM public.users WHERE id = 'cccccccc-0000-4000-8000-000000000003'),
+    'user',
+    'Insert cannot set elevated role'
+);
+
+SELECT is(
+    (SELECT points FROM public.users WHERE id = 'cccccccc-0000-4000-8000-000000000003'),
+    0,
+    'Insert cannot set inflated points'
+);
+
+-- Profile display update allowed; privileged columns stay put
+UPDATE public.users
+SET full_name = 'Safe Name',
+    role = 'admin',
+    points = 50000,
+    badges = ARRAY['hacked']
+WHERE id = 'cccccccc-0000-4000-8000-000000000003';
+
+SELECT is(
+    (SELECT full_name FROM public.users WHERE id = 'cccccccc-0000-4000-8000-000000000003'),
+    'Safe Name',
+    'User can update display fields'
+);
+
+SELECT results_eq(
+    $$
+    SELECT role, points, badges
+    FROM public.users
+    WHERE id = 'cccccccc-0000-4000-8000-000000000003'
+    $$,
+    $$
+    VALUES ('user'::varchar(50), 0, '{}'::text[])
+    $$,
+    'Update cannot escalate role, points, or badges'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## PR Summary & Link

- **Closes #4165**
- **Summary:** `public.users` UPDATE/INSERT RLS only checked `auth.uid() = id`, so a browser client could set `role='admin'` or inflate `points`. Added a BEFORE INSERT/UPDATE trigger that freezes privileged columns for `authenticated`/`anon`, tightened INSERT WITH CHECK, and left `service_role` able to mint/promote.

## Proof of Work (Screenshots / Logs)

Added `supabase/tests/rls/users_privileged_columns.test.sql` (pgTAP) covering:
- insert with elevated role/points gets clamped to `user` / `0`
- display field updates still work
- role/points/badges cannot be changed on UPDATE

## PR Type

- [x] `type: bug`
- [x] `type: security`

## Checklist

- [x] My PR has a linked issue (`Closes #4165`)
- [x] I have pulled the latest `main` and resolved any conflicts

Made with [Cursor](https://cursor.com)