### PR TITLE
fix(ml): allowlist Cloudinary image URLs to stop DNS rebinding

### DIFF
--- a/apps/api/src/routes/ml.ts
+++ b/apps/api/src/routes/ml.ts
@@ -1,7 +1,6 @@
 import { Router, Response } from "express";
 import { z } from "zod";
 import { createHash, createHmac, randomBytes } from "node:crypto";
-import { promises as dns } from "node:dns";
 import {
     getMlServiceUrl,
     getMlAuthHeaders,
@@ -11,7 +10,6 @@ import { requireAuth, AuthenticatedRequest } from "../middleware/auth";
 import logger from "../utils/logger";
 import { limiter } from "../middleware/rateLimit";
 import { redisClient } from "../utils/redis";
-import { isBlockedOutboundHost } from "../utils/security/urlValidator";
 
 const router = Router();
 
@@ -26,7 +24,8 @@ const analyzeResponseSchema = z.object({
     details: z.string(),
 });
 
-const LINK_LOCAL_HOSTNAMES = [".local", ".internal", ".nip.io", ".localtest.me"];
+/** Must match apps/ml/routers/analyze.py CLOUDINARY_IMAGE_HOST allowlist. */
+const CLOUDINARY_IMAGE_HOST = "res.cloudinary.com";
 
 const ML_ANALYSIS_CACHE_TTL_SECONDS = 3600; // 1 hour
 const ML_ANALYSIS_TIMEOUT_MS = 8000;
@@ -36,16 +35,27 @@ function buildCacheKey(imageUrl: string): string {
     return `ml:analyze:${hash}`;
 }
 
-async function isPrivateHostname(urlStr: string): Promise<boolean> {
+/**
+ * Allowlist Cloudinary delivery URLs only — avoids DNS-rebinding TOCTOU from
+ * resolve-then-fetch checks, and matches the ML service gate.
+ */
+function isAllowedAnalyzeImageUrl(urlStr: string): boolean {
     try {
-        const hostname = new URL(urlStr).hostname.replace(/^\[|\]$/g, "");
-        if (isBlockedOutboundHost(hostname)) return true;
-        if (LINK_LOCAL_HOSTNAMES.some((s) => hostname.endsWith(s))) return true;
+        const parsed = new URL(urlStr);
+        if (parsed.protocol !== "https:") return false;
+        if (parsed.username || parsed.password) return false;
+        if (parsed.port && parsed.port !== "443") return false;
+        if (parsed.hostname.toLowerCase() !== CLOUDINARY_IMAGE_HOST) return false;
+        if (parsed.search || parsed.hash) return false;
 
-        const addresses = await dns.resolve4(hostname);
-        return addresses.some((addr) => isBlockedOutboundHost(addr));
-    } catch {
+        const pathSegments = parsed.pathname.split("/").filter(Boolean);
+        // Expected: /{cloud_name}/image/upload/...
+        if (pathSegments.length < 3 || pathSegments[1] !== "image" || pathSegments[2] !== "upload") {
+            return false;
+        }
         return true;
+    } catch {
+        return false;
     }
 }
 
@@ -60,14 +70,14 @@ router.post("/analyze", limiter, requireAuth, async (req: AuthenticatedRequest, 
         return;
     }
 
-    if (await isPrivateHostname(parsed.data.imageUrl)) {
+    if (!isAllowedAnalyzeImageUrl(parsed.data.imageUrl)) {
         logger.warn("SSRF attempt blocked", {
             imageUrl: parsed.data.imageUrl,
             caller: req.user?.email ?? req.user?.id,
         });
         res.status(400).json({
             error: "Invalid request body",
-            details: [{ message: "imageUrl must point to a public HTTPS resource" }],
+            details: [{ message: "imageUrl must be a Cloudinary HTTPS image delivery URL" }],
         });
         return;
     }

--- a/apps/api/tests/ml.test.ts
+++ b/apps/api/tests/ml.test.ts
@@ -16,13 +16,6 @@ jest.mock("../src/middleware/auth", () => ({
     AuthenticatedRequest: Object,
 }));
 
-jest.mock("node:dns", () => ({
-    promises: {
-        resolve4: jest.fn(),
-    },
-}));
-
-import { promises as dnsMock } from "node:dns";
 import { Request, Response, NextFunction } from "express";
 
 function buildApp() {
@@ -33,6 +26,7 @@ function buildApp() {
 }
 
 const VALID_TOKEN = "Bearer test-auth-token";
+const VALID_CLOUDINARY_URL = "https://res.cloudinary.com/demo/image/upload/medicine.jpg";
 
 describe("ml routes", () => {
     const originalFetch = global.fetch;
@@ -41,7 +35,6 @@ describe("ml routes", () => {
     beforeEach(() => {
         process.env.ML_SERVICE_URL = "http://ml-service.test";
         jest.clearAllMocks();
-        (dnsMock.resolve4 as jest.Mock).mockResolvedValue(["203.0.113.42"]);
     });
 
     afterEach(() => {
@@ -52,7 +45,7 @@ describe("ml routes", () => {
     it("rejects unauthenticated requests", async () => {
         const response = await request(buildApp())
             .post("/api/ml/analyze")
-            .send({ imageUrl: "https://res.cloudinary.com/demo/image/upload/medicine.jpg" });
+            .send({ imageUrl: VALID_CLOUDINARY_URL });
 
         assert.equal(response.status, 401);
         assert.ok(response.body.error.includes("Unauthorized"));
@@ -82,7 +75,7 @@ describe("ml routes", () => {
         const response = await request(buildApp())
             .post("/api/ml/analyze")
             .set("Authorization", VALID_TOKEN)
-            .send({ imageUrl: "https://res.cloudinary.com/demo/image/upload/medicine.jpg" });
+            .send({ imageUrl: VALID_CLOUDINARY_URL });
 
         assert.equal(response.status, 200);
         assert.equal(response.body.verdict, "likely_genuine");
@@ -98,7 +91,7 @@ describe("ml routes", () => {
         const response = await request(buildApp())
             .post("/api/ml/analyze")
             .set("Authorization", VALID_TOKEN)
-            .send({ imageUrl: "https://res.cloudinary.com/demo/image/upload/medicine.jpg" });
+            .send({ imageUrl: VALID_CLOUDINARY_URL });
 
         assert.equal(response.status, 500);
         assert.equal(response.body.code, "ML_SERVICE_URL_MISSING");
@@ -212,46 +205,37 @@ describe("ml routes", () => {
         assert.equal(response.status, 400);
     });
 
-    it("blocks public-looking domains whose DNS resolves to a private IP", async () => {
-        (dnsMock.resolve4 as jest.Mock).mockResolvedValueOnce(["10.0.0.5"]);
-
-        const response = await request(buildApp())
-            .post("/api/ml/analyze")
-            .set("Authorization", VALID_TOKEN)
-            .send({ imageUrl: "https://innocent-looking.example.test/data" });
-
-        assert.equal(response.status, 400);
-    });
-
-    it("allows domains whose DNS resolves to a public IP", async () => {
-        (dnsMock.resolve4 as jest.Mock).mockResolvedValueOnce(["203.0.113.42"]);
-
-        global.fetch = async () =>
-            new globalThis.Response(
-                JSON.stringify({
-                    isFake: false,
-                    confidence: 0.81,
-                    verdict: "likely_genuine",
-                    details: "Passed visual quality scan.",
-                }),
-                { status: 200, headers: { "Content-Type": "application/json" } }
-            );
+    it("rejects non-Cloudinary public hosts (allowlist)", async () => {
+        global.fetch = async () => {
+            throw new Error("fetch should not be called for non-Cloudinary hosts");
+        };
 
         const response = await request(buildApp())
             .post("/api/ml/analyze")
             .set("Authorization", VALID_TOKEN)
             .send({ imageUrl: "https://public-host.example.test/photo.jpg" });
 
-        assert.equal(response.status, 200);
+        assert.equal(response.status, 400);
+        assert.match(
+            JSON.stringify(response.body.details),
+            /Cloudinary HTTPS image delivery URL/
+        );
     });
 
-    it("blocks domains when DNS resolution fails (fail closed)", async () => {
-        (dnsMock.resolve4 as jest.Mock).mockRejectedValueOnce(new Error("DNS resolution failed"));
-
+    it("rejects Cloudinary URLs with query strings", async () => {
         const response = await request(buildApp())
             .post("/api/ml/analyze")
             .set("Authorization", VALID_TOKEN)
-            .send({ imageUrl: "https://unresolvable.example.test/img.jpg" });
+            .send({ imageUrl: "https://res.cloudinary.com/demo/image/upload/medicine.jpg?x=1" });
+
+        assert.equal(response.status, 400);
+    });
+
+    it("rejects Cloudinary URLs that are not image/upload paths", async () => {
+        const response = await request(buildApp())
+            .post("/api/ml/analyze")
+            .set("Authorization", VALID_TOKEN)
+            .send({ imageUrl: "https://res.cloudinary.com/demo/raw/upload/file.bin" });
 
         assert.equal(response.status, 400);
     });


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue. (commented requesting assignment; cannot self-assign)
- [x] I verified that this PR **ONLY** touches the required files.

## PR Summary & Link

- **Closes #4235** (reopened from #4182)
- **Summary:** `/api/ml/analyze` no longer does a DNS check then trusts the hostname (TOCTOU/rebinding). It only accepts `https://res.cloudinary.com/.../image/upload/...` URLs, matching the ML service.

## Proof of Work (Screenshots / Logs)

```
PASS tests/ml.test.ts
Tests: 19 passed
```

## PR Type

- [x] `type: bug`
- [x] `type: security`

## Checklist

- [x] My PR has a linked issue (`Closes #4235`)
- [x] I have pulled the latest `main` and resolved any conflicts

Made with [Cursor](https://cursor.com)