### PR TITLE
refactor(api): share auth path and offline DB fallback helpers

### DIFF
--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -151,6 +151,132 @@ async function writeAuthCache(
     }
 }
 
+function rejectUnauthorized(res: Response, message: string): false {
+    res.status(401).json({ error: message });
+    return false;
+}
+
+function applyBypassUser(req: AuthenticatedRequest): boolean {
+    if (!canUseAuthBypass(req)) {
+        return false;
+    }
+    req.user = getMockUser();
+    return true;
+}
+
+async function handleOfflineAuth(
+    req: AuthenticatedRequest,
+    res: Response,
+    required: boolean
+): Promise<boolean> {
+    if (applyBypassUser(req)) {
+        return true;
+    }
+    if (required) {
+        return rejectUnauthorized(res, "Unauthorized: Authentication service is offline");
+    }
+    return true;
+}
+
+async function handleConnectionAuthFailure(
+    req: AuthenticatedRequest,
+    res: Response,
+    cacheKey: string,
+    cacheContext: string,
+    required: boolean,
+    errorMessage: string
+): Promise<boolean> {
+    const cachedUser = await readAuthCache(cacheKey, `${cacheContext} middleware fallback`);
+    if (cachedUser) {
+        req.user = cachedUser;
+        return true;
+    }
+
+    if (dbConfig) dbConfig.setOffline();
+    logger.warn({
+        message: "Supabase auth server returned connection error.",
+        error: errorMessage,
+    });
+
+    if (applyBypassUser(req) || !required) {
+        return true;
+    }
+
+    await clearAuthCache(cacheKey, `${cacheContext} (token error)`);
+    return rejectUnauthorized(res, "Unauthorized: Invalid or expired token");
+}
+
+async function handleGetUserFailure(
+    req: AuthenticatedRequest,
+    res: Response,
+    cacheKey: string,
+    cacheContext: string,
+    required: boolean,
+    error: { message?: string }
+): Promise<boolean> {
+    if (isSupabaseConnectionError(error.message)) {
+        return handleConnectionAuthFailure(
+            req,
+            res,
+            cacheKey,
+            cacheContext,
+            required,
+            error.message ?? ""
+        );
+    }
+
+    await clearAuthCache(cacheKey, `${cacheContext} (token error)`);
+    return rejectUnauthorized(res, "Unauthorized: Invalid or expired token");
+}
+
+async function attachAuthenticatedUser(
+    req: AuthenticatedRequest,
+    res: Response,
+    cacheKey: string,
+    cacheContext: string,
+    user: User | null
+): Promise<boolean> {
+    if (!user) {
+        await clearAuthCache(cacheKey, `${cacheContext} (no user)`);
+        return rejectUnauthorized(res, "Unauthorized: Invalid or expired token");
+    }
+
+    req.user = {
+        id: user.id,
+        email: user.email,
+        role: getUserRole(user),
+        raw: user,
+    };
+
+    await writeAuthCache(cacheKey, req.user, `${cacheContext} middleware`);
+    return true;
+}
+
+function handleAuthException(
+    req: AuthenticatedRequest,
+    res: Response,
+    required: boolean,
+    err: unknown
+): boolean {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    if (isSupabaseConnectionError(errMsg) && dbConfig) {
+        dbConfig.setOffline();
+    }
+
+    logger.warn({
+        message: required
+            ? "Supabase auth server request failed."
+            : "Supabase optional auth server request failed.",
+        error: errMsg,
+    });
+
+    if (applyBypassUser(req) || !required) {
+        return true;
+    }
+
+    return rejectUnauthorized(res, "Unauthorized: Authentication service unavailable");
+}
+
 /**
  * Shared auth path for required and optional middleware.
  * Returns true when the request should continue via next().
@@ -166,20 +292,13 @@ async function authenticateRequest(
 
     if (!token) {
         if (required) {
-            res.status(401).json({ error: "Unauthorized: Missing access token" });
-            return false;
+            return rejectUnauthorized(res, "Unauthorized: Missing access token");
         }
         return true;
     }
 
     if (dbConfig?.isSupabaseOffline) {
-        if (canUseAuthBypass(req)) {
-            req.user = getMockUser();
-        } else if (required) {
-            res.status(401).json({ error: "Unauthorized: Authentication service is offline" });
-            return false;
-        }
-        return true;
+        return handleOfflineAuth(req, res, required);
     }
 
     const cacheKey = `auth:user:${crypto.createHash("sha256").update(token).digest("hex")}`;
@@ -188,75 +307,12 @@ async function authenticateRequest(
         const { data, error } = await client.auth.getUser(token);
 
         if (error) {
-            if (isSupabaseConnectionError(error.message)) {
-                const cachedUser = await readAuthCache(
-                    cacheKey,
-                    `${cacheContext} middleware fallback`
-                );
-                if (cachedUser) {
-                    req.user = cachedUser;
-                    return true;
-                }
-
-                if (dbConfig) dbConfig.setOffline();
-                logger.warn({
-                    message: "Supabase auth server returned connection error.",
-                    error: error.message,
-                });
-                if (canUseAuthBypass(req)) {
-                    req.user = getMockUser();
-                    return true;
-                }
-                if (!required) {
-                    return true;
-                }
-                // required + no bypass: same as invalid token path below
-            }
-
-            await clearAuthCache(cacheKey, `${cacheContext} (token error)`);
-            res.status(401).json({ error: "Unauthorized: Invalid or expired token" });
-            return false;
+            return handleGetUserFailure(req, res, cacheKey, cacheContext, required, error);
         }
 
-        if (!data.user) {
-            await clearAuthCache(cacheKey, `${cacheContext} (no user)`);
-            res.status(401).json({ error: "Unauthorized: Invalid or expired token" });
-            return false;
-        }
-
-        req.user = {
-            id: data.user.id,
-            email: data.user.email,
-            role: getUserRole(data.user),
-            raw: data.user,
-        };
-
-        await writeAuthCache(cacheKey, req.user, `${cacheContext} middleware`);
-        return true;
+        return attachAuthenticatedUser(req, res, cacheKey, cacheContext, data.user);
     } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
-        if (isSupabaseConnectionError(errMsg)) {
-            if (dbConfig) dbConfig.setOffline();
-        }
-
-        logger.warn({
-            message: required
-                ? "Supabase auth server request failed."
-                : "Supabase optional auth server request failed.",
-            error: errMsg,
-        });
-
-        if (canUseAuthBypass(req)) {
-            req.user = getMockUser();
-            return true;
-        }
-        if (required) {
-            res.status(401).json({
-                error: "Unauthorized: Authentication service unavailable",
-            });
-            return false;
-        }
-        return true;
+        return handleAuthException(req, res, required, err);
     }
 }
 

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -4,6 +4,7 @@ import { SupabaseClient, User } from "@supabase/supabase-js";
 import { supabase, dbConfig } from "../db/client";
 import logger from "../utils/logger";
 import { redisClient } from "../utils/redis";
+import { isSupabaseConnectionError } from "../utils/withDbFallback";
 
 export type AuthRole = "user" | "admin" | "moderator";
 
@@ -103,138 +104,167 @@ const canUseAuthBypass = (req: Request): boolean => {
     return true;
 };
 
+async function clearAuthCache(cacheKey: string, context: string): Promise<void> {
+    try {
+        if (redisClient.isOpen) {
+            await redisClient.del(cacheKey);
+        }
+    } catch (err) {
+        logger.warn({
+            message: `Redis cache del error in ${context}`,
+            error: String(err),
+        });
+    }
+}
+
+async function readAuthCache(cacheKey: string, context: string): Promise<AuthenticatedUser | null> {
+    try {
+        if (redisClient.isOpen) {
+            const cached = await redisClient.get(cacheKey);
+            if (cached) {
+                return JSON.parse(cached) as AuthenticatedUser;
+            }
+        }
+    } catch (err) {
+        logger.warn({
+            message: `Redis cache get error in ${context}`,
+            error: String(err),
+        });
+    }
+    return null;
+}
+
+async function writeAuthCache(
+    cacheKey: string,
+    user: AuthenticatedUser,
+    context: string
+): Promise<void> {
+    try {
+        if (redisClient.isOpen) {
+            await redisClient.setEx(cacheKey, 30, JSON.stringify(user));
+        }
+    } catch (err) {
+        logger.warn({
+            message: `Redis cache set error in ${context}`,
+            error: String(err),
+        });
+    }
+}
+
+/**
+ * Shared auth path for required and optional middleware.
+ * Returns true when the request should continue via next().
+ */
+async function authenticateRequest(
+    req: AuthenticatedRequest,
+    res: Response,
+    client: SupabaseAuthClient,
+    required: boolean
+): Promise<boolean> {
+    const token = extractToken(req);
+    const cacheContext = required ? "requireAuth" : "optionalAuth";
+
+    if (!token) {
+        if (required) {
+            res.status(401).json({ error: "Unauthorized: Missing access token" });
+            return false;
+        }
+        return true;
+    }
+
+    if (dbConfig?.isSupabaseOffline) {
+        if (canUseAuthBypass(req)) {
+            req.user = getMockUser();
+        } else if (required) {
+            res.status(401).json({ error: "Unauthorized: Authentication service is offline" });
+            return false;
+        }
+        return true;
+    }
+
+    const cacheKey = `auth:user:${crypto.createHash("sha256").update(token).digest("hex")}`;
+
+    try {
+        const { data, error } = await client.auth.getUser(token);
+
+        if (error) {
+            if (isSupabaseConnectionError(error.message)) {
+                const cachedUser = await readAuthCache(
+                    cacheKey,
+                    `${cacheContext} middleware fallback`
+                );
+                if (cachedUser) {
+                    req.user = cachedUser;
+                    return true;
+                }
+
+                if (dbConfig) dbConfig.setOffline();
+                logger.warn({
+                    message: "Supabase auth server returned connection error.",
+                    error: error.message,
+                });
+                if (canUseAuthBypass(req)) {
+                    req.user = getMockUser();
+                    return true;
+                }
+                if (!required) {
+                    return true;
+                }
+                // required + no bypass: same as invalid token path below
+            }
+
+            await clearAuthCache(cacheKey, `${cacheContext} (token error)`);
+            res.status(401).json({ error: "Unauthorized: Invalid or expired token" });
+            return false;
+        }
+
+        if (!data.user) {
+            await clearAuthCache(cacheKey, `${cacheContext} (no user)`);
+            res.status(401).json({ error: "Unauthorized: Invalid or expired token" });
+            return false;
+        }
+
+        req.user = {
+            id: data.user.id,
+            email: data.user.email,
+            role: getUserRole(data.user),
+            raw: data.user,
+        };
+
+        await writeAuthCache(cacheKey, req.user, `${cacheContext} middleware`);
+        return true;
+    } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        if (isSupabaseConnectionError(errMsg)) {
+            if (dbConfig) dbConfig.setOffline();
+        }
+
+        logger.warn({
+            message: required
+                ? "Supabase auth server request failed."
+                : "Supabase optional auth server request failed.",
+            error: errMsg,
+        });
+
+        if (canUseAuthBypass(req)) {
+            req.user = getMockUser();
+            return true;
+        }
+        if (required) {
+            res.status(401).json({
+                error: "Unauthorized: Authentication service unavailable",
+            });
+            return false;
+        }
+        return true;
+    }
+}
+
 export const createAuthMiddleware =
     (client: SupabaseAuthClient = supabase) =>
     async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-        const token = extractToken(req);
