### PR TITLE
feat(notifications): add daily dosage reminder cron job

### DIFF
--- a/apps/api/src/cron/dosage-reminder.ts
+++ b/apps/api/src/cron/dosage-reminder.ts
@@ -1,13 +1,11 @@
 const cron = require("node-cron");
 import { supabase } from "../db/client";
 import logger from "../utils/logger";
-import { redisClient } from "../utils/redis";
 import { smsService } from "../services/sms-service";
 import { whatsappService } from "../services/whatsapp-service";
+import { createLock, acquireLock, releaseLock } from "../utils/distributedLock";
 
-const LOCK_KEY = "dosage-reminder:lock";
-const LOCK_TTL_MS = 4 * 60 * 1000; // 4 minutes, shorter than the 5-min tick
-const LOCK_VALUE = `${process.env.HOSTNAME ?? "api"}:${process.pid}`;
+const LOCK = createLock("dosage-reminder:lock", 4 * 60 * 1000); // 4 minutes, shorter than the 5-min tick
 // How close "now" must be to a scheduled time to count as due. The cron ticks
 // every 5 minutes, so a 5-minute tolerance window ensures no slot is missed
 // while still being tight enough to feel like a "daily reminder", not spam.
@@ -19,36 +17,6 @@ interface DueSchedule {
     medicine_name: string;
     dosage: string;
     times: string[];
-}
-
-async function acquireLock(): Promise<boolean> {
-    if (!redisClient.isOpen) {
-        logger.warn("Redis not connected; skipping distributed lock for dosage reminder cron.");
-        return true;
-    }
-    try {
-        const result = await redisClient.set(LOCK_KEY, LOCK_VALUE, { NX: true, PX: LOCK_TTL_MS });
-        return result === "OK";
-    } catch (err) {
-        logger.error({ message: "Failed to acquire dosage reminder lock", error: err });
-        return false;
-    }
-}
-
-async function releaseLock(): Promise<void> {
-    if (!redisClient.isOpen) return;
-    try {
-        const script = `
-            if redis.call("get", KEYS[1]) == ARGV[1] then
-                return redis.call("del", KEYS[1])
-            else
-                return 0
-            end
-        `;
-        await redisClient.eval(script, { keys: [LOCK_KEY], arguments: [LOCK_VALUE] });
-    } catch (err) {
-        logger.error({ message: "Failed to release dosage reminder lock", error: err });
-    }
 }
 
 function isTimeDue(timeStr: string, now: Date): boolean {
@@ -169,7 +137,7 @@ export async function runDosageReminderCheck(now: Date = new Date()): Promise<vo
 export const initDosageReminderCron = (): { stop: () => void } => {
     // Every 5 minutes, matching MATCH_WINDOW_MINUTES so no slot is skipped.
     return cron.schedule("*/5 * * * *", async () => {
-        const acquired = await acquireLock();
+        const acquired = await acquireLock(LOCK, "dosage reminder cron");
         if (!acquired) {
             logger.info("Dosage reminder lock held by another instance — skipping this tick.");
             return;
@@ -181,7 +149,7 @@ export const initDosageReminderCron = (): { stop: () => void } => {
                 error: err,
             });
         } finally {
-            await releaseLock();
+            await releaseLock(LOCK, "dosage reminder cron");
         }
     });
 };

--- a/apps/api/src/cron/dosage-reminder.ts
+++ b/apps/api/src/cron/dosage-reminder.ts
@@ -121,7 +121,28 @@ async function sendDosageReminder(schedule: DueSchedule): Promise<boolean> {
     const results = await Promise.allSettled(sendPromises);
     return results.some((r) => r.status === "fulfilled" && r.value);
 }
