### PR TITLE
fix(db): drop stale district-only index for district_alerts uniqueness migration

### DIFF
--- a/supabase/migrations/20260627000001_fix_district_alerts_uniqueness.sql
+++ b/supabase/migrations/20260627000001_fix_district_alerts_uniqueness.sql
@@ -65,6 +65,8 @@ END $$;
 ALTER TABLE district_alerts
     DROP CONSTRAINT IF EXISTS district_alerts_district_key;
 
+DROP INDEX IF EXISTS public.idx_district_alerts_district_unique;
+
 ALTER TABLE district_alerts
     ADD CONSTRAINT district_alerts_district_medicine_key
     UNIQUE (district, medicine_name);


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4249**
- **Summary:**
**What changed**
Updated [20260627000001_fix_district_alerts_uniqueness.sql](vscode-file://vscode-app/c:/Users/KIRTAN/AppData/Local/Programs/Microsoft%20VS%20Code/df53daabb1/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Added DROP INDEX IF EXISTS public.idx_district_alerts_district_unique; before creating the composite unique constraint on (district, medicine_name)
**Why**
The existing migration dropped only a nonexistent constraint
The stale district-only unique index remained and still blocked second medicine alerts per district
This fix allows the intended ON CONFLICT (district, medicine_name) upserts to succeed
**Branch**
Branch created and pushed: fix/district-alerts-uniqueness
PR URL: https://github.com/Kirtan-pc/sahidawa-india/pull/new/fix/district-alerts-uniqueness

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4249`)
- [x] I have pulled the latest `main` and resolved any conflicts