-
-        if (!token) {
-            res.status(401).json({ error: "Unauthorized: Missing access token" });
-            return;
-        }
-
-        if (dbConfig?.isSupabaseOffline) {
-            if (canUseAuthBypass(req)) {
-                req.user = getMockUser();
-                next();
-            } else {
-                res.status(401).json({ error: "Unauthorized: Authentication service is offline" });
-            }
-            return;
-        }
-
-        const cacheKey = `auth:user:${crypto.createHash("sha256").update(token).digest("hex")}`;
-
-        try {
-            const { data, error } = await client.auth.getUser(token);
-
-            if (error) {
-                const isConnectionError =
-                    error.message?.includes("fetch failed") ||
-                    error.message?.includes("timeout") ||
-                    error.message?.includes("connect") ||
-                    error.message?.includes("refused");
-
-                if (isConnectionError) {
-                    try {
-                        if (redisClient.isOpen) {
-                            const cached = await redisClient.get(cacheKey);
-                            if (cached) {
-                                req.user = JSON.parse(cached);
-                                next();
-                                return;
-                            }
-                        }
-                    } catch (err) {
-                        logger.warn({
-                            message: "Redis cache get error in auth middleware fallback",
-                            error: String(err),
-                        });
-                    }
-
-                    if (dbConfig) dbConfig.setOffline();
-                    logger.warn({
-                        message: "Supabase auth server returned connection error.",
-                        error: error.message,
-                    });
-                    if (canUseAuthBypass(req)) {
-                        req.user = getMockUser();
-                        next();
-                        return;
-                    }
-                }
-
-                try {
-                    if (redisClient.isOpen) {
-                        await redisClient.del(cacheKey);
-                    }
-                } catch (err) {
-                    logger.warn({
-                        message: "Redis cache del error in requireAuth (token error)",
-                        error: String(err),
-                    });
-                }
-                res.status(401).json({ error: "Unauthorized: Invalid or expired token" });
-                return;
-            }
-
-            if (!data.user) {
-                try {
-                    if (redisClient.isOpen) {
-                        await redisClient.del(cacheKey);
-                    }
-                } catch (err) {
-                    logger.warn({
-                        message: "Redis cache del error in requireAuth (no user)",
-                        error: String(err),
-                    });
-                }
-                res.status(401).json({ error: "Unauthorized: Invalid or expired token" });
-                return;
-            }
-
-            req.user = {
-                id: data.user.id,
-                email: data.user.email,
-                role: getUserRole(data.user),
-                raw: data.user,
-            };
-
-            try {
-                if (redisClient.isOpen) {
-                    await redisClient.setEx(cacheKey, 30, JSON.stringify(req.user));
-                }
-            } catch (err) {
-                logger.warn({
-                    message: "Redis cache set error in auth middleware",
-                    error: String(err),
-                });
-            }
-
+        if (await authenticateRequest(req, res, client, true)) {
             next();
-        } catch (err) {
-            const errMsg = err instanceof Error ? err.message : String(err);
-            if (
-                errMsg.includes("fetch failed") ||
-                errMsg.includes("refused") ||
-                errMsg.includes("timeout")
-            ) {
-                if (dbConfig) dbConfig.setOffline();
-            }
-
-            logger.warn({
-                message: "Supabase auth server request failed.",
-                error: errMsg,
-            });
-
-            if (canUseAuthBypass(req)) {
-                req.user = getMockUser();
-                next();
-            } else {
-                res.status(401).json({
-                    error: "Unauthorized: Authentication service unavailable",
-                });
-            }
         }
     };
 
