### PR TITLE
fix(alert-broadcaster): prevent duplicate broadcasts with lock renewal and in-process guard

### DIFF
--- a/apps/api/src/cron/alert-broadcaster.test.ts
+++ b/apps/api/src/cron/alert-broadcaster.test.ts
@@ -1,4 +1,7 @@
 // @ts-nocheck
+// Force the test branch of module constants (LOCK_RENEW_INTERVAL_MS, etc.)
+process.env.NODE_ENV = "test";
+
 // Fix: Mock WebSocket for Node.js versions < 22 to prevent Supabase Realtime client crash during test imports
 if (typeof globalThis.WebSocket === "undefined") {
     globalThis.WebSocket = class {} as any;
@@ -25,6 +28,10 @@ const mockRedisClient = {
             const [key] = keys;
             const [expected] = args;
             if (lockStore.get(key) === expected) {
+                if (args.length > 1) {
+                    // renew script: PEXPIRE — keep the lock alive
+                    return 1;
+                }
                 lockStore.delete(key);
                 return 1;
             }
@@ -33,15 +40,50 @@ const mockRedisClient = {
     ),
 };
 
+// When set, every supabase query awaits this gate before resolving so a test
+// can keep a broadcast run "in progress" on demand.
+let supabaseGate: Promise<void> | null = null;
+
+const dbState: Record<string, Array<Record<string, unknown>>> = {
+    district_alerts: [],
+    drug_alerts: [],
+    notification_subscribers: [],
+    batches: [],
+    expiry_digest_deliveries: [],
+    medicines: [],
+};
+
+function makeNextQuery() {
+    const builder: any = {
+        select: () => builder,
+        eq: () => builder,
+        ilike: () => builder,
+        range: () => builder,
+        gte: () => builder,
+        lte: () => builder,
+        not: () => builder,
+        in: () => builder,
+        update: () => builder,
+        upsert: () => builder,
+    };
+    builder.then = async (resolve: (value: unknown) => void) => {
+        if (supabaseGate) await supabaseGate;
+        const rows = dbState[builder.table] ?? [];
+        resolve({ data: rows, error: null });
+    };
+    return builder;
+}
+
 // ── Module mocks ───────────────────────────────────────────────────────────
 mock.module("../utils/redis", () => ({ redisClient: mockRedisClient }));
 
 mock.module("../db/client", () => ({
     supabase: {
-        from: () => ({
-            select: () => ({ eq: () => ({ data: [], error: null }) }),
-            update: () => ({ eq: () => ({ error: null }) }),
-        }),
+        from: (table: string) => {
+            const query = makeNextQuery();
+            query.table = table;
+            return query;
+        },
     },
     dbConfig: { isSupabaseOffline: false },
 }));
@@ -59,6 +101,8 @@ import { checkAndBroadcastAll } from "./alert-broadcaster";
 describe("checkAndBroadcastAll — distributed lock", () => {
     beforeEach(() => {
         lockStore.clear();
+        supabaseGate = null;
+        for (const table of Object.keys(dbState)) dbState[table] = [];
         mockRedisClient.set.mock.resetCalls();
         mockRedisClient.eval.mock.resetCalls();
     });
@@ -114,5 +158,54 @@ describe("checkAndBroadcastAll — distributed lock", () => {
         } finally {
             mockRedisClient.isOpen = true;
         }
+    });
+
+    it("skips broadcasting when a run is already in progress in this process", async () => {
+        // Hold the first broadcast pending so isBroadcasting stays true
+        let releaseGate!: () => void;
+        supabaseGate = new Promise((resolve) => (releaseGate = resolve));
+
+        const firstRun = checkAndBroadcastAll();
+
+        // Give the first run time to acquire the lock (NX) and enter its loop.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // A second tick fires while the first is mid-broadcast: the in-process
+        // guard must skip it *before* even trying to acquire the distributed lock.
+        await checkAndBroadcastAll();
+
+        // The second invocation never attempted to acquire the lock again.
+        assert.equal(mockRedisClient.set.mock.calls.length, 1, "lock acquired exactly once");
+        assert.equal(lockStore.size, 1, "first run still holds the lock");
+
+        releaseGate();
+        await firstRun;
+
+        assert.ok(mockRedisClient.eval.mock.calls.length >= 1, "renewal + final release");
+        assert.equal(lockStore.size, 0, "lock released once the run finished");
+    });
+
+    it("renews the lock TTL throughout a run that outlives the original TTL", async () => {
+        // Renewal cadence is 50ms in test; keep a run pending past several heartbeats.
+        let releaseGate!: () => void;
+        supabaseGate = new Promise((resolve) => (releaseGate = resolve));
+
+        const run = checkAndBroadcastAll();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        assert.equal(lockStore.size, 1, "lock acquired before the slow broadcast");
+
+        // Let the heartbeat refresh the lock several times while the broadcast
+        // is still stuck on the (idle) SMS/WhatsApp provider calls.
+        await new Promise((resolve) => setTimeout(resolve, 160));
+        assert.equal(lockStore.size, 1, "lock is still held after its original TTL window");
+        assert.ok(
+            mockRedisClient.eval.mock.calls.length >= 2,
+            "lock TTL was refreshed at least twice during the run"
+        );
+
+        releaseGate();
+        await run;
+
+        assert.equal(lockStore.size, 0, "lock finally released on completion");
     });
 });

