### PR TITLE
feat: add image validation before medicine OCR

### DIFF
--- a/apps/web/hooks/useMedicineImageUpload.ts
+++ b/apps/web/hooks/useMedicineImageUpload.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef } from "react";
 import Tesseract from "tesseract.js";
 import { toast } from "sonner";
 import imageCompression from "browser-image-compression";
@@ -12,6 +12,7 @@ import { structuredLog } from "@/lib/structuredLogger";
 import { saveScanHistory } from "@/lib/db/scanHistory";
 import { expiryToIso } from "@/lib/medicineDateUtils";
 import { preprocessMedicineImage } from "@/lib/imageEnhancer";
+import { validateMedicineImage } from "@/lib/imageValidation";
 
 type UseMedicineImageUploadProps = {
     handleVerify: (batch: string) => Promise<void>;
@@ -59,20 +60,23 @@ export function useMedicineImageUpload({
         setIsScanning(false);
     };
 
-    const MAX_FILE_SIZE = 10 * 1024 * 1024;
     const COMPRESSION_THRESHOLD = 2 * 1024 * 1024;
 
     const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
         if (!file) return;
 
-        let processedFile = file;
+        // Validate the original image before compression, preprocessing,
+        // barcode detection, or OCR processing.
+        const validation = await validateMedicineImage(file);
 
-        if (file.size > MAX_FILE_SIZE) {
-            toast.error("File exceeds 10MB limit");
+        if (!validation.valid) {
+            toast.error(validation.error);
             e.target.value = "";
             return;
         }
+
+        let processedFile = file;
 
         if (file.size > COMPRESSION_THRESHOLD) {
             try {
@@ -80,9 +84,10 @@ export function useMedicineImageUpload({
                     maxSizeMB: 2,
                     maxWidthOrHeight: 2400,
                     useWebWorker: true,
-                })) as File; // using 'as File' since typescript might infer Blob from compression
+                })) as File;
             } catch {
                 toast.error("Failed to compress image");
+                e.target.value = "";
                 return;
             }
         }
