### PR TITLE
feat(voice): add voice-activated medicine logging to interaction checker

### DIFF
--- a/apps/ml/main.py
+++ b/apps/ml/main.py
@@ -109,6 +109,13 @@ if not tts_loaded:
         "TTS routes are disabled. Install google-cloud-texttospeech or configure Azure TTS."
     )
 include_router_if_available(app, "routers.voice_verify", required=True, dependencies=auth)
+# Optional: voice-driven medicine-name extraction. Degrades gracefully to an
+# empty list when the LLM stack/API key is absent, so it need not be required.
+extract_loaded = include_router_if_available(
+    app, "routers.medicine_extract", required=False, dependencies=auth
+)
+if not extract_loaded:
+    logger.warning("Medicine-extraction routes are disabled in this runtime.")
 
 @app.get("/")
 @app.head("/")

--- a/apps/ml/routers/medicine_extract.py
+++ b/apps/ml/routers/medicine_extract.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+from typing import List
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+from starlette.concurrency import run_in_threadpool
+
+from services.medicine_extractor import extract_medicines_from_text
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/medicine-extract", tags=["Medicine Extraction"])
+
+# A single spoken utterance is short; 2k characters is a generous ceiling that
+# still guards the LLM call against oversized payloads.
+MAX_TEXT_LENGTH = 2000
+
+
+class MedicineExtractRequest(BaseModel):
+    text: str = Field(..., min_length=1, max_length=MAX_TEXT_LENGTH)
+
+
+class MedicineExtractResponse(BaseModel):
+    medicines: List[str]
+
+
+@router.post("", response_model=MedicineExtractResponse)
+async def medicine_extract(payload: MedicineExtractRequest) -> MedicineExtractResponse:
+    # extract_medicines_from_text makes a blocking LLM call — keep the event loop free.
+    medicines = await run_in_threadpool(extract_medicines_from_text, payload.text)
+    return MedicineExtractResponse(medicines=medicines)