@@ -243,130 +273,7 @@ export const requireAuth = createAuthMiddleware();
 export const createOptionalAuthMiddleware =
     (client: SupabaseAuthClient = supabase) =>
     async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
-        const token = extractToken(req);
-
-        if (!token) {
-            return next();
-        }
-
-        if (dbConfig?.isSupabaseOffline) {
-            if (canUseAuthBypass(req)) {
-                req.user = getMockUser();
-            }
-            return next();
-        }
-
-        const cacheKey = `auth:user:${crypto.createHash("sha256").update(token).digest("hex")}`;
-
-        try {
-            const { data, error } = await client.auth.getUser(token);
-
-            if (error) {
-                const isConnectionError =
-                    error.message?.includes("fetch failed") ||
-                    error.message?.includes("timeout") ||
-                    error.message?.includes("connect") ||
-                    error.message?.includes("refused");
-
-                if (isConnectionError) {
-                    try {
-                        if (redisClient.isOpen) {
-                            const cached = await redisClient.get(cacheKey);
-                            if (cached) {
-                                req.user = JSON.parse(cached);
-                                next();
-                                return;
-                            }
-                        }
-                    } catch (err) {
-                        logger.warn({
-                            message: "Redis cache get error in optional auth middleware fallback",
-                            error: String(err),
-                        });
-                    }
-
-                    if (dbConfig) dbConfig.setOffline();
-                    logger.warn({
-                        message: "Supabase auth server returned connection error.",
-                        error: error.message,
-                    });
-                    if (canUseAuthBypass(req)) {
-                        req.user = getMockUser();
-                    }
-                    next();
-                    return;
-                }
-
-                try {
-                    if (redisClient.isOpen) {
-                        await redisClient.del(cacheKey);
-                    }
-                } catch (err) {
-                    logger.warn({
-                        message: "Redis cache del error in optionalAuth (token error)",
-                        error: String(err),
-                    });
-                }
-                res.status(401).json({
-                    error: "Unauthorized: Invalid or expired token",
-                });
-                return;
-            }
-
-            if (!data.user) {
-                try {
-                    if (redisClient.isOpen) {
-                        await redisClient.del(cacheKey);
-                    }
-                } catch (err) {
-                    logger.warn({
-                        message: "Redis cache del error in optionalAuth (no user)",
-                        error: String(err),
-                    });
-                }
-                res.status(401).json({
-                    error: "Unauthorized: Invalid or expired token",
-                });
-                return;
-            }
-
-            req.user = {
-                id: data.user.id,
-                email: data.user.email,
-                role: getUserRole(data.user),
-                raw: data.user,
-            };
-
-            try {
-                if (redisClient.isOpen) {
-                    await redisClient.setEx(cacheKey, 30, JSON.stringify(req.user));
-                }
-            } catch (err) {
-                logger.warn({
-                    message: "Redis cache set error in optional auth middleware",
-                    error: String(err),
-                });
-            }
-
-            next();
-        } catch (err) {
-            const errMsg = err instanceof Error ? err.message : String(err);
-            if (
-                errMsg.includes("fetch failed") ||
-                errMsg.includes("refused") ||
-                errMsg.includes("timeout")
-            ) {
-                if (dbConfig) dbConfig.setOffline();
-            }
-
-            logger.warn({
-                message: "Supabase optional auth server request failed.",
-                error: errMsg,
-            });
-
-            if (canUseAuthBypass(req)) {
-                req.user = getMockUser();
-            }
+        if (await authenticateRequest(req, res, client, false)) {
             next();
         }
     };

