### PR TITLE
fix: parse alert_type to prevent indiscriminate counterfeit labeling on NSQ alerts

### DIFF
--- a/apps/api/src/routes/alerts.ts
+++ b/apps/api/src/routes/alerts.ts
@@ -246,8 +246,10 @@ alertsRouter.post(
             //   - byBrandName:    alerts that have only a brand name (no manufacturer)
             // Each bucket is resolved in a single UPDATE ... WHERE batch_number IN (...)
             // query, capping the total number of DB round-trips at 2 regardless of N.
-            const byManufacturer = new Map<string, string[]>(); // manufacturer -> batch_numbers[]
-            const byBrandName = new Map<string, string[]>(); // brand_name -> batch_numbers[]
+            const byManufacturerCounterfeit = new Map<string, string[]>();
+            const byManufacturerNSQ = new Map<string, string[]>();
+            const byBrandNameCounterfeit = new Map<string, string[]>();
+            const byBrandNameNSQ = new Map<string, string[]>();
             const noBatchAlerts: typeof validatedAlerts = [];
 
             for (const alert of validatedAlerts) {
@@ -255,44 +257,49 @@ alertsRouter.post(
                     noBatchAlerts.push(alert);
                     continue;
                 }
+                
+                const typeStr = (alert.alert_type || "").toLowerCase();
+                const isCounterfeit = typeStr.includes("counterfeit") || typeStr.includes("spurious");
+                
                 if (alert.manufacturer) {
-                    if (!byManufacturer.has(alert.manufacturer)) {
-                        byManufacturer.set(alert.manufacturer, []);
+                    const map = isCounterfeit ? byManufacturerCounterfeit : byManufacturerNSQ;
+                    if (!map.has(alert.manufacturer)) {
+                        map.set(alert.manufacturer, []);
                     }
-                    byManufacturer.get(alert.manufacturer)!.push(alert.batch_number);
+                    map.get(alert.manufacturer)!.push(alert.batch_number);
                 } else if (alert.reported_brand_name) {
-                    if (!byBrandName.has(alert.reported_brand_name)) {
-                        byBrandName.set(alert.reported_brand_name, []);
+                    const map = isCounterfeit ? byBrandNameCounterfeit : byBrandNameNSQ;
+                    if (!map.has(alert.reported_brand_name)) {
+                        map.set(alert.reported_brand_name, []);
                     }
-                    byBrandName.get(alert.reported_brand_name)!.push(alert.batch_number);
+                    map.get(alert.reported_brand_name)!.push(alert.batch_number);
                 }
             }
 
             const batchUpdatePromises: Promise<unknown>[] = [];
 
-            for (const [manufacturer, batchNumbers] of byManufacturer) {
-                batchUpdatePromises.push(
-                    Promise.resolve(
-                        supabase
-                            .from("medicines")
-                            .update({ status: medicineStatus, is_counterfeit_alert: true })
-                            .in("batch_number", batchNumbers)
-                            .eq("manufacturer", manufacturer)
-                    )
-                );
-            }
+            const pushUpdates = (
+                map: Map<string, string[]>, 
+                isCounterfeit: boolean, 
+                field: "manufacturer" | "brand_name"
+            ) => {
+                for (const [key, batchNumbers] of map) {
+                    batchUpdatePromises.push(
+                        Promise.resolve(
+                            supabase
+                                .from("medicines")
+                                .update({ status: medicineStatus, is_counterfeit_alert: isCounterfeit })
+                                .in("batch_number", batchNumbers)
+                                .eq(field === "brand_name" ? "brand_name" : "manufacturer", key)
+                        )
+                    );
+                }
+            };
 
-            for (const [brandName, batchNumbers] of byBrandName) {
-                batchUpdatePromises.push(
-                    Promise.resolve(
-                        supabase
-                            .from("medicines")
-                            .update({ status: medicineStatus, is_counterfeit_alert: true })
-                            .in("batch_number", batchNumbers)
-                            .eq("brand_name", brandName)
-                    )
-                );
-            }
+            pushUpdates(byManufacturerCounterfeit, true, "manufacturer");
+            pushUpdates(byManufacturerNSQ, false, "manufacturer");
+            pushUpdates(byBrandNameCounterfeit, true, "brand_name");
+            pushUpdates(byBrandNameNSQ, false, "brand_name");
 
             await Promise.all(batchUpdatePromises);
 


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4214 **
- **Summary:** Updated the `POST /ingest` endpoint in `alerts.ts` to respect the `alert_type` provided in the CDSCO payload. It now dynamically checks if the alert type contains "counterfeit" or "spurious". Medicines are then appropriately grouped into buckets and batch-updated so that only genuine counterfeit/spurious drugs are flagged with `is_counterfeit_alert: true`, while Not of Standard Quality (NSQ) drugs correctly receive `is_counterfeit_alert: false`.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_
*(Note: As this is a backend logic fix without UI changes, I have successfully run the backend build and type checks to confirm the code compiles correctly.)*

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4214`)
- [x] I have pulled the latest `main` and resolved any conflicts