@@ -92,8 +97,9 @@ export function useMedicineImageUpload({
                 processedFile,
                 preprocessWorkerRef.current
             );
+
             if (typeof enhancedResult !== "string") {
-                processedFile = enhancedResult as File; // maintaining type compatibility
+                processedFile = enhancedResult as File;
             }
         } catch (error) {
             console.warn("Image enhancement failed, falling back to original", error);
@@ -101,6 +107,7 @@ export function useMedicineImageUpload({
 
         const reader = new FileReader();
         let dataUrl: string;
+
         try {
             dataUrl = await new Promise<string>((resolve, reject) => {
                 reader.onloadend = () => resolve(reader.result as string);
@@ -112,12 +119,14 @@ export function useMedicineImageUpload({
             e.target.value = "";
             return;
         }
+
         setUploadedImage(dataUrl);
         e.target.value = "";
 
         if (abortControllerRef.current) {
             abortControllerRef.current.abort();
         }
+
         const controller = new AbortController();
         abortControllerRef.current = controller;
 
@@ -156,12 +165,16 @@ export function useMedicineImageUpload({
                 const reader = new BrowserMultiFormatReader(hints);
                 const zxingResult = await reader.decodeFromImageUrl(dataUrl);
                 const barcodeText = zxingResult.getText().trim();
+
                 if (barcodeText) {
                     barcodeFound = true;
+
                     if (!isMountedRef.current || controller.signal.aborted) return;
+
                     setBatchInput(barcodeText);
                     setOcrStatus("done");
                     toast.success(`Barcode detected: ${barcodeText} — verifying…`);
+
                     await handleVerify(barcodeText);
                     return;
                 }
@@ -184,15 +197,18 @@ export function useMedicineImageUpload({
 
             if (!ocrWorkerRef.current) {
                 const initPromise = Tesseract.createWorker("eng");
+
                 const timeoutPromise = new Promise<never>((_, reject) =>
                     setTimeout(() => reject(new Error("OCR initialization timed out")), 60000)
                 );
 
                 try {
                     const worker = await Promise.race([initPromise, timeoutPromise]);
+
                     await worker.setParameters({
                         tessedit_pageseg_mode: Tesseract.PSM.SPARSE_TEXT,
                     });
+
                     ocrWorkerRef.current = worker;
                 } catch (err) {
                     throw new Error(
@@ -203,16 +219,20 @@ export function useMedicineImageUpload({
                 }
             }
 
-            if (!isMountedRef.current || controller.signal.aborted || ocrCancelledRef.current)
+            if (!isMountedRef.current || controller.signal.aborted || ocrCancelledRef.current) {
                 return;
+            }
 
             let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
             const timeoutPromise = new Promise<never>((_, reject) => {
                 timeoutId = setTimeout(() => reject(new Error("OCR timed out")), 60000);
             });
 
             const ocrPromise = ocrWorkerRef.current.recognize(dataUrl);
+
             let raceResult;
+
             try {
                 raceResult = await Promise.race([ocrPromise, timeoutPromise]);
             } finally {
@@ -220,17 +240,22 @@ export function useMedicineImageUpload({
                     clearTimeout(timeoutId);
                 }
             }
+
             const { data } = raceResult;
 
-            if (!isMountedRef.current || controller.signal.aborted || ocrCancelledRef.current)
+            if (!isMountedRef.current || controller.signal.aborted || ocrCancelledRef.current) {
                 return;
+            }
 
             const rawText = data.text;
+
             if (!rawText || !rawText.trim()) {
                 toast.warning("No clear text found in image.");
+
                 setVerifyError(
                     "Failed to read medicine text. Please ensure the image is clear or upload another one."
                 );
+
                 setOcrStatus("error");
                 setShowResult(true);
                 setIsScanning(false);
@@ -240,6 +265,7 @@ export function useMedicineImageUpload({
             setOcrText(rawText);
             setOcrConfidence(data.confidence / 100);
             setOcrStatus("done");
+
             toast.success("OCR extraction complete!");
 
             // Parse OCR Text using utility regex
@@ -261,6 +287,7 @@ export function useMedicineImageUpload({
             if (parsedBatchNum) {
                 try {
                     const batchRes = await verifyMedicine(parsedBatchNum, controller.signal);
+
                     if (batchRes.verified) {
                         finalResult = batchRes;
                     }
@@ -282,14 +309,18 @@ export function useMedicineImageUpload({
             if (!finalResult && medName) {
                 try {
                     const matchRes = await fuzzyMatchBrand(medName, controller.signal);
+
                     if (matchRes && matchRes.length > 0) {
                         const topMatch = matchRes[0];
+
                         if (topMatch.score >= 60) {
                             setParsedBrand(topMatch.name);
+
                             const brandRes = await verifyMedicineByBrand(
                                 topMatch.name,
                                 controller.signal
                             );
+
                             if (brandRes.verified) {
                                 finalResult = brandRes;
                             }
@@ -312,14 +343,20 @@ export function useMedicineImageUpload({
 
             if (finalResult && finalResult.verified) {
                 const updatedMedicine = { ...finalResult.medicine };
+
                 if (parsedBatchNum) {
                     updatedMedicine.batch_number = parsedBatchNum;
                 }
+
                 if (parsedExpiryStr) {
                     updatedMedicine.expiry_date = expiryToIso(parsedExpiryStr);
                 }
+
                 await processVerificationResult(
-                    { verified: true, medicine: updatedMedicine },
+                    {
+                        verified: true,
+                        medicine: updatedMedicine,
+                    },
                     parsedBrand
                 );
             } else {
@@ -329,14 +366,16 @@ export function useMedicineImageUpload({
                         verified: false,
                         message: "No match found in CDSCO Database",
                     } satisfies VerifyResult);
+
                 await processVerificationResult(
                     unverifiedResult,
                     parsedBrand || medName || undefined
                 );
             }
         } catch (err) {
-            if (!isMountedRef.current || controller.signal.aborted || ocrCancelledRef.current)
+            if (!isMountedRef.current || controller.signal.aborted || ocrCancelledRef.current) {
                 return;
+            }
 
             if (ocrWorkerRef.current) {
                 await ocrWorkerRef.current.terminate();
@@ -344,13 +383,16 @@ export function useMedicineImageUpload({
             }
 
             const errorMsg = err instanceof Error ? err.message : String(err);
+
             if (errorMsg === "OCR timed out" || errorMsg === "OCR initialization timed out") {
                 toast.error(
                     "OCR timed out. Please check your internet connection or try a clearer image."
                 );
+
                 setVerifyError(
                     "The scan took too long. This may be due to a slow internet connection or a complex image. Please check your connection and try again."
                 );
+
                 void saveScanHistory({
                     id: crypto.randomUUID(),
                     timestamp: Date.now(),
@@ -361,9 +403,11 @@ export function useMedicineImageUpload({
                 });
             } else {
                 toast.error("Failed to extract text from image.");
+
                 setVerifyError(
                     "Unable to read text from this image. Please try a clearer photo or enter the batch number manually."
                 );
+
                 void saveScanHistory({
                     id: crypto.randomUUID(),
                     timestamp: Date.now(),
@@ -373,6 +417,7 @@ export function useMedicineImageUpload({
                     console.error("Failed to save scan history:", error);
                 });
             }
+
             setOcrStatus("error");
         } finally {
             if (isMountedRef.current && !controller.signal.aborted && !ocrCancelledRef.current) {

--- a/apps/web/lib/imageValidation.ts
+++ b/apps/web/lib/imageValidation.ts
@@ -1,0 +1,69 @@
+export const MEDICINE_IMAGE_MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+export const MEDICINE_IMAGE_MIN_WIDTH = 640;
+export const MEDICINE_IMAGE_MIN_HEIGHT = 480;
+
+export const SUPPORTED_MEDICINE_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"] as const;
+
+export type ImageValidationResult = { valid: true } | { valid: false; error: string };
+
+function getImageDimensions(file: File): Promise<{ width: number; height: number }> {
+    return new Promise((resolve, reject) => {
+        const objectUrl = URL.createObjectURL(file);
+        const image = new Image();
+
+        image.onload = () => {
+            const dimensions = {
+                width: image.naturalWidth,
+                height: image.naturalHeight,
+            };
+
+            URL.revokeObjectURL(objectUrl);
+            resolve(dimensions);
+        };
+
+        image.onerror = () => {
+            URL.revokeObjectURL(objectUrl);
+            reject(new Error("Unable to read image dimensions"));
+        };
+
+        image.src = objectUrl;
+    });
+}
+
+export async function validateMedicineImage(file: File): Promise<ImageValidationResult> {
+    if (
+        !SUPPORTED_MEDICINE_IMAGE_TYPES.includes(
+            file.type as (typeof SUPPORTED_MEDICINE_IMAGE_TYPES)[number]
+        )
+    ) {
+        return {
+            valid: false,
+            error: "Unsupported image format. Please upload a JPG, PNG, or WebP image.",
+        };
+    }
+
+    if (file.size > MEDICINE_IMAGE_MAX_SIZE) {
+        return {
+            valid: false,
+            error: "Image exceeds the 10MB file size limit.",
+        };
+    }
+
+    try {
+        const { width, height } = await getImageDimensions(file);
+
+        if (width < MEDICINE_IMAGE_MIN_WIDTH || height < MEDICINE_IMAGE_MIN_HEIGHT) {
+            return {
+                valid: false,
+                error: `Image resolution is too low. Please upload an image of at least ${MEDICINE_IMAGE_MIN_WIDTH}×${MEDICINE_IMAGE_MIN_HEIGHT} pixels.`,
+            };
+        }
+    } catch {
+        return {
+            valid: false,
+            error: "Could not read this image. Please choose another image file.",
+        };
+    }
+
+    return { valid: true };
+}

--- a/apps/web/tests/image-validation.test.ts
+++ b/apps/web/tests/image-validation.test.ts
@@ -1,0 +1,228 @@
+import {
+    MEDICINE_IMAGE_MAX_SIZE,
+    MEDICINE_IMAGE_MIN_HEIGHT,
+    MEDICINE_IMAGE_MIN_WIDTH,
+    SUPPORTED_MEDICINE_IMAGE_TYPES,
+    validateMedicineImage,
+} from "@/lib/imageValidation";
+
+describe("validateMedicineImage", () => {
+    const originalImage = global.Image;
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+
+    class MockImage {
+        naturalWidth = MEDICINE_IMAGE_MIN_WIDTH;
+        naturalHeight = MEDICINE_IMAGE_MIN_HEIGHT;
+
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+
+        set src(_value: string) {
+            setTimeout(() => {
+                this.onload?.();
+            }, 0);
+        }
+    }
+
+    beforeEach(() => {
+        Object.defineProperty(global, "Image", {
+            configurable: true,
+            writable: true,
+            value: MockImage,
+        });
+
+        Object.defineProperty(URL, "createObjectURL", {
+            configurable: true,
+            writable: true,
+            value: jest.fn(() => "blob:medicine-image"),
+        });
+
+        Object.defineProperty(URL, "revokeObjectURL", {
+            configurable: true,
+            writable: true,
+            value: jest.fn(),
+        });
+    });
+
+    afterEach(() => {
+        Object.defineProperty(global, "Image", {
+            configurable: true,
+            writable: true,
+            value: originalImage,
+        });
+
+        Object.defineProperty(URL, "createObjectURL", {
+            configurable: true,
+            writable: true,
+            value: originalCreateObjectURL,
+        });
+
+        Object.defineProperty(URL, "revokeObjectURL", {
+            configurable: true,
+            writable: true,
+            value: originalRevokeObjectURL,
+        });
+
+        jest.restoreAllMocks();
+    });
+
+    it("accepts a valid JPEG image", async () => {
+        const file = new File(["valid-image"], "medicine.jpg", {
+            type: "image/jpeg",
+        });
+
+        const result = await validateMedicineImage(file);
+
+        expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts all configured supported image formats", () => {
+        expect(SUPPORTED_MEDICINE_IMAGE_TYPES).toEqual(["image/jpeg", "image/png", "image/webp"]);
+    });
+
+    it("rejects unsupported image formats before reading dimensions", async () => {
+        const file = new File(["image"], "medicine.gif", {
+            type: "image/gif",
+        });
+
+        const result = await validateMedicineImage(file);
+
+        expect(result).toEqual({
+            valid: false,
+            error: "Unsupported image format. Please upload a JPG, PNG, or WebP image.",
+        });
+
+        expect(URL.createObjectURL).not.toHaveBeenCalled();
+    });
+
+    it("rejects images larger than the maximum file size", async () => {
+        const file = new File(["image"], "medicine.jpg", {
+            type: "image/jpeg",
+        });
+
+        Object.defineProperty(file, "size", {
+            configurable: true,
+            value: MEDICINE_IMAGE_MAX_SIZE + 1,
+        });
+
+        const result = await validateMedicineImage(file);
+
+        expect(result).toEqual({
+            valid: false,
+            error: "Image exceeds the 10MB file size limit.",
+        });
+
+        expect(URL.createObjectURL).not.toHaveBeenCalled();
+    });
+
+    it("rejects images below the minimum width", async () => {
+        class LowWidthImage extends MockImage {
+            naturalWidth = MEDICINE_IMAGE_MIN_WIDTH - 1;
+            naturalHeight = MEDICINE_IMAGE_MIN_HEIGHT;
+        }
+
+        Object.defineProperty(global, "Image", {
+            configurable: true,
+            writable: true,
+            value: LowWidthImage,
+        });
+
+        const file = new File(["image"], "medicine.png", {
+            type: "image/png",
+        });
+
+        const result = await validateMedicineImage(file);
+
+        expect(result).toEqual({
+            valid: false,
+            error: `Image resolution is too low. Please upload an image of at least ${MEDICINE_IMAGE_MIN_WIDTH}×${MEDICINE_IMAGE_MIN_HEIGHT} pixels.`,
+        });
+    });
+
+    it("rejects images below the minimum height", async () => {
+        class LowHeightImage extends MockImage {
+            naturalWidth = MEDICINE_IMAGE_MIN_WIDTH;
+            naturalHeight = MEDICINE_IMAGE_MIN_HEIGHT - 1;
+        }
+
+        Object.defineProperty(global, "Image", {
+            configurable: true,
+            writable: true,
+            value: LowHeightImage,
+        });
+
+        const file = new File(["image"], "medicine.webp", {
+            type: "image/webp",
+        });
+
+        const result = await validateMedicineImage(file);
+
+        expect(result).toEqual({
+            valid: false,
+            error: `Image resolution is too low. Please upload an image of at least ${MEDICINE_IMAGE_MIN_WIDTH}×${MEDICINE_IMAGE_MIN_HEIGHT} pixels.`,
+        });
+    });
+
+    it("returns a readable error when image dimensions cannot be loaded", async () => {
+        class BrokenImage extends MockImage {
+            set src(_value: string) {
+                setTimeout(() => {
+                    this.onerror?.();
+                }, 0);
+            }
+        }
+
+        Object.defineProperty(global, "Image", {
+            configurable: true,
+            writable: true,
+            value: BrokenImage,
+        });
+
+        const file = new File(["broken"], "medicine.jpg", {
+            type: "image/jpeg",
+        });
+
+        const result = await validateMedicineImage(file);
+
+        expect(result).toEqual({
+            valid: false,
+            error: "Could not read this image. Please choose another image file.",
+        });
+    });
+
+    it("revokes the temporary object URL after successful validation", async () => {
+        const file = new File(["image"], "medicine.jpg", {
+            type: "image/jpeg",
+        });
+
+        await validateMedicineImage(file);
+
+        expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:medicine-image");
+    });
+
+    it("revokes the temporary object URL when image loading fails", async () => {
+        class BrokenImage extends MockImage {
+            set src(_value: string) {
+                setTimeout(() => {
+                    this.onerror?.();
+                }, 0);
+            }
+        }
+
+        Object.defineProperty(global, "Image", {
+            configurable: true,
+            writable: true,
+            value: BrokenImage,
+        });
+
+        const file = new File(["broken"], "medicine.jpg", {
+            type: "image/jpeg",
+        });
+
+        await validateMedicineImage(file);
+
+        expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:medicine-image");
+    });
+});


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4226**
- **Summary:** Adds client-side image quality validation before medicine barcode/OCR processing. The validation checks supported image formats, the existing 10 MB file-size limit, and minimum image dimensions before allowing the image to continue through the scanning pipeline. Invalid images are stopped early with clear, actionable feedback. Unit tests have also been added for the validation logic.

## 📸 Proof of Work (Screenshots / Logs)

### Automated Test Proof

<img width="1142" height="495" alt="Screenshot 2026-08-08 161743" src="https://github.com/user-attachments/assets/c0cbc5a7-de77-4901-bb9a-ffe878623710" />



### Test Results

- `npm test --workspace=web -- image-validation.test.ts --runInBand`
- **9/9 tests passed**
- Prettier check passed
- Circular dependency check passed

### Tested Scenarios

- Valid JPEG image is accepted
- Supported JPEG, PNG, and WebP formats are accepted
- Unsupported image formats are rejected
- Images exceeding the 10 MB limit are rejected
- Images below the minimum width are rejected
- Images below the minimum height are rejected
- Unreadable/corrupted images return an actionable error
- Temporary object URLs are cleaned up correctly

> **Build note:** The repository-wide build is currently blocked by an unrelated existing TypeScript error in `apps/api/src/routes/asha.ts`. The feature-specific test suite passes successfully.


## 🏷️ PR Type

- [ ] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4226`)
- [x] I have pulled the latest `main` and resolved any conflicts