--- a/apps/ml/services/medicine_extractor.py
+++ b/apps/ml/services/medicine_extractor.py
@@ -1,0 +1,183 @@
+"""
+Conversational medicine-name extraction.
+
+Given free-form, code-switched (Hindi/English) speech transcripts such as
+"Main subah Paracetamol aur raat ko Metformin leta hu", extract just the
+medicine names as a clean list — ["Paracetamol", "Metformin"].
+
+Mirrors the LangChain + Gemini structured-output pattern already used by
+``services/alert_extractor.py`` (the codebase's standard LLM stack), rather
+than introducing a new provider. Falls back to Groq when configured, and
+degrades gracefully to an empty list when no LLM is available so callers
+never crash on a missing API key.
+"""
+
+import logging
+import os
+import re
+from typing import List
+
+from pydantic import BaseModel, Field
+
+try:
+    from langchain_google_genai import ChatGoogleGenerativeAI
+    from langchain_core.prompts import ChatPromptTemplate
+
+    LANGCHAIN_AVAILABLE = True
+except ImportError:
+    LANGCHAIN_AVAILABLE = False
+    logging.warning(
+        "LangChain or langchain-google-genai is not installed. "
+        "Medicine extractor will return an empty list if called."
+    )
+
+logger = logging.getLogger(__name__)
+
+# Guardrails on the returned list — a single conversational utterance realistically
+# names only a handful of medicines; anything beyond this is almost certainly noise.
+MAX_MEDICINES = 20
+MAX_NAME_LENGTH = 100
+
+
+class ExtractedMedicine(BaseModel):
+    name: str = Field(
+        description="A single medicine name exactly as a pharmacist would write it "
+        "(brand or generic), with no dosage, frequency, or timing words."
+    )
+
+
+class MedicineList(BaseModel):
+    medicines: List[ExtractedMedicine] = Field(
+        default_factory=list,
+        description="Every distinct medicine mentioned in the text.",
+    )
+
+
+def _clean_name(value: str) -> str:
+    """Trim, collapse internal whitespace, and strip control/angle characters."""
+    if not value:
+        return ""
+    value = re.sub(r"[\x00-\x1f\x7f-\x9f<>]", "", str(value))
+    value = re.sub(r"\s+", " ", value).strip()
+    return value[:MAX_NAME_LENGTH]
+
+
+def _normalise(names: List[str]) -> List[str]:
+    """Clean, drop empties/noise, and de-duplicate case-insensitively (order-preserving)."""
+    seen: set[str] = set()
+    result: List[str] = []
+    for raw in names:
+        name = _clean_name(raw)
+        if len(name) < 2:
+            continue
+        # Reject anything with no alphabetic character (pure digits/punctuation).
+        if not re.search(r"[A-Za-zऀ-ॿ]", name):
+            continue
+        key = name.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(name)
+        if len(result) >= MAX_MEDICINES:
+            break
+    return result
+
+
+def _build_structured_llm():
+    """Assemble a structured-output LLM (Gemini primary, Groq fallback)."""
+    google_api_key = os.getenv("GOOGLE_API_KEY")
+    groq_api_key = os.getenv("GROQ_API_KEY")
+
+    if not google_api_key and not groq_api_key:
+        logger.warning(
+            "No API key set (GOOGLE_API_KEY or GROQ_API_KEY). Cannot extract medicines."
+        )
+        return None
+
+    google_structured = None
+    if google_api_key:
+        llm_google = ChatGoogleGenerativeAI(
+            model="gemini-2.0-flash", temperature=0, google_api_key=google_api_key
+        )
+        google_structured = llm_google.with_structured_output(MedicineList)
+
+    groq_structured = None
+    if groq_api_key:
+        try:
+            from langchain_groq import ChatGroq
+
+            llm_groq = ChatGroq(
+                model="llama-3.3-70b-versatile", temperature=0, groq_api_key=groq_api_key
+            )
+            groq_structured = llm_groq.with_structured_output(MedicineList)
+        except ImportError:
+            logger.warning("langchain-groq not installed. Groq fallback unavailable.")
+
+    if google_structured and groq_structured:
+        return google_structured.with_fallbacks([groq_structured])
+    return google_structured or groq_structured
+
+
+def extract_medicines_from_text(text: str) -> List[str]:
+    """
+    Extract medicine names from conversational, possibly code-switched, text.
+
+    Parameters
+    ----------
+    text:
+        A speech transcript, e.g. "Main subah Paracetamol aur raat ko Metformin leta hu".
+
+    Returns
+    -------
+    A de-duplicated list of medicine names, e.g. ["Paracetamol", "Metformin"].
+    Returns an empty list when the text is blank or no LLM is available.
+    """
+    if not text or not text.strip():
+        return []
+
+    if not LANGCHAIN_AVAILABLE:
+        logger.error("LangChain dependencies missing — cannot extract medicines.")
+        return []
+
+    try:
+        structured_llm = _build_structured_llm()
+        if structured_llm is None:
+            return []
+
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    "You are a clinical assistant that extracts medicine names from a "
+                    "patient's spoken words. The speech is often conversational and mixes "
+                    "Hindi and English (Hinglish). Return ONLY the names of medicines "
+                    "(brand or generic). Do NOT include dosages (500mg), frequencies "
+                    "(twice daily, subah, raat), symptoms, foods, or any other words. "
+                    "Correct obvious spelling/transliteration so the name matches how a "
+                    "pharmacist would write it. If no medicine is mentioned, return an "
+                    "empty list.",
+                ),
+                ("human", "Extract the medicine names from this text:\n\n{text}"),
+            ]
+        )
+
+        chain = prompt | structured_llm
+        result = chain.invoke({"text": text})
+
+        items = getattr(result, "medicines", None)
+        if items is None and isinstance(result, dict):
+            items = result.get("medicines", [])
+        if not items:
+            return []
+
+        names: List[str] = []
+        for item in items:
+            if isinstance(item, dict):
+                names.append(item.get("name", ""))
+            else:
+                names.append(getattr(item, "name", ""))
+
+        return _normalise(names)
+    except Exception as exc:
+        logger.error("Error extracting medicines from text: %s", exc)
+        return []

--- a/apps/web/app/[locale]/interaction-checker/page.tsx
+++ b/apps/web/app/[locale]/interaction-checker/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { fuzzyMatchBrand } from "@/lib/api";
 import { checkInteractions, type InteractionResult } from "@/lib/api/interactions";
