### PR TITLE
fix(api): keep public /health shallow and gate details

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -52,7 +52,7 @@ import helmet from "helmet";
 import morgan from "morgan";
 import compression from "compression";
 import adminRoutes from "./routes/admin.routes";
-import { requireAuth, requireRole } from "./middleware/auth";
+import { requireAuth, requireRole, isLocalhostRequest, AuthenticatedRequest } from "./middleware/auth";
 import reportsRouter from "./routes/reports";
 import pharmaciesRouter from "./routes/pharmacies";
 import verifyRouter from "./routes/verify";
@@ -97,7 +97,12 @@ app.use(requestIdMiddleware);
 app.use(errorMetricsMiddleware);
 
 // ── Health Check (lightweight reachability ping) ───────────────────────────
-app.get("/health", healthLimiter, async (_req: Request, res: Response) => {
+// Public probe stays shallow — no env, memory, dependency, or ML URL details.
+app.get("/health", healthLimiter, (_req: Request, res: Response) => {
+    res.status(200).json({ status: "ok" });
+});
+
+async function detailedHealthHandler(_req: Request, res: Response) {
     const overallStart = Date.now();
     try {
         // Database check with latency measurement
@@ -206,7 +211,22 @@ app.get("/health", healthLimiter, async (_req: Request, res: Response) => {
             timestamp: new Date().toISOString(),
         });
     }
-});
+}
+
+function requireDetailedHealthAccess(
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction
+): void {
+    if (isLocalhostRequest(req)) {
+        next();
+        return;
+    }
+
+    void requireAuth(req, res, () => {
+        requireRole("admin")(req, res, next);
+    });
+}
 
 // Protect all other routes with the general limiter
 app.use(limiter);
@@ -228,6 +248,9 @@ app.use(httpsRedirect);
 app.use(compression());
 // ── Global Middleware Configuration ───────────────────────────────────────
 app.use(cookieParser());
+
+// Detailed health — localhost or authenticated admin only (no public infra disclosure).
+app.get("/health/details", healthLimiter, requireDetailedHealthAccess, detailedHealthHandler);
 
 // ── CSRF Protection (double-submit cookie pattern) ─────────────────────────
 app.use(cors(createCorsOptions()));
@@ -357,7 +380,12 @@ app.get("/", (_req: Request, res: Response) => {
         version: process.env.npm_package_version || "0.1.0",
         status: "running",
         environment: process.env.NODE_ENV || "development",
-        endpoints: { health: "/health", docs: "/api/docs", csrfToken: "/api/csrf-token" },
+        endpoints: {
+            health: "/health",
+            healthDetails: "/health/details",
+            docs: "/api/docs",
+            csrfToken: "/api/csrf-token",
+        },
         repository: "https://github.com/RatLoopz/sahidawa-india",
         timestamp: new Date().toISOString(),
     });

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -102,100 +102,140 @@ app.get("/health", healthLimiter, (_req: Request, res: Response) => {
     res.status(200).json({ status: "ok" });
 });
 
