### PR TITLE
fix: log warnings when notification cache cleanup fails

### DIFF
--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -323,7 +323,9 @@ async function clearPendingPhoneChange(userId: string): Promise<void> {
     if (!redisClient.isOpen) return;
     try {
         await redisClient.del(getPendingPhoneChangeKey(userId));
-    } catch {}
+    } catch (err) {
+        logger.warn("Failed to clear pending phone change", { err, userId });
+    }
 }
 
 router.get("/status", limiter, optionalAuth, async (req: AuthenticatedRequest, res) => {
@@ -888,7 +890,9 @@ router.patch(
                         .eq("user_id", req.user.id)
                         .maybeSingle();
                     currentSubscriber = data;
-                } catch {}
+                } catch (err) {
+                    logger.warn("Failed to load notification subscriber", { err });
+                }
             }
             if (!currentSubscriber) {
                 currentSubscriber = memorySubscriberStore.find((s) => s.user_id === req.user!.id);


### PR DESCRIPTION
## Summary
Adds error logging to two empty catch blocks in the notifications route so Redis/DB cleanup failures are observable instead of silently swallowed.

## Changes
- `clearPendingPhoneChange` now logs a warning when Redis cleanup fails
- Subscriber load now logs when the DB lookup throws

## Checklist
- [x] No new dependencies
- [x] Uses existing logger