+import { VoiceInputButton } from "@/components/ui/VoiceInputButton";
 import { PageHeader } from "../components/PageHeader";
 import { MAX_INTERACTION_MEDICINES } from "@sahidawa/shared";
 
@@ -198,6 +199,29 @@ export default function InteractionCheckerPage() {
         inputRef.current?.focus();
     };
 
+    // Add several medicines at once (e.g. from voice extraction). Computing the
+    // whole list in one pass avoids the stale-state race of calling
+    // handleAddMedicine in a loop, and enforces sanitization/dedupe/max limit.
+    const handleAddMedicines = (medNames: string[]) => {
+        const updated = [...selectedMedicines];
+
+        for (const medName of medNames) {
+            if (updated.length >= MAX_INTERACTION_MEDICINES) break;
+
+            const sanitized = medName.trim().replace(/[\x00-\x1F\x7F-\x9F<>]/g, "");
+            if (!sanitized || sanitized.length > 100) continue;
+
+            const exists = updated.some((m) => m.toLowerCase() === sanitized.toLowerCase());
+            if (!exists) updated.push(sanitized);
+        }
+
+        if (updated.length > selectedMedicines.length) {
+            saveMedicinesList(updated);
+        }
+        setSearchQuery("");
+        setSuggestions([]);
+    };
+
     const handleRemoveMedicine = (indexToRemove: number) => {
         const updated = selectedMedicines.filter((_, idx) => idx !== indexToRemove);
         saveMedicinesList(updated);
@@ -323,6 +347,18 @@ export default function InteractionCheckerPage() {
                                 <Plus size={18} />
                                 <span>{t("addButton")}</span>
                             </button>
+                            <VoiceInputButton
+                                onMedicinesExtracted={handleAddMedicines}
+                                labels={{
+                                    button: t("voice.button"),
+                                    listening: t("voice.listening"),
+                                    processing: t("voice.processing"),
+                                    unsupported: t("voice.unsupported"),
+                                    permissionDenied: t("voice.permissionDenied"),
+                                    error: t("voice.error"),
+                                    noMedicines: t("voice.noMedicines"),
+                                }}
+                            />
                         </div>
 
                         {/* Suggestions Dropdown */}

--- a/apps/web/app/api/voice/medicine-extract/route.ts
+++ b/apps/web/app/api/voice/medicine-extract/route.ts
@@ -1,0 +1,172 @@
+import { NextResponse } from "next/server";
+import { structuredLog } from "@/lib/structuredLogger";
+import { rateLimit } from "@/lib/rateLimit";
+import { getClientIp } from "@/lib/getClientIp";
+import { getMlServiceUrl, getMlAuthHeaders } from "@/lib/mlService";
+
+const ROUTE = "/api/voice/medicine-extract";
+const ML_EXTRACT_TIMEOUT_MS = 30_000;
+// Matches the ML service's MAX_TEXT_LENGTH — a spoken utterance is short.
+const MAX_TEXT_LENGTH = 2000;
+
+async function readJsonSafely(source: Request | Response) {
+    try {
+        return await source.json();
+    } catch {
+        return null;
+    }
+}
+
+export async function POST(req: Request) {
+    const startTime = Date.now();
+
+    const ip = getClientIp(req);
+    const { success } = await rateLimit.limit(ip);
+    if (!success) {
+        return NextResponse.json(
+            { error: "Too many requests. Please try again in a few moments." },
+            { status: 429 }
+        );
+    }
+
+    const body = await readJsonSafely(req);
+    const text = body && typeof body === "object" ? body.text : undefined;
+
+    if (typeof text !== "string" || !text.trim()) {
+        return NextResponse.json({ error: "Transcript text is required." }, { status: 400 });
+    }
+
+    if (text.length > MAX_TEXT_LENGTH) {
+        return NextResponse.json(
+            { error: `Transcript too long. Maximum length is ${MAX_TEXT_LENGTH} characters.` },
+            { status: 413 }
+        );
+    }
+
+    const mlServiceUrl = getMlServiceUrl();
+    if (!mlServiceUrl) {
+        structuredLog({
+            log_level: "error",
+            route: ROUTE,
+            error: {
+                message: "ML_SERVICE_URL is not configured",
+                code: 503,
+                stack: undefined,
+            },
+            meta: { missingVars: ["ML_SERVICE_URL"] },
+        });
+        return NextResponse.json(
+            {
+                error: "Medicine extraction service is currently unavailable.",
+                code: "ML_SERVICE_URL_MISSING",
+            },
+            { status: 503 }
+        );
+    }
+
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(() => abortController.abort(), ML_EXTRACT_TIMEOUT_MS);
+
+    try {
+        const upstreamResponse = await fetch(`${mlServiceUrl}/medicine-extract`, {
+            method: "POST",
+            headers: {
+                ...getMlAuthHeaders(),
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ text: text.trim() }),
+            signal: abortController.signal,
+        });
+
+        const latency_ms = Date.now() - startTime;
+        const upstreamData = await readJsonSafely(upstreamResponse);
+
+        if (!upstreamData || typeof upstreamData !== "object") {
+            structuredLog({
+                log_level: "error",
+                route: ROUTE,
+                latency_ms,
+                error: {
+                    message: "Extraction service returned an invalid response",
+                    code: 502,
+                    stack: undefined,
+                },
+                meta: { textLength: text.length },
+            });
+            return NextResponse.json(
+                { error: "Extraction service returned an invalid response." },
+                { status: 502 }
+            );
+        }
+
+        if (!upstreamResponse.ok) {
+            const statusCode = upstreamResponse.status;
+            const errorDetail =
+                typeof upstreamData.detail === "string" && upstreamData.detail.trim()
+                    ? upstreamData.detail
+                    : "Medicine extraction failed.";
+
+            structuredLog({
+                log_level: statusCode === 503 || statusCode === 429 ? "error" : "warn",
+                route: ROUTE,
+                latency_ms,
+                error: { message: errorDetail, code: statusCode, stack: undefined },
+                meta: { textLength: text.length },
+            });
+            return NextResponse.json({ error: errorDetail }, { status: statusCode });
+        }
+
+        const medicines = Array.isArray(upstreamData.medicines)
+            ? upstreamData.medicines.filter(
+                  (name: unknown): name is string => typeof name === "string"
+              )
+            : [];
+
+        structuredLog({
+            log_level: "info",
+            route: ROUTE,
+            latency_ms,
+            meta: { textLength: text.length, medicineCount: medicines.length },
+        });
+
+        return NextResponse.json({ medicines });
+    } catch (error) {
+        const latency_ms = Date.now() - startTime;
+
+        if (error instanceof Error && error.name === "AbortError") {
+            structuredLog({
+                log_level: "error",
+                route: ROUTE,
+                latency_ms,
+                error: {
+                    message: "Extraction service timed out",
+                    code: 504,
+                    stack: error.stack,
+                },
+                meta: { timeoutMs: ML_EXTRACT_TIMEOUT_MS },
+            });
+            return NextResponse.json(
+                { error: "Medicine extraction service timed out." },
+                { status: 504 }
+            );
+        }
+
+        structuredLog({
+            log_level: "error",
+            route: ROUTE,
+            latency_ms,
+            error: {
+                message: "Could not reach the extraction service",
+                code: 503,
+                stack: error instanceof Error ? error.stack : undefined,
+            },
+            meta: {},
+        });
+        return NextResponse.json(
+            { error: "Could not reach the medicine extraction service." },
+            { status: 503 }
+        );
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}

--- a/apps/web/components/ui/VoiceInputButton.tsx
+++ b/apps/web/components/ui/VoiceInputButton.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, Mic, Square } from "lucide-react";
+import { useVoiceRecorder, type VoiceRecorderError } from "@/hooks/useVoiceRecorder";
+import { transcribeRecordedAudio } from "@/app/[locale]/voice/lib/transcription";
+
+export interface VoiceInputLabels {
+    /** aria-label for the idle mic button. */
+    button: string;
+    /** Shown while recording (also the stop-button aria-label). */
+    listening: string;
+    /** Shown while transcribing + extracting. */
+    processing: string;
+    /** Browser lacks microphone recording support. */
+    unsupported: string;
+    /** Mic permission denied / unavailable. */
+    permissionDenied: string;
+    /** Generic transcription/extraction failure. */
+    error: string;
+    /** Audio understood but no medicine name found. */
+    noMedicines: string;
+}
+
+interface VoiceInputButtonProps {
+    /** Called with the medicine names extracted from speech. */
+    onMedicinesExtracted: (medicines: string[]) => void;
+    labels: VoiceInputLabels;
+    /** Optional BCP-47 hint passed to the transcription service. */
+    language?: string;
+    disabled?: boolean;
+    className?: string;
+}
+
+function extensionForType(type: string): string {
+    if (type.includes("mp4")) return "mp4";
+    if (type.includes("ogg")) return "ogg";
+    if (type.includes("wav")) return "wav";
+    return "webm";
+}
+
+/**
+ * One-tap microphone button that captures speech, transcribes it, and extracts
+ * medicine names — letting users add medicines without typing hard-to-spell
+ * drug names. Reuses the existing recording + transcription plumbing and the
+ * /api/voice/medicine-extract endpoint; the caller decides what to do with the
+ * extracted names (e.g. populate a search/cart).
+ */
+export function VoiceInputButton({
+    onMedicinesExtracted,
+    labels,
+    language,
+    disabled = false,
+    className = "",
+}: VoiceInputButtonProps) {
+    const {
+        isSupported,
+        isRecording,
+        error: recorderError,
+        start,
+        stop,
+        reset,
+    } = useVoiceRecorder();
+    const [isProcessing, setIsProcessing] = useState(false);
+    const [statusError, setStatusError] = useState<string | null>(null);
+
+    const recorderErrorMessage = (err: VoiceRecorderError | null): string | null => {
+        switch (err) {
+            case "unsupported":
+                return labels.unsupported;
+            case "permission":
+                return labels.permissionDenied;
+            case "too-large":
+            case "empty":
+                return labels.noMedicines;
+            case "unknown":
+                return labels.error;
+            default:
+                return null;
+        }
+    };
+
+    const message = statusError ?? recorderErrorMessage(recorderError);
+
+    const handleStart = async () => {
+        setStatusError(null);
+        reset();
+        await start();
+    };
+
+    const handleStop = async () => {
+        setIsProcessing(true);
+        try {
+            const blob = await stop();
+            if (!blob) {
+                // Hook already set an appropriate error (permission/empty/too-large).
+                return;
+            }
+
+            const file = new File([blob], `voice-input.${extensionForType(blob.type)}`, {
+                type: blob.type,
+            });
+
+            const { transcript } = await transcribeRecordedAudio(file, language);
+            if (!transcript.trim()) {
+                setStatusError(labels.noMedicines);
+                return;
+            }
+
+            const response = await fetch("/api/voice/medicine-extract", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ text: transcript }),
+            });
+            const data = await response.json().catch(() => null);
+
+            if (!response.ok) {
+                setStatusError(
+                    data && typeof data.error === "string" && data.error.trim()
+                        ? data.error
+                        : labels.error
+                );
+                return;
+            }
+
+            const medicines: string[] = Array.isArray(data?.medicines)
+                ? data.medicines.filter((name: unknown): name is string => typeof name === "string")
+                : [];
+
+            if (medicines.length === 0) {
+                setStatusError(labels.noMedicines);
+                return;
+            }
+
+            onMedicinesExtracted(medicines);
+        } catch {
+            setStatusError(labels.error);
+        } finally {
+            setIsProcessing(false);
+        }
+    };
+
+    if (!isSupported) {
+        // Nothing to render if the browser can't record — keeps the layout clean.
+        return null;
+    }
+
+    const busy = isProcessing;
+    const label = busy ? labels.processing : isRecording ? labels.listening : labels.button;
+
+    return (
+        <div className={`flex flex-col items-center ${className}`}>
+            <button
+                type="button"
+                onClick={isRecording ? handleStop : handleStart}
+                disabled={disabled || busy}
+                aria-label={label}
+                aria-pressed={isRecording}
+                title={label}
+                className={`relative flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-white shadow-sm transition disabled:opacity-50 ${
+                    isRecording
+                        ? "bg-red-600 hover:bg-red-700"
+                        : "bg-emerald-600 hover:bg-emerald-700"
+                } focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:outline-none`}
+            >
+                {isRecording && (
+                    // Animated pulse ring communicates "listening" at a glance.
+                    <span
+                        aria-hidden="true"
+                        className="absolute inset-0 animate-ping rounded-xl bg-red-500 opacity-60"
+                    />
+                )}
+                <span className="relative flex items-center justify-center">
+                    {busy ? (
+                        <Loader2 size={20} className="animate-spin" aria-hidden="true" />
+                    ) : isRecording ? (
+                        <Square size={18} aria-hidden="true" />
+                    ) : (
+                        <Mic size={20} aria-hidden="true" />
+                    )}
+                </span>
+            </button>
+
+            {(isRecording || busy || message) && (
+                <span
+                    role="status"
+                    aria-live="polite"
+                    className={`mt-1 max-w-[8rem] text-center text-xs font-semibold ${
+                        message && !isRecording && !busy
+                            ? "text-red-600 dark:text-red-400"
+                            : "text-(--color-text-muted)"
+                    }`}
+                >
+                    {message && !isRecording && !busy ? message : label}
+                </span>
+            )}
+        </div>
+    );
+}

