### PR TITLE
fix(scan-submit): clean up multer temp uploads on idempotency short-circuits

### DIFF
--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import type { AuthenticatedRequest } from "../middleware/auth";
 import { z } from "zod";
 import multer from "multer";
@@ -101,6 +101,37 @@ function cleanupTempFiles(filePaths: string[]): () => void {
             }
         }
     };
+}
+
+/**
+ * Collects the temp-uploads paths multer wrote for this request. Both /extract
+ * and /submit write with the same disk storage engine (UPLOAD_DIR), so every
+ * uploaded file present on the request at cleanup-registration time is covered.
+ */
+function collectUploadedTempPaths(req: Request): string[] {
+    const uploadedFiles: Express.Multer.File[] = [
+        ...((req.files as any)?.image ?? []),
+        ...((req.files as any)?.voice ?? []),
+    ];
+    return uploadedFiles
+        .filter((f): f is Express.Multer.File => !!f?.filename)
+        .map((f) => path.join(UPLOAD_DIR, path.basename(f.filename)));
+}
+
+/**
+ * Registers res.once("finish") / res.once("close") cleanup for every temp
+ * upload immediately after multer has written the files — BEFORE the
+ * idempotency middleware runs. The idempotency middleware short-circuits on
+ * several paths (missing key → 400, Redis replay → 200, completed key → 200,
+ * in-flight duplicate → 409) and returns before the /submit handler body ever
+ * executes. Cleanup registered only inside the handler therefore leaked every
+ * replayed/retried upload to disk. Issue #4243.
+ */
+function registerTempUploadCleanup(req: Request, res: Response, next: NextFunction): void {
+    const cleanup = cleanupTempFiles(collectUploadedTempPaths(req));
+    res.once("finish", cleanup);
+    res.once("close", cleanup);
+    next();
 }
 
 /**
@@ -638,24 +669,12 @@ router.post(
     uploadRateLimiter,
     validateUploadSize,
     upload.fields([{ name: "image" }, { name: "voice" }]),
+    // Register temp-file cleanup immediately after multer so the files are
+    // removed even on idempotency short-circuit paths (400/200/409) that
+    // return before this handler body runs (issue #4243).
+    registerTempUploadCleanup,
     idempotencyMiddleware,
     async (req: AuthenticatedRequest, res: Response) => {
-        // ── Request-scoped temp-file cleanup ────────────────────────────────
-        // Collect every temp file multer may have written for this request so
-        // they are removed the moment the response is finished — reusing the
-        // same cleanup helper as /extract (issue #4112).
-        const uploadedFiles: Express.Multer.File[] = [
-            ...((req.files as any)?.image ?? []),
-            ...((req.files as any)?.voice ?? []),
-        ];
-        const tempFilePaths = uploadedFiles
-            .filter((f): f is Express.Multer.File => !!f?.filename)
-            .map((f) => path.join(UPLOAD_DIR, path.basename(f.filename)));
-
-        const cleanup = cleanupTempFiles(tempFilePaths);
-        res.once("finish", cleanup);
-        res.once("close", cleanup);
-
         const idempotencyKey = (req as any).idempotencyKey;
         const submitSchema = z
             .object({

--- a/apps/api/tests/scanSubmitCleanup.test.ts
+++ b/apps/api/tests/scanSubmitCleanup.test.ts
@@ -275,3 +275,137 @@ describe("POST /api/v1/scan/submit — temp file cleanup (#4112)", () => {
         expect(cleanedTempPaths(unlinkSpy).length).toBe(0);
     });
 });
+
+describe("POST /api/v1/scan/submit — temp file cleanup on idempotency short-circuits (#4243)", () => {
+    let server: http.Server;
+    let unlinkSpy: jest.SpyInstance;
+
+    beforeAll((done) => {
+        server = http.createServer(app);
+        server.listen(0, done);
+    });
+
+    afterAll((done) => {
+        server.closeAllConnections?.();
+        server.close(() => done());
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        unlinkSpy = jest.spyOn(fs, "unlinkSync");
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("deletes the uploaded files when the Idempotency-Key header is missing (400)", async () => {
+        // No Idempotency-Key header: idempotencyMiddleware returns 400 before
+        // the /submit handler body ever runs. Multer still wrote the file, so
+        // the pre-idempotency cleanup must remove it.
+        const res = await request(server)
+            .post(SUBMIT_URL)
+            .field("deviceId", "device-1")
+            .field("clientUpdatedAt", Date.now().toString())
+            .attach("image", JPEG_BUF, {
+                filename: "nokey.jpg",
+                contentType: "image/jpeg",
+            });
+
+        expect(res.status).toBe(400);
+        await waitFor(() => cleanedTempPaths(unlinkSpy).length > 0);
+        const cleaned = cleanedTempPaths(unlinkSpy);
+        expect(cleaned.some((p) => p.endsWith(".jpg"))).toBe(true);
+        for (const p of cleaned) {
+            expect(fs.existsSync(p)).toBe(false);
+        }
+    });
+
+    it("deletes the uploaded files when Redis returns a cached replay (200)", async () => {
+        // Redis already has an idem:<key> entry: idempotencyMiddleware returns
+        // the cached 200 without running the handler — cleanup must still run.
+        (redisClient.get as jest.Mock).mockResolvedValue(
+            JSON.stringify({ scanId: "cached-scan", parts: { image: "synced", voice: "synced" } })
+        );
+
+        const res = await request(server)
+            .post(SUBMIT_URL)
+            .set("Idempotency-Key", "cleanup-redis-replay-key")
+            .field("deviceId", "device-1")
+            .field("clientUpdatedAt", Date.now().toString())
+            .attach("image", JPEG_BUF, {
+                filename: "replay.jpg",
+                contentType: "image/jpeg",
+            });
+
+        expect(res.status).toBe(200);
+        await waitFor(() => cleanedTempPaths(unlinkSpy).length > 0);
+        const cleaned = cleanedTempPaths(unlinkSpy);
+        expect(cleaned.some((p) => p.endsWith(".jpg"))).toBe(true);
+        for (const p of cleaned) {
+            expect(fs.existsSync(p)).toBe(false);
+        }
+    });
+
+    it("deletes the uploaded files when the key is already completed (200)", async () => {
+        // Reservation INSERT hits the primary-key conflict (23505), then the
+        // prior request already recorded a scan_id → completed-key 200 replay.
+        (redisClient.get as jest.Mock).mockResolvedValue(null);
+        (supabase.insert as jest.Mock).mockReturnValueOnce(
+            Promise.resolve({ data: null, error: { code: "23505", message: "duplicate key" } })
+        );
+        (supabase.maybeSingle as jest.Mock).mockResolvedValueOnce({
+            data: { scan_id: "already-done" },
+            error: null,
+        });
+
+        const res = await request(server)
+            .post(SUBMIT_URL)
+            .set("Idempotency-Key", "cleanup-completed-key")
+            .field("deviceId", "device-1")
+            .field("clientUpdatedAt", Date.now().toString())
+            .attach("image", JPEG_BUF, {
+                filename: "completed.jpg",
+                contentType: "image/jpeg",
+            });
+
+        expect(res.status).toBe(200);
+        await waitFor(() => cleanedTempPaths(unlinkSpy).length > 0);
+        const cleaned = cleanedTempPaths(unlinkSpy);
+        expect(cleaned.some((p) => p.endsWith(".jpg"))).toBe(true);
+        for (const p of cleaned) {
+            expect(fs.existsSync(p)).toBe(false);
+        }
+    });
+
+    it("deletes the uploaded files when the key is in-flight (409)", async () => {
+        // Reservation INSERT hits 23505 and scan_id is still null → the other
+        // request is in-flight → 409 without ever reaching the handler.
+        (redisClient.get as jest.Mock).mockResolvedValue(null);
+        (supabase.insert as jest.Mock).mockReturnValueOnce(
+            Promise.resolve({ data: null, error: { code: "23505", message: "duplicate key" } })
+        );
+        (supabase.maybeSingle as jest.Mock).mockResolvedValueOnce({
+            data: { scan_id: null },
+            error: null,
+        });
+
+        const res = await request(server)
+            .post(SUBMIT_URL)
+            .set("Idempotency-Key", "cleanup-inflight-key")
+            .field("deviceId", "device-1")
+            .field("clientUpdatedAt", Date.now().toString())
+            .attach("voice", WEBM_BUF, {
+                filename: "inflight.webm",
+                contentType: "audio/webm",
+            });
+
+        expect(res.status).toBe(409);
+        await waitFor(() => cleanedTempPaths(unlinkSpy).length > 0);
+        const cleaned = cleanedTempPaths(unlinkSpy);
+        expect(cleaned.some((p) => p.endsWith(".webm"))).toBe(true);
+        for (const p of cleaned) {
+            expect(fs.existsSync(p)).toBe(false);
+        }
+    });
+});


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4243**
- **Summary:**
Fix (apps/api/src/routes/scan.ts)
- New registerTempUploadCleanup middleware: collects all req.files multer wrote (collectUploadedTempPaths) and registers res.once("finish" / "close") → cleanupTempFiles, then calls next().
- Inserted it immediately after upload.fields(...) and before idempotencyMiddleware, so every response outcome — including all four idempotency short-circuits — triggers file cleanup.
- Removed the now-redundant cleanup block inside the /submit handler (same cleanupTempFiles/res.once helpers are reused, keeping one source of truth).
Tests (apps/api/tests/scanSubmitCleanup.test.ts)
Added 4 regression tests spying on fs.unlinkSync for the short-circuit paths:
- missing Idempotency-Key → 400, files deleted
- Redis cached replay → 200, files deleted
- key already completed (23505 + scan_id set) → 200, files deleted
- key in-flight (23505 + scan_id null) → 409, files deleted


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4243 `)
- [x] I have pulled the latest `main` and resolved any conflicts
