### PR TITLE
fix(api): wire SMS worker into API background jobs and await graceful shutdown

### DIFF
--- a/apps/api/src/gracefulShutdown.ts
+++ b/apps/api/src/gracefulShutdown.ts
@@ -95,7 +95,7 @@ export function createGracefulShutdown(server: Server, options: ShutdownOptions 
         timeout.unref();
 
         try {
-            jobScheduler.shutdown();
+            await jobScheduler.shutdown();
             logger.info("Background jobs stopped during graceful shutdown", { reason });
 
             await closeServer(server);

--- a/apps/api/src/services/jobScheduler.service.ts
+++ b/apps/api/src/services/jobScheduler.service.ts
@@ -4,9 +4,10 @@ import { startTempCleanupJob } from "../cron/tempCleanup";
 import { initExpiryCron } from "../cron/expiry-check";
 import { initDistrictAlertSyncCron } from "../cron/districtAlertSync";
 import { startPgCronMonitor } from "../cron/pgCronMonitor";
+import { startSmsWorker } from "../workers/smsWorker";
 
 interface StoppableJob {
-    stop: () => void;
+    stop: () => void | Promise<void>;
 }
 
 class JobScheduler {
@@ -23,11 +24,12 @@ class JobScheduler {
         this.jobs.push(initExpiryCron());
         this.jobs.push(initDistrictAlertSyncCron());
         this.jobs.push(startPgCronMonitor());
+        this.jobs.push(startSmsWorker());
         logger.info("All background jobs have been started.");
     }
 
-    public shutdown(): void {
-        this.jobs.forEach((job) => job.stop());
+    public async shutdown(): Promise<void> {
+        await Promise.all(this.jobs.map((job) => job.stop()));
         logger.info("All background jobs have been stopped.");
         this.jobs = [];
     }

--- a/apps/api/src/workers/smsWorker.ts
+++ b/apps/api/src/workers/smsWorker.ts
@@ -59,16 +59,55 @@ export async function processSmsJob(job: Job): Promise<void> {
     throw new Error(`Twilio SMS API error: ${response.status} ${errText}`);
 }
 
-const connection = new IORedis(process.env.REDIS_URL as string, { maxRetriesPerRequest: null });
+let worker: Worker | null = null;
+let connection: IORedis | null = null;
 
-new Worker(
-    "sms-queue",
-    async (job: Job) => {
-        await processSmsJob(job);
-    },
-    {
-        connection: connection as any,
+export function startSmsWorker(): { stop: () => Promise<void> } {
+    if (process.env.NODE_ENV === "test") {
+        logger.info("SMS Worker disabled in test environment.");
+        return { stop: async () => {} };
     }
-);
 
-logger.info("SMS Worker started");
+    if (worker) {
+        logger.warn("SMS Worker already started.");
+        return { stop: async () => {} };
+    }
+
+    const redisUrl = process.env.REDIS_URL;
+    if (!redisUrl) {
+        throw new Error("REDIS_URL is required to start the SMS Worker.");
+    }
+
+    connection = new IORedis(redisUrl, { maxRetriesPerRequest: null });
+    worker = new Worker(
+        "sms-queue",
+        async (job: Job) => {
+            await processSmsJob(job);
+        },
+        {
+            connection: connection as any,
+        }
+    );
+
+    worker.on("failed", (failedJob, error) => {
+        logger.error(
+            `SMS Worker job failed for ${failedJob.id}: ${error?.message ?? error}`
+        );
+    });
+
+    logger.info("SMS Worker started");
+
+    return {
+        stop: async () => {
+            if (worker) {
+                await worker.close();
+                worker = null;
+            }
+            if (connection) {
+                connection.disconnect();
+                connection = null;
+            }
+            logger.info("SMS Worker stopped");
+        },
+    };
+}

--- a/apps/api/tests/jobScheduler.test.ts
+++ b/apps/api/tests/jobScheduler.test.ts
@@ -1,0 +1,42 @@
+import { jobScheduler } from "../src/services/jobScheduler.service";
+import * as smsWorkerModule from "../src/workers/smsWorker";
+
+jest.mock("../src/cron/alert-broadcaster", () => ({
+    startAlertBroadcaster: () => ({ stop: () => {} }),
+}));
+jest.mock("../src/cron/tempCleanup", () => ({
+    startTempCleanupJob: () => ({ stop: () => {} }),
+}));
+jest.mock("../src/cron/expiry-check", () => ({
+    initExpiryCron: () => ({ stop: () => {} }),
+}));
+jest.mock("../src/cron/districtAlertSync", () => ({
+    initDistrictAlertSyncCron: () => ({ stop: () => {} }),
+}));
+jest.mock("../src/cron/pgCronMonitor", () => ({
+    startPgCronMonitor: () => ({ stop: () => {} }),
+}));
+
+const startSmsWorkerMock = jest.spyOn(smsWorkerModule, "startSmsWorker").mockImplementation(() => ({
+    stop: () => {},
+}));
+
+afterEach(() => {
+    startSmsWorkerMock.mockClear();
+    jobScheduler.shutdown();
+});
+
+describe("JobScheduler", () => {
+    it("starts the SMS worker when background jobs are started", () => {
+        jobScheduler.start();
+
+        expect(startSmsWorkerMock).toHaveBeenCalled();
+    });
+
+    it("does not start the SMS worker twice when start is called again", () => {
+        jobScheduler.start();
+        jobScheduler.start();
+
+        expect(startSmsWorkerMock).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4247**
- **Summary:**
Fix Applied
What changed
[smsWorker.ts](vscode-file://vscode-app/c:/Users/KIRTAN/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Converted SMS worker from module-load side effect into a managed [startSmsWorker()](vscode-file://vscode-app/c:/Users/KIRTAN/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html) function.
Added [stop()](vscode-file://vscode-app/c:/Users/KIRTAN/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html) logic to cleanly close BullMQ worker and Redis connection.
Disabled actual worker startup in [NODE_ENV=test](vscode-file://vscode-app/c:/Users/KIRTAN/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
[jobScheduler.service.ts](vscode-file://vscode-app/c:/Users/KIRTAN/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Imported and started the SMS worker alongside the existing cron jobs.
Updated shutdown support to tolerate async stop functions.
[gracefulShutdown.ts](vscode-file://vscode-app/c:/Users/KIRTAN/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Awaited [jobScheduler.shutdown()](vscode-file://vscode-app/c:/Users/KIRTAN/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to ensure background jobs stop cleanly during termination.
[jobScheduler.test.ts](vscode-file://vscode-app/c:/Users/KIRTAN/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Added regression coverage verifying the SMS worker is started by the job scheduler.
Validation
Ran API tests: npm exec --workspace apps/api -- jest --forceExit --silent jobScheduler.test.ts apps/api/tests/smsWorker.test.ts
Result: 2 passed



## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4247`)
- [x] I have pulled the latest `main` and resolved any conflicts
