### PR TITLE
fix(api): restore bot fingerprint consistency check

### DIFF
--- a/apps/api/src/middleware/botDetection.ts
+++ b/apps/api/src/middleware/botDetection.ts
@@ -77,7 +77,7 @@ export interface BotDetectionOptions {
 }
 
 export function botDetection(options: BotDetectionOptions = {}) {
-    return (req: Request, res: Response, next: NextFunction): void => {
+    return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
         if (process.env.NODE_ENV === "test") return next();
 
         const ua = req.headers["user-agent"] ?? "";
@@ -119,16 +119,17 @@ export function botDetection(options: BotDetectionOptions = {}) {
             timingStore.set(ip, { deltas: [], lastRequest: now });
         }
 
-        // 3. Fingerprint consistency (synchronous check for accurate scoring)
+        // 3. Fingerprint consistency
         const fp = fingerprint(req);
         const fpKey = `bot:fp:${ip}`;
         if (redisClient.isOpen) {
-            // Use cached fingerprint from prior request for synchronous comparison
-            const prevFp = (req as any)._prevFingerprint as string | undefined;
-            if (prevFp !== undefined) {
-                if (prevFp === fp) {
+            try {
+                const prevFp = await redisClient.get(fpKey);
+                if (prevFp !== null && prevFp === fp) {
                     score.fingerprint += 10; // same fingerprint = slightly bot-like
                 }
+            } catch {
+                // Redis GET failure — fail open, treat as no previous fingerprint
             }
             // Store current fingerprint for next request comparison (fire-and-forget)
             redisClient.setEx(fpKey, 3600, fp).catch(() => {});

--- a/apps/api/tests/botDetection.test.ts
+++ b/apps/api/tests/botDetection.test.ts
@@ -1,0 +1,197 @@
+import { redisClient } from "../src/utils/redis";
+
+const mockedRedis = jest.mocked(redisClient);
+
+// botDetection skips when NODE_ENV === "test". We need to override it so the
+// middleware actually runs its logic during tests.
+const OLD_ENV = process.env.NODE_ENV;
+
+beforeEach(() => {
+    process.env.NODE_ENV = "development";
+    jest.clearAllMocks();
+});
+
+afterAll(() => {
+    process.env.NODE_ENV = OLD_ENV;
+});
+
+function makeReq(overrides: Record<string, unknown> = {}) {
+    return {
+        ip: "1.2.3.4",
+        headers: {
+            "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            "accept-language": "en-US",
+            "accept-encoding": "gzip, deflate, br",
+            "sec-ch-ua": '"Chromium";v="120"',
+            "sec-ch-ua-platform": '"Windows"',
+            ...overrides,
+        },
+    } as any;
+}
+
+function makeRes() {
+    return {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+    } as any;
+}
+
+function makeNext() {
+    return jest.fn();
+}
+
+describe("botDetection", () => {
+    // Must import lazily AFTER setting NODE_ENV so the early-return guard is
+    // bypassed during module evaluation.
+    let botDetection: typeof import("../src/middleware/botDetection").botDetection;
+
+    beforeAll(async () => {
+        // Dynamic import so NODE_ENV is already overridden when the module loads.
+        const mod = await import("../src/middleware/botDetection");
+        botDetection = mod.botDetection;
+    });
+
+    describe("fingerprint consistency (#4221)", () => {
+        it("awards fingerprint score when Redis returns a matching fingerprint", async () => {
+            const fp = 'en-US|gzip, deflate, br|"Chromium";v="120"|"Windows"';
+            (mockedRedis.get as jest.Mock).mockResolvedValue(fp);
+
+            const req = makeReq();
+            const res = makeRes();
+            const next = makeNext();
+
+            await botDetection()(req, res, next);
+
+            expect(mockedRedis.get).toHaveBeenCalledWith("bot:fp:1.2.3.4");
+            expect(mockedRedis.setEx).toHaveBeenCalledWith("bot:fp:1.2.3.4", 3600, fp);
+            expect(req.botScore).toBeGreaterThanOrEqual(10);
+            expect(req.isLikelyBot).toBe(false);
+            expect(next).toHaveBeenCalled();
+        });
+
+        it("does not award fingerprint score when Redis returns a different fingerprint", async () => {
+            (mockedRedis.get as jest.Mock).mockResolvedValue("old-fingerprint");
+
+            const req = makeReq();
+            const res = makeRes();
+            const next = makeNext();
+
+            await botDetection()(req, res, next);
+
+            expect(mockedRedis.get).toHaveBeenCalledWith("bot:fp:1.2.3.4");
+            expect(req.botScore).toBe(0);
+            expect(next).toHaveBeenCalled();
+        });
+
+        it("does not award fingerprint score on first request (no previous fingerprint)", async () => {
+            (mockedRedis.get as jest.Mock).mockResolvedValue(null);
+
+            const req = makeReq();
+            const res = makeRes();
+            const next = makeNext();
+
+            await botDetection()(req, res, next);
+
+            expect(mockedRedis.get).toHaveBeenCalledWith("bot:fp:1.2.3.4");
+            expect(req.botScore).toBe(0);
+            expect(next).toHaveBeenCalled();
+        });
+
+        it("continues gracefully when Redis GET fails", async () => {
+            (mockedRedis.get as jest.Mock).mockRejectedValue(new Error("Redis unavailable"));
+
+            const req = makeReq();
+            const res = makeRes();
+            const next = makeNext();
+
+            // Must not throw
+            await expect(botDetection()(req, res, next)).resolves.toBeUndefined();
+
+            expect(next).toHaveBeenCalled();
+            // Fingerprint score should remain 0 (safe default)
+            expect(req.botScore).toBe(0);
+        });
+
+        it("continues gracefully when Redis SETEx fails", async () => {
+            (mockedRedis.get as jest.Mock).mockResolvedValue(null);
+            (mockedRedis.setEx as jest.Mock).mockRejectedValue(new Error("Redis write failed"));
+
+            const req = makeReq();
+            const res = makeRes();
+            const next = makeNext();
+
+            // Must not throw — setEx is fire-and-forget with .catch()
+            await expect(botDetection()(req, res, next)).resolves.toBeUndefined();
+
+            expect(next).toHaveBeenCalled();
+        });
+    });
+
+    describe("User-Agent heuristic", () => {
+        it("flags missing/short user-agent", async () => {
+            (mockedRedis.get as jest.Mock).mockResolvedValue(null);
+
+            const req = makeReq({ "user-agent": "" });
+            const res = makeRes();
+            const next = makeNext();
+
+            await botDetection()(req, res, next);
+
+            expect(req.botScore).toBeGreaterThanOrEqual(30);
+            expect(next).toHaveBeenCalled();
+        });
+
+        it("flags known bot user-agent patterns", async () => {
+            (mockedRedis.get as jest.Mock).mockResolvedValue(null);
+
+            const req = makeReq({ "user-agent": "python-requests/2.28.0" });
+            const res = makeRes();
+            const next = makeNext();
+
+            await botDetection()(req, res, next);
+
+            expect(req.botScore).toBeGreaterThanOrEqual(40);
+            expect(next).toHaveBeenCalled();
+        });
+    });
+
+    describe("blocking", () => {
+        it("returns 403 when blockBots is true and bot detected", async () => {
+            (mockedRedis.get as jest.Mock).mockResolvedValue(null);
+
+            // "curl" is short (< 10) → +30 and matches BOT_UA_PATTERNS → +40 = 70 total
+            const req = makeReq({ "user-agent": "curl" });
+            const res = makeRes();
+            const next = makeNext();
+
+            await botDetection({ blockBots: true })(req, res, next);
+
+            expect(res.status).toHaveBeenCalledWith(403);
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({ error: expect.any(String) })
+            );
+            expect(next).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("skip in test environment", () => {
+        it("skips detection when NODE_ENV is test", async () => {
+            process.env.NODE_ENV = "test";
+
+            const req = makeReq();
+            const res = makeRes();
+            const next = makeNext();
+
+            // Re-import won't help; the check is at runtime, not module load.
+            // Just call the factory directly.
+            const mod = await import("../src/middleware/botDetection");
+            await mod.botDetection()(req, res, next);
+
+            expect(next).toHaveBeenCalled();
+            expect(req.botScore).toBeUndefined();
+            expect(mockedRedis.get).not.toHaveBeenCalled();
+
+            process.env.NODE_ENV = "development";
+        });
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #4221**
* **Summary:**

  * Restores the bot detection fingerprint consistency check by reading the previous fingerprint from Redis before overwriting it.
  * Replaces the unused `req._prevFingerprint` property with `redisClient.get(fpKey)`.
  * Preserves fail-open behavior when Redis is unavailable or the GET operation fails.
  * Adds regression tests covering matching, different, and missing fingerprints, Redis failures, bot detection heuristics, blocking, and test-environment bypass.
  * No changes to package.json, lockfiles, or unrelated application code.

## 📸 Proof of Work (Screenshots / Logs)

> [!NOTE]
> No screenshots are applicable because this is a backend middleware/Redis behavior fix with no frontend/UI changes.

### Test Results

```text
npx jest tests/botDetection.test.ts --forceExit --no-coverage
✓ 9 tests passed

npx jest --forceExit --silent
✓ 68 suites passed
✓ 762 tests passed
✓ 1 skipped

npx tsc --noEmit -p tsconfig.json
1 pre-existing error in apps/api/src/routes/asha.ts:80
(unrelated to this PR)

git diff --check
✓ Clean — no whitespace errors
```

### Implementation Verification

* Redis fingerprint is read before the current fingerprint is stored.
* Matching fingerprints receive the configured fingerprint score.
* Missing/different fingerprints receive no fingerprint score.
* Redis GET failures fail open and do not block requests.
* Existing Redis SET failure handling is preserved.
* Existing UA and timing heuristics are unchanged.
* Existing bot blocking threshold and `NODE_ENV === "test"` bypass are unchanged.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #4221`)
* [x] I have pulled the latest `main` and resolved any conflicts

**Comment**

The fingerprint consistency heuristic was previously non-functional because `_prevFingerprint` was never populated. This PR restores the intended Redis-backed comparison while keeping Redis failures non-blocking and preserving the existing bot-detection behavior.

The full test suite passes with **68 suites, 762 tests passed, and 1 skipped**. The TypeScript error in `apps/api/src/routes/asha.ts:80` is pre-existing and unrelated to this change.