### PR TITLE
perf(history): add Skeleton loading states that mirror the scan-history layout

### DIFF
--- a/apps/web/app/[locale]/history/loading.tsx
+++ b/apps/web/app/[locale]/history/loading.tsx
@@ -1,33 +1,56 @@
+import { Skeleton } from "@/components/ui/Skeleton";
+
 export default function Loading() {
     return (
         <div className="min-h-screen bg-(--color-surface-page) p-6 text-(--color-text-primary)">
             <div className="mx-auto max-w-3xl">
-                {/* Title Skeleton */}
-                <div className="mb-6 h-10 w-64 animate-pulse rounded-xl bg-white/5" />
+                {/* Title + connection status badge */}
+                <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+                    <Skeleton className="h-10 w-64 rounded-xl" />
+                    <Skeleton className="h-6 w-28 rounded-full" />
+                </div>
 
                 {/* Action Buttons Skeleton */}
                 <div className="mb-6 flex flex-wrap gap-3">
-                    <div className="h-10 w-36 animate-pulse rounded-xl bg-white/5" />
-                    <div className="h-10 w-36 animate-pulse rounded-xl bg-white/5" />
+                    <Skeleton className="h-10 w-36 rounded-xl" />
+                    <Skeleton className="h-10 w-36 rounded-xl" />
                 </div>
 
                 {/* Stats Summary Grid Skeleton */}
                 <div className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-4">
                     {[...Array(4)].map((_, i) => (
-                        <div
-                            key={i}
-                            className="h-24 animate-pulse rounded-2xl border border-white/10 bg-white/5"
-                        />
+                        <Skeleton key={i} className="h-24 rounded-2xl border border-white/10" />
                     ))}
                 </div>
 
-                {/* History Cards List Skeleton */}
+                {/* Filter / search bar skeleton (matches the real controls row) */}
+                <div className="mb-4 flex flex-wrap gap-3">
+                    <Skeleton className="min-w-[200px] flex-1 rounded-xl" />
+                    <Skeleton className="h-10 w-28 rounded-xl" />
+                    <Skeleton className="h-10 w-32 rounded-xl" />
+                </div>
+
+                {/* History Cards List Skeleton — mirrors a real history card's
+                    internal layout (title, status, timestamp, delete button)
+                    to avoid Cumulative Layout Shift when content arrives. */}
                 <div className="space-y-4">
-                    {[...Array(3)].map((_, i) => (
+                    {[...Array(5)].map((_, i) => (
                         <div
                             key={i}
-                            className="h-[128px] animate-pulse rounded-2xl border border-white/10 bg-white/5"
-                        />
+                            className="rounded-2xl border border-white/10 bg-white/5 p-5 shadow-lg backdrop-blur-sm"
+                        >
+                            <div className="flex items-start justify-between gap-4">
+                                <div className="w-full">
+                                    <div className="flex items-center gap-1">
+                                        <Skeleton className="h-6 w-40" />
+                                        <Skeleton className="h-5 w-5 rounded-md" />
+                                    </div>
+                                    <Skeleton className="mt-2 h-4 w-28" />
+                                    <Skeleton className="mt-2 h-4 w-44" />
+                                </div>
+                                <Skeleton className="h-9 w-20 rounded-lg" />
+                            </div>
+                        </div>
                     ))}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
Fixes #4277

Implements an improved `loading.tsx` for the scan history route (`/history`) so users see skeleton placeholders (instead of a blank/spinner view) while Supabase fetches records.

## Problem
The existing `apps/web/app/[locale]/history/loading.tsx` used plain `animate-pulse` divs and a single `h-[128px]` block per card. That block did **not** match the real history card's internal layout (medicine name + copy button, status line, timestamp, delete button), and there was no skeleton for the search/filter bar — so the page shifted noticeably when content arrived (Cumulative Layout Shift).

## Changes
- Switched to the existing reusable `Skeleton` component (`@/components/ui/Skeleton`) — the shimmer style already used by the other `loading.tsx` files (schedule, reports, admin, map).
- Title row now mirrors the real header (title + connection-status badge).
- Stats grid (4 cards) retained.
- Added a **filter/search bar skeleton** (search input + select + sort button) that previously had no placeholder — a CLS source.
- History list renders **5 placeholder cards** (acceptance criteria: ≥4-5) whose internal layout mirrors a real card: title + copy button, status line, timestamp line, and a delete button on the right.

## Acceptance criteria
- [x] `loading.tsx` is implemented in the `history` route.
- [x] Skeleton layout closely matches the actual history list layout to prevent CLS.
- [x] Skeletons use `animate-pulse` (via the `Skeleton` shimmer component).
- [x] No console errors or hydration mismatches (server component, no client-only APIs).

## Files touched
- `apps/web/app/[locale]/history/loading.tsx`

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._