### PR TITLE
fix: prevent Overpass cache stampede

### DIFF
--- a/apps/web/app/api/overpass/route.ts
+++ b/apps/web/app/api/overpass/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createHash } from "crypto";
+import { createHash, randomUUID } from "crypto";
 import { rateLimit } from "@/lib/rateLimit";
 import { getClientIp } from "@/lib/getClientIp";
 import { redis } from "@/lib/redis";
@@ -76,8 +76,84 @@ export async function POST(req: NextRequest) {
             console.warn("[overpass] Redis GET failed:", redisErr);
         }
 
-        // Cache miss (or invalid cache): query all mirrors in parallel
-        const controllers: AbortController[] = [];
+        const lockKey = `overpass_lock:${hash}`;
+        const lockToken = randomUUID();
+        let isLeader = false;
+        let lockAcquired = false;
+
+        try {
+            const lockResult = await redis.set(lockKey, lockToken, { nx: true, ex: 35 });
+            if (lockResult === "OK") {
+                isLeader = true;
+                lockAcquired = true;
+            }
+        } catch (redisErr) {
+            console.warn("[overpass] Redis SET lock failed, assuming leader:", redisErr);
+            isLeader = true;
+        }
+
+        if (!isLeader) {
+            const maxWaitMs = 25000;
+            const intervalMs = 2000;
+            let waited = 0;
+
+            while (waited < maxWaitMs) {
+                await new Promise((resolve) => setTimeout(resolve, intervalMs));
+                waited += intervalMs;
+
+                try {
+                    const cached = await redis.get(cacheKey);
+                    if (cached) {
+                        try {
+                            const parsed = typeof cached === "string" ? JSON.parse(cached) : cached;
+                            if (parsed && Array.isArray(parsed.elements)) {
+                                return NextResponse.json(parsed, {
+                                    headers: { "X-Cache": "HIT-WAIT" },
+                                });
+                            }
+                        } catch (parseErr) {
+                            console.warn("[overpass] Failed to parse polled cache");
+                        }
+                    }
+
+                    const currentLock = await redis.get(lockKey);
+                    if (!currentLock) {
+                        break;
+                    }
+                } catch (redisErr) {
+                    console.warn("[overpass] Polling Redis failed:", redisErr);
+                    break;
+                }
+            }
+        } else {
+            // Double check cache in case it was written between our first check and lock acquisition
+            if (lockAcquired) {
+                try {
+                    const cached = await redis.get(cacheKey);
+                    if (cached) {
+                        const parsed = typeof cached === "string" ? JSON.parse(cached) : cached;
+                        if (parsed && Array.isArray(parsed.elements)) {
+                            const luaScript = `
+                                if redis.call("GET", KEYS[1]) == ARGV[1] then
+                                    return redis.call("DEL", KEYS[1])
+                                end
+                                return 0
+                            `;
+                            await redis.eval(luaScript, [lockKey], [lockToken]);
+                            return NextResponse.json(parsed, {
+                                headers: { "X-Cache": "HIT" },
+                            });
+                        }
+                    }
+                } catch (e) {
+                    // Ignore and proceed to fetch
+                }
+            }
+        }
+
+        try {
+            // Cache miss (or invalid cache): query all mirrors in parallel
+            const controllers: AbortController[] = [];
         const fetchPromises = OVERPASS_MIRRORS.map(async (mirror) => {
             const controller = new AbortController();
             controllers.push(controller);
@@ -147,6 +223,21 @@ export async function POST(req: NextRequest) {
         return NextResponse.json(fastestData, {
             headers: { "X-Cache": "MISS" },
         });
+        } finally {
+            if (lockAcquired) {
+                try {
+                    const luaScript = `
+                        if redis.call("GET", KEYS[1]) == ARGV[1] then
+                            return redis.call("DEL", KEYS[1])
+                        end
+                        return 0
+                    `;
+                    await redis.eval(luaScript, [lockKey], [lockToken]);
+                } catch (e) {
+                    console.warn("[overpass] Failed to release lock safely:", e);
+                }
+            }
+        }
     } catch (err) {
         console.error("[overpass] Uncaught error:", err);
         return NextResponse.json(


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR ONLY touches the required file.

> [!WARNING]
> PR contains only the changes required for this issue. No unrelated files have been modified.

## 📋 PR Summary & Link

- **Closes #4289 
- **Summary:**
  - Prevented cache stampede in the Overpass API route.
  - Added query-specific Redis distributed locking using atomic `SET NX` with TTL.
  - Concurrent identical requests now coalesce around a single upstream fetch instead of independently querying Overpass mirrors.
  - Added a cache double-check after lock acquisition to prevent unnecessary upstream requests.
  - Added bounded cache polling for requests waiting on an existing lock.
  - Implemented token-safe atomic lock release using Redis Lua `EVAL`.
  - Preserved the existing Overpass mirror fetching and caching behavior.
  - Added Redis failure handling so the API can fall back to the existing upstream behavior.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**

### Testing / Verification

- The implementation was reviewed against concurrent-request scenarios and Redis lock race conditions.
- Verified that the lock is query-specific and has a TTL to prevent deadlocks.
- Verified that lock ownership is checked before releasing the lock.
- Verified that the existing Overpass mirror-fetching behavior remains unchanged.
- Verified that only the intended file was modified.

### Environment Limitation

> [!NOTE]
> Automated Jest tests could not be executed locally because the current environment does not have the required `node_modules`/Jest dependencies installed.
>
> Running the test command resulted in:
>
> `jest is not recognized as an internal or external command`
>
> Therefore, no automated test result is being claimed locally.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [x] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [x] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## 🔧 Implementation Details

### Distributed Request Coalescing

Concurrent requests for the same Overpass query now use a shared Redis lock:

```text
Request A ──> Cache MISS ──> Acquire Lock ──> Upstream Fetch ──> Cache
Request B ──> Cache MISS ──> Wait ────────────────> Cache HIT
Request C ──> Cache MISS ──> Wait ────────────────> Cache HIT