### PR TITLE
feat: add voice language support

### DIFF
--- a/apps/web/app/[locale]/voice/lib/languages.ts
+++ b/apps/web/app/[locale]/voice/lib/languages.ts
@@ -1,3 +1,4 @@
+
 export type VoiceLanguageOption = {
     value: string;
     label: string;
@@ -5,9 +6,17 @@ export type VoiceLanguageOption = {
     responseLanguage: string;
     speechSynthesisLang: string;
 };
-
+ 
+// Shape returned by GET /api/medicine/languages (proxied from the ML
+// service's /voice/languages endpoint). Keys are 2-letter ISO codes
+// (e.g. "hi", "ta"), values are the script name — the script isn't
+// used here, we only care which codes are present.
+export type SupportedVoiceLanguagesResponse = {
+    supported_languages: Record<string, string>;
+};
+ 
 export const DEFAULT_VOICE_LANGUAGE = "en-IN";
-
+ 
 const LOCALE_TO_VOICE_LANGUAGE: Record<string, string> = {
     en: "en-IN",
     hi: "hi-IN",
@@ -16,7 +25,7 @@ const LOCALE_TO_VOICE_LANGUAGE: Record<string, string> = {
     mr: "mr-IN",
     te: "te-IN",
 };
-
+ 
 export const VOICE_LANGUAGE_OPTIONS: VoiceLanguageOption[] = [
     {
         value: "en-IN",
@@ -61,13 +70,13 @@ export const VOICE_LANGUAGE_OPTIONS: VoiceLanguageOption[] = [
         speechSynthesisLang: "te-IN",
     },
 ];
-
+ 
 export function getVoiceLanguageOption(value: string): VoiceLanguageOption {
     return (
         VOICE_LANGUAGE_OPTIONS.find((option) => option.value === value) ?? VOICE_LANGUAGE_OPTIONS[0]
     );
 }
-
+ 
 export function resolveVoiceWorkflowLanguage(
     sessionLanguage: string | null | undefined,
     activeLanguage: string | null | undefined,
@@ -76,16 +85,94 @@ export function resolveVoiceWorkflowLanguage(
     if (sessionLanguage?.trim()) {
         return sessionLanguage;
     }
-
+ 
     return activeLanguage?.trim() ? activeLanguage : selectedLanguage;
 }
-
+ 
 export function getVoiceLanguageForLocale(locale: string): string {
     const normalized = locale.toLowerCase();
-
+ 
     return (
         LOCALE_TO_VOICE_LANGUAGE[normalized] ??
         LOCALE_TO_VOICE_LANGUAGE[normalized.split("-")[0]] ??
         DEFAULT_VOICE_LANGUAGE
     );
 }
+ 
+/**
+ * Filters VOICE_LANGUAGE_OPTIONS down to the languages the ML voice
+ * pipeline currently supports, matching on the 2-letter language
+ * prefix of each option's locale code (e.g. "hi-IN" -> "hi").
+ *
+ * VOICE_LANGUAGE_OPTIONS stays the source of display metadata
+ * (labels, speech-recognition codes) — this only decides which of
+ * those options are currently selectable.
+ *
+ * If filtering would remove every option (e.g. an unrecognised
+ * response shape from the backend), the full hardcoded list is kept
+ * instead of leaving the picker empty.
+ */
+export function filterSupportedVoiceLanguages(
+    supportedCodes: Iterable<string>,
+    options: VoiceLanguageOption[] = VOICE_LANGUAGE_OPTIONS
+): VoiceLanguageOption[] {
+    const normalizedSupported = new Set(
+        Array.from(supportedCodes, (code) => code.trim().toLowerCase()).filter(Boolean)
+    );
+ 
+    if (normalizedSupported.size === 0) {
+        return options;
+    }
+ 
+    const filtered = options.filter((option) =>
+        normalizedSupported.has(option.value.split("-")[0].toLowerCase())
+    );
+ 
+    return filtered.length > 0 ? filtered : options;
+}
+ 
+/**
+ * Fetches the list of Indian languages the ML voice pipeline currently
+ * supports via GET /api/medicine/languages, and uses it to filter
+ * VOICE_LANGUAGE_OPTIONS down to just the currently-selectable ones.
+ *
+ * Falls back to the full hardcoded VOICE_LANGUAGE_OPTIONS list if the
+ * request fails, times out, or the service returns an unexpected
+ * shape — the picker should always render something, never break.
+ */
+export async function fetchSupportedVoiceLanguages(
+    apiBase: string,
+    options: { signal?: AbortSignal } = {}
+): Promise<VoiceLanguageOption[]> {
+    try {
+        const res = await fetch(`${apiBase}/api/medicine/languages`, {
+            signal: options.signal,
+        });
+ 
+        if (!res.ok) {
+            return VOICE_LANGUAGE_OPTIONS;
+        }
+ 
+        const data = (await res.json()) as Partial<SupportedVoiceLanguagesResponse>;
+        const supportedCodes = data?.supported_languages;
+ 
+        if (!supportedCodes || typeof supportedCodes !== "object") {
+            return VOICE_LANGUAGE_OPTIONS;
+        }
+ 
+        return filterSupportedVoiceLanguages(Object.keys(supportedCodes));
+    } catch {
+        // Network failure, abort, timeout, or malformed JSON — degrade
+        // gracefully to the full hardcoded list rather than breaking
+        // the picker.
+        return VOICE_LANGUAGE_OPTIONS;
+    }
+}
+ 
+
+
+
+
+
+
+

--- a/apps/web/app/[locale]/voice/page.tsx
+++ b/apps/web/app/[locale]/voice/page.tsx
@@ -22,11 +22,14 @@ import {
     VOICE_FOCUS_RING_CLASS,
 } from "./lib/accessibility";
 import {
+    fetchSupportedVoiceLanguages,
     getVoiceLanguageOption,
     getVoiceLanguageForLocale,
     resolveVoiceWorkflowLanguage,
     VOICE_LANGUAGE_OPTIONS,
+    type VoiceLanguageOption,
 } from "./lib/languages";
+import { API_BASE } from "@/lib/apiConfig";
 import { formatVoiceShareReport } from "./lib/report";
 import {
     getPreferredRecordingMimeType,
@@ -168,6 +171,8 @@ export default function VoiceTriagePage() {
     const [mode, setMode] = useState<"triage" | "verify">("triage");
     const [step, setStep] = useState<VoiceStep>("initial");
     const [selectedLanguage, setSelectedLanguage] = useState(getVoiceLanguageForLocale(locale));
+    const [availableLanguageOptions, setAvailableLanguageOptions] =
+        useState<VoiceLanguageOption[]>(VOICE_LANGUAGE_OPTIONS);
     const [activeLanguageCode, setActiveLanguageCode] = useState<string | null>(null);
     const [isListening, setIsListening] = useState(false);
     const [isSpeaking, setIsSpeaking] = useState(false);
@@ -288,6 +293,30 @@ export default function VoiceTriagePage() {
             return null;
         }
     }
+
+    useEffect(() => {
+        const controller = new AbortController();
+
+        fetchSupportedVoiceLanguages(API_BASE, { signal: controller.signal }).then((options) => {
+            if (controller.signal.aborted) {
+                return;
+            }
+            setAvailableLanguageOptions(options);
+            // If the currently selected language got filtered out (e.g. the
+            // ML service temporarily dropped it), fall back to the first
+            // still-supported option rather than leaving the picker on a
+            // value that's no longer in its own option list.
+            setSelectedLanguage((current) =>
+                options.some((option) => option.value === current)
+                    ? current
+                    : (options[0]?.value ?? current)
+            );
+        });
+
+        return () => {
+            controller.abort();
+        };
+    }, []);
 
     useEffect(() => {
         return () => {
@@ -1303,7 +1332,7 @@ export default function VoiceTriagePage() {
                                 disabled={isLanguageSelectionLocked}
                                 className={`w-full rounded-2xl border border-(--color-border-muted) bg-(--color-surface-page) px-4 py-3 text-sm font-semibold text-(--color-text-primary) shadow-sm disabled:cursor-not-allowed disabled:bg-(--color-surface-muted) ${VOICE_FOCUS_RING_CLASS}`}
                             >
-                                {VOICE_LANGUAGE_OPTIONS.map((option) => (
+                                {availableLanguageOptions.map((option) => (
                                     <option key={option.value} value={option.value}>
                                         {option.label}
                                     </option>


### PR DESCRIPTION
This PR closes #4318 by adding support for voice-language handling and updating the voice experience to work with the supported language configuration. It introduces the required language definitions in languages.ts and integrates them into the voice page so that language selection and voice-related behavior remain consistent with the application’s existing localization setup. The changes are scoped to the voice functionality and are intended to provide a cleaner, more maintainable way to manage supported voice languages while ensuring the updated configuration is correctly consumed by the voice interface. Overall, this improves the voice feature’s language support and establishes a more structured foundation for extending additional languages in the future.