### PR TITLE
fix(db): make drug_alerts medicine linking deterministic with ORDER BY match scoring and tie-breaker

### DIFF
--- a/apps/api/src/repositories/scan.repository.ts
+++ b/apps/api/src/repositories/scan.repository.ts
@@ -26,6 +26,8 @@ export const scanRepository = {
             .or(
                 `brand_name.ilike."%${escapePostgrest(matchedName)}%",generic_name.ilike."%${escapePostgrest(matchedName)}%"`
             )
+            .order("created_at", { ascending: false })
+            .order("id", { ascending: true })
             .limit(1)
             .maybeSingle();
         if (error) throw error;
@@ -59,6 +61,8 @@ export const scanRepository = {
             .or(
                 `brand_name.ilike."%${escapePostgrest(brandName)}%",generic_name.ilike."%${escapePostgrest(brandName)}%"`
             )
+            .order("created_at", { ascending: false })
+            .order("id", { ascending: true })
             .limit(1)
             .maybeSingle();
         if (error) throw error;

--- a/apps/api/src/routes/batch.ts
+++ b/apps/api/src/routes/batch.ts
@@ -171,6 +171,8 @@ router.get(
                 }
 
                 const { data: medicineData, error: medicineError } = await query
+                    .order("created_at", { ascending: false })
+                    .order("id", { ascending: true })
                     .limit(1)
                     .maybeSingle();
 
@@ -430,7 +432,11 @@ router.post("/report", batchLimiter, async (req: Request, res: Response) => {
             query = query.eq("brand_name", brandName);
         }
 
-        const { data: medicineMatch } = await query.limit(1).maybeSingle();
+        const { data: medicineMatch } = await query
+            .order("created_at", { ascending: false })
+            .order("id", { ascending: true })
+            .limit(1)
+            .maybeSingle();
 
         if (medicineMatch) {
             medicine_id = medicineMatch.id;

--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -578,6 +578,8 @@ router.post("/verify-brand", scanQueryLimiter, async (req: Request, res: Respons
                 "id, brand_name, generic_name, manufacturer, batch_number, expiry_date, cdsco_approval_status, is_counterfeit_alert, is_cdsco_verified, cdsco_match_score, matched_cdsco_product, matched_cdsco_manufacturer, product_match_score, manufacturer_match_score"
             )
             .ilike("brand_name", `%${escapedBrand}%`)
+            .order("created_at", { ascending: false })
+            .order("id", { ascending: true })
             .limit(1)
             .maybeSingle();
 
@@ -597,6 +599,8 @@ router.post("/verify-brand", scanQueryLimiter, async (req: Request, res: Respons
                     "id, brand_name, generic_name, manufacturer, batch_number, expiry_date, cdsco_approval_status, is_counterfeit_alert, is_cdsco_verified, cdsco_match_score, matched_cdsco_product, matched_cdsco_manufacturer, product_match_score, manufacturer_match_score"
                 )
                 .ilike("generic_name", `%${escapedBrand}%`)
+                .order("created_at", { ascending: false })
+                .order("id", { ascending: true })
                 .limit(1)
                 .maybeSingle();
 
@@ -763,8 +767,8 @@ router.post(
                 part_type,
                 status,
             }));
-            await req.supabase!
-                .from("scan_submission_parts")
+            await req
+                .supabase!.from("scan_submission_parts")
                 .upsert(rows, { onConflict: "scan_id,part_type" });
 
             const result = { scanId: resolvedScanId, parts };
@@ -775,8 +779,8 @@ router.post(
                 });
             }
 
-            const { error: idemUpdateError } = await req.supabase!
-                .from("submission_idempotency")
+            const { error: idemUpdateError } = await req
+                .supabase!.from("submission_idempotency")
                 .update({ scan_id: resolvedScanId })
                 .eq("idempotency_key", idempotencyKey);
 
@@ -800,8 +804,8 @@ router.post(
 
             if (idempotencyKey) {
                 try {
-                    await req.supabase!
-                        .from("submission_idempotency")
+                    await req
+                        .supabase!.from("submission_idempotency")
                         .delete()
                         .eq("idempotency_key", idempotencyKey);
                 } catch {

--- a/apps/api/src/services/drugLookup.service.ts
+++ b/apps/api/src/services/drugLookup.service.ts
@@ -96,7 +96,11 @@ export async function lookupDrugByBatch(
             query = query.eq("brand_name", identifier.brand_name);
         }
 
-        const { data, error } = await query.limit(1).maybeSingle();
+        const { data, error } = await query
+            .order("created_at", { ascending: false })
+            .order("id", { ascending: true })
+            .limit(1)
+            .maybeSingle();
 
         if (error) {
             dbError = error;

--- a/apps/api/tests/batch.test.ts
+++ b/apps/api/tests/batch.test.ts
@@ -7,6 +7,7 @@ jest.mock("../src/db/client", () => {
         from: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         eq: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
         maybeSingle: jest.fn(),
     };

--- a/apps/api/tests/drug_alert_linking.test.ts
+++ b/apps/api/tests/drug_alert_linking.test.ts
@@ -1,0 +1,69 @@
+import { lookupDrugByBatch } from "../src/services/drugLookup.service";
+import { scanRepository } from "../src/repositories/scan.repository";
+
+jest.mock("../src/db/client", () => {
+    const chain: any = {};
+    chain.select = jest.fn().mockReturnValue(chain);
+    chain.eq = jest.fn().mockReturnValue(chain);
+    chain.or = jest.fn().mockReturnValue(chain);
+    chain.ilike = jest.fn().mockReturnValue(chain);
+    chain.order = jest.fn().mockReturnValue(chain);
+    chain.limit = jest.fn().mockReturnValue(chain);
+    chain.maybeSingle = jest.fn().mockResolvedValue({
+        data: { id: "med-123", brand_name: "Test Brand", batch_number: "BATCH1" },
+        error: null,
+    });
+
+    return {
+        supabase: {
+            from: jest.fn().mockReturnValue(chain),
+            chain,
+        },
+    };
+});
+
+jest.mock("../src/utils/redis", () => ({
+    redisClient: {
+        isOpen: true,
+        get: jest.fn().mockResolvedValue(null),
+        set: jest.fn().mockResolvedValue("OK"),
+        incr: jest.fn().mockResolvedValue(1),
+        zIncrBy: jest.fn().mockResolvedValue(1),
+        expire: jest.fn().mockResolvedValue(true),
+    },
+    connectRedis: jest.fn(),
+}));
+
+import { supabase } from "../src/db/client";
+
+describe("Deterministic Medicine Lookups", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("lookupDrugByBatch applies explicit created_at DESC and id ASC ordering before limit(1)", async () => {
+        const result = await lookupDrugByBatch("BATCH1", { brand_name: "Test Brand" });
+        expect(result).toBeDefined();
+
+        const chain = (supabase as any).chain;
+        expect(chain.order).toHaveBeenCalledWith("created_at", { ascending: false });
+        expect(chain.order).toHaveBeenCalledWith("id", { ascending: true });
+        expect(chain.limit).toHaveBeenCalledWith(1);
+    });
+
+    it("scanRepository.findMedicineByMatchedName applies explicit ordering", async () => {
+        await scanRepository.findMedicineByMatchedName("Test Brand");
+        const chain = (supabase as any).chain;
+        expect(chain.order).toHaveBeenCalledWith("created_at", { ascending: false });
+        expect(chain.order).toHaveBeenCalledWith("id", { ascending: true });
+        expect(chain.limit).toHaveBeenCalledWith(1);
+    });
+
+    it("scanRepository.findMedicineByBrandName applies explicit ordering", async () => {
+        await scanRepository.findMedicineByBrandName("Test Brand");
+        const chain = (supabase as any).chain;
+        expect(chain.order).toHaveBeenCalledWith("created_at", { ascending: false });
+        expect(chain.order).toHaveBeenCalledWith("id", { ascending: true });
+        expect(chain.limit).toHaveBeenCalledWith(1);
+    });
+});

--- a/apps/api/tests/rls_migration.test.ts
+++ b/apps/api/tests/rls_migration.test.ts
@@ -82,3 +82,40 @@ describe("RLS Migration — tracked_medicines guest policy", () => {
         expect(sql).toContain("WITH CHECK (");
     });
 });
+
+describe("Drug Alerts Migration — Deterministic Medicine Linking Trigger", () => {
+    const migrationPath = join(MIGRATIONS_DIR, "20260720000000_fix_drug_alerts_medicine_id.sql");
+    const sql = readFileSync(migrationPath, "utf8");
+
+    it("includes ORDER BY match scoring and tie-breaker in link_drug_alert_to_medicine trigger", () => {
+        expect(sql).toContain("CREATE OR REPLACE FUNCTION public.link_drug_alert_to_medicine()");
+        expect(sql).toContain("ORDER BY");
+        expect(sql).toContain(
+            "WHEN (NEW.manufacturer IS NOT NULL AND manufacturer = NEW.manufacturer)"
+        );
+        expect(sql).toContain(
+            "AND (NEW.reported_brand_name IS NOT NULL AND brand_name = NEW.reported_brand_name) THEN 0"
+        );
+        expect(sql).toContain("created_at DESC");
+        expect(sql).toContain("id ASC");
+    });
+
+    it("includes deterministic ORDER BY in backfill UPDATE query", () => {
+        expect(sql).toContain("UPDATE public.drug_alerts da");
+        expect(sql).toContain("SET medicine_id = (");
+        expect(sql).toContain("m.created_at DESC");
+        expect(sql).toContain("m.id ASC");
+    });
+
+    it("includes new migration file with deterministic trigger and backfill", () => {
+        const newMigrationSql = readFileSync(
+            join(MIGRATIONS_DIR, "20260811220000_fix_drug_alert_medicine_linking_determinism.sql"),
+            "utf8"
+        );
+        expect(newMigrationSql).toContain(
+            "CREATE OR REPLACE FUNCTION public.link_drug_alert_to_medicine()"
+        );
+        expect(newMigrationSql).toContain("created_at DESC");
+        expect(newMigrationSql).toContain("id ASC");
+    });
+});

--- a/apps/api/tests/verify.test.ts
+++ b/apps/api/tests/verify.test.ts
@@ -6,6 +6,7 @@ jest.mock("../src/db/client", () => {
         from: jest.fn().mockReturnThis(),
         select: jest.fn().mockReturnThis(),
         ilike: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
         limit: jest.fn().mockReturnThis(),
         maybeSingle: jest.fn(),
         eq: jest.fn().mockReturnThis(),

--- a/supabase/migrations/20260811220000_fix_drug_alert_medicine_linking_determinism.sql
+++ b/supabase/migrations/20260811220000_fix_drug_alert_medicine_linking_determinism.sql
@@ -1,4 +1,7 @@
--- 1. Create a function to auto-link medicine_id for drug_alerts based on batch and brand/manufacturer
+-- Fix non-deterministic medicine linking for drug_alerts.
+-- Prioritizes exact matches on both manufacturer and brand_name over single field matches,
+-- and tie-breaks deterministically with created_at DESC, id ASC.
+
 CREATE OR REPLACE FUNCTION public.link_drug_alert_to_medicine()
 RETURNS TRIGGER
 LANGUAGE plpgsql
@@ -28,7 +31,7 @@ BEGIN
 END;
 $$;
 
--- 2. Attach the trigger to drug_alerts
+-- Re-attach trigger
 DROP TRIGGER IF EXISTS trg_drug_alerts_link_medicine ON public.drug_alerts;
 CREATE TRIGGER trg_drug_alerts_link_medicine
   BEFORE INSERT OR UPDATE
@@ -36,7 +39,7 @@ CREATE TRIGGER trg_drug_alerts_link_medicine
   FOR EACH ROW
   EXECUTE FUNCTION public.link_drug_alert_to_medicine();
 
--- 3. Backfill existing records that have NULL medicine_id
+-- Deterministic backfill update for existing unlinked alerts
 UPDATE public.drug_alerts da
 SET medicine_id = (
   SELECT m.id
@@ -57,4 +60,3 @@ SET medicine_id = (
   LIMIT 1
 )
 WHERE da.medicine_id IS NULL;
-


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4286 **
- **Summary:**
Changes
Database:



20260720000000_fix_drug_alerts_medicine_id.sql
: Added ORDER BY with match-quality scoring (both manufacturer + brand = 0, manufacturer-only = 1, brand-only = 2) and a stable tie-breaker (created_at DESC, id ASC). Null-guarded IS NOT NULL checks prevent accidental matches on NULL columns. Rewrote backfill UPDATE with the same correlated subquery and scoring.


20260811220000_fix_drug_alert_medicine_linking_determinism.sql
: New migration so deployed databases receive the trigger and backfill update.
API Services & Routes:



drugLookup.service.ts
: Added .order("created_at", { ascending: false }).order("id", { ascending: true }) before .limit(1).


batch.ts
: Applied same ordering to both medicine queries (batch fallback + counterfeit report).


scan.ts
: Applied ordering to both verify-brand name/generic lookups.


scan.repository.ts
: Applied ordering to findMedicineByMatchedName and findMedicineByBrandName.
Tests:



drug_alert_linking.test.ts
: New unit tests verifying .order() is called before .limit(1) in lookupDrugByBatch, findMedicineByMatchedName, and findMedicineByBrandName.


rls_migration.test.ts
: Added migration assertions verifying ORDER BY, match-scoring CASE expressions, and created_at DESC/id ASC tie-breakers.


batch.test.ts
, 

verify.test.ts
: Added order: jest.fn().mockReturnThis() to mock stubs to accommodate the new query builder chain.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [x] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4286 `)
- [x] I have pulled the latest `main` and resolved any conflicts
