### PR TITLE
fix(admin): use getUser() for admin authorization checks

### DIFF
--- a/apps/web/app/[locale]/admin/approval/page.tsx
+++ b/apps/web/app/[locale]/admin/approval/page.tsx
@@ -23,7 +23,7 @@ import {
     Database,
 } from "lucide-react";
 import { useSession } from "@/src/components/AuthProvider";
-import { canMutateAdminData, getAdminRoleFromSession } from "@/lib/adminAuth";
+import { canMutateAdminData, getAdminRoleFromUser } from "@/lib/adminAuth";
 
 type VerificationStatus = "pending" | "approved" | "rejected";
 
@@ -109,7 +109,7 @@ export default function ApprovalQueuePage() {
 
     useEffect(() => {
         if (authLoading) return;
-        const role = getAdminRoleFromSession(session);
+        const role = getAdminRoleFromUser(session?.user);
         setCanMutate(canMutateAdminData(role));
     }, [authLoading, session]);
 

--- a/apps/web/app/[locale]/admin/dashboard/page.tsx
+++ b/apps/web/app/[locale]/admin/dashboard/page.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { LiveMessage } from "@/components/ui/LiveMessage";
-import { canMutateAdminData, getAdminRoleFromSession, type AdminRole } from "@/lib/adminAuth";
+import { canMutateAdminData, getAdminRoleFromUser, type AdminRole } from "@/lib/adminAuth";
 import { ADMIN_API_BASE } from "@/lib/adminApi";
 import { useSession } from "@/src/components/AuthProvider";
 
@@ -154,7 +154,7 @@ export default function AdminDashboard() {
 
     useEffect(() => {
         if (authLoading) return;
-        setAdminRole(getAdminRoleFromSession(session));
+        setAdminRole(getAdminRoleFromUser(session?.user));
     }, [authLoading, token]);
 
     useEffect(() => {

--- a/apps/web/app/[locale]/admin/layout.tsx
+++ b/apps/web/app/[locale]/admin/layout.tsx
@@ -3,7 +3,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/routing";
-import { getAdminRoleFromSession } from "@/lib/adminAuth";
+import { getAdminRoleFromUser } from "@/lib/adminAuth";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
 
 export const dynamic = "force-dynamic";
@@ -37,15 +37,17 @@ export default async function AdminLayout({
             },
         },
     });
+    // getUser() revalidates the JWT with Supabase Auth; getSession() only reads local storage.
     const {
-        data: { session },
-    } = await supabase.auth.getSession();
+        data: { user },
+        error: userError,
+    } = await supabase.auth.getUser();
 
-    if (!session) {
+    if (userError || !user) {
         return redirect(`/${resolvedParams.locale}/login`);
     }
 
-    const role = getAdminRoleFromSession(session);
+    const role = getAdminRoleFromUser(user);
 
     if (role !== "admin" && role !== "moderator") {
         return (

--- a/apps/web/app/api/admin/rate-limit-metrics/route.ts
+++ b/apps/web/app/api/admin/rate-limit-metrics/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
 import { cookies } from "next/headers";
-import { getAdminRoleFromSession } from "@/lib/adminAuth";
+import { getAdminRoleFromUser } from "@/lib/adminAuth";
 import { rateLimit } from "@/lib/rateLimit";
 import { getClientIp } from "@/lib/getClientIp";
 import {
@@ -16,7 +16,7 @@ import {
  * Secure admin-only endpoint that exposes persisted rate limit analytics.
  * Returns blocked IPs, rejection counts, and metrics window information.
  *
- * Security: Admin/Moderator only (verified via Supabase session)
+ * Security: Admin/Moderator only (verified via supabase.auth.getUser())
  * Related: Issue #2699 — Unified Rate Limiter Monitoring & Metrics Dashboard
  */
 
@@ -53,16 +53,16 @@ export async function GET(req: NextRequest) {
             },
         });
         const {
-            data: { session },
-            error: sessionError,
-        } = await supabase.auth.getSession();
+            data: { user },
+            error: userError,
+        } = await supabase.auth.getUser();
 
-        if (sessionError || !session) {
+        if (userError || !user) {
             return NextResponse.json({ error: "Unauthorized: Please sign in" }, { status: 401 });
         }
 
-        // Check admin role
-        const adminRole = getAdminRoleFromSession(session);
+        // Check admin role from server-validated user
+        const adminRole = getAdminRoleFromUser(user);
         if (adminRole !== "admin" && adminRole !== "moderator") {
             return NextResponse.json(
                 { error: "Forbidden: Admin access required" },

--- a/apps/web/lib/adminAuth.ts
+++ b/apps/web/lib/adminAuth.ts
@@ -16,6 +16,11 @@ export function getAdminRoleFromUser(
     return toAdminRole(user?.app_metadata?.role);
 }
 
+/**
+ * Prefer getAdminRoleFromUser() after supabase.auth.getUser() for any
+ * authorization decision. This helper only unwraps session.user for UI code
+ * that already holds a Session object — it does not validate the JWT.
+ */
 export function getAdminRoleFromSession(
     session: Pick<Session, "user"> | null | undefined
 ): AdminRole | null {


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## PR Summary & Link

- **Closes #4169**
- **Summary:** Admin layout and `/api/admin/rate-limit-metrics` were calling `supabase.auth.getSession()` for authz, which only reads the local JWT. Switched those checks to `getUser()` + `getAdminRoleFromUser()`. Client admin pages now resolve role from `session.user` the same way. Documented that `getAdminRoleFromSession` is not a JWT validation path.

## Proof of Work (Screenshots / Logs)

```
PASS tests/adminAuth.test.ts (11)
PASS tests/admin-dashboard-role-gating.test.tsx (3)
```

## PR Type

- [x] `type: bug`
- [x] `type: security`

## Checklist

- [x] My PR has a linked issue (`Closes #4169`)
- [x] I have pulled the latest `main` and resolved any conflicts

Made with [Cursor](https://cursor.com)