+async function processScheduleTime(
+    schedule: DueSchedule,
+    timeStr: string,
+    now: Date,
+    todayStr: string
+): Promise<void> {
+    if (!isTimeDue(timeStr, now)) return;
 
+    const sent = await alreadySent(schedule.id, timeStr, todayStr);
+    if (sent) return;
+
+    const delivered = await sendDosageReminder(schedule);
+    if (delivered) {
+        await markSent(schedule.id, timeStr, todayStr);
+        return;
+    }
+
+    logger.warn("Dosage reminder not delivered; will retry next tick.", {
+        scheduleId: schedule.id,
+        timeStr,
+    });
+}
 export async function runDosageReminderCheck(now: Date = new Date()): Promise<void> {
     const todayStr = now.toISOString().split("T")[0];
 
@@ -139,22 +160,8 @@ export async function runDosageReminderCheck(now: Date = new Date()): Promise<vo
 
     for (const schedule of (schedules as DueSchedule[]) ?? []) {
         const times: string[] = Array.isArray(schedule.times) ? schedule.times : [];
-
         for (const timeStr of times) {
-            if (!isTimeDue(timeStr, now)) continue;
-
-            const sent = await alreadySent(schedule.id, timeStr, todayStr);
-            if (sent) continue;
-
-            const delivered = await sendDosageReminder(schedule);
-            if (delivered) {
-                await markSent(schedule.id, timeStr, todayStr);
-            } else {
-                logger.warn("Dosage reminder not delivered; will retry next tick.", {
-                    scheduleId: schedule.id,
-                    timeStr,
-                });
-            }
+            await processScheduleTime(schedule, timeStr, now, todayStr);
         }
     }
 }

--- a/apps/api/src/cron/dosage-reminder.ts
+++ b/apps/api/src/cron/dosage-reminder.ts
@@ -1,0 +1,180 @@
+const cron = require("node-cron");
+import { supabase } from "../db/client";
+import logger from "../utils/logger";
+import { redisClient } from "../utils/redis";
+import { smsService } from "../services/sms-service";
+import { whatsappService } from "../services/whatsapp-service";
+
+const LOCK_KEY = "dosage-reminder:lock";
+const LOCK_TTL_MS = 4 * 60 * 1000; // 4 minutes, shorter than the 5-min tick
+const LOCK_VALUE = `${process.env.HOSTNAME ?? "api"}:${process.pid}`;
+// How close "now" must be to a scheduled time to count as due. The cron ticks
+// every 5 minutes, so a 5-minute tolerance window ensures no slot is missed
+// while still being tight enough to feel like a "daily reminder", not spam.
+const MATCH_WINDOW_MINUTES = 5;
+
+interface DueSchedule {
+    id: string;
+    user_id: string;
+    medicine_name: string;
+    dosage: string;
+    times: string[];
+}
+
+async function acquireLock(): Promise<boolean> {
+    if (!redisClient.isOpen) {
+        logger.warn("Redis not connected; skipping distributed lock for dosage reminder cron.");
+        return true;
+    }
+    try {
+        const result = await redisClient.set(LOCK_KEY, LOCK_VALUE, { NX: true, PX: LOCK_TTL_MS });
+        return result === "OK";
+    } catch (err) {
+        logger.error({ message: "Failed to acquire dosage reminder lock", error: err });
+        return false;
+    }
+}
+
+async function releaseLock(): Promise<void> {
+    if (!redisClient.isOpen) return;
+    try {
+        const script = `
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("del", KEYS[1])
+            else
+                return 0
+            end
+        `;
+        await redisClient.eval(script, { keys: [LOCK_KEY], arguments: [LOCK_VALUE] });
+    } catch (err) {
+        logger.error({ message: "Failed to release dosage reminder lock", error: err });
+    }
+}
+
+function isTimeDue(timeStr: string, now: Date): boolean {
+    const [hh, mm] = timeStr.split(":").map(Number);
+    if (Number.isNaN(hh) || Number.isNaN(mm)) return false;
+
+    const scheduled = new Date(now);
+    scheduled.setHours(hh, mm, 0, 0);
+
+    const diffMinutes = Math.abs(now.getTime() - scheduled.getTime()) / (1000 * 60);
+    return diffMinutes <= MATCH_WINDOW_MINUTES;
+}
+
+async function alreadySent(scheduleId: string, timeStr: string, dateStr: string): Promise<boolean> {
+    const { data, error } = await supabase
+        .from("dosage_reminder_deliveries")
+        .select("id")
+        .eq("schedule_id", scheduleId)
+        .eq("scheduled_time", timeStr)
+        .eq("reminder_date", dateStr)
+        .maybeSingle();
+
+    if (error) {
+        logger.error({ message: "Failed to check dosage reminder delivery record", error });
+        return false;
+    }
+    return Boolean(data);
+}
+
+async function markSent(scheduleId: string, timeStr: string, dateStr: string): Promise<void> {
+    const { error } = await supabase
+        .from("dosage_reminder_deliveries")
+        .upsert(
+            { schedule_id: scheduleId, scheduled_time: timeStr, reminder_date: dateStr },
+            { onConflict: "schedule_id,scheduled_time,reminder_date" }
+        );
+    if (error) {
+        logger.error({ message: "Failed to record dosage reminder delivery", error });
+    }
+}
+
+async function sendDosageReminder(schedule: DueSchedule): Promise<boolean> {
+    const { data: subscriber, error } = await supabase
+        .from("notification_subscribers")
+        .select("phone, language, channels")
+        .eq("user_id", schedule.user_id)
+        .eq("is_active", true)
+        .eq("status", "active")
+        .maybeSingle();
+
+    if (error) {
+        logger.error({ message: "Failed to fetch subscriber for dosage reminder", error });
+        return false;
+    }
+    if (!subscriber?.phone) return false;
+
+    const message = `SahiDawa Reminder: Time to take ${schedule.medicine_name} (${schedule.dosage}).`;
+
+    const sendPromises: Promise<boolean>[] = [];
+    if (subscriber.channels?.includes("sms")) {
+        sendPromises.push(smsService.send(subscriber.phone, message, subscriber.language ?? "en"));
+    }
+    if (subscriber.channels?.includes("whatsapp")) {
+        sendPromises.push(
+            whatsappService.send(subscriber.phone, message, subscriber.language ?? "en")
+        );
+    }
+    if (sendPromises.length === 0) return false;
+
+    const results = await Promise.allSettled(sendPromises);
+    return results.some((r) => r.status === "fulfilled" && r.value);
+}
+
+export async function runDosageReminderCheck(now: Date = new Date()): Promise<void> {
+    const todayStr = now.toISOString().split("T")[0];
+
+    const { data: schedules, error } = await supabase
+        .from("medicine_schedules")
+        .select("id, user_id, medicine_name, dosage, times")
+        .eq("is_active", true)
+        .lte("start_date", todayStr)
+        .or(`end_date.is.null,end_date.gte.${todayStr}`);
+
+    if (error) {
+        logger.error({ message: "Failed to fetch active medicine schedules", error });
+        return;
+    }
+
+    for (const schedule of (schedules as DueSchedule[]) ?? []) {
+        const times: string[] = Array.isArray(schedule.times) ? schedule.times : [];
+
+        for (const timeStr of times) {
+            if (!isTimeDue(timeStr, now)) continue;
+
+            const sent = await alreadySent(schedule.id, timeStr, todayStr);
+            if (sent) continue;
+
+            const delivered = await sendDosageReminder(schedule);
+            if (delivered) {
+                await markSent(schedule.id, timeStr, todayStr);
+            } else {
+                logger.warn("Dosage reminder not delivered; will retry next tick.", {
+                    scheduleId: schedule.id,
+                    timeStr,
+                });
+            }
+        }
+    }
+}
+
+export const initDosageReminderCron = (): { stop: () => void } => {
+    // Every 5 minutes, matching MATCH_WINDOW_MINUTES so no slot is skipped.
+    return cron.schedule("*/5 * * * *", async () => {
+        const acquired = await acquireLock();
+        if (!acquired) {
+            logger.info("Dosage reminder lock held by another instance — skipping this tick.");
+            return;
+        }
+        try {
+            await runDosageReminderCheck();
+        } catch (err) {
+            logger.error("Dosage reminder cron: unhandled error during scheduled run", {
+                error: err,
+            });
+        } finally {
+            await releaseLock();
+        }
+    });
+};

