### PR TITLE
fix(webhooks): capture drug:batch and brand_cache keys in invalidation response

### DIFF
--- a/apps/api/src/routes/webhooks.ts
+++ b/apps/api/src/routes/webhooks.ts
@@ -116,7 +116,8 @@ router.post(
 
             // 1. Invalidate drug lookup cache (helper scans and deletes matching keys)
             if (batchNumber) {
-                await invalidateCacheByPattern(`drug:batch:${batchNumber}*`);
+                const batchKeys = await invalidateCacheByPattern(`drug:batch:${batchNumber}*`);
+                keysToDelete.push(...batchKeys);
             }
 
             // 2. Invalidate voice search cache for matching brand and generic names
@@ -147,7 +148,8 @@ router.post(
             // entries keyed by any user-supplied substring (e.g. "dolo"), which exact-name
             // deletion above cannot enumerate — sweep the whole namespace on that rare event.
             if (verificationStatusChanged(oldRecord, record)) {
-                await invalidateCacheByPattern("brand_cache:*");
+                const brandCacheKeys = await invalidateCacheByPattern("brand_cache:*");
+                keysToDelete.push(...brandCacheKeys);
             }
 
             // 4. Perform deletion if keys exist


### PR DESCRIPTION




### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

> [!WARNING]
> PRs with unrelated files will not be reviewed and may be closed.

## 📋 PR Summary & Link

- **Closes #4327**
- **Summary:**
Captured both return values and spread them into keysToDelete. The existing Set deduplication on line 154 handles any overlaps between the collected keys and the scanned keys.
Testing
- Lint and type checks pass (prettier, madge --circular).
- No logic changes beyond capturing and merging the two return values.

## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [ ] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4327`)
- [x] I have pulled the latest `main` and resolved any conflicts
