### PR TITLE
fix(wishlist): repair corrupted GET list handler that broke API build (#4357)

### DIFF
--- a/apps/api/src/routes/wishlist.ts
+++ b/apps/api/src/routes/wishlist.ts
@@ -260,31 +260,14 @@ router.get(
             return;
         }
 
-        let page = parseInt(req.query.page as string, 10);
-        let limit = parseInt(req.query.limit as string, 10);
+        const rawPage = parseInt(req.query.page as string, 10);
+        const rawLimit = parseInt(req.query.limit as string, 10);
 
-        if (isNaN(page) || page <= 0) {
-            page = 1;
-        }
-        if (isNaN(limit) || limit <= 0) {
-            limit = 20;
-        }
-        if (limit > 100) {
-            limit = 100;
-        }
-
-        const from = (page - 1) * limit;
-        const to = from + limit - 1;
+        const page = isNaN(rawPage) || rawPage < 1 ? 1 : rawPage;
+        const limit = isNaN(rawLimit) || rawLimit < 1 ? 20 : Math.min(rawLimit, 100);
+        const offset = (page - 1) * limit;
 
         try {
-            const rawPage = parseInt(req.query.page as string, 10);
-            const rawLimit = parseInt(req.query.limit as string, 10);
-
-            const page = isNaN(rawPage) || rawPage < 1 ? 1 : rawPage;
-            const limit = isNaN(rawLimit) || rawLimit < 1 ? 20 : Math.min(rawLimit, 100);
-
-            const offset = (page - 1) * limit;
-
             const {
                 data: wishlistItems,
                 error: fetchError,
@@ -295,7 +278,6 @@ router.get(
                 .eq("user_id", req.user.id)
                 .order("created_at", { ascending: false })
                 .range(offset, offset + limit - 1);
-                .range(from, to);
 
             if (fetchError) {
                 next(fetchError);
@@ -303,9 +285,6 @@ router.get(
             }
 
             const totalCount = count ?? 0;
-
-            res.json({
-            const totalCount = count || 0;
             const totalPages = Math.ceil(totalCount / limit);
 
             res.json({
@@ -315,10 +294,6 @@ router.get(
                 count: totalCount,
                 totalPages,
                 items: wishlistItems || [],
-                count: totalCount,
-                page,
-                limit,
-                totalPages: Math.ceil(totalCount / limit),
             });
         } catch (err) {
             next(err);


### PR DESCRIPTION
## Summary

The `GET /` (paginated list) handler in `apps/api/src/routes/wishlist.ts` was committed on `main` with **two conflicting copies of its pagination logic merged on top of each other**. The file does not parse as valid TypeScript (`SyntaxError: Unexpected token (298:16)`), which:

- breaks `tsc` compilation of the whole `apps/api` package,
- breaks runtime import of the wishlist router (and since `app.ts` mounts every route, the entire Express app fails to start),
- breaks the entire Jest suite — any test that imports `app` fails to parse.

## Root Cause

Two revisions of the same pagination logic were merged without removing the prior version:

\`\`\`ts
let page = parseInt(req.query.page as string, 10);   // outer decl
let limit = parseInt(req.query.limit as string, 10);
...
const from = (page - 1) * limit;
const to = from + limit - 1;

try {
    const rawPage = parseInt(req.query.page as string, 10);
    const rawLimit = parseInt(req.query.limit as string, 10);
    const page = ...;        // redeclares block-scoped page  (SyntaxError)
    const limit = ...;       // redeclares block-scoped limit (SyntaxError)
    const offset = (page - 1) * limit;

    const { data, error, count } = await req.supabase
        .from("wishlists").select(...).eq(...).order(...)
        .range(offset, offset + limit - 1);
        .range(from, to);    // orphaned method call after ';' (SyntaxError)

    const totalCount = count ?? 0;
    res.json({               // dangling, never closed
    const totalCount = count || 0;   // SyntaxError: unexpected token
    ...
    res.json({ success: true, page, limit, count, totalPages, items,
               count, page, limit, totalPages }); // duplicate keys
}
\`\`\`

## Changes

`apps/api/src/routes/wishlist.ts` — replace the handler body with a single, deduplicated implementation:

- parse `rawPage` / `rawLimit` once,
- clamp to defaults (`page=1`, `limit=20`, cap `100`),
- compute `offset = (page - 1) * limit`,
- issue a single `.range(offset, offset + limit - 1)`,
- return one `res.json({ success, page, limit, count, totalPages, items })`.

## Validation

- `npx tsc --noEmit` no longer reports a wishlist.ts parse error (remaining `@sahidawa/types` "cannot find module" errors are pre-existing and unrelated — they come from the workspace packages not being built locally).
- `npx jest tests/wishlist.test.ts` — the existing **18** pagination + merge tests were **blocked by the SyntaxError (0 ran)** and now **all 18 pass**.
- `npx jest tests/alternatives.test.ts` — was **also blocked** (imports `app`, which imports wishlist) and now **6/6 pass** (unblocked by this fix).
- Verified the regression: with the fix reverted (`git stash`), `wishlist.test.ts` fails with `SyntaxError ... Unexpected token (298:16)` and `0` tests run; with the fix, 18/18 pass.
- `tests/safety.test.ts` has 2 pre-existing failures (a 30s Redis-mock timeout and a DB-profile case) that are **unrelated** — that test imports `safetyRouter` directly, not `app`/`wishlist`, and fails identically on `main`.

## Related Issue

Closes #4357

_Note: This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._