### PR TITLE
fix: Preserve Offline scans after transient failures

### DIFF
--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -16,6 +16,16 @@ export { API_BASE, getCsrfToken, refreshCsrfToken };
 const fuzzyMatchCache = createSWRCache<FuzzyMatch[]>(60_000); // 60s TTL
 const verifyBrandCache = createSWRCache<VerifyResult>(300_000); // 5min TTL
 
+export class ApiHttpError extends Error {
+    readonly status: number;
+
+    constructor(message: string, status: number) {
+        super(message);
+        this.name = "ApiHttpError";
+        this.status = status;
+    }
+}
+
 export async function fetchWithCsrf<T>(
     url: string,
     options: Omit<import("./apiWithRetry").FetchOptions, "headers"> & {
@@ -47,7 +57,7 @@ export async function fetchWithCsrf<T>(
             error?: { message?: string } | string;
         };
         const errorMessage = typeof body.error === "object" ? body.error.message : body.error;
-        throw new Error(errorMessage ?? "Server error occurred. Please retry.");
+        throw new ApiHttpError(errorMessage ?? "Server error occurred. Please retry.", res.status);
     }
 
     return res.json() as Promise<T>;
@@ -382,8 +392,9 @@ export async function verifyMedicine(
                 };
             }
             if (endpoint) {
-                throw new Error(
-                    "Stored ML verification endpoint returned an unsuccessful response"
+                throw new ApiHttpError(
+                    "Stored ML verification endpoint returned an unsuccessful response",
+                    mlRes.status
                 );
             }
         } catch (error) {

--- a/apps/web/lib/scanQueueSync.ts
+++ b/apps/web/lib/scanQueueSync.ts
@@ -1,7 +1,22 @@
-import { verifyMedicine } from "@/lib/api";
+import { verifyMedicine, ApiHttpError } from "@/lib/api";
 import { getSyncQueue, removeFromSyncQueue } from "@/lib/db/syncQueue";
 import { recordSyncScanHistory } from "@/lib/scanHistoryUtils";
 import { toast } from "sonner";
+
+function extractHttpStatus(error: unknown): number | undefined {
+    if (error instanceof ApiHttpError) {
+        return error.status;
+    }
+    if (
+        typeof error === "object" &&
+        error !== null &&
+        "status" in error &&
+        typeof (error as { status?: unknown }).status === "number"
+    ) {
+        return (error as { status: number }).status;
+    }
+    return undefined;
+}
 
 export function isNetworkFailure(error: unknown): boolean {
     if (!(error instanceof Error)) return false;
@@ -13,6 +28,32 @@ export function isNetworkFailure(error: unknown): boolean {
         message.includes("aborted") ||
         message.includes("timeout")
     );
+}
+
+export function isRetryableSyncFailure(error: unknown): boolean {
+    if (typeof window !== "undefined" && typeof navigator !== "undefined" && !navigator.onLine) {
+        return true;
+    }
+    if (isNetworkFailure(error)) {
+        return true;
+    }
+    const status = extractHttpStatus(error);
+    if (status !== undefined) {
+        if (status === 408 || status === 429 || (status >= 500 && status <= 599)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export function isKnownPermanentFailure(error: unknown): boolean {
+    const status = extractHttpStatus(error);
+    if (status !== undefined) {
+        if (status >= 400 && status < 500 && status !== 408 && status !== 429) {
+            return true;
+        }
+    }
+    return false;
 }
 
 export async function syncPendingScans(onSynced?: (count: number) => void): Promise<number> {
@@ -80,10 +121,15 @@ export async function syncPendingScans(onSynced?: (count: number) => void): Prom
                     );
                 }
             } catch (error) {
-                if (!navigator.onLine || isNetworkFailure(error)) {
+                if (isRetryableSyncFailure(error)) {
                     break;
                 }
-                await removeFromSyncQueue(item.id);
+                if (isKnownPermanentFailure(error)) {
+                    await removeFromSyncQueue(item.id);
+                    continue;
+                }
+                console.error(`[scanQueueSync] Unknown error syncing scan item ${item.id}:`, error);
+                break;
             }
         }
     } finally {

--- a/apps/web/tests/scanQueueSync.test.ts
+++ b/apps/web/tests/scanQueueSync.test.ts
@@ -40,9 +40,20 @@ jest.mock("sonner", () => ({
     },
 }));
 
-jest.mock("../lib/api", () => ({
-    verifyMedicine: jest.fn(),
-}));
+jest.mock("../lib/api", () => {
+    class ApiHttpError extends Error {
+        readonly status: number;
+        constructor(message: string, status: number) {
+            super(message);
+            this.name = "ApiHttpError";
+            this.status = status;
+        }
+    }
+    return {
+        verifyMedicine: jest.fn(),
+        ApiHttpError,
+    };
+});
 
 jest.mock("../lib/scanHistoryUtils", () => ({
     recordScanHistory: jest.fn(),
@@ -55,8 +66,13 @@ import {
     removeFromSyncQueue,
     clearSyncQueue,
 } from "../lib/db/syncQueue";
-import { syncPendingScans, isNetworkFailure } from "../lib/scanQueueSync";
-import { verifyMedicine } from "../lib/api";
+import {
+    syncPendingScans,
+    isNetworkFailure,
+    isRetryableSyncFailure,
+    isKnownPermanentFailure,
+} from "../lib/scanQueueSync";
+import { verifyMedicine, ApiHttpError } from "../lib/api";
 import { recordScanHistory, recordSyncScanHistory } from "../lib/scanHistoryUtils";
 
 describe("syncQueue", () => {
@@ -214,5 +230,107 @@ describe("scanQueueSync", () => {
         expect(second).toBe(0);
         expect(mockedVerify).toHaveBeenCalledTimes(1);
         expect(await getSyncQueue()).toHaveLength(0);
+    });
+
+    it("keeps queued item when verifyMedicine throws HTTP 500", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockRejectedValue(new ApiHttpError("Internal Server Error", 500));
+
+        await addToSyncQueue("BATCH-500", "en");
+        const synced = await syncPendingScans();
+
+        expect(synced).toBe(0);
+        expect(await getSyncQueue()).toHaveLength(1);
+    });
+
+    it("keeps queued item when verifyMedicine throws HTTP 502", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockRejectedValue(new ApiHttpError("Bad Gateway", 502));
+
+        await addToSyncQueue("BATCH-502", "en");
+        const synced = await syncPendingScans();
+
+        expect(synced).toBe(0);
+        expect(await getSyncQueue()).toHaveLength(1);
+    });
+
+    it("keeps queued item when verifyMedicine throws HTTP 503", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockRejectedValue(new ApiHttpError("Service Unavailable", 503));
+
+        await addToSyncQueue("BATCH-503", "en");
+        const synced = await syncPendingScans();
+
+        expect(synced).toBe(0);
+        expect(await getSyncQueue()).toHaveLength(1);
+    });
+
+    it("keeps queued item when verifyMedicine throws HTTP 504", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockRejectedValue(new ApiHttpError("Gateway Timeout", 504));
+
+        await addToSyncQueue("BATCH-504", "en");
+        const synced = await syncPendingScans();
+
+        expect(synced).toBe(0);
+        expect(await getSyncQueue()).toHaveLength(1);
+    });
+
+    it("keeps queued item when verifyMedicine throws network failure", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockRejectedValue(new Error("Failed to fetch"));
+
+        await addToSyncQueue("BATCH-NET", "en");
+        const synced = await syncPendingScans();
+
+        expect(synced).toBe(0);
+        expect(await getSyncQueue()).toHaveLength(1);
+    });
+
+    it("removes scan from queue on successful verification", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockResolvedValue({
+            verified: true,
+            medicine: {
+                brand_name: "GenuineMed",
+                generic_name: "Gen",
+                manufacturer: "Maker",
+                batch_number: "BATCH-OK",
+                expiry_date: "2028-01-01",
+                cdsco_approval_status: "approved",
+                is_counterfeit_alert: false,
+            },
+        } as any);
+
+        await addToSyncQueue("BATCH-OK", "en");
+        const synced = await syncPendingScans();
+
+        expect(synced).toBe(1);
+        expect(await getSyncQueue()).toHaveLength(0);
+    });
+
+    it("removes scan from queue on known permanent failure (e.g. HTTP 400 Bad Request)", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockRejectedValue(new ApiHttpError("Bad Request", 400));
+
+        await addToSyncQueue("BATCH-400", "en");
+        const synced = await syncPendingScans();
+
+        expect(synced).toBe(0);
+        expect(await getSyncQueue()).toHaveLength(0);
+    });
+
+    it("keeps queued item and logs error on unknown/unclassified error", async () => {
+        const mockedVerify = verifyMedicine as jest.MockedFunction<typeof verifyMedicine>;
+        mockedVerify.mockRejectedValue(new Error("Unclassified error message"));
+        const spyError = jest.spyOn(console, "error").mockImplementation(() => {});
+
+        await addToSyncQueue("BATCH-UNKNOWN", "en");
+        const synced = await syncPendingScans();
+
+        expect(synced).toBe(0);
+        expect(await getSyncQueue()).toHaveLength(1);
+        expect(spyError).toHaveBeenCalled();
+        spyError.mockRestore();
     });
 });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4272 