--- a/apps/api/src/routes/interactions.ts
+++ b/apps/api/src/routes/interactions.ts
@@ -11,6 +11,7 @@ import zlib from "zlib";
 import { MAX_INTERACTION_MEDICINES } from "@sahidawa/shared";
 import { promises as fs } from "fs";
 import path from "path";
+import { markOfflineOnConnectionError } from "../utils/withDbFallback";
 
 const router = Router();
 
@@ -475,13 +476,7 @@ async function resolveMedicinesToGenerics(
 
                 if (error) {
                     dbFailed = true;
-                    if (
-                        error.message?.includes("fetch failed") ||
-                        error.message?.includes("refused") ||
-                        error.message?.includes("timeout")
-                    ) {
-                        if (dbConfig) dbConfig.isSupabaseOffline = true;
-                    }
+                    markOfflineOnConnectionError(error);
                     break;
                 }
 
@@ -496,13 +491,7 @@ async function resolveMedicinesToGenerics(
 
                     if (error) {
                         dbFailed = true;
-                        if (
-                            error.message?.includes("fetch failed") ||
-                            error.message?.includes("refused") ||
-                            error.message?.includes("timeout")
-                        ) {
-                            if (dbConfig) dbConfig.isSupabaseOffline = true;
-                        }
+                        markOfflineOnConnectionError(error);
                         break;
                     }
                 }
@@ -521,13 +510,7 @@ async function resolveMedicinesToGenerics(
         } catch (dbErr: unknown) {
             dbFailed = true;
             const msg = dbErr instanceof Error ? dbErr.message : String(dbErr);
-            if (
-                msg.includes("fetch failed") ||
-                msg.includes("refused") ||
-                msg.includes("timeout")
-            ) {
-                if (dbConfig) dbConfig.isSupabaseOffline = true;
-            }
+            markOfflineOnConnectionError(msg);
         }
     }
 

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -16,6 +16,7 @@ import logger from "../utils/logger";
 import { redisClient } from "../utils/redis";
 import { signGuestToken, verifyGuestPhone, isGuestTokenConfigured } from "../utils/guestToken";
 import { safeCompare } from "../utils/cryptoUtils";
