### PR TITLE
fix(api): gate /alerts/ingest on alerts:ingest API key scope

### DIFF
--- a/apps/api/src/middleware/apiKeyAuth.ts
+++ b/apps/api/src/middleware/apiKeyAuth.ts
@@ -16,6 +16,26 @@ export interface ApiKeyRequest extends Request {
     apiKey?: ApiKeyInfo;
 }
 
+/**
+ * Route middleware that requires the authenticated API key to carry a specific
+ * scope. Must run after `requireApiKey` so `req.apiKey` is populated. Returns
+ * 403 when the key is valid but lacks the required scope, so a narrowly-scoped
+ * key can never act with elevated privileges.
+ */
+export const requireApiKeyScope = (scope: string) => {
+    return (req: ApiKeyRequest, res: Response, next: NextFunction) => {
+        if (!req.apiKey) {
+            res.status(401).json({ error: "Unauthorized" });
+            return;
+        }
+        if (!req.apiKey.scopes?.includes(scope)) {
+            res.status(403).json({ error: "Forbidden: API key lacks required scope" });
+            return;
+        }
+        next();
+    };
+};
+
 export const requireApiKey = async (req: ApiKeyRequest, res: Response, next: NextFunction) => {
     const apiKey = req.headers["x-api-secret"] as string | undefined;
 

--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { triggerRecallAlert } from "../services/notifications";
 import { validateMedicineStatus, getValidStatusList } from "../validators/medicine.validator";
 import { escapeIlike } from "../utils/db";
-import { requireApiKey, ApiKeyRequest } from "../middleware/apiKeyAuth";
+import { requireApiKey, requireApiKeyScope, ApiKeyRequest } from "../middleware/apiKeyAuth";
 import logger from "../utils/logger";
 import { redisClient } from "../utils/redis";
 import { KEY_PREFIXES, invalidateCacheByPattern } from "../services/cache.service";
@@ -191,183 +191,189 @@ alertsRouter.get("/", alertsReadLimiter, async (req: Request, res: Response) => 
  * POST /api/v1/alerts/ingest
  * Protected endpoint to ingest parsed CDSCO alerts from the ML agent.
  */
-alertsRouter.post("/ingest", requireApiKey, limiter, async (req: ApiKeyRequest, res: Response) => {
-    const ingestSchema = z
-        .object({
-            alerts: AlertsArraySchema,
-        })
-        .strict();
-
-    const parseResult = ingestSchema.safeParse(req.body);
-    if (!parseResult.success) {
-        res.status(400).json({
-            error: "Invalid payload schema or unknown fields",
-            details: parseResult.error,
-        });
-        return;
-    }
-
-    const validatedAlerts = parseResult.data.alerts;
-
-    try {
-        // 2. Upsert alerts — ON CONFLICT DO NOTHING prevents duplicate rows
-        // when concurrent scraper instances race past the pre-check in deduplicate_alerts().
-        const { data: insertedAlerts, error: insertError } = await supabase
-            .from("drug_alerts")
-            .upsert(validatedAlerts, {
-                onConflict: "batch_number,source_url",
-                ignoreDuplicates: true,
+alertsRouter.post(
+    "/ingest",
+    requireApiKey,
+    requireApiKeyScope("alerts:ingest"),
+    limiter,
+    async (req: ApiKeyRequest, res: Response) => {
+        const ingestSchema = z
+            .object({
+                alerts: AlertsArraySchema,
             })
-            .select();
+            .strict();
 
-        if (insertError) {
-            logger.error("Error inserting alerts", { error: insertError });
-            res.status(500).json({ error: "Database error inserting alerts" });
-            return;
-        }
-
-        // 3. Update medicines table based on matched batches
-        const medicineStatus = "recalled";
-        if (!validateMedicineStatus(medicineStatus)) {
+        const parseResult = ingestSchema.safeParse(req.body);
+        if (!parseResult.success) {
             res.status(400).json({
-                error: `Invalid medicine status. Valid values are: ${getValidStatusList()}`,
+                error: "Invalid payload schema or unknown fields",
+                details: parseResult.error,
             });
             return;
         }
 
-        // Batch the medicine status updates to avoid O(N) individual UPDATE queries.
-        // Alerts are grouped into two buckets by their secondary discriminator:
-        //   - byManufacturer: alerts that have a manufacturer field
-        //   - byBrandName:    alerts that have only a brand name (no manufacturer)
-        // Each bucket is resolved in a single UPDATE ... WHERE batch_number IN (...)
-        // query, capping the total number of DB round-trips at 2 regardless of N.
-        const byManufacturer = new Map<string, string[]>(); // manufacturer -> batch_numbers[]
-        const byBrandName = new Map<string, string[]>(); // brand_name -> batch_numbers[]
-        const noBatchAlerts: typeof validatedAlerts = [];
+        const validatedAlerts = parseResult.data.alerts;
 
-        for (const alert of validatedAlerts) {
-            if (!alert.batch_number) {
-                noBatchAlerts.push(alert);
-                continue;
+        try {
+            // 2. Upsert alerts — ON CONFLICT DO NOTHING prevents duplicate rows
+            // when concurrent scraper instances race past the pre-check in deduplicate_alerts().
+            const { data: insertedAlerts, error: insertError } = await supabase
+                .from("drug_alerts")
+                .upsert(validatedAlerts, {
+                    onConflict: "batch_number,source_url",
+                    ignoreDuplicates: true,
+                })
+                .select();
+
+            if (insertError) {
+                logger.error("Error inserting alerts", { error: insertError });
+                res.status(500).json({ error: "Database error inserting alerts" });
+                return;
             }
-            if (alert.manufacturer) {
-                if (!byManufacturer.has(alert.manufacturer)) {
-                    byManufacturer.set(alert.manufacturer, []);
-                }
-                byManufacturer.get(alert.manufacturer)!.push(alert.batch_number);
-            } else if (alert.reported_brand_name) {
-                if (!byBrandName.has(alert.reported_brand_name)) {
-                    byBrandName.set(alert.reported_brand_name, []);
-                }
-                byBrandName.get(alert.reported_brand_name)!.push(alert.batch_number);
-            }
-        }
 
-        const batchUpdatePromises: Promise<unknown>[] = [];
-
-        for (const [manufacturer, batchNumbers] of byManufacturer) {
-            batchUpdatePromises.push(
-                Promise.resolve(
-                    supabase
-                        .from("medicines")
-                        .update({ status: medicineStatus, is_counterfeit_alert: true })
-                        .in("batch_number", batchNumbers)
-                        .eq("manufacturer", manufacturer)
-                )
-            );
-        }
-
-        for (const [brandName, batchNumbers] of byBrandName) {
-            batchUpdatePromises.push(
-                Promise.resolve(
-                    supabase
-                        .from("medicines")
-                        .update({ status: medicineStatus, is_counterfeit_alert: true })
-                        .in("batch_number", batchNumbers)
-                        .eq("brand_name", brandName)
-                )
-            );
-        }
-
-        await Promise.all(batchUpdatePromises);
-
-        // 3.5 Invalidate the cache for the updated batch numbers
-        // Use pattern-based invalidation (drug:batch:<batch>*) to delete both batch-only
-        // and composite keys (drug:batch:<batch>|<barcode>|<brand>). This prevents stale
-        // counterfeit/recall data from being served from cache after an alert is ingested.
-        const batchNumbersToInvalidate = validatedAlerts
-            .map((alert) => alert.batch_number)
-            .filter(Boolean) as string[];
-
-        if (batchNumbersToInvalidate.length > 0 && redisClient.isOpen) {
-            try {
-                for (const batch of batchNumbersToInvalidate) {
-                    await invalidateCacheByPattern(`${KEY_PREFIXES.DRUG_CACHE}${batch}*`);
-                }
-            } catch (err) {
-                logger.error({
-                    message: "Failed to invalidate cache for alert batches",
-                    error: err,
+            // 3. Update medicines table based on matched batches
+            const medicineStatus = "recalled";
+            if (!validateMedicineStatus(medicineStatus)) {
+                res.status(400).json({
+                    error: `Invalid medicine status. Valid values are: ${getValidStatusList()}`,
                 });
+                return;
             }
-        }
 
-        // NEW: Invalidate all paginated list caches since new alerts change page 1 results
-        if (redisClient.isOpen) {
-            try {
-                const listKeys: string[] = [];
-                for await (const key of redisClient.scanIterator({
-                    MATCH: "alerts:list:*",
-                })) {
-                    if (Array.isArray(key)) {
-                        listKeys.push(...(key as string[]));
-                    } else {
-                        listKeys.push(key as unknown as string);
+            // Batch the medicine status updates to avoid O(N) individual UPDATE queries.
+            // Alerts are grouped into two buckets by their secondary discriminator:
+            //   - byManufacturer: alerts that have a manufacturer field
+            //   - byBrandName:    alerts that have only a brand name (no manufacturer)
+            // Each bucket is resolved in a single UPDATE ... WHERE batch_number IN (...)
+            // query, capping the total number of DB round-trips at 2 regardless of N.
+            const byManufacturer = new Map<string, string[]>(); // manufacturer -> batch_numbers[]
+            const byBrandName = new Map<string, string[]>(); // brand_name -> batch_numbers[]
+            const noBatchAlerts: typeof validatedAlerts = [];
+
+            for (const alert of validatedAlerts) {
+                if (!alert.batch_number) {
+                    noBatchAlerts.push(alert);
+                    continue;
+                }
+                if (alert.manufacturer) {
+                    if (!byManufacturer.has(alert.manufacturer)) {
+                        byManufacturer.set(alert.manufacturer, []);
                     }
+                    byManufacturer.get(alert.manufacturer)!.push(alert.batch_number);
+                } else if (alert.reported_brand_name) {
+                    if (!byBrandName.has(alert.reported_brand_name)) {
+                        byBrandName.set(alert.reported_brand_name, []);
+                    }
+                    byBrandName.get(alert.reported_brand_name)!.push(alert.batch_number);
                 }
-                if (listKeys.length > 0) {
-                    await redisClient.del(listKeys);
-                }
-            } catch (err) {
-                logger.error({
-                    message: "Failed to invalidate alerts:list cache",
-                    error: err,
-                });
             }
-        }
 
-        // 4. Dispatch Web Push Notifications using shared service
-        if (insertedAlerts && insertedAlerts.length > 0) {
-            const pushPromises = insertedAlerts.map((alert) => {
-                return triggerRecallAlert({
-                    id: alert.id ? String(alert.id) : "unknown",
-                    medicineName: alert.reported_brand_name || "Unknown Medicine",
-                    batchNumber: alert.batch_number,
-                    manufacturer: alert.manufacturer,
-                    reason: `Alert of type ${alert.alert_type || "NSQ"} in ${alert.state || "Unknown region"}`,
-                    severity: "high",
-                    source: "CDSCO Live Feed",
-                    recalledAt: alert.reported_at || new Date().toISOString(),
+            const batchUpdatePromises: Promise<unknown>[] = [];
+
+            for (const [manufacturer, batchNumbers] of byManufacturer) {
+                batchUpdatePromises.push(
+                    Promise.resolve(
+                        supabase
+                            .from("medicines")
+                            .update({ status: medicineStatus, is_counterfeit_alert: true })
+                            .in("batch_number", batchNumbers)
+                            .eq("manufacturer", manufacturer)
+                    )
+                );
+            }
+
+            for (const [brandName, batchNumbers] of byBrandName) {
+                batchUpdatePromises.push(
+                    Promise.resolve(
+                        supabase
+                            .from("medicines")
+                            .update({ status: medicineStatus, is_counterfeit_alert: true })
+                            .in("batch_number", batchNumbers)
+                            .eq("brand_name", brandName)
+                    )
+                );
+            }
+
+            await Promise.all(batchUpdatePromises);
+
+            // 3.5 Invalidate the cache for the updated batch numbers
+            // Use pattern-based invalidation (drug:batch:<batch>*) to delete both batch-only
+            // and composite keys (drug:batch:<batch>|<barcode>|<brand>). This prevents stale
+            // counterfeit/recall data from being served from cache after an alert is ingested.
+            const batchNumbersToInvalidate = validatedAlerts
+                .map((alert) => alert.batch_number)
+                .filter(Boolean) as string[];
+
+            if (batchNumbersToInvalidate.length > 0 && redisClient.isOpen) {
+                try {
+                    for (const batch of batchNumbersToInvalidate) {
+                        await invalidateCacheByPattern(`${KEY_PREFIXES.DRUG_CACHE}${batch}*`);
+                    }
+                } catch (err) {
+                    logger.error({
+                        message: "Failed to invalidate cache for alert batches",
+                        error: err,
+                    });
+                }
+            }
+
+            // NEW: Invalidate all paginated list caches since new alerts change page 1 results
+            if (redisClient.isOpen) {
+                try {
+                    const listKeys: string[] = [];
+                    for await (const key of redisClient.scanIterator({
+                        MATCH: "alerts:list:*",
+                    })) {
+                        if (Array.isArray(key)) {
+                            listKeys.push(...(key as string[]));
+                        } else {
+                            listKeys.push(key as unknown as string);
+                        }
+                    }
+                    if (listKeys.length > 0) {
+                        await redisClient.del(listKeys);
+                    }
+                } catch (err) {
+                    logger.error({
+                        message: "Failed to invalidate alerts:list cache",
+                        error: err,
+                    });
+                }
+            }
+
+            // 4. Dispatch Web Push Notifications using shared service
+            if (insertedAlerts && insertedAlerts.length > 0) {
+                const pushPromises = insertedAlerts.map((alert) => {
+                    return triggerRecallAlert({
+                        id: alert.id ? String(alert.id) : "unknown",
+                        medicineName: alert.reported_brand_name || "Unknown Medicine",
+                        batchNumber: alert.batch_number,
+                        manufacturer: alert.manufacturer,
+                        reason: `Alert of type ${alert.alert_type || "NSQ"} in ${alert.state || "Unknown region"}`,
+                        severity: "high",
+                        source: "CDSCO Live Feed",
+                        recalledAt: alert.reported_at || new Date().toISOString(),
+                    });
                 });
+                await Promise.all(pushPromises);
+            }
+
+            logger.info("Alerts ingested successfully", {
+                caller: req.apiKey?.userId,
+                count: insertedAlerts?.length,
             });
-            await Promise.all(pushPromises);
+
+            res.status(200).json({
+                success: true,
+                message: "Alerts ingested and notifications dispatched",
+                inserted: insertedAlerts?.length,
+            });
+        } catch (error) {
+            logger.error("Unexpected error in /ingest", { error, caller: req.apiKey?.userId });
+            res.status(500).json({ error: "Internal server error" });
         }
-
-        logger.info("Alerts ingested successfully", {
-            caller: req.apiKey?.userId,
-            count: insertedAlerts?.length,
-        });
-
-        res.status(200).json({
-            success: true,
-            message: "Alerts ingested and notifications dispatched",
-            inserted: insertedAlerts?.length,
-        });
-    } catch (error) {
-        logger.error("Unexpected error in /ingest", { error, caller: req.apiKey?.userId });
-        res.status(500).json({ error: "Internal server error" });
     }
-});
+);
 
 /**
  * PATCH /api/v1/alerts/:id/snooze

--- a/apps/api/tests/alertsPagination.test.ts
+++ b/apps/api/tests/alertsPagination.test.ts
@@ -94,6 +94,19 @@ function mockApiKeyValid() {
     });
 }
 
+function mockApiKeyWithoutIngestScope() {
+    getChain().maybeSingle.mockResolvedValue({
+        data: {
+            id: "valid",
+            user_id: "user-1",
+            scopes: ["alerts:read"],
+            key_salt: testSalt,
+            key_hash: testHash,
+        },
+        error: null,
+    });
+}
+
 function mockApiKeyInvalid() {
     getChain().maybeSingle.mockResolvedValue({
         data: null,
@@ -330,5 +343,17 @@ describe("POST /api/v1/alerts/ingest — API key authentication", () => {
 
         expect(res.status).toBe(400);
         expect(res.body.error).toMatch(/invalid/i);
+    });
+
+    it("returns 403 when the API key lacks the alerts:ingest scope", async () => {
+        mockApiKeyWithoutIngestScope();
+
+        const res = await request(app)
+            .post("/api/v1/alerts/ingest")
+            .set("x-api-secret", "valid.key")
+            .send({ alerts: [] });
+
+        expect(res.status).toBe(403);
+        expect(res.body.error).toMatch(/scope/i);
     });
 });


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4199**
- **Summary:**
The POST /api/v1/alerts/ingest route was protected only by requireApiKey, but the scopes the middleware loaded into req.apiKey.scopes were never consulted. Any valid key — including narrowly-scoped read-only keys — had the same privilege as the intended moderation credential, enabling attackers to reclassify medicines as recalled and mass-broadcast fake recall alerts.
Changes:
apps/api/src/middleware/apiKeyAuth.ts — added requireApiKeyScope(scope) middleware that returns 403 when req.apiKey.scopes lacks the required scope.
apps/api/src/routes/alerts.ts:194-199 — applied requireApiKeyScope("alerts:ingest") to the /ingest route.
apps/api/tests/alertsPagination.test.ts — added a test asserting a valid key lacking the scope gets 403 (20/20 tests pass).



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4199`)
- [x] I have pulled the latest `main` and resolved any conflicts