- **Summary:**
  
  Fixes an issue where offline medicine scans could be removed from the
  synchronization queue after transient server or verification failures.

  Previously, HTTP errors such as `500`, `502`, `503`, and `504` could be
  converted into generic errors and were not always identified as retryable.
  This could cause a queued offline scan to be removed without successful
  synchronization.

  ### Changes made

  - Preserve HTTP status codes for API errors.
  - Added retryable error classification for transient failures.
  - Treat HTTP `408`, `429`, and `5xx` responses as retryable.
  - Keep offline scans in the queue after network/transient failures.
  - Remove scans only after successful synchronization or explicitly handled
    permanent failures.
  - Keep unknown/unclassified errors queued to prevent accidental data loss.
  - Added regression tests for transient server failures and successful
    synchronization.
  - Preserved the existing offline queue and synchronization architecture.

  ### Database

  No database changes were made.

  - No Supabase migrations
  - No database schema changes
  - No table/column changes
  - No RPC changes
  - No triggers/functions changed
  - No IndexedDB schema changes

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Testing performed

The following checks were run locally:

```text
HTTP 500 → scan remains queued
HTTP 502 → scan remains queued
HTTP 503 → scan remains queued
HTTP 504 → scan remains queued
Network failure → scan remains queued
Successful verification → scan removed from queue
Unknown/unclassified error → scan remains queued