### PR TITLE
fix(api): stem-match emergency keywords so inflected phrasing isn't missed

### DIFF
--- a/apps/api/src/services/medicineRag.service.ts
+++ b/apps/api/src/services/medicineRag.service.ts
@@ -35,20 +35,30 @@ export const MEDICINE_RAG_DISCLAIMER =
  * self-medicate. Kept intentionally small and language-light; the voice flow
  * already runs richer multilingual emergency detection on the client.
  */
-const EMERGENCY_KEYWORDS = [
-    "chest pain",
-    "heart attack",
-    "stroke",
-    "unconscious",
-    "not breathing",
-    "difficulty breathing",
-    "shortness of breath",
-    "severe bleeding",
-    "suicide",
-    "seizure",
-    "paralysis",
-    "fainting",
-    "high fever",
+// Each keyword pairs a canonical label (returned in `matched`, so consumers keep
+// seeing readable words rather than stems) with a word-boundary regex. Stems are
+// used where common inflected forms would otherwise be missed — e.g. "suicidal"
+// did not match a plain "suicide" substring, and "can't breathe" did not match
+// any breathing phrase. The leading \b avoids matching a stem inside an unrelated
+// word (e.g. "keystroke" no longer trips "stroke").
+const EMERGENCY_KEYWORDS: { keyword: string; pattern: RegExp }[] = [
+    { keyword: "chest pain", pattern: /\bchest pain/ },
+    { keyword: "heart attack", pattern: /\bheart attack/ },
+    { keyword: "stroke", pattern: /\bstroke/ },
+    { keyword: "unconscious", pattern: /\bunconscious/ },
+    // "breath" stem covers "not breathing", "difficulty breathing", "shortness of
+    // breath", and "can't"/"cannot"/"cant breathe" (all start with "breath").
+    { keyword: "difficulty breathing", pattern: /\bbreath/ },
+    { keyword: "severe bleeding", pattern: /\bsevere bleeding/ },
+    // "suicid" stem → suicidal, suicide(s), suicided.
+    { keyword: "suicide", pattern: /\bsuicid/ },
+    // "seizur" stem → seizure(s).
+    { keyword: "seizure", pattern: /\bseizur/ },
+    // "paraly" stem → paralysis, paralyzed, paralyzing.
+    { keyword: "paralysis", pattern: /\bparaly/ },
+    // "faint" stem → faint, fainted, fainting, faints.
+    { keyword: "fainting", pattern: /\bfaint/ },
+    { keyword: "high fever", pattern: /\bhigh fever/ },
 ];
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -180,7 +190,9 @@ export function formatMedicineMatch(row: MedicineRow): MedicineMatch {
  */
 export function assessUrgency(text: string): UrgencyAssessment {
     const normalized = text.toLowerCase();
-    const matched = EMERGENCY_KEYWORDS.filter((keyword) => normalized.includes(keyword));
+    const matched = EMERGENCY_KEYWORDS.filter(({ pattern }) => pattern.test(normalized)).map(
+        ({ keyword }) => keyword
+    );
     return { emergency: matched.length > 0, matched };
 }
 

--- a/apps/api/tests/triage.test.ts
+++ b/apps/api/tests/triage.test.ts
@@ -4,7 +4,8 @@ process.env.SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || "test-anon-key"
 // null so the deterministic pg_trgm fallback is exercised instead of network.
 delete process.env.GEMINI_API_KEY;
 
-(globalThis as unknown as { WebSocket: any }).WebSocket = (globalThis as unknown as { WebSocket: any }).WebSocket || class {};
+(globalThis as unknown as { WebSocket: any }).WebSocket =
+    (globalThis as unknown as { WebSocket: any }).WebSocket || class {};
 
 jest.mock("../src/db/client", () => ({
     supabase: {
@@ -79,6 +80,27 @@ describe("medicineRag pure helpers", () => {
     it("flags urgent-care keywords", () => {
         expect(assessUrgency("I have severe chest pain").emergency).toBe(true);
         expect(assessUrgency("mild headache and runny nose").emergency).toBe(false);
+    });
+
+    it("flags inflected variants of emergency keywords via stem matching", () => {
+        // Each of these previously slipped past exact-substring matching.
+        expect(assessUrgency("I feel suicidal").emergency).toBe(true);
+        expect(assessUrgency("can't breathe").emergency).toBe(true);
+        expect(assessUrgency("she fainted").emergency).toBe(true);
+        expect(assessUrgency("having a seizure right now").emergency).toBe(true);
+        expect(assessUrgency("left arm is paralyzed").emergency).toBe(true);
+    });
+
+    it("still returns readable canonical keywords in matched, not stems", () => {
+        expect(assessUrgency("I feel suicidal").matched).toContain("suicide");
+        expect(assessUrgency("cannot breathe").matched).toContain("difficulty breathing");
+        expect(assessUrgency("left arm is paralyzed").matched).toContain("paralysis");
+    });
+
+    it("does not flag ordinary, non-urgent phrasing", () => {
+        expect(assessUrgency("mild headache and runny nose").emergency).toBe(false);
+        // "keystroke" must not trip the "stroke" keyword now that \b guards it.
+        expect(assessUrgency("I pressed the wrong keystroke").emergency).toBe(false);
     });
 
     it("returns null from embedQuery when no API key is configured", async () => {


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link

- **Closes #** <issue-number-if-any>
- **Summary:** `assessUrgency` in `apps/api/src/services/medicineRag.service.ts` used exact substring matching against `EMERGENCY_KEYWORDS`, producing dangerous false negatives on common phrasing — most critically **"I feel suicidal" did not match "suicide"** (they diverge at the 7th character), and "can't breathe" / "fainted" matched nothing either.
  - Replaced the `includes()` check with **word-boundary regex matching**. `EMERGENCY_KEYWORDS` is now a list of `{ keyword, pattern }`, pairing each canonical label with a stem/prefix pattern:
    - `\bsuicid` → suicidal, suicide(s), suicided
    - `\bfaint` → faint, fainted, fainting, faints
    - `\bbreath` → not breathing, difficulty breathing, shortness of breath, **and** can't / cannot / cant breathe (all start with "breath")
    - `\bseizur` → seizure(s); `\bparaly` → paralysis, paralyzed, paralyzing
  - The leading `\b` stops a stem from matching inside an unrelated word — so `"keystroke"` no longer trips `"stroke"` (which the old `includes()` **would** have).
  - `matched` still returns the **readable canonical keyword** (not the stem), so the `UrgencyAssessment` shape (`{ emergency, matched }`) is unchanged and `triage.ts`'s `urgentKeywords` consumer (validated as `z.array(z.string())`) is unaffected. No API contract or route changes.
  - Design note: for emergency triage, false positives (over-flagging) are far safer than the false negatives being fixed here, so the broad `breath` stem is an intentional, safety-biased trade-off.
  - Scope: `apps/api/src/services/medicineRag.service.ts` and its test file `apps/api/tests/triage.test.ts` only.

## 📸 Proof of Work (Screenshots / Logs)

Added tests for every fixed variant plus a regression guard, and re-ran the triage suite:


New assertions:
- `emergency: true` for "I feel suicidal", "can't breathe", "she fainted", "having a seizure right now", "left arm is paralyzed".
- `matched` returns canonical keywords ("suicide", "difficulty breathing", "paralysis"), not stems.
- `"I pressed the wrong keystroke"` → `emergency: false` (word-boundary guard).
- Existing cases unchanged: "I have severe chest pain" → true, "mild headache and runny nose" → false.

## 🏷️ PR Type

- [x] 🐛 `type: bug`

## ✅ Checklist

- [x] My PR has a linked issue Closes #4270
- [x] I have pulled the latest `main` and resolved any conflicts
