### PR TITLE
fix(login): trim email before signInWithPassword to prevent whitespace-induced auth failures

### DIFF
--- a/apps/web/app/[locale]/login/page.tsx
+++ b/apps/web/app/[locale]/login/page.tsx
@@ -108,7 +108,7 @@ export default function LoginPage() {
 
         try {
             const { data, error } = await supabase.auth.signInWithPassword({
-                email,
+                email: email.trim(),
                 password,
             });
 


### PR DESCRIPTION



### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4325**
- **Summary:**
Changed email → email.trim() in the signInWithPassword call at apps/web/app/[locale]/login/page.tsx:111, consistent with how the signup page already handles it at signup/page.tsx:115.
Testing
- Lint and type checks pass (prettier, madge --circular).
- No additional logic changed — single-line fix.


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4325 `)
- [x] I have pulled the latest `main` and resolved any conflicts