--- a/apps/api/src/services/jobScheduler.service.ts
+++ b/apps/api/src/services/jobScheduler.service.ts
@@ -20,13 +20,15 @@ class JobScheduler {
             return;
         }
 
-        this.jobs.push(startAlertBroadcaster());
-        this.jobs.push(startTempCleanupJob());
-        this.jobs.push(initExpiryCron());
-        this.jobs.push(initDosageReminderCron());
-        this.jobs.push(initDistrictAlertSyncCron());
-        this.jobs.push(startPgCronMonitor());
-        this.jobs.push(startSmsWorker());
+        this.jobs.push(
+            startAlertBroadcaster(),
+            startTempCleanupJob(),
+            initExpiryCron(),
+            initDosageReminderCron(),
+            initDistrictAlertSyncCron(),
+            startPgCronMonitor(),
+            startSmsWorker()
+        );
         logger.info("All background jobs have been started.");
     }
 

--- a/apps/api/src/services/jobScheduler.service.ts
+++ b/apps/api/src/services/jobScheduler.service.ts
@@ -2,6 +2,7 @@ import logger from "../utils/logger";
 import { startAlertBroadcaster } from "../cron/alert-broadcaster";
 import { startTempCleanupJob } from "../cron/tempCleanup";
 import { initExpiryCron } from "../cron/expiry-check";
