### PR TITLE
fix(api): prevent OTP rate limit bypass by scoping to target phone number

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -269,24 +269,8 @@ export const analyticsLimiter = rateLimit({
     },
 });
 
-/** Authentication endpoints — strict limit to prevent credential brute-forcing and OTP bombing. */
-export const authLimiter = rateLimit({
-    skip: () => process.env.NODE_ENV === "test",
-    windowMs: 60 * 1000,
-    max: 5,
-    standardHeaders: true,
-    legacyHeaders: false,
-    store: buildStore("auth"),
-    validate: false,
-    handler: (_req, res) => {
-        res.status(429).json({
-            error: "Too many authentication attempts. Please try again later.",
-        });
-    },
-});
-
 /**
- * Builds the bucket key for {@link authTargetLimiter}.
+ * Builds the bucket key for authentication limiters.
  *
  * Exported so the key derivation can be unit-tested on its own - a mismatch
  * here silently degrades the limiter to per-IP instead of failing loudly.
@@ -319,6 +303,25 @@ export const authTargetKeyGenerator = (req: Request): string => {
     return (req.ip || "unknown").replace(/:/g, "_");
 };
 
+/** Authentication endpoints — strict limit to prevent credential brute-forcing and OTP bombing. */
+export const authLimiter = rateLimit({
+    skip: () => process.env.NODE_ENV === "test",
+    windowMs: 60 * 1000,
+    max: 5,
+    keyGenerator: authTargetKeyGenerator,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: buildStore("auth"),
+    validate: false,
+    handler: (_req, res) => {
+        res.status(429).json({
+            error: "Too many authentication attempts. Please try again later.",
+        });
+    },
+});
+
+
+
 /** Target-based limiter to prevent OTP bombing against a specific user/target irrespective of IP */
 export const authTargetLimiter = rateLimit({
     skip: () => process.env.NODE_ENV === "test",
@@ -341,6 +344,7 @@ export const notificationRegisterLimiter = rateLimit({
     skip: () => process.env.NODE_ENV === "test",
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 5,
+    keyGenerator: authTargetKeyGenerator,
     standardHeaders: true,
     legacyHeaders: false,
     validate: false,


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4329 **
- **Summary:** Updated the authentication rate limiters (`authLimiter` and `notificationRegisterLimiter`) in `apps/api/src/middleware/rateLimit.ts` to use `authTargetKeyGenerator`. This prevents attackers from bypassing OTP brute-force protections by rotating IP addresses, as rate limits are now strictly scoped to the target phone number being authenticated.

## 📸 Proof of Work (Screenshots / Logs)

> [!IMPORTANT]
> **No Pull Request will be merged without proof of testing!**
>
> - **Frontend/UI changes:** You MUST attach screenshots or screen recordings (GIFs/Videos) showing the UI changes.
>
> _Please drag & drop your screenshots/GIFs here:_
*(Note: As this is a backend security fix for API rate limiting, no UI changes are present. I have successfully run the backend build and verified the rate limiters now accurately scope by phone number in the request body rather than `req.ip`.)*

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [x] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4329`)
- [x] I have pulled the latest `main` and resolved any conflicts
