### PR TITLE
feat(profile): Fake Medicine Hunter badge for 5+ verified reports (#4278)

### DIFF
--- a/apps/web/app/[locale]/profile/page.tsx
+++ b/apps/web/app/[locale]/profile/page.tsx
@@ -5,11 +5,13 @@ import { useTranslations } from "next-intl";
 import { Link, useRouter } from "@/i18n/routing";
 import { User, ShieldCheck, Bell, ChevronRight, ArrowLeft, LogIn, LogOut } from "lucide-react";
 import ABHABadge from "@/components/ABHABadge";
+import FakeMedicineHunterBadge from "@/components/FakeMedicineHunterBadge";
 import { useSession } from "@/src/components/AuthProvider";
 import { setSessionAccessToken } from "@/lib/accessToken";
 import { clearReadCache } from "@/lib/offline/db";
 import { createBrowserClient } from "@supabase/ssr";
 import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
+import { getVerifiedReportCount, FAKE_MEDICINE_HUNTER_THRESHOLD } from "@/lib/counterfeitReports";
 
 type ProfileSession =
     | { status: "checking" }
@@ -87,8 +89,9 @@ function readSessionFromToken(token: string | null): {
 export default function ProfilePage() {
     const t = useTranslations("Profile");
     const router = useRouter();
-    const { token, isLoading: authLoading } = useSession();
+    const { token, session: authSession, isLoading: authLoading } = useSession();
     const [session, setSession] = useState<ProfileSession>({ status: "checking" });
+    const [verifiedReportCount, setVerifiedReportCount] = useState<number | null>(null);
 
     const supabase = useMemo(() => createBrowserClient(getSupabaseUrl(), getSupabaseAnonKey()), []);
 
@@ -121,6 +124,29 @@ export default function ProfilePage() {
             setSession({ status: "error" });
         }
     }, [authLoading, token]);
+
+    // Fetch the user's verified counterfeit-report count for the
+    // "Fake Medicine Hunter" achievement badge. Runs only once signed in;
+    // failures are swallowed (resolves to null → no badge) so the profile
+    // page never breaks on a missing table or RLS denial.
+    useEffect(() => {
+        if (authLoading || !authSession?.user?.id) {
+            setVerifiedReportCount(null);
+            return;
+        }
+        const userId = authSession.user.id;
+        let cancelled = false;
+        getVerifiedReportCount(userId)
+            .then((count) => {
+                if (!cancelled) setVerifiedReportCount(count);
+            })
+            .catch(() => {
+                if (!cancelled) setVerifiedReportCount(null);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [authLoading, authSession?.user?.id]);
 
     const handleRetry = () => {
         setSession({ status: "checking" });
@@ -226,8 +252,15 @@ export default function ProfilePage() {
                                 </p>
 
                                 {session.status === "authenticated" && (
-                                    <div className="mt-2">
+                                    <div className="mt-2 flex flex-wrap items-center gap-2">
                                         <ABHABadge linked={true} />
+                                        {verifiedReportCount !== null &&
+                                            verifiedReportCount >=
+                                                FAKE_MEDICINE_HUNTER_THRESHOLD && (
+                                                <FakeMedicineHunterBadge
+                                                    count={verifiedReportCount}
+                                                />
+                                            )}
                                     </div>
                                 )}
                             </div>

--- a/apps/web/components/FakeMedicineHunterBadge.tsx
+++ b/apps/web/components/FakeMedicineHunterBadge.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { ShieldCheck } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Tooltip } from "@/components/ui/Tooltip";
+
+interface FakeMedicineHunterBadgeProps {
+    /** Verified counterfeit-medicine report count for the signed-in user. */
+    count: number;
+}
+
+export default function FakeMedicineHunterBadge({ count }: FakeMedicineHunterBadgeProps) {
+    const t = useTranslations("Profile");
+
+    return (
+        <Tooltip content={t("fakeMedicineHunterTooltip")} position="top">
+            <span
+                role="img"
+                aria-label={t("fakeMedicineHunterTooltip")}
+                className="inline-flex items-center gap-1.5 rounded-full border border-amber-300/60 bg-gradient-to-br from-amber-200 via-yellow-300 to-amber-400 px-3 py-1 text-xs font-bold text-amber-900 shadow-sm transition-transform hover:scale-[1.03] dark:border-amber-500/40 dark:from-amber-500/20 dark:via-yellow-500/20 dark:to-amber-600/20 dark:text-amber-200"
+            >
+                <ShieldCheck size={14} className="shrink-0" />
+                {t("fakeMedicineHunterBadge")} · {count}
+            </span>
+        </Tooltip>
+    );
+}

--- a/apps/web/lib/counterfeitReports.ts
+++ b/apps/web/lib/counterfeitReports.ts
@@ -1,0 +1,26 @@
+import { supabase } from "@/lib/supabase";
+
+export const FAKE_MEDICINE_HUNTER_THRESHOLD = 5;
+
+/**
+ * Count a user's verified counterfeit-medicine reports.
+ *
+ * The badge in the profile dashboard is awarded once this count crosses
+ * FAKE_MEDICINE_HUNTER_THRESHOLD. The query is guarded so a missing table
+ * or RLS denial resolves to 0 (no badge) rather than throwing — the badge
+ * is a nice-to-have and must never break the profile page.
+ */
+export async function getVerifiedReportCount(userId: string): Promise<number> {
+    const { count, error } = await supabase
+        .from("counterfeit_reports")
+        .select("id", { count: "exact", head: true })
+        .eq("user_id", userId)
+        .eq("status", "verified");
+
+    if (error) {
+        console.error("Failed to load verified report count:", error.message);
+        return 0;
+    }
+
+    return count ?? 0;
+}

--- a/apps/web/messages/as.json
+++ b/apps/web/messages/as.json
@@ -1433,7 +1433,9 @@
         "abhaSetup": "ABHA ছেটআপ",
         "abhaRecords": "ABHA ৰেকৰ্ড",
         "notificationSettings": "জাননী ছেটিংছ",
-        "privacySecurity": "গোপনীয়তা আৰু সুৰক্ষা"
+        "privacySecurity": "গোপনীয়তা আৰু সুৰক্ষা",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/bn.json
+++ b/apps/web/messages/bn.json
@@ -1433,7 +1433,9 @@
         "abhaSetup": "ABHA সেটআপ",
         "abhaRecords": "ABHA রেকর্ড",
         "notificationSettings": "বিজ্ঞপ্তি সেটিংস",
-        "privacySecurity": "গোপনীয়তা ও নিরাপত্তা"
+        "privacySecurity": "গোপনীয়তা ও নিরাপত্তা",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1705,7 +1705,9 @@
         "abhaSetup": "ABHA Setup",
         "abhaRecords": "ABHA Records",
         "notificationSettings": "Notification Settings",
-        "privacySecurity": "Privacy & Security"
+        "privacySecurity": "Privacy & Security",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Navbar": {
         "logo_alt": "SahiDawa Logo"

--- a/apps/web/messages/gu.json
+++ b/apps/web/messages/gu.json
@@ -1433,7 +1433,9 @@
         "abhaSetup": "ABHA સેટઅપ",
         "abhaRecords": "ABHA રેકોર્ડ્સ",
         "notificationSettings": "સૂચના સેટિંગ્સ",
-        "privacySecurity": "ગોપનીયતા અને સુરક્ષા"
+        "privacySecurity": "ગોપનીયતા અને સુરક્ષા",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1666,7 +1666,9 @@
         "abhaSetup": "ABHA सेटअप",
         "abhaRecords": "ABHA रिकॉर्ड्स",
         "notificationSettings": "सूचना सेटिंग्स",
-        "privacySecurity": "गोपनीयता और सुरक्षा"
+        "privacySecurity": "गोपनीयता और सुरक्षा",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/kn.json
+++ b/apps/web/messages/kn.json
@@ -1433,7 +1433,9 @@
         "abhaSetup": "ABHA ಸೆಟಪ್",
         "abhaRecords": "ABHA ದಾಖಲೆಗಳು",
         "notificationSettings": "ಅಧಿಸೂಚನೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳು",
-        "privacySecurity": "ಗೌಪ್ಯತೆ ಮತ್ತು ಭದ್ರತೆ"
+        "privacySecurity": "ಗೌಪ್ಯತೆ ಮತ್ತು ಭದ್ರತೆ",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/kok.json
+++ b/apps/web/messages/kok.json
@@ -1497,7 +1497,9 @@
         "abhaSetup": "ABHA सेटअप",
         "abhaRecords": "ABHA नोंदी",
         "notificationSettings": "सूचोवणी सेटिंग्ज",
-        "privacySecurity": "खासगीपण आनी सुरक्षा"
+        "privacySecurity": "खासगीपण आनी सुरक्षा",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/ks.json
+++ b/apps/web/messages/ks.json
@@ -1378,7 +1378,9 @@
         "abhaSetup": "ABHA سیٹ اپ",
         "abhaRecords": "ABHA ریکارڈ",
         "notificationSettings": "اطلاعی ترتیٖباں",
-        "privacySecurity": "رازداری تہٕ حفاظت"
+        "privacySecurity": "رازداری تہٕ حفاظت",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/mai.json
+++ b/apps/web/messages/mai.json
@@ -1622,7 +1622,9 @@
         "abhaSetup": "ABHA सेटअप",
         "abhaRecords": "ABHA रिकॉर्ड",
         "notificationSettings": "सूचना सेटिंग्स",
-        "privacySecurity": "गोपनीयता आ सुरक्षा"
+        "privacySecurity": "गोपनीयता आ सुरक्षा",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/ml.json
+++ b/apps/web/messages/ml.json
@@ -1377,7 +1377,9 @@
         "abhaSetup": "ABHA സെറ്റപ്പ്",
         "abhaRecords": "ABHA രേഖകൾ",
         "notificationSettings": "അറിയിപ്പ് ക്രമീകരണങ്ങൾ",
-        "privacySecurity": "സ്വകാര്യതയും സുരക്ഷയും"
+        "privacySecurity": "സ്വകാര്യതയും സുരക്ഷയും",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/mni.json
+++ b/apps/web/messages/mni.json
@@ -1546,7 +1546,9 @@
         "abhaSetup": "ABHA সেটআপ",
         "abhaRecords": "ABHA রেকর্ড",
         "notificationSettings": "নোটিফিকেসন সেটিং",
-        "privacySecurity": "ৱাফম অমসুং সেকురిति"
+        "privacySecurity": "ৱাফম অমসুং সেকురిति",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/mr.json
+++ b/apps/web/messages/mr.json
@@ -1433,7 +1433,9 @@
         "abhaSetup": "ABHA सेटअप",
         "abhaRecords": "ABHA नोंदी",
         "notificationSettings": "सूचना सेटिंग्ज",
-        "privacySecurity": "गोपनीयता आणि सुरक्षा"
+        "privacySecurity": "गोपनीयता आणि सुरक्षा",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/or.json
+++ b/apps/web/messages/or.json
@@ -1433,7 +1433,9 @@
         "abhaSetup": "ABHA ସେଟଅପ୍",
         "abhaRecords": "ABHA ରେକର୍ଡ",
         "notificationSettings": "ବିଜ୍ଞପ୍ତି ସେଟିଂସ୍",
-        "privacySecurity": "ଗୋପନୀୟତା ଏବଂ ସୁରକ୍ଷା"
+        "privacySecurity": "ଗୋପନୀୟତା ଏବଂ ସୁରକ୍ଷା",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/pa.json
+++ b/apps/web/messages/pa.json
@@ -1433,7 +1433,9 @@
         "abhaSetup": "ABHA ਸੈੱਟਅੱਪ",
         "abhaRecords": "ABHA ਰਿਕਾਰਡ",
         "notificationSettings": "ਸੂਚਨਾ ਸੈਟਿੰਗਾਂ",
-        "privacySecurity": "ਗੋਪਨੀਯਤਾ ਅਤੇ ਸੁਰੱਖਿਆ"
+        "privacySecurity": "ਗੋਪਨੀਯਤਾ ਅਤੇ ਸੁਰੱਖਿਆ",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/sa.json
+++ b/apps/web/messages/sa.json
@@ -1377,7 +1377,9 @@
         "abhaSetup": "ABHA सज्जीकरणम्",
         "abhaRecords": "ABHA अभिलेखाः",
         "notificationSettings": "सूचना विन्यासाः",
-        "privacySecurity": "गोपनीयता सुरक्षा च"
+        "privacySecurity": "गोपनीयता सुरक्षा च",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/sd.json
+++ b/apps/web/messages/sd.json
@@ -1546,7 +1546,9 @@
         "abhaSetup": "ABHA سيٽ اپ",
         "abhaRecords": "ABHA رڪارڊ",
         "notificationSettings": "اطلاعي سيٽنگون",
-        "privacySecurity": "رازداري ۽ سلامتي"
+        "privacySecurity": "رازداري ۽ سلامتي",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/ta.json
+++ b/apps/web/messages/ta.json
@@ -1433,7 +1433,9 @@
         "abhaSetup": "ABHA அமைப்பு",
         "abhaRecords": "ABHA பதிவுகள்",
         "notificationSettings": "அறிவிப்பு அமைப்புகள்",
-        "privacySecurity": "தனியுரிமை மற்றும் பாதுகாப்பு"
+        "privacySecurity": "தனியுரிமை மற்றும் பாதுகாப்பு",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/te.json
+++ b/apps/web/messages/te.json
@@ -1433,7 +1433,9 @@
         "abhaSetup": "ABHA సెటప్",
         "abhaRecords": "ABHA రికార్డులు",
         "notificationSettings": "నోటిఫికేషన్ సెట్టింగ్‌లు",
-        "privacySecurity": "గోప్యత మరియు భద్రత"
+        "privacySecurity": "గోప్యత మరియు భద్రత",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/messages/ur.json
+++ b/apps/web/messages/ur.json
@@ -1377,7 +1377,9 @@
         "abhaSetup": "ABHA سیٹ اپ",
         "abhaRecords": "ABHA ریکارڈز",
         "notificationSettings": "اطلاعی ترتیبات",
-        "privacySecurity": "رازداری اور تحفظ"
+        "privacySecurity": "رازداری اور تحفظ",
+        "fakeMedicineHunterBadge": "Fake Medicine Hunter",
+        "fakeMedicineHunterTooltip": "Awarded for reporting 5+ verified counterfeit medicines."
     },
     "Privacy": {
         "hero": {

--- a/apps/web/tests/counterfeitReports.test.ts
+++ b/apps/web/tests/counterfeitReports.test.ts
@@ -1,0 +1,89 @@
+/** @jest-environment jsdom */
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import { getVerifiedReportCount, FAKE_MEDICINE_HUNTER_THRESHOLD } from "@/lib/counterfeitReports";
+
+const mockSelect = jest.fn();
+const mockEq = jest.fn();
+
+jest.mock("@/lib/supabase", () => ({
+    supabase: {
+        from: jest.fn(() => ({
+            select: (...args: unknown[]) => mockSelect(...args),
+        })),
+    },
+}));
+
+beforeEach(() => {
+    mockSelect.mockReset();
+    mockEq.mockReset();
+    // Chain: select() -> eq() -> eq() -> { count, error }
+    mockSelect.mockReturnValue({
+        eq: (...args: unknown[]) => mockEq(...args),
+    });
+    mockEq.mockReturnValue({
+        eq: () => ({ count: 0, error: null }),
+    });
+});
+
+describe("lib/counterfeitReports", () => {
+    it("exposes a 5-report threshold for the badge", () => {
+        expect(FAKE_MEDICINE_HUNTER_THRESHOLD).toBe(5);
+    });
+
+    it("returns the verified report count for the user", async () => {
+        mockEq.mockReturnValue({
+            eq: () => ({ count: 7, error: null }),
+        });
+
+        const count = await getVerifiedReportCount("user-123");
+
+        expect(count).toBe(7);
+        expect(mockSelect).toHaveBeenCalledWith("id", { count: "exact", head: true });
+    });
+
+    it("returns 0 when the user has no verified reports", async () => {
+        mockEq.mockReturnValue({
+            eq: () => ({ count: 0, error: null }),
+        });
+
+        const count = await getVerifiedReportCount("user-empty");
+
+        expect(count).toBe(0);
+    });
+
+    it("filters by user_id and status='verified'", async () => {
+        const eqCalls: Array<[string, unknown]> = [];
+        mockSelect.mockReturnValue({
+            eq: (col: string, val: unknown) => {
+                eqCalls.push([col, val]);
+                return {
+                    eq: (col2: string, val2: unknown) => {
+                        eqCalls.push([col2, val2]);
+                        return { count: 3, error: null };
+                    },
+                };
+            },
+        });
+
+        const count = await getVerifiedReportCount("user-abc");
+
+        expect(count).toBe(3);
+        expect(eqCalls).toEqual([
+            ["user_id", "user-abc"],
+            ["status", "verified"],
+        ]);
+    });
+
+    it("swallows errors and returns 0 so the profile page never breaks", async () => {
+        mockEq.mockReturnValue({
+            eq: () => ({
+                count: null,
+                error: { message: "relation counterfeit_reports does not exist" },
+            }),
+        });
+
+        const count = await getVerifiedReportCount("user-err");
+
+        expect(count).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #4278

Implements the **"Fake Medicine Hunter" achievement badge** on the profile dashboard. Users who have reported more than 5 verified counterfeit medicines now see a gold-gradient badge (Shield icon + report count) next to their ABHA badge, with a tooltip explaining the achievement.

## Changes

- **`apps/web/lib/counterfeitReports.ts`** (new) — `getVerifiedReportCount(userId)` queries the `counterfeit_reports` table with `count: exact, head: true`, filtered by `user_id` and `status = 'verified'`. Exposes `FAKE_MEDICINE_HUNTER_THRESHOLD = 5`. The query is guarded: a missing table, RLS denial, or any Supabase error resolves to `0` (no badge) rather than throwing — the badge is a nice-to-have and must never break the profile page.
- **`apps/web/components/FakeMedicineHunterBadge.tsx`** (new) — Badge component using `lucide-react` `ShieldCheck` with an amber/gold gradient background, the user's live count, and a `@radix-ui/react-tooltip` (via the existing `Tooltip` UI component) reading "Awarded for reporting 5+ verified counterfeit medicines." Styled to match the glassmorphism aesthetic (dark-mode aware, hover scale, responsive flex-wrap).
- **`apps/web/app/[locale]/profile/page.tsx`** — Now reads `session` from `useSession()` to get `authSession.user.id`, adds `verifiedReportCount` state, and a `useEffect` that fetches the count once signed in (cancellation-safe). Renders `FakeMedicineHunterBadge` **only** when `verifiedReportCount >= 5`. The badge sits in the existing user-info row alongside `ABHABadge` (flex-wrap so both badges lay out cleanly on mobile).
- **`apps/web/messages/*.json`** (19 locales) — Adds `fakeMedicineHunterBadge` ("Fake Medicine Hunter") and `fakeMedicineHunterTooltip` keys to the `Profile` block in every locale file, keeping full key coverage (verified via `i18n:check-missing`). English strings are used across all locales as a consistent baseline for the translator community to localize.

## Acceptance Criteria

- [x] Profile page queries the user's verified report count (`getVerifiedReportCount`)
- [x] Badge renders dynamically **only if** `count >= 5` (threshold constant)
- [x] Hovering the badge shows a tooltip explaining the achievement
- [x] UI is responsive (flex-wrap) and matches the modern glassmorphism aesthetic (dark-mode aware)

## Verification

- `tsc --noEmit` — 0 errors
- `eslint` on all 3 new/changed source files — clean (the only repo-wide lint error, `govtStores` in `app/api/chat/route.ts`, is pre-existing on `upstream/main` and unrelated)
- `prettier --check` — all changed files pass
- `i18n:check-missing` — all 19 locales have complete key coverage
- `jest tests/counterfeitReports.test.ts` — 5/5 pass (covers threshold value, count query shape, `user_id`+`status` filter chain, empty result, and the error-swallowing fallback that keeps the profile page alive on a missing table)

Branch is based on `upstream/main` (fork was synced first); no `package-lock.json` or unrelated drift is included.

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
