### PR TITLE
fix: prevent numbers and special characters in full name during sign-up

### DIFF
--- a/apps/web/app/[locale]/signup/page.tsx
+++ b/apps/web/app/[locale]/signup/page.tsx
@@ -20,6 +20,7 @@ import { getSupabaseUrl, getSupabaseAnonKey } from "@/lib/env";
 import { FaGithub } from "react-icons/fa6";
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const FULL_NAME_PATTERN = /^[A-Za-z\s]+$/;
 
 function isStrongPassword(password: string): boolean {
     return (
@@ -61,6 +62,10 @@ export default function SignUpPage() {
 
         if (!trimmedName) {
             return t("errors.fullNameRequired");
+        }
+
+        if (!FULL_NAME_PATTERN.test(trimmedName)) {
+            return t("errors.fullNameInvalid");
         }
 
         if (!trimmedEmail) {
@@ -304,6 +309,7 @@ export default function SignUpPage() {
                                     placeholder={t("fullNamePlaceholder")}
                                     value={fullName}
                                     onChange={(e) => setFullName(e.target.value)}
+                                    pattern="[A-Za-z\s]+"
                                     required
                                     disabled={isMissingEnvVars}
                                     className="w-full bg-transparent text-(--color-text-primary) outline-none placeholder:text-(--color-text-muted) disabled:cursor-not-allowed disabled:opacity-50"

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -869,6 +869,7 @@
         "success": "Account created successfully! Redirecting...",
         "successConfirmEmail": "Account created! Check your email to confirm your account before signing in.",
         "errors": {
+            "fullNameInvalid": "Full name can only contain letters and spaces.",
             "databaseNotConfigured": "Authentication is not configured for this environment.",
             "generic": "Unable to create account. Please try again.",
             "fullNameRequired": "Full name is required.",


### PR DESCRIPTION
### 🛑 STOP: Assignment & File Scope Check

- [x] I am assigned to this issue.
- [x] I verified that this PR **ONLY** touches the required files.


## 📋 PR Summary & Link

- **Closes:**  #4313 
- **Summary:**
        - Added full-name validation to the sign-up form.
        - Prevented names containing numeric characters from being accepted.
        - Added a user-friendly validation error message.

## 📸 Proof of Work (Screenshots / Logs)

Before:

<img width="1216" height="1004" alt="image" src="https://github.com/user-attachments/assets/78681367-3e99-418a-a0bc-7f996403dfd9" />




After:

<img width="697" height="807" alt="image" src="https://github.com/user-attachments/assets/c34bcf01-aa5d-42b0-83a9-872f1081ef67" />


## 🏷️ PR Type

- [x] 🐛 `type: bug`
- [ ] ✨ `type: feature`
- [ ] 📖 `type: docs`
- [ ] 🧪 `type: testing`
- [x] 🔒 `type: security`
- [ ] ⚡ `type: performance`
- [ ] 🎨 `type: design`
- [ ] ♻️ `type: refactor`
- [ ] 🛠️ `type: devops`
- [ ] ♿ `type: accessibility`

## ✅ Checklist

- [x] My PR has a linked issue (`Closes #4313 `)
- [x] I have pulled the latest `main` and resolved any conflicts