--- a/apps/web/hooks/useVoiceRecorder.ts
+++ b/apps/web/hooks/useVoiceRecorder.ts
@@ -1,0 +1,159 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+    MAX_RECORDING_DURATION_MS,
+    getPreferredRecordingMimeType,
+    isRecordingBlobTooLarge,
+    supportsAudioRecording,
+} from "@/app/[locale]/voice/lib/recording";
+
+export type VoiceRecorderError = "unsupported" | "permission" | "too-large" | "empty" | "unknown";
+
+export interface UseVoiceRecorder {
+    /** True only after mount, once we know the browser supports MediaRecorder. */
+    isSupported: boolean;
+    isRecording: boolean;
+    error: VoiceRecorderError | null;
+    /** Request the mic and begin recording. Sets `error` and stays idle on failure. */
+    start: () => Promise<void>;
+    /** Stop recording and resolve the captured audio (or null if nothing usable). */
+    stop: () => Promise<Blob | null>;
+    /** Clear any error state. */
+    reset: () => void;
+}
+
+/**
+ * Reusable microphone-capture hook.
+ *
+ * A thin wrapper around the existing voice recording primitives
+ * (`app/[locale]/voice/lib/recording.ts`) so mic handling can be embedded
+ * outside the large /voice page flow — e.g. a one-tap button on a search bar.
+ * It deliberately owns only capture; transcription/extraction live in the caller.
+ */
+export function useVoiceRecorder(): UseVoiceRecorder {
+    const [isSupported, setIsSupported] = useState(false);
+    const [isRecording, setIsRecording] = useState(false);
+    const [error, setError] = useState<VoiceRecorderError | null>(null);
+
+    const recorderRef = useRef<MediaRecorder | null>(null);
+    const streamRef = useRef<MediaStream | null>(null);
+    const chunksRef = useRef<Blob[]>([]);
+    const autoStopRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // MediaRecorder / getUserMedia are only available in the browser, so resolve
+    // support after mount to avoid an SSR/client hydration mismatch.
+    useEffect(() => {
+        setIsSupported(
+            typeof window !== "undefined" &&
+                supportsAudioRecording(window) &&
+                Boolean(navigator.mediaDevices?.getUserMedia)
+        );
+    }, []);
+
+    const cleanup = useCallback(() => {
+        if (autoStopRef.current) {
+            clearTimeout(autoStopRef.current);
+            autoStopRef.current = null;
+        }
+        streamRef.current?.getTracks().forEach((track) => track.stop());
+        streamRef.current = null;
+        recorderRef.current = null;
+    }, []);
+
+    // Stop the mic and release resources if the component unmounts mid-recording.
+    useEffect(() => cleanup, [cleanup]);
+
+    const reset = useCallback(() => setError(null), []);
+
+    const start = useCallback(async () => {
+        setError(null);
+
+        if (recorderRef.current) {
+            // Already recording — ignore duplicate starts.
+            return;
+        }
+
+        if (typeof window === "undefined" || !supportsAudioRecording(window)) {
+            setError("unsupported");
+            return;
+        }
+
+        let stream: MediaStream;
+        try {
+            stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        } catch {
+            setError("permission");
+            return;
+        }
+
+        const mimeType = getPreferredRecordingMimeType(
+            window.MediaRecorder as unknown as { isTypeSupported?: (t: string) => boolean }
+        );
+
+        let recorder: MediaRecorder;
+        try {
+            recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+        } catch {
+            stream.getTracks().forEach((track) => track.stop());
+            setError("unknown");
+            return;
+        }
+
+        chunksRef.current = [];
+        recorder.ondataavailable = (event) => {
+            if (event.data && event.data.size > 0) {
+                chunksRef.current.push(event.data);
+            }
+        };
+
+        streamRef.current = stream;
+        recorderRef.current = recorder;
+        recorder.start();
+        setIsRecording(true);
+
+        // Hard cap the recording length, matching the /voice page limit.
+        autoStopRef.current = setTimeout(() => {
+            if (recorderRef.current?.state === "recording") {
+                recorderRef.current.stop();
+            }
+        }, MAX_RECORDING_DURATION_MS);
+    }, []);
+
+    const stop = useCallback((): Promise<Blob | null> => {
+        return new Promise((resolve) => {
+            const recorder = recorderRef.current;
+
+            if (!recorder || recorder.state === "inactive") {
+                cleanup();
+                setIsRecording(false);
+                resolve(null);
+                return;
+            }
+
+            recorder.onstop = () => {
+                const type = recorder.mimeType || chunksRef.current[0]?.type || "audio/webm";
+                const blob = new Blob(chunksRef.current, { type });
+                chunksRef.current = [];
+                cleanup();
+                setIsRecording(false);
+
+                if (blob.size === 0) {
+                    setError("empty");
+                    resolve(null);
+                    return;
+                }
+                if (isRecordingBlobTooLarge(blob)) {
+                    setError("too-large");
+                    resolve(null);
+                    return;
+                }
+                resolve(blob);
+            };
+
+            recorder.stop();
+        });
+    }, [cleanup]);
+
+    return { isSupported, isRecording, error, start, stop, reset };
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1395,7 +1395,16 @@
         "mechanism": "Mechanism:",
         "source": "Source:",
         "errorMessage": "Failed to complete interaction check. Please try again.",
-        "offlineBadge": "Offline Result — Connect to internet for latest data"
+        "offlineBadge": "Offline Result — Connect to internet for latest data",
+        "voice": {
+            "button": "Add medicines by voice",
+            "listening": "Listening… tap to stop",
+            "processing": "Adding medicines…",
+            "unsupported": "Voice input isn't supported on this browser",
+            "permissionDenied": "Microphone access is needed for voice input",
+            "error": "Couldn't add medicines by voice. Please try again.",
+            "noMedicines": "No medicine names detected. Please try again."
+        }
     },
     "ScanHistory": {
         "export_modal_title": "Export Scan History",


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check
- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.

## 📋 PR Summary & Link
- **Closes #4301**
- **Summary:** Adds a one-tap 🎤 button to the Interaction Checker search bar.
  It reuses the existing voice recording + `/api/voice/transcribe` (ASR)
  pipeline, then sends the transcript to a new Gemini-backed extraction endpoint
  (`/api/voice/medicine-extract` → ML `/medicine-extract`) that pulls medicine
  names from conversational, code-switched Hindi/English speech and adds them to
  the check list — no typing required. New reusable `useVoiceRecorder` hook and
  `VoiceInputButton` component. The ML extractor mirrors the existing
  `alert_extractor.py` LangChain/Gemini pattern (no new LLM provider).

  Note: `my-medicines` (also mentioned in scope) is a read-only cabinet with no
  search input, so the mic was integrated only into the interaction checker.



## 🏷️ PR Type
- [x] ✨ `type: feature`
- [x] 🎨 `type: design`
- [x] ♿ `type: accessibility`

## ✅ Checklist
- [x] My PR has a linked issue (Closes #4301 )
- [x] I have pulled the latest `main` and resolved any conflicts