+async function probeDatabase(): Promise<{ error: unknown; latencyMs: number }> {
+    const dbStart = Date.now();
+    const { error } = await supabase.from("medicines").select("id").limit(1);
+    return { error, latencyMs: Date.now() - dbStart };
+}
+
+async function probeRedis(): Promise<{ status: string; latencyMs: number | null }> {
+    if (!redisClient.isOpen) {
+        return { status: "disconnected", latencyMs: null };
+    }
+
+    const redisStart = Date.now();
+    try {
+        await redisClient.ping();
+        return { status: "connected", latencyMs: Date.now() - redisStart };
+    } catch {
+        return { status: "unhealthy", latencyMs: Date.now() - redisStart };
+    }
+}
+
+async function probeMlService(): Promise<{
+    status: string;
+    latencyMs: number;
+    url: string | null;
+}> {
+    const mlUrl = getMlServiceUrl();
+    if (!mlUrl) {
+        return { status: "not-configured", latencyMs: 0, url: null };
+    }
+
+    const mlStart = Date.now();
+    try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 3000);
+        const mlRes = await fetch(mlUrl, { method: "HEAD", signal: controller.signal });
+        clearTimeout(timeout);
+        return {
+            status: mlRes.ok ? "healthy" : "unreachable",
+            latencyMs: Date.now() - mlStart,
+            url: mlUrl,
+        };
+    } catch {
+        return { status: "unreachable", latencyMs: Date.now() - mlStart, url: mlUrl };
+    }
+}
+
+function buildDetailedHealthPayload(input: {
+    dbError: unknown;
+    dbLatencyMs: number;
+    redisStatus: string;
+    redisLatencyMs: number | null;
+    mlStatus: string;
+    mlLatencyMs: number;
+    mlUrl: string | null;
+    responseTimeMs: number;
+}) {
+    const {
+        dbError,
+        dbLatencyMs,
+        redisStatus,
+        redisLatencyMs,
+        mlStatus,
+        mlLatencyMs,
+        mlUrl,
+        responseTimeMs,
+    } = input;
+
+    // ML service is optional — "not-configured" does not degrade overallStatus.
+    const overallStatus =
+        !dbError && redisStatus === "connected" && (mlUrl === null || mlStatus === "healthy")
+            ? "healthy"
+            : "degraded";
+
+    return {
+        status: overallStatus,
+        service: "sahidawa-api",
+        version: process.env.npm_package_version || "unknown",
+        environment: process.env.NODE_ENV || "development",
+        uptime: `${Math.floor(process.uptime())}s`,
+        dependencies: {
+            database: {
+                status: dbError ? "down" : "up",
+                latencyMs: dbLatencyMs,
+                ...(dbError && { error: "Database connection failed" }),
+            },
+            redis: {
+                status: redisStatus === "connected" ? "up" : redisStatus,
+                latencyMs: redisLatencyMs,
+            },
+            mlService: {
+                status: mlStatus === "healthy" ? "up" : mlStatus,
+                latencyMs: mlLatencyMs,
+                ...(mlUrl && { url: mlUrl }),
+            },
+        },
+        database: { status: dbError ? "unreachable" : "connected" },
+        services: {
+            api: "healthy",
+            redis: redisStatus,
+            mlService: mlStatus,
+        },
+        system: {
+            nodeVersion: process.version,
+            platform: process.platform,
+            memoryUsage: {
+                rss: `${Math.round(process.memoryUsage().rss / 1024 / 1024)} MB`,
+                heapUsed: `${Math.round(process.memoryUsage().heapUsed / 1024 / 1024)} MB`,
+            },
+        },
+        responseTimeMs,
+        timestamp: new Date().toISOString(),
+    };
+}
+
 async function detailedHealthHandler(_req: Request, res: Response) {
     const overallStart = Date.now();
     try {
-        // Database check with latency measurement
-        const dbStart = Date.now();
-        const { error } = await supabase.from("medicines").select("id").limit(1);
-        const dbLatencyMs = Date.now() - dbStart;
-        const uptime = process.uptime();
+        const database = await probeDatabase();
+        const redis = await probeRedis();
+        const ml = await probeMlService();
 
-        // Redis check with latency measurement
-        let redisLatencyMs: number | null = null;
-        let redisStatus = redisClient.isOpen ? "connected" : "disconnected";
-        if (redisClient.isOpen) {
-            const redisStart = Date.now();
-            try {
-                await redisClient.ping();
-                redisStatus = "connected";
-            } catch {
-                redisStatus = "unhealthy";
-            }
-            redisLatencyMs = Date.now() - redisStart;
-        }
-
-        // ML service — check config first, then do a lightweight reachability ping
-        let mlStatus: string;
-        let mlLatencyMs = 0;
-        const mlUrl = getMlServiceUrl();
-        if (!mlUrl) {
-            mlStatus = "not-configured";
-        } else {
-            const mlStart = Date.now();
-            try {
-                const controller = new AbortController();
-                const timeout = setTimeout(() => controller.abort(), 3000);
-                const mlRes = await fetch(mlUrl, { method: "HEAD", signal: controller.signal });
-                clearTimeout(timeout);
-                mlStatus = mlRes.ok ? "healthy" : "unreachable";
-            } catch {
-                mlStatus = "unreachable";
-            }
-            mlLatencyMs = Date.now() - mlStart;
-        }
-
-        // Overall status
-        // ML service is optional — "not-configured" does not degrade overallStatus.
-        const overallStatus =
-            !error && redisStatus === "connected" && (mlUrl === null || mlStatus === "healthy")
-                ? "healthy"
-                : "degraded";
-
-        const healthData = {
-            status: overallStatus,
-            service: "sahidawa-api",
-            version: process.env.npm_package_version || "unknown",
-            environment: process.env.NODE_ENV || "development",
-            uptime: `${Math.floor(uptime)}s`,
-            // New structured dependencies format
-            dependencies: {
-                database: {
-                    status: error ? "down" : "up",
-                    latencyMs: dbLatencyMs,
-                    ...(error && { error: "Database connection failed" }),
-                },
-                redis: {
-                    status: redisStatus === "connected" ? "up" : redisStatus,
-                    latencyMs: redisLatencyMs,
-                },
-                mlService: {
-                    status: mlStatus === "healthy" ? "up" : mlStatus,
-                    latencyMs: mlLatencyMs,
-                    ...(mlUrl && { url: mlUrl }),
-                },
-            },
-            // Backwards-compatible flat format for existing monitoring
-            database: { status: error ? "unreachable" : "connected" },
-            services: {
-                api: "healthy",
-                redis: redisStatus,
-                mlService: mlStatus,
-            },
-            system: {
-                nodeVersion: process.version,
-                platform: process.platform,
-                memoryUsage: {
-                    rss: `${Math.round(process.memoryUsage().rss / 1024 / 1024)} MB`,
-                    heapUsed: `${Math.round(process.memoryUsage().heapUsed / 1024 / 1024)} MB`,
-                },
-            },
+        const healthData = buildDetailedHealthPayload({
+            dbError: database.error,
+            dbLatencyMs: database.latencyMs,
+            redisStatus: redis.status,
+            redisLatencyMs: redis.latencyMs,
+            mlStatus: ml.status,
+            mlLatencyMs: ml.latencyMs,
+            mlUrl: ml.url,
             responseTimeMs: Date.now() - overallStart,
-            timestamp: new Date().toISOString(),
-        };
+        });
 
-        if (error) {
-            logger.error("Health check database failure", { error });
+        if (database.error) {
+            logger.error("Health check database failure", { error: database.error });
             return res.status(503).json(healthData);
         }
 

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -71,7 +71,7 @@ const getMockUser = (): AuthenticatedUser => {
  */
 const LOCALHOST_IPS = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
 
-const isLocalhostRequest = (req: Request): boolean => {
+export const isLocalhostRequest = (req: Request): boolean => {
     const addr = req.socket?.remoteAddress ?? req.ip ?? "";
     return LOCALHOST_IPS.has(addr);
 };

--- a/apps/api/tests/health.test.ts
+++ b/apps/api/tests/health.test.ts
@@ -1,0 +1,127 @@
+// @ts-nocheck
+process.env.SUPABASE_URL = process.env.SUPABASE_URL || "http://localhost:54321";
+process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY =
+    process.env.SUPABASE_SERVICE_ROLE_KEY || "test-service-role-key";
+
+(globalThis as unknown as { WebSocket: any }).WebSocket =
+    (globalThis as unknown as { WebSocket: any }).WebSocket || class {};
+
+const mockLimit = jest.fn().mockResolvedValue({ data: [{ id: "1" }], error: null });
+
+jest.mock("../src/db/client", () => ({
+    supabase: {
+        from: jest.fn(() => ({
+            select: jest.fn(() => ({
+                limit: mockLimit,
+            })),
+        })),
+    },
+    dbConfig: { isSupabaseOffline: false, setOffline: jest.fn(), setOnline: jest.fn() },
+}));
+
+jest.mock("../src/utils/redis", () => ({
+    redisClient: {
+        isOpen: true,
+        ping: jest.fn().mockResolvedValue("PONG"),
+        get: jest.fn(),
+        set: jest.fn(),
+        setEx: jest.fn(),
+        del: jest.fn(),
+    },
+}));
+
+jest.mock("../src/config/mlService", () => ({
+    validateMlServiceConfig: jest.fn(),
+    getMlServiceUrl: jest.fn(() => null),
+    getMlAuthHeaders: jest.fn(() => ({})),
+    MISSING_ML_SERVICE_URL_MESSAGE: "ML_SERVICE_URL missing",
+}));
+
+const mockIsLocalhostRequest = jest.fn(() => false);
+
+jest.mock("../src/middleware/auth", () => ({
+    requireAuth: (req: any, res: any, next: any) => {
+        const token = req.headers.authorization?.slice(7);
+        if (!token) {
+            return res.status(401).json({ error: "Unauthorized: Missing access token" });
+        }
+        req.user = {
+            id: "test-user-id",
+            email: "test@example.com",
+            role: token === "admin-token" ? "admin" : "user",
+        };
+        next();
+    },
+    optionalAuth: (_req: any, _res: any, next: any) => next(),
+    requireRole:
+        (...roles: string[]) =>
+        (req: any, res: any, next: any) => {
+            if (!req.user) {
+                return res.status(401).json({ error: "Authentication is required" });
+            }
+            if (!roles.includes(req.user.role)) {
+                return res.status(403).json({ error: "Insufficient permissions" });
+            }
+            next();
+        },
+    isLocalhostRequest: (req: any) => mockIsLocalhostRequest(req),
+    AuthenticatedRequest: Object,
+}));
+
+import request from "supertest";
+import app from "../src/app";
+
+describe("health endpoints", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockIsLocalhostRequest.mockReturnValue(false);
+        mockLimit.mockResolvedValue({ data: [{ id: "1" }], error: null });
+    });
+
+    it("returns a shallow public /health payload", async () => {
+        const res = await request(app).get("/health");
+
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ status: "ok" });
+        expect(res.body).not.toHaveProperty("dependencies");
+        expect(res.body).not.toHaveProperty("system");
+        expect(res.body).not.toHaveProperty("environment");
+        expect(JSON.stringify(res.body)).not.toContain("memoryUsage");
+    });
+
+    it("rejects unauthenticated /health/details from non-localhost", async () => {
+        const res = await request(app).get("/health/details");
+
+        expect(res.status).toBe(401);
+        expect(res.body).not.toHaveProperty("dependencies");
+    });
+
+    it("rejects non-admin authenticated /health/details from non-localhost", async () => {
+        const res = await request(app)
+            .get("/health/details")
+            .set("Authorization", "Bearer user-token");
+
+        expect(res.status).toBe(403);
+    });
+
+    it("returns detailed health for admins", async () => {
+        const res = await request(app)
+            .get("/health/details")
+            .set("Authorization", "Bearer admin-token");
+
+        expect(res.status).toBe(200);
+        expect(res.body.service).toBe("sahidawa-api");
+        expect(res.body.dependencies).toBeDefined();
+        expect(res.body.system).toBeDefined();
+    });
+
+    it("allows detailed health from localhost without auth", async () => {
+        mockIsLocalhostRequest.mockReturnValue(true);
+
+        const res = await request(app).get("/health/details");
+
+        expect(res.status).toBe(200);
+        expect(res.body.dependencies).toBeDefined();
+    });
+});


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue. (requested via /assign on #4234; previous PR #4237 was auto-closed)
- [x] I verified that this PR **ONLY** touches the required files.

## PR Summary & Link

- **Closes #4234** (reopened from #4183)
- **Summary:** Public `GET /health` returns `{ status: "ok" }`. Detailed dependency/system payload is on `GET /health/details` (localhost or admin). Probe helpers split out for Sonar complexity.

## Proof of Work (Screenshots / Logs)

```
PASS tests/health.test.ts
Tests: 5 passed
```

## PR Type

- [x] `type: bug`
- [x] `type: security`

## Checklist

- [x] My PR has a linked issue (`Closes #4234`)
- [x] I have pulled the latest `main` and resolved any conflicts

Made with [Cursor](https://cursor.com)