### PR TITLE
fix(map): remove stack trace from nearby endpoint error response

### DIFF
--- a/apps/api/src/routes/map.ts
+++ b/apps/api/src/routes/map.ts
@@ -287,7 +287,6 @@ router.get(
             logger.error({ message: "Error fetching nearby facilities", error: err });
             res.status(500).json({
                 error: "Internal server error",
-                details: err instanceof Error ? err.stack : String(err),
             });
         }
     }


### PR DESCRIPTION


### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4326**
- **Summary:**
Deleted the details field from the JSON response. The response now returns only { error: "Internal server error" }, matching standard practice. Server-side logging via logger.error is preserved and unchanged.
Testing
- Lint and type checks pass (prettier, madge --circular).
- Single-line removal — no logic changes.


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4326`)
- [x] I have pulled the latest `main` and resolved any conflicts
