### PR TITLE
fix(abha): keep ABDM tokens server-side after OTP verify

### DIFF
--- a/apps/api/src/services/abha.service.ts
+++ b/apps/api/src/services/abha.service.ts
@@ -68,7 +68,7 @@ export const verifyOTP = async (
     abhaAddress: string,
     txnId: string,
     otp: string
-): Promise<{ token: string }> => {
+): Promise<{ linked: true }> => {
     logger.info("ABHA OTP verification requested", {
         userId,
         txnId,
@@ -127,8 +127,10 @@ export const verifyOTP = async (
         status: "SUCCESS",
     });
 
+    // Keep the ABDM bearer server-side only (encrypted at rest). Returning it
+    // to the browser lets XSS/devtools exfiltrate health-record credentials.
     return {
-        token,
+        linked: true,
     };
 };
 

--- a/apps/api/tests/abha.routes.test.ts
+++ b/apps/api/tests/abha.routes.test.ts
@@ -27,7 +27,7 @@ jest.mock("../src/middleware/auth", () => ({
 
 jest.mock("../src/services/abha.service", () => ({
     generateOTP: jest.fn().mockResolvedValue({ txnId: "mock-txn-id" }),
-    verifyOTP: jest.fn().mockResolvedValue({ token: "mock-token" }),
+    verifyOTP: jest.fn().mockResolvedValue({ linked: true }),
     uploadVerification: jest.fn().mockResolvedValue({ success: true }),
     getPrescriptions: jest.fn().mockResolvedValue([]),
     unlinkABHA: jest.fn().mockResolvedValue({ success: true }),
@@ -140,7 +140,8 @@ describe("POST /api/v1/abha/verify-otp", () => {
             .post("/api/v1/abha/verify-otp")
             .send({ abhaAddress: "testuser@abdm", txnId: "txn-1", otp: "123456" });
         expect(response.status).toBe(200);
-        expect(response.body.token).toBe("mock-token");
+        expect(response.body.linked).toBe(true);
+        expect(response.body.token).toBeUndefined();
     });
 });
 

--- a/apps/api/tests/abha.service.test.ts
+++ b/apps/api/tests/abha.service.test.ts
@@ -119,7 +119,7 @@ describe("ABHA service ABDM sandbox integration", () => {
         expect(otpRequestBody.loginId.length).toBeGreaterThan(100);
     });
 
-    it("verifies an ABHA OTP and keeps the token response contract stable", async () => {
+    it("verifies an ABHA OTP and does not return the ABDM token to the client", async () => {
         fetchMock
             .mockResolvedValueOnce(jsonResponse(200, { accessToken: "session-access-token" }))
             .mockResolvedValueOnce(
@@ -133,7 +133,7 @@ describe("ABHA service ABDM sandbox integration", () => {
         await expect(
             verifyOTP("test-user-id", "test@sbx", "otp-txn-id", "123456")
         ).resolves.toEqual({
-            token: "abha-login-token",
+            linked: true,
         });
 
         expect(fetchMock).toHaveBeenNthCalledWith(

--- a/apps/web/lib/api/abha.ts
+++ b/apps/web/lib/api/abha.ts
@@ -6,7 +6,7 @@ export type { ABHALinkResponse, ABHAPrescription, ABHAVerificationData };
 // ─── Interfaces ───────────────────────────────────────────────────────────────
 
 export interface ABHAVerifyResponse {
-    token: string;
+    linked: true;
 }
 
 export interface ABHAUploadResponse {


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## PR Summary & Link

- **Closes #4258** (reopened from #4180)
- **Summary:** `verifyOTP` still encrypts and stores the ABDM bearer, but the API response is now `{ linked: true }` — no plaintext token to the browser.

## Proof of Work (Screenshots / Logs)

```
PASS tests/abha.routes.test.ts
PASS tests/abha.service.test.ts
Tests: 23 passed
```

## PR Type

- [x] `type: bug`
- [x] `type: security`

## Checklist

- [x] My PR has a linked issue (`Closes #4258`)
- [x] I have pulled the latest `main` and resolved any conflicts

Made with [Cursor](https://cursor.com)