### PR TITLE
fix(api): respect snoozed alerts in broadcaster

### DIFF
--- a/apps/api/src/cron/alert-broadcaster.ts
+++ b/apps/api/src/cron/alert-broadcaster.ts
@@ -360,7 +360,8 @@ export async function broadcastDrugAlerts(): Promise<void> {
         const { data: alerts, error: alertsError } = await supabase
             .from("drug_alerts")
             .select("*")
-            .eq("broadcasted", false);
+            .eq("broadcasted", false)
+            .or(`snoozed_until.is.null,snoozed_until.lte.${new Date().toISOString()}`);
 
         if (alertsError) {
             logger.error({

--- a/apps/api/tests/alertBroadcaster.test.ts
+++ b/apps/api/tests/alertBroadcaster.test.ts
@@ -117,6 +117,7 @@ function createSubscriberQueryMock(capturedEqArgs: string[]) {
 function createAlertTable(alerts: Record<string, unknown>[]) {
     const chain: Record<string, unknown> = {
         eq: jest.fn(() => chain),
+        or: jest.fn(() => chain),
         then: (resolve: (value: unknown) => void) => resolve({ data: alerts, error: null }),
     };
 
@@ -448,17 +449,19 @@ describe("broadcastDrugAlerts", () => {
             if (table === "drug_alerts") {
                 return {
                     select: jest.fn().mockReturnValue({
-                        eq: jest.fn().mockResolvedValue({
-                            data: [
-                                {
-                                    id: "drug-alert-1",
-                                    district: "Delhi",
-                                    reported_brand_name: "Paracetamol",
-                                    batch_number: "B1",
-                                    broadcasted: false,
-                                },
-                            ],
-                            error: null,
+                        eq: jest.fn().mockReturnValue({
+                            or: jest.fn().mockResolvedValue({
+                                data: [
+                                    {
+                                        id: "drug-alert-1",
+                                        district: "Delhi",
+                                        reported_brand_name: "Paracetamol",
+                                        batch_number: "B1",
+                                        broadcasted: false,
+                                    },
+                                ],
+                                error: null,
+                            }),
                         }),
                     }),
                     update: markSpy,
@@ -494,17 +497,19 @@ describe("broadcastDrugAlerts", () => {
             if (table === "drug_alerts") {
                 return {
                     select: jest.fn().mockReturnValue({
-                        eq: jest.fn().mockResolvedValue({
-                            data: [
-                                {
-                                    id: "drug-alert-1",
-                                    district: "Mumbai",
-                                    reported_brand_name: "Ibuprofen",
-                                    batch_number: "B2",
-                                    broadcasted: false,
-                                },
-                            ],
-                            error: null,
+                        eq: jest.fn().mockReturnValue({
+                            or: jest.fn().mockResolvedValue({
+                                data: [
+                                    {
+                                        id: "drug-alert-1",
+                                        district: "Mumbai",
+                                        reported_brand_name: "Ibuprofen",
+                                        batch_number: "B2",
+                                        broadcasted: false,
+                                    },
+                                ],
+                                error: null,
+                            }),
                         }),
                     }),
                     update: markSpy,
@@ -530,6 +535,146 @@ describe("broadcastDrugAlerts", () => {
 
         expect(smsService.send).toHaveBeenCalledTimes(1);
         expect(markSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not broadcast a drug alert that is currently snoozed", async () => {
+        (smsService.send as jest.Mock).mockResolvedValue(true);
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "drug_alerts") {
+                return {
+                    select: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockReturnValue({
+                            or: jest.fn().mockResolvedValue({
+                                data: [],
+                                error: null,
+                            }),
+                        }),
+                    }),
+                    update: jest.fn(),
+                };
+            }
+            if (table === "notification_subscribers") {
+                return createSubscriberTable([
+                    {
+                        id: "sub-1",
+                        phone: "+911234567890",
+                        language: "en",
+                        channels: ["sms"],
+                        district: "Delhi",
+                        is_active: true,
+                        status: "active",
+                    },
+                ]);
+            }
+            return {};
+        });
+
+        await broadcastDrugAlerts();
+
+        expect(smsService.send).not.toHaveBeenCalled();
+    });
+
+    it("broadcasts a drug alert whose snooze period has expired", async () => {
+        const markSpy = jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+        });
+        (smsService.send as jest.Mock).mockResolvedValue(true);
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "drug_alerts") {
+                return {
+                    select: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockReturnValue({
+                            or: jest.fn().mockResolvedValue({
+                                data: [
+                                    {
+                                        id: "drug-alert-1",
+                                        district: "Delhi",
+                                        reported_brand_name: "Paracetamol",
+                                        batch_number: "B1",
+                                        broadcasted: false,
+                                        snoozed_until: "2026-01-01T00:00:00.000Z",
+                                    },
+                                ],
+                                error: null,
+                            }),
+                        }),
+                    }),
+                    update: markSpy,
+                };
+            }
+            if (table === "notification_subscribers") {
+                return createSubscriberTable([
+                    {
+                        id: "sub-1",
+                        phone: "+911234567890",
+                        language: "en",
+                        channels: ["sms"],
+                        district: "Delhi",
+                        is_active: true,
+                        status: "active",
+                    },
+                ]);
+            }
+            return {};
+        });
+
+        await broadcastDrugAlerts();
+
+        expect(smsService.send).toHaveBeenCalledTimes(1);
+        expect(markSpy).toHaveBeenCalledWith({ broadcasted: true });
+    });
+
+    it("broadcasts a drug alert with null snoozed_until", async () => {
+        const markSpy = jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({ data: null, error: null }),
+        });
+        (smsService.send as jest.Mock).mockResolvedValue(true);
+
+        (mockedSupabase.from as jest.Mock).mockImplementation((table: string) => {
+            if (table === "drug_alerts") {
+                return {
+                    select: jest.fn().mockReturnValue({
+                        eq: jest.fn().mockReturnValue({
+                            or: jest.fn().mockResolvedValue({
+                                data: [
+                                    {
+                                        id: "drug-alert-1",
+                                        district: "Delhi",
+                                        reported_brand_name: "Paracetamol",
+                                        batch_number: "B1",
+                                        broadcasted: false,
+                                        snoozed_until: null,
+                                    },
+                                ],
+                                error: null,
+                            }),
+                        }),
+                    }),
+                    update: markSpy,
+                };
+            }
+            if (table === "notification_subscribers") {
+                return createSubscriberTable([
+                    {
+                        id: "sub-1",
+                        phone: "+911234567890",
+                        language: "en",
+                        channels: ["sms"],
+                        district: "Delhi",
+                        is_active: true,
+                        status: "active",
+                    },
+                ]);
+            }
+            return {};
+        });
+
+        await broadcastDrugAlerts();
+
+        expect(smsService.send).toHaveBeenCalledTimes(1);
+        expect(markSpy).toHaveBeenCalledWith({ broadcasted: true });
     });
 });
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #4250**
* **Summary:** Fixed `broadcastDrugAlerts()` to exclude drug alerts that are currently snoozed. The broadcaster now allows unsnoozed alerts (`snoozed_until = NULL`) and alerts whose snooze period has expired, while continuing to exclude already-broadcast alerts.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> * Backend-only change; no frontend/UI changes or screenshots are applicable.
> * Regression tests: **33 passed, 33 total**
> * `git diff --check`: passed
> * Pre-commit checks (Prettier + circular dependency check): passed

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [ ] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #4250`)
* [x] I have pulled the latest `main` and resolved any conflicts