### PR TITLE
fix(abha): encrypt stored tokens with AES-256-GCM

### DIFF
--- a/apps/api/src/services/abha.service.ts
+++ b/apps/api/src/services/abha.service.ts
@@ -315,13 +315,17 @@ export function encryptToken(
     token: string,
     secret?: string
 ): { encryptedToken: string; iv: string; salt: string } {
-    const iv = crypto.randomBytes(16);
+    const iv = crypto.randomBytes(12);
     const salt = crypto.randomBytes(16);
-    const key = crypto.scryptSync(secret || getRequiredEnv("ABDM_SANDBOX_CLIENT_SECRET"), salt, 32);
-    const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
-    let encryptedToken = cipher.update(token, "utf8", "hex");
-    encryptedToken += cipher.final("hex");
-    return { encryptedToken, iv: iv.toString("hex"), salt: salt.toString("hex") };
+    const key = crypto.scryptSync(resolveTokenEncryptionSecret(secret), salt, 32);
+    const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+    const encrypted = Buffer.concat([cipher.update(token, "utf8"), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    return {
+        encryptedToken: `gcm:${Buffer.concat([encrypted, tag]).toString("hex")}`,
+        iv: iv.toString("hex"),
+        salt: salt.toString("hex"),
+    };
 }
 
 export function decryptToken(
@@ -330,13 +334,63 @@ export function decryptToken(
     saltHex: string,
     secret?: string
 ): string {
+    if (encryptedToken.startsWith("gcm:")) {
+        return decryptTokenGcm(encryptedToken.slice(4), ivHex, saltHex, secret);
+    }
+
+    // Legacy CBC records written before authenticated encryption.
+    return decryptTokenCbc(encryptedToken, ivHex, saltHex, secret);
+}
+
+function decryptTokenGcm(
+    ciphertextHex: string,
+    ivHex: string,
+    saltHex: string,
+    secret?: string
+): string {
+    const payload = Buffer.from(ciphertextHex, "hex");
+    if (payload.length <= 16) {
+        throw new Error("Invalid GCM ciphertext");
+    }
+
+    const encrypted = payload.subarray(0, payload.length - 16);
+    const tag = payload.subarray(payload.length - 16);
     const iv = Buffer.from(ivHex, "hex");
     const salt = Buffer.from(saltHex, "hex");
-    const key = crypto.scryptSync(secret || getRequiredEnv("ABDM_SANDBOX_CLIENT_SECRET"), salt, 32);
+    const key = crypto.scryptSync(resolveTokenEncryptionSecret(secret), salt, 32);
+    const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString("utf8");
+}
+
+function decryptTokenCbc(
+    encryptedToken: string,
+    ivHex: string,
+    saltHex: string,
+    secret?: string
+): string {
+    const iv = Buffer.from(ivHex, "hex");
+    const salt = Buffer.from(saltHex, "hex");
+    const key = crypto.scryptSync(resolveTokenEncryptionSecret(secret), salt, 32);
     const decipher = crypto.createDecipheriv("aes-256-cbc", key, iv);
     let decrypted = decipher.update(encryptedToken, "hex", "utf8");
     decrypted += decipher.final("utf8");
     return decrypted;
+}
+
+function resolveTokenEncryptionSecret(secret?: string): string {
+    if (secret?.trim()) {
+        return secret.trim();
+    }
+
+    const dedicated = process.env.ABHA_TOKEN_ENCRYPTION_KEY?.trim();
+    if (dedicated) {
+        return dedicated;
+    }
+
+    // Fall back to the ABDM client secret only when a dedicated key is unset
+    // (local/dev). Production should set ABHA_TOKEN_ENCRYPTION_KEY.
+    return getRequiredEnv("ABDM_SANDBOX_CLIENT_SECRET");
 }
 
 const isMappedAbdmError = (message: string): boolean =>

--- a/apps/api/tests/abha.service.test.ts
+++ b/apps/api/tests/abha.service.test.ts
@@ -1,5 +1,12 @@
 import { generateKeyPairSync } from "node:crypto";
-import { generateOTP, verifyOTP, resetAbdmPublicKeyCache } from "../src/services/abha.service";
+import crypto from "node:crypto";
+import {
+    generateOTP,
+    verifyOTP,
+    resetAbdmPublicKeyCache,
+    encryptToken,
+    decryptToken,
+} from "../src/services/abha.service";
 
 jest.mock("../src/utils/logger", () => ({
     __esModule: true,
@@ -201,6 +208,49 @@ describe("ABHA service ABDM sandbox integration", () => {
         await expect(generateOTP("deepak@sbx")).rejects.toThrow(
             "ABDM sandbox request failed: getaddrinfo ENOTFOUND"
         );
+    });
+});
+
+describe("ABHA token encryption", () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = {
+            ...originalEnv,
+            ABHA_TOKEN_ENCRYPTION_KEY: "dedicated-abha-encryption-key",
+            ABDM_SANDBOX_CLIENT_SECRET: "sandbox-client-secret",
+        };
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
+    it("round-trips with AES-256-GCM and a dedicated key", () => {
+        const { encryptedToken, iv, salt } = encryptToken("abdm-bearer-token");
+
+        expect(encryptedToken.startsWith("gcm:")).toBe(true);
+        expect(decryptToken(encryptedToken, iv, salt)).toBe("abdm-bearer-token");
+    });
+
+    it("rejects tampered GCM ciphertext", () => {
+        const { encryptedToken, iv, salt } = encryptToken("abdm-bearer-token");
+        const tampered = `${encryptedToken.slice(0, -2)}ff`;
+
+        expect(() => decryptToken(tampered, iv, salt)).toThrow();
+    });
+
+    it("still decrypts legacy AES-CBC payloads", () => {
+        const iv = crypto.randomBytes(16);
+        const salt = crypto.randomBytes(16);
+        const key = crypto.scryptSync("legacy-secret", salt, 32);
+        const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
+        let encryptedToken = cipher.update("legacy-abdm-token", "utf8", "hex");
+        encryptedToken += cipher.final("hex");
+
+        expect(
+            decryptToken(encryptedToken, iv.toString("hex"), salt.toString("hex"), "legacy-secret")
+        ).toBe("legacy-abdm-token");
     });
 });
 


### PR DESCRIPTION
### STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## PR Summary & Link

- **Closes #4259** (reopened from #4181; replaces closed #4262)
- **Summary:** Token-at-rest crypto moves from AES-CBC to AES-256-GCM. Prefers `ABHA_TOKEN_ENCRYPTION_KEY` when set, otherwise falls back to the existing ABDM client secret. Legacy CBC rows still decrypt; new writes are GCM-only. No `.env.example` changes.

## Proof of Work (Screenshots / Logs)

```
PASS tests/abha.service.test.ts
Tests: 9 passed (GCM round-trip, tamper reject, CBC legacy decrypt)
```

## PR Type

- [x] `type: bug`
- [x] `type: security`

## Checklist

- [x] My PR has a linked issue (`Closes #4259`)
- [x] I have pulled the latest `main` and resolved any conflicts

Made with [Cursor](https://cursor.com)