### PR TITLE
fix(auth): stop mirroring access tokens into localStorage

### DIFF
--- a/apps/web/app/[locale]/admin/pharmacies/page.tsx
+++ b/apps/web/app/[locale]/admin/pharmacies/page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@/i18n/routing";
 import { ADMIN_API_BASE } from "@/lib/adminApi";
+import { getSessionAccessToken } from "@/lib/accessToken";
 import {
     Loader2,
     RefreshCw,
@@ -29,8 +30,7 @@ type Pharmacy = {
 };
 
 function getToken(): string {
-    if (typeof window === "undefined") return "";
-    return localStorage.getItem("sb-access-token") ?? "";
+    return getSessionAccessToken();
 }
 
 function timeAgo(dateStr: string): string {

--- a/apps/web/app/[locale]/admin/pharmacies/pending/page.tsx
+++ b/apps/web/app/[locale]/admin/pharmacies/pending/page.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@/i18n/routing";
 import { ADMIN_API_BASE } from "@/lib/adminApi";
+import { getSessionAccessToken } from "@/lib/accessToken";
 import {
     CheckCircle,
     Clock,
@@ -30,8 +31,7 @@ type PendingPharmacy = {
 };
 
 function getToken(): string {
-    if (globalThis.window === undefined) return "";
-    return localStorage.getItem("sb-access-token") ?? "";
+    return getSessionAccessToken();
 }
 
 function timeAgo(dateStr: string): string {

--- a/apps/web/app/[locale]/admin/synonyms/page.tsx
+++ b/apps/web/app/[locale]/admin/synonyms/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { createBrowserClient } from "@supabase/ssr";
 import { ADMIN_API_BASE } from "@/lib/adminApi";
+import { getSessionAccessToken } from "@/lib/accessToken";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
 import { Loader2, RefreshCw, Trash2, Plus, AlertCircle, FileText, Upload } from "lucide-react";
 import { toast } from "sonner";
@@ -19,8 +20,7 @@ interface OcrSynonym {
 }
 
 function getToken(): string {
-    if (typeof window === "undefined") return "";
-    return localStorage.getItem("sb-access-token") ?? "";
+    return getSessionAccessToken();
 }
 
 /**

--- a/apps/web/app/[locale]/profile/page.tsx
+++ b/apps/web/app/[locale]/profile/page.tsx
@@ -6,11 +6,10 @@ import { Link, useRouter } from "@/i18n/routing";
 import { User, ShieldCheck, Bell, ChevronRight, ArrowLeft, LogIn, LogOut } from "lucide-react";
 import ABHABadge from "@/components/ABHABadge";
 import { useSession } from "@/src/components/AuthProvider";
+import { setSessionAccessToken } from "@/lib/accessToken";
 import { clearReadCache } from "@/lib/offline/db";
 import { createBrowserClient } from "@supabase/ssr";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
-
-const ACCESS_TOKEN_KEY = "sb-access-token";
 
 type ProfileSession =
     | { status: "checking" }
@@ -114,7 +113,7 @@ export default function ProfilePage() {
             const result = readSessionFromToken(token);
 
             if (result.clearToken) {
-                localStorage.removeItem(ACCESS_TOKEN_KEY);
+                setSessionAccessToken(null);
             }
 
             setSession(result.session);
@@ -125,17 +124,16 @@ export default function ProfilePage() {
 
     const handleRetry = () => {
         setSession({ status: "checking" });
-        const token = localStorage.getItem(ACCESS_TOKEN_KEY);
         try {
             const result = readSessionFromToken(token);
-            if (result.clearToken) localStorage.removeItem(ACCESS_TOKEN_KEY);
+            if (result.clearToken) setSessionAccessToken(null);
             setSession(result.session);
         } catch {
             setSession({ status: "error" });
         }
     };
     const handleSignOut = () => {
-        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        setSessionAccessToken(null);
         // Clear the cookie-backed session too. Without this, the middleware
         // keeps seeing a valid session while the app is signed out, which
         // causes protected flows to bounce between login and the app.

--- a/apps/web/app/[locale]/voice/lib/streaming.ts
+++ b/apps/web/app/[locale]/voice/lib/streaming.ts
@@ -3,6 +3,7 @@ import {
     type VoiceTranscriptionPayload,
 } from "./transcription";
 import { API_BASE } from "@/lib/apiConfig";
+import { getSessionAccessToken } from "@/lib/accessToken";
 
 type VoiceStreamingCallback = (payload: VoiceTranscriptionPayload) => void;
 
@@ -43,7 +44,7 @@ export function getVoiceStreamingUrl(baseUrl?: string, ticket?: string) {
  * which lets the caller fall back to recorded upload.
  */
 export async function fetchVoiceStreamTicket(): Promise<string | null> {
-    const token = typeof window === "undefined" ? "" : localStorage.getItem("sb-access-token");
+    const token = getSessionAccessToken();
     if (!token) {
         return null;
     }

--- a/apps/web/components/admin/CacheStatsCard.tsx
+++ b/apps/web/components/admin/CacheStatsCard.tsx
@@ -3,10 +3,10 @@
 import { useEffect, useState } from "react";
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
 import { ADMIN_API_BASE } from "@/lib/adminApi";
+import { getSessionAccessToken } from "@/lib/accessToken";
 
 function getToken(): string {
-    if (typeof window === "undefined") return "";
-    return localStorage.getItem("sb-access-token") ?? "";
+    return getSessionAccessToken();
 }
 
 interface CacheStats {

--- a/apps/web/lib/accessToken.ts
+++ b/apps/web/lib/accessToken.ts
@@ -1,0 +1,30 @@
+/**
+ * Session access token helpers.
+ *
+ * Tokens live in memory (and Supabase's own session store) only.
+ * Never mirror them into localStorage — XSS can otherwise steal the
+ * full bearer for health data via a well-known key like `sb-access-token`.
+ */
+
+const LEGACY_ACCESS_TOKEN_KEY = "sb-access-token";
+
+let memoryAccessToken: string | null = null;
+
+export function clearLegacyAccessTokenStorage(): void {
+    if (typeof window === "undefined") return;
+    try {
+        window.localStorage.removeItem(LEGACY_ACCESS_TOKEN_KEY);
+    } catch {
+        // Private mode / disabled storage — nothing else to do.
+    }
+}
+
+export function setSessionAccessToken(token: string | null): void {
+    memoryAccessToken = token && token.length > 0 ? token : null;
+    clearLegacyAccessTokenStorage();
+}
+
+export function getSessionAccessToken(): string {
+    if (typeof window === "undefined") return "";
+    return memoryAccessToken ?? "";
+}

--- a/apps/web/lib/scheduleApi.ts
+++ b/apps/web/lib/scheduleApi.ts
@@ -1,4 +1,5 @@
 import { API_BASE, getCsrfToken } from "./api";
+import { getSessionAccessToken } from "./accessToken";
 import { fetchWithRetry, offlineRequestQueue, DoseQueuedOfflineError } from "./apiWithRetry";
 import { readCacheGet, readCachePut } from "./offline/db";
 
@@ -47,8 +48,7 @@ export interface AdherenceStats {
 }
 
 function getToken(): string {
-    if (typeof window === "undefined") return "";
-    return localStorage.getItem("sb-access-token") ?? "";
+    return getSessionAccessToken();
 }
 
 /**

--- a/apps/web/src/components/AuthProvider.tsx
+++ b/apps/web/src/components/AuthProvider.tsx
@@ -2,6 +2,7 @@
 
 import { createBrowserClient } from "@supabase/ssr";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
+import { setSessionAccessToken } from "@/lib/accessToken";
 import { createContext, useContext, useEffect, useState, useMemo, type ReactNode } from "react";
 import type { Session } from "@supabase/supabase-js";
 import { clearSyncQueueForLogout, registerCurrentUser } from "@/lib/syncUserScoping";
@@ -35,11 +36,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 const s = data.session ?? null;
                 setSession(s);
                 setIsLoading(false);
-                if (s?.access_token) {
-                    localStorage.setItem("sb-access-token", s.access_token);
-                } else {
-                    localStorage.removeItem("sb-access-token");
-                }
+                setSessionAccessToken(s?.access_token ?? null);
                 syncServiceWorkerSession(s);
             })
             .catch((err) => {
@@ -48,7 +45,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 // treat an unreadable session as signed-out so protected pages
                 // render their graceful re-authentication state.
                 setIsLoading(false);
-                localStorage.removeItem("sb-access-token");
+                setSessionAccessToken(null);
                 syncServiceWorkerSession(null);
             });
 
@@ -56,11 +53,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             data: { subscription },
         } = supabase.auth.onAuthStateChange((_event, session) => {
             setSession(session);
-            if (session?.access_token) {
-                localStorage.setItem("sb-access-token", session.access_token);
-            } else {
-                localStorage.removeItem("sb-access-token");
-            }
+            setSessionAccessToken(session?.access_token ?? null);
             syncServiceWorkerSession(session);
         });
 

--- a/apps/web/tests/admin-dashboard-role-gating.test.tsx
+++ b/apps/web/tests/admin-dashboard-role-gating.test.tsx
@@ -145,7 +145,6 @@ describe("AdminDashboard role-based mutation controls", () => {
     beforeEach(() => {
         mockSessionRole = null;
         mockGetSession.mockClear();
-        localStorage.setItem("sb-access-token", "test-token");
         Object.defineProperty(global, "fetch", {
             configurable: true,
             writable: true,

--- a/apps/web/tests/auth-provider-sync-scoping.test.tsx
+++ b/apps/web/tests/auth-provider-sync-scoping.test.tsx
@@ -68,6 +68,7 @@ describe("AuthProvider sync queue user-scoping", () => {
 
         expect(registerCurrentUser).toHaveBeenCalledWith("user-A");
         expect(clearSyncQueueForLogout).not.toHaveBeenCalled();
+        expect(localStorage.getItem("sb-access-token")).toBeNull();
     });
 
     it("clears the queue and unregisters the user when the session ends", async () => {

--- a/apps/web/tests/profile-auth-status.test.tsx
+++ b/apps/web/tests/profile-auth-status.test.tsx
@@ -5,6 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { TextDecoder as NodeTextDecoder } from "util";
 
 import ProfilePage from "../app/[locale]/profile/page";
+import { setSessionAccessToken, getSessionAccessToken } from "@/lib/accessToken";
 
 const mockPush = jest.fn();
 let mockToken: string | null = null;
@@ -84,6 +85,7 @@ describe("ProfilePage auth status", () => {
         }
 
         localStorage.clear();
+        setSessionAccessToken(null);
         mockToken = null;
         mockPush.mockClear();
     });
@@ -123,6 +125,7 @@ describe("ProfilePage auth status", () => {
 
     it("clears malformed access tokens instead of rendering them", async () => {
         mockToken = "not-a-valid-jwt";
+        setSessionAccessToken("not-a-valid-jwt");
         localStorage.setItem("sb-access-token", "not-a-valid-jwt");
 
         render(<ProfilePage />);
@@ -132,6 +135,7 @@ describe("ProfilePage auth status", () => {
             "href",
             "/login"
         );
+        expect(getSessionAccessToken()).toBe("");
         expect(localStorage.getItem("sb-access-token")).toBeNull();
         expect(document.body).not.toHaveTextContent("not-a-valid-jwt");
     });
@@ -142,12 +146,14 @@ describe("ProfilePage auth status", () => {
             exp: Math.floor(Date.now() / 1000) - 60,
         });
         mockToken = token;
+        setSessionAccessToken(token);
         localStorage.setItem("sb-access-token", token);
 
         render(<ProfilePage />);
 
         expect(await screen.findByText("Guest User")).toBeInTheDocument();
         expect(screen.getByText("No account connected")).toBeInTheDocument();
+        expect(getSessionAccessToken()).toBe("");
         expect(localStorage.getItem("sb-access-token")).toBeNull();
     });
 
@@ -157,12 +163,14 @@ describe("ProfilePage auth status", () => {
             exp: Math.floor(Date.now() / 1000) + 3600,
         });
         mockToken = token;
+        setSessionAccessToken(token);
         localStorage.setItem("sb-access-token", token);
 
         render(<ProfilePage />);
 
         fireEvent.click(await screen.findByRole("button", { name: /sign out/i }));
 
+        expect(getSessionAccessToken()).toBe("");
         expect(localStorage.getItem("sb-access-token")).toBeNull();
         expect(mockPush).toHaveBeenCalledWith("/");
 

--- a/apps/web/tests/scheduleApi.test.ts
+++ b/apps/web/tests/scheduleApi.test.ts
@@ -20,6 +20,7 @@ import {
     type Schedule,
     type TodaySchedule,
 } from "@/lib/scheduleApi";
+import { setSessionAccessToken } from "@/lib/accessToken";
 import { getCsrfToken } from "@/lib/api";
 import { fetchWithRetry } from "@/lib/apiWithRetry";
 
@@ -44,6 +45,7 @@ describe("scheduleApi", () => {
             writable: true,
         });
         localStorage.clear();
+        setSessionAccessToken(null);
         mockGetCsrfToken.mockReset();
         mockGetCsrfToken.mockResolvedValue("csrf-token-123");
         mockFetchWithRetry.mockReset();
@@ -87,7 +89,7 @@ describe("scheduleApi", () => {
     });
 
     it("sends createSchedule as a JSON POST with auth headers", async () => {
-        localStorage.setItem("sb-access-token", "token-123");
+        setSessionAccessToken("token-123");
         const payload = {
             medicine_name: "Paracetamol",
             dosage: "500mg",
@@ -119,7 +121,7 @@ describe("scheduleApi", () => {
     });
 
     it("adds CSRF protection to schedule updates and deletions", async () => {
-        localStorage.setItem("sb-access-token", "token-123");
+        setSessionAccessToken("token-123");
         mockFetchWithRetry
             .mockResolvedValueOnce({
                 ok: true,
@@ -172,7 +174,7 @@ describe("scheduleApi", () => {
             created_at: "2027-01-01T09:00:00Z",
             ...dosePayload,
         };
-        localStorage.setItem("sb-access-token", "token-123");
+        setSessionAccessToken("token-123");
         mockFetchWithRetry.mockResolvedValueOnce({
             ok: true,
             json: async () => ({ dose: createdDose }),


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## PR Summary & Link

- **Closes #4257** (reopened from #4168)
- **Summary:** AuthProvider no longer writes `sb-access-token` to localStorage. Session bearer stays in memory / Supabase session; callers use `getSessionAccessToken()`. Leftover localStorage keys are cleared.

## Proof of Work (Screenshots / Logs)

```
PASS tests/scheduleApi.test.ts
PASS tests/admin-dashboard-role-gating.test.tsx
PASS tests/profile-auth-status.test.tsx
PASS tests/auth-provider-sync-scoping.test.tsx
Tests: 18 passed
```

## PR Type

- [x] `type: bug`
- [x] `type: security`

## Checklist

- [x] My PR has a linked issue (`Closes #4257`)
- [x] I have pulled the latest `main` and resolved any conflicts

Made with [Cursor](https://cursor.com)