+import { initDosageReminderCron } from "../cron/dosage-reminder";
 import { initDistrictAlertSyncCron } from "../cron/districtAlertSync";
 import { startPgCronMonitor } from "../cron/pgCronMonitor";
 import { startSmsWorker } from "../workers/smsWorker";
@@ -22,6 +23,7 @@ class JobScheduler {
         this.jobs.push(startAlertBroadcaster());
         this.jobs.push(startTempCleanupJob());
         this.jobs.push(initExpiryCron());
+        this.jobs.push(initDosageReminderCron());
         this.jobs.push(initDistrictAlertSyncCron());
         this.jobs.push(startPgCronMonitor());
         this.jobs.push(startSmsWorker());

--- a/apps/api/src/utils/distributedLock.ts
+++ b/apps/api/src/utils/distributedLock.ts
@@ -1,0 +1,42 @@
+import { redisClient } from "./redis";
+import logger from "./logger";
+
+export interface DistributedLock {
+    key: string;
+    ttlMs: number;
+    value: string;
+}
+
+export function createLock(key: string, ttlMs: number): DistributedLock {
+    return { key, ttlMs, value: `${process.env.HOSTNAME ?? "api"}:${process.pid}` };
+}
+
+export async function acquireLock(lock: DistributedLock, context: string): Promise<boolean> {
+    if (!redisClient.isOpen) {
+        logger.warn(`Redis not connected; skipping distributed lock for ${context}.`);
+        return true;
+    }
+    try {
+        const result = await redisClient.set(lock.key, lock.value, { NX: true, PX: lock.ttlMs });
+        return result === "OK";
+    } catch (err) {
+        logger.error({ message: `Failed to acquire lock for ${context}`, error: err });
+        return false;
+    }
+}
+
+export async function releaseLock(lock: DistributedLock, context: string): Promise<void> {
+    if (!redisClient.isOpen) return;
+    try {
+        const script = `
+            if redis.call("get", KEYS[1]) == ARGV[1] then
+                return redis.call("del", KEYS[1])
+            else
+                return 0
+            end
+        `;
+        await redisClient.eval(script, { keys: [lock.key], arguments: [lock.value] });
+    } catch (err) {
+        logger.error({ message: `Failed to release lock for ${context}`, error: err });
+    }
+}

--- a/supabase/migrations/20260812220000_create_dosage_reminder_deliveries.sql
+++ b/supabase/migrations/20260812220000_create_dosage_reminder_deliveries.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS public.dosage_reminder_deliveries (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    schedule_id UUID NOT NULL REFERENCES public.medicine_schedules(id) ON DELETE CASCADE,
+    scheduled_time TEXT NOT NULL,
+    reminder_date DATE NOT NULL,
+    sent_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (schedule_id, scheduled_time, reminder_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dosage_reminder_deliveries_date
+    ON public.dosage_reminder_deliveries(reminder_date);


### PR DESCRIPTION
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #4303**
- **Summary:** Adds the daily dosage-reminder cron. Every 5 minutes it scans active `medicine_schedules`, matches any dose time within a 5-minute window, and sends a WhatsApp/SMS reminder via the existing `notification_subscribers` + `whatsapp-service`/`sms-service`. A new `dosage_reminder_deliveries` table dedupes so the same dose isn't sent twice in one day. Registered in `jobScheduler.service.ts` alongside the other crons. Opt-in/opt-out UI, subscriber table, and WhatsApp client already existed on `main` — this PR only fills the missing cron piece.

## 📸 Proof of Work (Screenshots / Logs)
Backend-only cron job, no UI changes in this PR — opt-in/opt-out UI already exists at `/settings`.

`npx tsc --noEmit` passes clean on all changed files (pre-existing unrelated error in `partner.ts` confirmed present on `main` before this branch).

## 🏷️ PR Type
- [x] ✨ `type: feature`
- [x] 🛠️ `type: devops`

## ✅ Checklist
- [x] My PR has a linked issue (`Closes #4303`)
- [x] I have pulled the latest `main` and resolved any conflicts