### PR TITLE
fix(asha): stop client self-minting on /award-points

### DIFF
--- a/apps/api/src/routes/asha.ts
+++ b/apps/api/src/routes/asha.ts
@@ -1,8 +1,6 @@
 import { Router, Response, NextFunction } from "express";
-import { z } from "zod";
 import { supabase } from "../db/client";
 import { AuthenticatedRequest, requireAuth } from "../middleware/auth";
-import { limiter } from "../middleware/rateLimit";
 import logger from "../utils/logger";
 
 const ashaRouter = Router();
@@ -57,84 +55,15 @@ ashaRouter.get(
     }
 );
 
-// POST /api/v1/asha/award-points
-const awardPointsSchema = z.object({
-    points: z.number().int().positive().max(100),
-    reason: z.string().min(1).max(255),
+// POST /api/v1/asha/award-points was removed: clients must not mint their own
+// points. Awards happen only from verified server-side events (scan/report).
+ashaRouter.post("/award-points", requireAuth, (_req, res: Response) => {
+    return res.status(410).json({
+        error: "Client point minting is disabled",
+        message:
+            "Points are awarded by verified server-side events only, not by client request.",
+    });
 });
-
-ashaRouter.post(
-    "/award-points",
-    requireAuth,
-    limiter,
-    async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-        try {
-            const userId = req.user!.id;
-
-            const parsed = awardPointsSchema.safeParse(req.body);
-            if (!parsed.success) {
-                return res
-                    .status(400)
-                    .json({ error: "Invalid points data", details: parsed.error.issues });
-            }
-
-            const { points, reason } = parsed.data;
-
-            // Fetch current points
-            const { data: userProfile, error: fetchError } = await supabase
-                .from("users")
-                .select("points, badges")
-                .eq("id", userId)
-                .maybeSingle();
-
-            if (fetchError || !userProfile) {
-                return res.status(500).json({ error: "Failed to fetch profile" });
-            }
-
-            const newPoints = userProfile.points + points;
-            let newBadges = [...(userProfile.badges || [])];
-
-            // Badge logic based on points
-            if (newPoints >= 100 && !newBadges.includes("Village Guardian")) {
-                newBadges.push("Village Guardian");
-            }
-            if (newPoints >= 500 && !newBadges.includes("Health Champion")) {
-                newBadges.push("Health Champion");
-            }
-
-            const { data: updatedProfile, error: updateError } = await supabase
-                .from("users")
-                .update({
-                    points: newPoints,
-                    badges: newBadges,
-                    updated_at: new Date().toISOString(),
-                })
-                .eq("id", userId)
-                .select()
-                .single();
-
-            if (updateError) {
-                logger.error(`Error updating points: ${updateError.message}`);
-                return res.status(500).json({ error: "Failed to award points" });
-            }
-
-            // Return updated stats and newly unlocked badges if any
-            const newUnlockedBadges = newBadges.filter(
-                (b) => !(userProfile.badges || []).includes(b)
-            );
-
-            return res.json({
-                success: true,
-                message: `Awarded ${points} points for ${reason}`,
-                points: updatedProfile.points,
-                badges: updatedProfile.badges,
-                unlockedBadges: newUnlockedBadges,
-            });
-        } catch (err) {
-            next(err);
-        }
-    }
-);
 
 // GET /api/v1/asha/leaderboard
 ashaRouter.get(

--- a/apps/api/tests/asha.awardPoints.test.ts
+++ b/apps/api/tests/asha.awardPoints.test.ts
@@ -1,0 +1,63 @@
+// @ts-nocheck
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || "http://localhost:54321";
+process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "test-anon-key";
+process.env.DNS_LOOKUP_TIMEOUT_MS = process.env.DNS_LOOKUP_TIMEOUT_MS || "50";
+
+(globalThis as unknown as { WebSocket: any }).WebSocket =
+    (globalThis as unknown as { WebSocket: any }).WebSocket || class {};
+
+jest.mock("../src/db/client", () => ({
+    supabase: {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        insert: jest.fn().mockReturnThis(),
+        update: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn().mockResolvedValue({ data: null, error: null }),
+        single: jest.fn().mockResolvedValue({ data: null, error: null }),
+    },
+}));
+
+jest.mock("../src/middleware/auth", () => ({
+    requireAuth: (req: any, res: any, next: any) => {
+        const token = req.headers.authorization?.slice(7);
+        if (!token) {
+            return res.status(401).json({ error: "Unauthenticated" });
+        }
+        req.user = { id: "test-user-id", email: "test@example.com", role: "user" };
+        next();
+    },
+    optionalAuth: (_req: any, _res: any, next: any) => next(),
+    requireRole: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+import request from "supertest";
+import app from "../src/app";
+import { supabase } from "../src/db/client";
+
+describe("ASHA award-points", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("rejects unauthenticated mint attempts", async () => {
+        const res = await request(app)
+            .post("/api/v1/asha/award-points")
+            .send({ points: 100, reason: "self mint" });
+
+        expect(res.status).toBe(401);
+    });
+
+    it("does not mint points for authenticated clients", async () => {
+        const res = await request(app)
+            .post("/api/v1/asha/award-points")
+            .set("Authorization", "Bearer test-token")
+            .send({ points: 100, reason: "self mint" });
+
+        expect(res.status).toBe(410);
+        expect(res.body.error).toMatch(/disabled/i);
+        expect(supabase.from).not.toHaveBeenCalled();
+    });
+});

--- a/apps/web/components/asha/AshaGamifiedDashboard.tsx
+++ b/apps/web/components/asha/AshaGamifiedDashboard.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 import { useAshaDashboard } from "../../hooks/useAshaDashboard";
 import { PointsProgressBar } from "./PointsProgressBar";
 import { LeaderboardWidget } from "./LeaderboardWidget";
 import { BadgeUnlockModal } from "./BadgeUnlockModal";
-import { motion } from "framer-motion";
 
 export function AshaGamifiedDashboard() {
-    const { stats, leaderboard, loading, error, unlockedBadges, awardPoints, clearUnlockedBadges } =
+    const { stats, leaderboard, loading, error, unlockedBadges, clearUnlockedBadges } =
         useAshaDashboard();
-    const [isAwarding, setIsAwarding] = useState(false);
 
     if (loading) {
         return (
@@ -37,17 +35,6 @@ export function AshaGamifiedDashboard() {
     if (currentPoints >= 500) nextMilestone = 1000;
     if (currentPoints >= 1000) nextMilestone = currentPoints + 500;
 
-    const handleSimulateAction = async (points: number, actionName: string) => {
-        setIsAwarding(true);
-        try {
-            await awardPoints(points, actionName);
-        } catch (err) {
-            console.error(err);
-        } finally {
-            setIsAwarding(false);
-        }
-    };
-
     return (
         <div className="mx-auto max-w-4xl space-y-8">
             <header className="mb-8">
@@ -62,49 +49,36 @@ export function AshaGamifiedDashboard() {
                 <div className="space-y-8 md:col-span-2">
                     <PointsProgressBar points={currentPoints} targetPoints={nextMilestone} />
 
-                    {/* Action Cards (Gamification loop triggers) */}
                     <div>
-                        <h2 className="mb-4 text-xl font-bold text-slate-800">Available Tasks</h2>
+                        <h2 className="mb-4 text-xl font-bold text-slate-800">How to earn tokens</h2>
                         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                            <motion.button
-                                whileHover={{ scale: 1.02 }}
-                                whileTap={{ scale: 0.98 }}
-                                onClick={() =>
-                                    handleSimulateAction(10, "Verified Pharmacy Location")
-                                }
-                                disabled={isAwarding}
-                                className="flex flex-col items-start rounded-2xl border border-slate-100 bg-white p-5 text-left shadow-sm transition-shadow hover:shadow-md disabled:opacity-50"
-                            >
+                            <div className="flex flex-col items-start rounded-2xl border border-slate-100 bg-white p-5 text-left shadow-sm">
                                 <span className="mb-3 rounded-lg bg-blue-100 p-2 text-blue-700">
                                     📍
                                 </span>
                                 <h3 className="font-semibold text-slate-700">Verify Pharmacy</h3>
                                 <p className="mt-1 mb-3 text-sm text-slate-500">
-                                    Confirm a newly added Jan Aushadhi store.
+                                    Confirm a newly added Jan Aushadhi store. Tokens are awarded
+                                    after the server verifies the action.
                                 </p>
                                 <span className="text-sm font-bold text-emerald-600">
                                     +10 Tokens
                                 </span>
-                            </motion.button>
+                            </div>
 
-                            <motion.button
-                                whileHover={{ scale: 1.02 }}
-                                whileTap={{ scale: 0.98 }}
-                                onClick={() => handleSimulateAction(25, "Reported Fake Medicine")}
-                                disabled={isAwarding}
-                                className="flex flex-col items-start rounded-2xl border border-slate-100 bg-white p-5 text-left shadow-sm transition-shadow hover:shadow-md disabled:opacity-50"
-                            >
+                            <div className="flex flex-col items-start rounded-2xl border border-slate-100 bg-white p-5 text-left shadow-sm">
                                 <span className="mb-3 rounded-lg bg-red-100 p-2 text-red-700">
                                     🚨
                                 </span>
                                 <h3 className="font-semibold text-slate-700">Report Counterfeit</h3>
                                 <p className="mt-1 mb-3 text-sm text-slate-500">
-                                    Submit a verified report for a fake drug.
+                                    Submit a verified report for a fake drug. Tokens are awarded
+                                    after the server verifies the report.
                                 </p>
                                 <span className="text-sm font-bold text-emerald-600">
                                     +25 Tokens
                                 </span>
-                            </motion.button>
+                            </div>
                         </div>
                     </div>
 

--- a/apps/web/hooks/useAshaDashboard.ts
+++ b/apps/web/hooks/useAshaDashboard.ts
@@ -43,35 +43,6 @@ export function useAshaDashboard() {
         }
     }, []);
 
-    const awardPoints = useCallback(async (points: number, reason: string) => {
-        try {
-            const data = await fetchWithCsrf<any>("/api/v1/asha/award-points", {
-                method: "POST",
-                body: JSON.stringify({ points, reason }),
-            });
-
-            setStats((prev) =>
-                prev ? { ...prev, points: data.points, badges: data.badges } : null
-            );
-
-            if (data.unlockedBadges && data.unlockedBadges.length > 0) {
-                setUnlockedBadges((prev) => [...prev, ...data.unlockedBadges]);
-            }
-
-            // Refresh leaderboard
-            const leaderboardData = await fetchWithCsrf<{ leaderboard: LeaderboardEntry[] }>(
-                "/api/v1/asha/leaderboard",
-                { method: "GET" }
-            );
-            setLeaderboard(leaderboardData.leaderboard);
-
-            return data;
-        } catch (err: any) {
-            console.error(err);
-            throw err;
-        }
-    }, []);
-
     const clearUnlockedBadges = useCallback(() => {
         setUnlockedBadges([]);
     }, []);
@@ -86,7 +57,6 @@ export function useAshaDashboard() {
         loading,
         error,
         unlockedBadges,
-        awardPoints,
         clearUnlockedBadges,
         refresh: fetchDashboardData,
     };


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## PR Summary & Link

- **Closes #4166**
- **Summary:** `POST /api/v1/asha/award-points` only needed `requireAuth` and accepted client-chosen `points`/`reason`, so anyone logged in could mint leaderboard points. Endpoint now returns 410 and no longer writes points. Dashboard simulate buttons removed; task cards are informational only.

## Proof of Work (Screenshots / Logs)

```
PASS tests/asha.awardPoints.test.ts
  rejects unauthenticated mint attempts (401)
  does not mint points for authenticated clients (410, no supabase write)
```

## PR Type

- [x] `type: bug`
- [x] `type: security`

## Checklist

- [x] My PR has a linked issue (`Closes #4166`)
- [x] I have pulled the latest `main` and resolved any conflicts

Made with [Cursor](https://cursor.com)