### PR TITLE
fix(db): revoke EXECUTE from PUBLIC on SECURITY DEFINER RPCs and add search_path hardening

### DIFF
--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -309,14 +309,14 @@ router.post(
             await refreshLiveSafety(req.supabase!, data);
 
             // Look up batch recall status from batches table
-            const { data: batchData } = await req.supabase!
-                .from("batches")
+            const { data: batchData } = await req
+                .supabase!.from("batches")
                 .select("recall_status")
                 .eq("batch_number", batchNumber)
                 .maybeSingle();
             const batch_status = getBatchStatus(batchData?.recall_status);
 
-            const { data: counts, error: countError } = await req.supabase!
+            const { data: counts, error: countError } = await supabase
                 .rpc("get_scan_counts", { p_batch_number: data.batch_number })
                 .maybeSingle();
 
@@ -354,7 +354,7 @@ router.post(
 
             setImmediate(async () => {
                 try {
-                    const { error: insertError } = await req.supabase!.from("scan_history").insert([
+                    const { error: insertError } = await supabase.from("scan_history").insert([
                         {
                             batch_number: data.batch_number,
                             medicine_id: data.id,

--- a/apps/api/tests/rls_migration.test.ts
+++ b/apps/api/tests/rls_migration.test.ts
@@ -82,3 +82,52 @@ describe("RLS Migration — tracked_medicines guest policy", () => {
         expect(sql).toContain("WITH CHECK (");
     });
 });
+
+describe("RPC Security Migration — REVOKE PUBLIC EXECUTE and search_path hardening", () => {
+    it("revokes execute on get_scan_counts from public and sets search_path in migration", () => {
+        const scanCountsMigration = readFileSync(
+            join(MIGRATIONS_DIR, "20260629000000_add_scan_history_idx_and_rpc.sql"),
+            "utf8"
+        );
+        expect(scanCountsMigration).toContain("SET search_path = public, pg_temp");
+        expect(scanCountsMigration).toContain(
+            "REVOKE EXECUTE ON FUNCTION public.get_scan_counts(text) FROM PUBLIC;"
+        );
+        expect(scanCountsMigration).toContain(
+            "GRANT EXECUTE ON FUNCTION public.get_scan_counts(text) TO service_role;"
+        );
+    });
+
+    it("revokes execute on get_failed_pg_cron_jobs from public and sets search_path in migration", () => {
+        const cronMonitorMigration = readFileSync(
+            join(MIGRATIONS_DIR, "20260711000000_create_pg_cron_monitor_rpc.sql"),
+            "utf8"
+        );
+        expect(cronMonitorMigration).toContain("SET search_path = public, pg_temp");
+        expect(cronMonitorMigration).toContain(
+            "REVOKE EXECUTE ON FUNCTION public.get_failed_pg_cron_jobs(text, timestamptz) FROM PUBLIC;"
+        );
+        expect(cronMonitorMigration).toContain(
+            "GRANT EXECUTE ON FUNCTION public.get_failed_pg_cron_jobs(text, timestamptz) TO service_role;"
+        );
+    });
+
+    it("includes latest migration revoking public execution for both RPCs", () => {
+        const newMigration = readFileSync(
+            join(MIGRATIONS_DIR, "20260811210000_revoke_anon_rpc_permissions.sql"),
+            "utf8"
+        );
+        expect(newMigration).toContain(
+            "REVOKE EXECUTE ON FUNCTION public.get_scan_counts(text) FROM PUBLIC;"
+        );
+        expect(newMigration).toContain(
+            "GRANT EXECUTE ON FUNCTION public.get_scan_counts(text) TO service_role;"
+        );
+        expect(newMigration).toContain(
+            "REVOKE EXECUTE ON FUNCTION public.get_failed_pg_cron_jobs(text, timestamptz) FROM PUBLIC;"
+        );
+        expect(newMigration).toContain(
+            "GRANT EXECUTE ON FUNCTION public.get_failed_pg_cron_jobs(text, timestamptz) TO service_role;"
+        );
+    });
+});

--- a/supabase/migrations/20260629000000_add_scan_history_idx_and_rpc.sql
+++ b/supabase/migrations/20260629000000_add_scan_history_idx_and_rpc.sql
@@ -1,14 +1,19 @@
 CREATE INDEX IF NOT EXISTS idx_scan_history_batch_created
 ON scan_history (batch_number, created_at DESC);
 
-CREATE OR REPLACE FUNCTION get_scan_counts(p_batch_number text)
+CREATE OR REPLACE FUNCTION public.get_scan_counts(p_batch_number text)
 RETURNS TABLE (count_24h bigint, count_7d bigint)
 LANGUAGE sql
 SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
     SELECT
         COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '24 hours') AS count_24h,
         COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '7 days') AS count_7d
-    FROM scan_history
+    FROM public.scan_history
     WHERE batch_number = p_batch_number AND created_at >= NOW() - INTERVAL '7 days';
 $$;
+
+REVOKE EXECUTE ON FUNCTION public.get_scan_counts(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_scan_counts(text) TO service_role;
+

--- a/supabase/migrations/20260811210000_revoke_anon_rpc_permissions.sql
+++ b/supabase/migrations/20260811210000_revoke_anon_rpc_permissions.sql
@@ -1,4 +1,24 @@
--- RPC to fetch failed pg_cron jobs, allowing the API service_role to access cron.job_run_details
+-- Revoke EXECUTE on security definer RPCs from PUBLIC/anon role and grant exclusively to service_role.
+-- Fixes side-channel data leak where anon key could invoke get_scan_counts and get_failed_pg_cron_jobs.
+
+-- 1. get_scan_counts
+CREATE OR REPLACE FUNCTION public.get_scan_counts(p_batch_number text)
+RETURNS TABLE (count_24h bigint, count_7d bigint)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+    SELECT
+        COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '24 hours') AS count_24h,
+        COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '7 days') AS count_7d
+    FROM public.scan_history
+    WHERE batch_number = p_batch_number AND created_at >= NOW() - INTERVAL '7 days';
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_scan_counts(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_scan_counts(text) TO service_role;
+
+-- 2. get_failed_pg_cron_jobs
 CREATE OR REPLACE FUNCTION public.get_failed_pg_cron_jobs(p_job_name text, p_since_time timestamptz)
 RETURNS TABLE (
     jobid bigint,
@@ -34,4 +54,3 @@ $$;
 
 REVOKE EXECUTE ON FUNCTION public.get_failed_pg_cron_jobs(text, timestamptz) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.get_failed_pg_cron_jobs(text, timestamptz) TO service_role;
-


### PR DESCRIPTION

### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4285 **
- **Summary:**
Changes Made


20260629000000_add_scan_history_idx_and_rpc.sql
: Added SET search_path = public, pg_temp, REVOKE EXECUTE ON FUNCTION public.get_scan_counts(text) FROM PUBLIC;, and GRANT EXECUTE ON FUNCTION public.get_scan_counts(text) TO service_role;.


20260711000000_create_pg_cron_monitor_rpc.sql
: Added SET search_path = public, pg_temp, REVOKE EXECUTE ON FUNCTION public.get_failed_pg_cron_jobs(text, timestamptz) FROM PUBLIC;, and GRANT EXECUTE ON FUNCTION public.get_failed_pg_cron_jobs(text, timestamptz) TO service_role;.


20260811210000_revoke_anon_rpc_permissions.sql
: Created a new migration file so existing deployed databases receive the privilege revokes and search path updates when running pending migrations.


verify.ts
: Updated get_scan_counts invocation and scan_history insertion to use the service-role client (supabase), ensuring legitimate API calls succeed while anon key calls directly to PostgREST RPC endpoints return 403/405 error responses.


rls_migration.test.ts
: Added unit test assertions to verify REVOKE EXECUTE, GRANT TO service_role, and SET search_path = public, pg_temp across migration files.
3. Verification
Ran unit tests: npx jest rls_migration.test.ts (12/12 passed).
Ran route tests: npx jest verify.test.ts (7/7 passed).
Verified linting, circular dependency checks, and security audits passed clean.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4285 `)
- [x] I have pulled the latest `main` and resolved any conflicts
