### PR TITLE
fix(api): use SameSite=None for CSRF cookies in production to support cross-origin frontend

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -268,7 +268,7 @@ const { doubleCsrfProtection, generateCsrfToken: generateToken } = doubleCsrf({
         process.env.NODE_ENV === "production" ? "__Host-psifi.x-csrf-token" : "psifi.x-csrf-token",
     cookieOptions: {
         httpOnly: true,
-        sameSite: process.env.NODE_ENV === "production" ? "strict" : "lax",
+        sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
         secure: process.env.NODE_ENV === "production",
         path: "/",
     },
@@ -304,7 +304,7 @@ app.get("/api/csrf-token", (req: Request, res: Response) => {
 
         res.cookie(ANON_SESSION_COOKIE, anonId, {
             httpOnly: true,
-            sameSite: "strict",
+            sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
             secure: process.env.NODE_ENV === "production",
             path: "/",
         });


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #4290**
- **Summary:**
The Scheme Eligibility submission failed with "invalid csrf token" because the frontend and backend are on different origins (Vercel and Render). CSRF cookies were set with `SameSite=Strict`, which browsers never send on cross-site requests — so the POST request always arrived with a valid token but no matching cookie, and was correctly rejected.

Both the main CSRF cookie and the anon session cookie now use `SameSite=None` in production (paired with the existing `Secure` flag, as the spec requires), while staying `SameSite=Lax` in development for same-origin local testing.

## 📸 Proof of Work (Screenshots / Logs)
<img width="1919" height="942" alt="image" src="https://github.com/user-attachments/assets/cd5a2dca-267a-4aa8-8869-759bbb885f51" />



## 🏷️ PR Type
- [x] 🐛 `type: bug`
- [x] 🔒 `type: security`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #4290`)
- [x] I have pulled the latest `main` and resolved any conflicts