+import { markOfflineOnConnectionError, withDbFallback } from "../utils/withDbFallback";
 import {
     getMockRecallFeed,
     getVapidPublicKey,
@@ -345,46 +346,26 @@ router.get("/status", limiter, optionalAuth, async (req: AuthenticatedRequest, r
         }
 
         let subscriber = null;
-        let dbFailed = dbConfig?.isSupabaseOffline;
 
-        if (!dbFailed) {
-            try {
+        subscriber = await withDbFallback(
+            async () => {
                 const { data, error } = await query.maybeSingle();
                 if (error) {
-                    dbFailed = true;
-                    if (
-                        error.message?.includes("fetch failed") ||
-                        error.message?.includes("refused") ||
-                        error.message?.includes("timeout")
-                    ) {
-                        if (dbConfig) dbConfig.setOffline();
-                    }
-                } else {
-                    subscriber = data;
+                    markOfflineOnConnectionError(error);
+                    throw error;
                 }
-            } catch (dbError: unknown) {
-                dbFailed = true;
-                const msg = dbError instanceof Error ? dbError.message : String(dbError);
-                if (
-                    msg.includes("fetch failed") ||
-                    msg.includes("refused") ||
-                    msg.includes("timeout")
-                ) {
-                    if (dbConfig) dbConfig.setOffline();
+                return data;
+            },
+            () => {
+                logger.warn(
+                    "Supabase database is offline. Falling back to in-memory subscription store."
+                );
+                if (req.user) {
+                    return memorySubscriberStore.find((s) => s.user_id === req.user!.id) ?? null;
                 }
+                return memorySubscriberStore.get(guestPhone!) ?? null;
             }
-        }
-
-        if (dbFailed) {
-            logger.warn(
-                "Supabase database is offline. Falling back to in-memory subscription store."
-            );
-            if (req.user) {
-                subscriber = memorySubscriberStore.find((s) => s.user_id === req.user!.id);
-            } else {
-                subscriber = memorySubscriberStore.get(guestPhone!);
-            }
-        }
+        );
 
         if (!subscriber) {
             res.json({ registered: false });

--- a/apps/api/src/utils/withDbFallback.ts
+++ b/apps/api/src/utils/withDbFallback.ts
@@ -1,0 +1,65 @@
+import { dbConfig } from "../db/client";
+
+/**
+ * Detects Supabase/network outage style failures used across auth and route
+ * offline fallbacks.
+ */
+export function isSupabaseConnectionError(message: string | null | undefined): boolean {
+    if (!message) return false;
+    return (
+        message.includes("fetch failed") ||
+        message.includes("refused") ||
+        message.includes("timeout") ||
+        message.includes("connect")
+    );
+}
+
+/**
+ * Runs a primary DB-backed operation, falling back when Supabase is already
+ * offline or the primary path hits a connection-style failure.
+ */
+export async function withDbFallback<T>(
+    primary: () => Promise<T>,
+    fallback: () => Promise<T> | T
+): Promise<T> {
+    if (dbConfig?.isSupabaseOffline) {
+        return await fallback();
+    }
+
+    try {
+        return await primary();
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (isSupabaseConnectionError(message)) {
+            if (dbConfig) {
+                if (typeof dbConfig.setOffline === "function") {
+                    dbConfig.setOffline();
+                } else {
+                    dbConfig.isSupabaseOffline = true;
+                }
+            }
+        }
+        return await fallback();
+    }
+}
+
+/**
+ * Marks Supabase offline when an error object/message looks like a connection
+ * failure. Returns true when the caller should treat the DB as failed.
+ */
+export function markOfflineOnConnectionError(
+    error: { message?: string } | string | null | undefined
+): boolean {
+    const message = typeof error === "string" ? error : error?.message;
+    if (!isSupabaseConnectionError(message)) {
+        return Boolean(error);
+    }
+    if (dbConfig) {
+        if (typeof dbConfig.setOffline === "function") {
+            dbConfig.setOffline();
+        } else {
+            dbConfig.isSupabaseOffline = true;
+        }
+    }
+    return true;
+}

--- a/apps/api/tests/withDbFallback.test.ts
+++ b/apps/api/tests/withDbFallback.test.ts
@@ -1,0 +1,52 @@
+import { dbConfig } from "../src/db/client";
+import {
+    isSupabaseConnectionError,
+    markOfflineOnConnectionError,
+    withDbFallback,
+} from "../src/utils/withDbFallback";
+
+describe("withDbFallback helpers", () => {
+    beforeEach(() => {
+        dbConfig.isSupabaseOffline = false;
+        dbConfig.offlineSince = null;
+    });
+
+    it("detects connection-style error messages", () => {
+        expect(isSupabaseConnectionError("fetch failed")).toBe(true);
+        expect(isSupabaseConnectionError("connection refused")).toBe(true);
+        expect(isSupabaseConnectionError("request timeout")).toBe(true);
+        expect(isSupabaseConnectionError("could not connect")).toBe(true);
+        expect(isSupabaseConnectionError("row not found")).toBe(false);
+    });
+
+    it("marks supabase offline on connection errors", () => {
+        expect(markOfflineOnConnectionError({ message: "fetch failed" })).toBe(true);
+        expect(dbConfig.isSupabaseOffline).toBe(true);
+    });
+
+    it("uses fallback when already offline", async () => {
+        dbConfig.isSupabaseOffline = true;
+        const primary = jest.fn(async () => "primary");
+        const result = await withDbFallback(primary, () => "fallback");
+
+        expect(result).toBe("fallback");
+        expect(primary).not.toHaveBeenCalled();
+    });
+
+    it("returns primary result when healthy", async () => {
+        const result = await withDbFallback(async () => "primary", () => "fallback");
+        expect(result).toBe("primary");
+    });
+
+    it("falls back and marks offline on connection failures", async () => {
+        const result = await withDbFallback(
+            async () => {
+                throw new Error("fetch failed");
+            },
+            () => "fallback"
+        );
+
+        expect(result).toBe("fallback");
+        expect(dbConfig.isSupabaseOffline).toBe(true);
+    });
+});


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue. (commented requesting assignment; cannot self-assign)
- [x] I verified that this PR **ONLY** touches the required files.

## PR Summary & Link

- **Closes #4231** (reopened from #4186)
- **Summary:** `requireAuth` / `optionalAuth` now share one `authenticateRequest` path. Added `withDbFallback` + connection-error helpers and adopted them in notifications status + interactions name resolution (also fixes interactions writing `isSupabaseOffline` without `setOffline()`).

## Proof of Work (Screenshots / Logs)

```
PASS tests/auth.test.ts
PASS tests/withDbFallback.test.ts
PASS tests/interactions.test.ts
PASS tests/notifications.test.ts
```

## PR Type

- [x] `type: refactor`
- [x] `type: bug`

## Checklist

- [x] My PR has a linked issue (`Closes #4231`)
- [x] I have pulled the latest `main` and resolved any conflicts

Made with [Cursor](https://cursor.com)