--- a/apps/api/src/cron/alert-broadcaster.ts
+++ b/apps/api/src/cron/alert-broadcaster.ts
@@ -10,8 +10,16 @@ const CHECK_INTERVAL_MS = process.env.NODE_ENV === "test" ? 1000 : 30000; // 30 
 const PAGE_SIZE = 1000;
 const NOTIFICATION_CHUNK_SIZE = 50;
 const LOCK_KEY = "alert-broadcaster:lock";
-const LOCK_TTL_MS = 25_000; // slightly under the 30-second interval
+const LOCK_TTL_MS = 25_000; // 25s TTL, replenished by renewLock() so it outlives long runs
+// Heartbeat cadence is well under the TTL so a busy RPC/sms/whatsapp provider
+// call can never let the distributed lock expire mid-broadcast.
+const LOCK_RENEW_INTERVAL_MS = process.env.NODE_ENV === "test" ? 50 : Math.floor(LOCK_TTL_MS / 2);
 const LOCK_VALUE = `${process.env.HOSTNAME ?? "api"}:${process.pid}`;
+
+// In-process run guard: without it a single instance can overlap its own ticks
+// when a broadcast run outlives the 30s scheduler interval and the distributed
+// lock has already expired mid-run.
+let isBroadcasting = false;
 
 export const broadcastConfig = {
     MARK_BROADCASTED_CHUNK_SIZE: 500,
@@ -157,6 +165,28 @@ async function releaseLock(): Promise<void> {
         await redisClient.eval(script, { keys: [LOCK_KEY], arguments: [LOCK_VALUE] });
     } catch (err) {
         logger.error({ message: "Failed to release broadcaster lock", error: err });
+    }
+}
+
+/**
+ * Replenishes the lock TTL so a slow broadcast run can never exceed the
+ * original lock expiry and hand the lock over to the next scheduler tick or
+ * another pod. Atomic Lua script: the TTL is extended only while this process
+ * still owns the lock.
+ */
+async function renewLock(): Promise<void> {
+    if (!redisClient.isOpen) return;
+    try {
+        const script = `
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("pexpire", KEYS[1], ARGV[2])
+            else
+                return 0
+            end
+        `;
+        await redisClient.eval(script, { keys: [LOCK_KEY], arguments: [LOCK_VALUE, LOCK_TTL_MS] });
+    } catch (err) {
+        logger.error({ message: "Failed to renew broadcaster lock", error: err });
     }
 }
 
@@ -711,17 +741,37 @@ export async function checkAndBroadcastAll(): Promise<void> {
         return;
     }
 
+    // In-process run guard: never start a second broadcast in this process
+    // while one is still in flight, even if the distributed lock has expired.
+    if (isBroadcasting) {
+        logger.info("Alert broadcaster already running in this process — skipping this tick.");
+        return;
+    }
+
     const acquired = await acquireLock();
     if (!acquired) {
         logger.info("Alert broadcaster lock held by another instance — skipping this tick.");
         return;
     }
 
+    isBroadcasting = true;
+
+    // Heartbeat: keep replenishing the lock TTL for the whole duration of the
+    // run so slow SMS/WhatsApp provider calls can never let it expire.
+    const renewalId = setInterval(() => {
+        renewLock().catch((err) => {
+            logger.error("Alert broadcaster: failed to renew lock", { error: err });
+        });
+    }, LOCK_RENEW_INTERVAL_MS);
+    renewalId.unref?.();
+
     try {
         await broadcastDistrictAlerts();
         await broadcastDrugAlerts();
         await broadcastExpiryAlerts();
     } finally {
+        clearInterval(renewalId);
+        isBroadcasting = false;
         await releaseLock();
     }
 }


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4242**
- **Summary:**
In apps/api/src/cron/alert-broadcaster.ts:
1. Lock TTL renewal — new renewLock() runs a compare-and-PEXPIRE Lua script on a setInterval heartbeat (LOCK_RENEW_INTERVAL_MS = LOCK_TTL_MS / 2). The TTL is extended only while this process still owns the lock, so a slow run can't hand it to another tick/pod. Old releaseLock() (del only-if-owner) is unchanged for the graceful-cleanup path.
2. In-process run guard — new module-level isBroadcasting flag set true after acquireLock() and reset in finally. checkAndBroadcastAll() now returns early if a run is already in flight in this process, before even attempting the distributed lock.
This makes acquisition exclusive both across pods (renewed Redis lock) and within a pod (guard), eliminating duplicate sends even on slow broadcast windows. The renewal timer is unref()'d so it never keeps the process alive.
Tests
Extended alert-broadcaster.test.ts (node:test / mock.module style):
- skips a second checkAndBroadcastAll() while a run is in progress (guard)
- renews the lock TTL multiple times during a run that outlives the original TTL
Existing distributed-lock tests updated accordingly and passing behavior preserved. Jest collection isn't wired to src/cron/*.test.ts in jest.config.js, so these run standalone via the Node test runner.



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4242 `)
- [x] I have pulled the latest `main` and resolved any conflicts
