### PR TITLE
fix(api): escape XML in Twilio webhook responses

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -207,6 +207,15 @@ const updatePhoneSchema = z
     })
     .strict();
 
+export function escapeXml(text: string): string {
+    return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&apos;");
+}
+
 const twilioWebhookSchema = z.object({
     From: z
         .string()
@@ -1258,7 +1267,7 @@ router.post(
             res.setHeader("Content-Type", "text/xml");
             res.send(`<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-    <Message>${replyMessage}</Message>
+    <Message>${escapeXml(replyMessage)}</Message>
 </Response>`);
         } catch (err) {
             logger.error({ message: "Error in Twilio webhook", error: err });

--- a/apps/api/tests/notifications.test.ts
+++ b/apps/api/tests/notifications.test.ts
@@ -150,6 +150,7 @@ jest.mock("../src/utils/redis", () => ({
 import express from "express";
 import request from "supertest";
 import notificationsRouter from "../src/routes/notifications";
+import { escapeXml } from "../src/routes/notifications";
 import { computeTwilioSignature } from "../src/middleware/twilioSignature";
 import { signGuestToken, verifyGuestPhone } from "../src/utils/guestToken";
 import { Request, Response, NextFunction } from "express";
@@ -380,6 +381,79 @@ describe("notifications routes", () => {
         expect(response.status).toBe(200);
         expect(response.headers["content-type"]).toContain("text/xml");
         expect(response.text).toContain("unsubscribed");
+    });
+
+    it("returns well-formed TwiML for opt-out with <Response> root element", async () => {
+        const params = { From: "+919876543210", Body: "STOP" };
+        const signature = computeTwilioSignature(
+            "test-auth-token",
+            "http://localhost/api/notifications/twilio-webhook",
+            params
+        );
+
+        const response = await request(app)
+            .post("/api/notifications/twilio-webhook")
+            .type("form")
+            .set("X-Twilio-Signature", signature)
+            .send(params);
+
+        expect(response.status).toBe(200);
+        expect(response.text).toMatch(/<\?xml version="1\.0" encoding="UTF-8"\?>/);
+        expect(response.text).toContain("<Response>");
+        expect(response.text).toContain("</Response>");
+        expect(response.text).toContain("<Message>");
+        expect(response.text).toContain("</Message>");
+    });
+
+    it("returns well-formed TwiML for opt-in (START command)", async () => {
+        const params = { From: "+919876543210", Body: "START" };
+        const signature = computeTwilioSignature(
+            "test-auth-token",
+            "http://localhost/api/notifications/twilio-webhook",
+            params
+        );
+
+        const response = await request(app)
+            .post("/api/notifications/twilio-webhook")
+            .type("form")
+            .set("X-Twilio-Signature", signature)
+            .send(params);
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain("<Response>");
+        expect(response.text).toContain("<Message>");
+        expect(response.text).toContain("Welcome back");
+    });
+
+    it("returns well-formed TwiML for unrecognized command (default reply)", async () => {
+        const params = { From: "+919876543210", Body: "HELLO" };
+        const signature = computeTwilioSignature(
+            "test-auth-token",
+            "http://localhost/api/notifications/twilio-webhook",
+            params
+        );
+
+        const response = await request(app)
+            .post("/api/notifications/twilio-webhook")
+            .type("form")
+            .set("X-Twilio-Signature", signature)
+            .send(params);
+
+        expect(response.status).toBe(200);
+        expect(response.text).toContain("<Response>");
+        expect(response.text).toContain("<Message>");
+        expect(response.text).toContain("Reply STOP to unsubscribe");
+    });
+
+    it("escapes XML-sensitive characters in reply messages (defensive test)", async () => {
+        expect(escapeXml("STOP & START")).toBe("STOP &amp; START");
+        expect(escapeXml("A < B")).toBe("A &lt; B");
+        expect(escapeXml("A > B")).toBe("A &gt; B");
+        expect(escapeXml('"quoted"')).toBe("&quot;quoted&quot;");
+        expect(escapeXml("it's")).toBe("it&apos;s");
+        expect(escapeXml("</Message><XSS>injected</XSS>")).toBe(
+            "&lt;/Message&gt;&lt;XSS&gt;injected&lt;/XSS&gt;"
+        );
     });
 
     it("broadcasts messages to subscribers", async () => {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

* [x] I am assigned to this issue.
* [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

* **Closes #4252**
* **Summary:** Escape XML-sensitive characters in the Twilio webhook `replyMessage` before interpolating it into the TwiML response. Added a reusable `escapeXml` helper and regression coverage to prevent malformed TwiML/XML injection.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> * **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.

Backend-only change — no UI changes or screenshots are applicable.

**Test results:**

```text
npx jest --config jest.config.js tests/notifications.test.ts --forceExit --silent
PASS — 49 passed, 49 total

npx jest --config jest.config.js tests/twilioWebhookSignature.test.ts --forceExit --silent
PASS — 7 passed, 7 total

git diff --check
PASS — no whitespace errors
```

The regression coverage verifies:

* STOP webhook returns valid TwiML structure.
* START webhook returns valid TwiML structure.
* Default webhook response returns valid TwiML structure.
* `&`, `<`, `>`, `"`, and `'` are XML-escaped correctly.
* XML injection payloads cannot break out of the `<Message>` element.

## 🏷️ PR Type

* [x] 🐛 `type: bug`
* [ ] ✨ `type: feature`
* [ ] 📖 `type: docs`
* [x] 🧪 `type: testing`
* [ ] 🔒 `type: security`
* [ ] ⚡ `type: performance`
* [ ] 🎨 `type: design`
* [ ] ♻️ `type: refactor`
* [ ] 🛠️ `type: devops`
* [ ] ♿ `type: accessibility`

## ✅ Checklist

* [x] My PR has a linked issue (`Closes #4252`)
* [x] I have pulled the latest `main` and resolved any conflicts