### PR TITLE
fix(scan): overlay live safety on verify-brand cache hits (#4146)

### DIFF
--- a/apps/api/src/routes/scan.ts
+++ b/apps/api/src/routes/scan.ts
@@ -23,6 +23,7 @@ import { supabase } from "../db/client";
 import { optionalAuth } from "../middleware/auth";
 import { escapeIlike, escapePostgrest, buildOrConditions } from "../utils/db";
 import { computeVerifiedStatus } from "../utils/verification";
+import { refreshLiveSafety } from "../utils/safetyOverlay";
 import { scanService } from "../services/scan.service";
 
 const router = Router();
@@ -563,7 +564,19 @@ router.post("/verify-brand", scanQueryLimiter, async (req: Request, res: Respons
             const cached = await redisClient.get(cacheKey);
             if (cached) {
                 logger.info(`Cache HIT for verify-brand: "${brandName}"`);
-                res.status(200).json(JSON.parse(cached));
+                // The cache stores a 24h snapshot of the medicine row. Safety-critical
+                // fields (counterfeit alert, CDSCO status) may have changed since it was
+                // written, and webhook-based invalidation can be missed — so overlay the
+                // live safety fields and recompute the verdict instead of trusting the
+                // cached `verified` value (issue #4146).
+                const cachedResponse = JSON.parse(cached);
+                const cachedMedicine = cachedResponse?.medicine ?? cachedResponse;
+                await refreshLiveSafety(supabase, cachedMedicine);
+                const liveResponse = {
+                    verified: computeVerifiedStatus(cachedMedicine),
+                    medicine: cachedMedicine,
+                };
+                res.status(200).json(liveResponse);
                 return;
             }
         }
@@ -623,6 +636,11 @@ router.post("/verify-brand", scanQueryLimiter, async (req: Request, res: Respons
             });
             return;
         }
+
+        // Overlay live safety-critical fields so a stale DB snapshot (or a row
+        // updated between the brand lookup and now) can never flip the verdict
+        // to a stale "verified: true" after a recall/counterfeit update (#4146).
+        await refreshLiveSafety(supabase, data);
 
         const responseData = {
             verified: computeVerifiedStatus(data),

--- a/apps/api/src/routes/verify.ts
+++ b/apps/api/src/routes/verify.ts
@@ -8,56 +8,12 @@ import { lookupDrugByBatch, ServiceUnavailableError } from "../services/drugLook
 import { escapeIlike } from "../utils/db";
 import { isAllowedOrigin } from "../utils/originCheck";
 import { medicineNameNormalizer } from "../utils/medicineNameNormalizer";
+import { refreshLiveSafety } from "../utils/safetyOverlay";
 
 function getBatchStatus(recallStatus: string | null | undefined): "safe" | "recalled" | "unknown" {
     if (!recallStatus || recallStatus === "none") return "safe";
     if (recallStatus === "recalled") return "recalled";
     return "unknown";
-}
-
-// Safety-critical fields that must never be served stale. These drive the
-// "safe" vs "recalled"/"counterfeit" verdict shown to users.
-const SAFETY_OVERLAY_FIELDS = [
-    "cdsco_approval_status",
-    "is_counterfeit_alert",
-    "is_cdsco_verified",
-    "cdsco_match_score",
-    "matched_cdsco_product",
-    "matched_cdsco_manufacturer",
-    "product_match_score",
-    "manufacturer_match_score",
-];
-
-/**
- * Overlays the latest safety-critical fields from the database onto the
- * medicine record returned by lookupDrugByBatch().
- *
- * lookupDrugByBatch() may serve a cached medicine snapshot (TTL up to 24h) and
- * cache invalidation depends on external webhooks that can be missed. Reading
- * these fields live guarantees the verify endpoint always reflects the latest
- * safety state (new recalls, counterfeit flags, CDSCO changes) instead of
- * serving a stale "safe" result indefinitely. Falls back to the cached values
- * if the live read fails so the endpoint degrades gracefully.
- */
-async function refreshLiveSafety(client: any, data: any): Promise<void> {
-    const { data: live, error } = await client
-        .from("medicines")
-        .select(SAFETY_OVERLAY_FIELDS.join(", "))
-        .eq("id", data.id)
-        .maybeSingle();
-
-    if (error) {
-        logger.error("Failed to refresh live safety status", {
-            error,
-            medicineId: data.id,
-            route: "/api/verify",
-        });
-        return;
-    }
-
-    if (live) {
-        Object.assign(data, live);
-    }
 }
 
 function maskClientIp(ip: string | undefined): string | null {

--- a/apps/api/src/utils/safetyOverlay.ts
+++ b/apps/api/src/utils/safetyOverlay.ts
@@ -1,0 +1,50 @@
+import logger from "./logger";
+
+/**
+ * Safety-critical medicine fields that must never be served stale. These drive
+ * the "safe" vs "recalled"/"counterfeit" verdict shown to users on the
+ * verification endpoints.
+ */
+export const SAFETY_OVERLAY_FIELDS = [
+    "cdsco_approval_status",
+    "is_counterfeit_alert",
+    "is_cdsco_verified",
+    "cdsco_match_score",
+    "matched_cdsco_product",
+    "matched_cdsco_manufacturer",
+    "product_match_score",
+    "manufacturer_match_score",
+] as const;
+
+/**
+ * Overlays the latest safety-critical fields from the database onto a medicine
+ * record that may have come from a cache snapshot.
+ *
+ * Lookup results (batch or brand) can be served from Redis with a TTL up to 24h,
+ * and cache invalidation depends on external webhooks that can be missed. Reading
+ * these fields live guarantees the verification endpoints always reflect the
+ * latest safety state (new recalls, counterfeit flags, CDSCO changes) instead of
+ * serving a stale "safe" result indefinitely. Falls back to the cached values if
+ * the live read fails so the endpoint degrades gracefully.
+ */
+export async function refreshLiveSafety(client: any, data: any): Promise<void> {
+    if (!data?.id) return;
+
+    const { data: live, error } = await client
+        .from("medicines")
+        .select(SAFETY_OVERLAY_FIELDS.join(", "))
+        .eq("id", data.id)
+        .maybeSingle();
+
+    if (error) {
+        logger.error("Failed to refresh live safety status", {
+            error,
+            medicineId: data.id,
+        });
+        return;
+    }
+
+    if (live) {
+        Object.assign(data, live);
+    }
+}

--- a/apps/api/tests/routes/scan.verify-brand.test.ts
+++ b/apps/api/tests/routes/scan.verify-brand.test.ts
@@ -1,0 +1,199 @@
+import request from "supertest";
+import express from "express";
+
+// Mock the supabase client so the route does not depend on a live database.
+// Each chained method returns the client (mockReturnThis) so the terminal
+// .maybeSingle() call can be queued per-test.
+jest.mock("../../src/db/client", () => ({
+    supabase: {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        ilike: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        maybeSingle: jest.fn(),
+        rpc: jest.fn(),
+    },
+}));
+
+// Mock Redis: isOpen + a controllable `get` (cache contents) and a no-op `set`.
+jest.mock("../../src/utils/redis", () => ({
+    redisClient: {
+        isOpen: true,
+        get: jest.fn(),
+        set: jest.fn().mockResolvedValue("OK"),
+        del: jest.fn().mockResolvedValue(1),
+        connect: jest.fn().mockResolvedValue(true),
+        on: jest.fn(),
+        scanIterator: jest.fn(),
+    },
+    connectRedis: jest.fn(),
+}));
+
+// Pass-through rate limiter so the route handler runs directly.
+jest.mock("../../src/middleware/rateLimit", () => {
+    const mockStore = {
+        increment: jest.fn().mockResolvedValue({ totalHits: 1, resetTime: Date.now() + 60000 }),
+        decrement: jest.fn().mockResolvedValue(undefined),
+        resetKey: jest.fn().mockResolvedValue(undefined),
+        resetAll: jest.fn().mockResolvedValue(undefined),
+    };
+    const passThrough = (_req: any, _res: any, next: any) => next();
+    return {
+        buildStore: jest.fn(() => mockStore),
+        scanQueryLimiter: passThrough,
+        verifyLimiter: passThrough,
+        uploadRateLimiter: passThrough,
+        limiter: passThrough,
+        batchLimiter: passThrough,
+        reportLimiter: passThrough,
+        lasaLimiter: passThrough,
+        compareLimiter: passThrough,
+        interactionCheckLimiter: passThrough,
+        interactionIdsLimiter: passThrough,
+        eligibilityLimiter: passThrough,
+        triageLimiter: passThrough,
+        analyticsLimiter: passThrough,
+        authLimiter: passThrough,
+        authTargetLimiter: passThrough,
+        notificationRegisterLimiter: passThrough,
+        trackingLimiter: passThrough,
+        webhookLimiter: passThrough,
+    };
+});
+
+jest.mock("../../src/utils/logger", () => ({
+    __esModule: true,
+    default: {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+import { supabase } from "../../src/db/client";
+import { redisClient } from "../../src/utils/redis";
+import scanRouter from "../../src/routes/scan";
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/scan", scanRouter);
+
+/**
+ * Regression tests for issue #4146: /api/v1/scan/verify-brand must not serve a
+ * stale safety verdict from its 24h brand cache. Safety-critical fields
+ * (is_counterfeit_alert, is_cdsco_verified, CDSCO status) are overlaid live on
+ * every response — whether the medicine came from the Redis cache or a fresh DB
+ * lookup — and the `verified` verdict is recomputed from the overlaid fields.
+ */
+describe("POST /api/v1/scan/verify-brand — live safety overlay (#4146)", () => {
+    const safeMedicine = {
+        id: "med-1",
+        brand_name: "Dolo 650",
+        generic_name: "Paracetamol",
+        manufacturer: "Micro Labs",
+        batch_number: "BN1",
+        expiry_date: "2027-01-01",
+        cdsco_approval_status: "approved",
+        is_counterfeit_alert: false,
+        is_cdsco_verified: true,
+        cdsco_match_score: 100,
+        matched_cdsco_product: "Dolo 650",
+        matched_cdsco_manufacturer: "Micro Labs",
+        product_match_score: 100,
+        manufacturer_match_score: 100,
+    };
+
+    const counterfeitOverlay = {
+        cdsco_approval_status: "recalled",
+        is_counterfeit_alert: true,
+        is_cdsco_verified: true,
+        cdsco_match_score: 100,
+        matched_cdsco_product: "Dolo 650",
+        matched_cdsco_manufacturer: "Micro Labs",
+        product_match_score: 100,
+        manufacturer_match_score: 100,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (redisClient as any).isOpen = true;
+    });
+
+    it("recomputes verified=false when a cached 'safe' medicine is now counterfeit (cache HIT)", async () => {
+        // Cache holds a 24h-old snapshot that says the medicine is safe.
+        (redisClient.get as jest.Mock).mockResolvedValueOnce(
+            JSON.stringify({ verified: true, medicine: { ...safeMedicine } })
+        );
+
+        // refreshLiveSafety reads the live row, which now flags a counterfeit alert.
+        const maybeSingle = (supabase.from as jest.Mock)().maybeSingle as jest.Mock;
+        maybeSingle.mockResolvedValueOnce({ data: counterfeitOverlay, error: null });
+
+        const res = await request(app)
+            .post("/api/v1/scan/verify-brand")
+            .send({ brandName: "Dolo 650" });
+
+        expect(res.status).toBe(200);
+        // The cached value said verified: true, but the live overlay must win.
+        expect(res.body.verified).toBe(false);
+        expect(res.body.medicine.is_counterfeit_alert).toBe(true);
+        expect(res.body.medicine.cdsco_approval_status).toBe("recalled");
+    });
+
+    it("recomputes verified=false on a fresh DB lookup when the live row is counterfeit", async () => {
+        (redisClient.get as jest.Mock).mockResolvedValueOnce(null); // cache miss
+
+        const maybeSingle = (supabase.from as jest.Mock)().maybeSingle as jest.Mock;
+        // 1st maybeSingle: brand_name lookup returns the stored (safe) row.
+        maybeSingle.mockResolvedValueOnce({ data: { ...safeMedicine }, error: null });
+        // 2nd maybeSingle: refreshLiveSafety overlays the live counterfeit flags.
+        maybeSingle.mockResolvedValueOnce({ data: counterfeitOverlay, error: null });
+
+        const res = await request(app)
+            .post("/api/v1/scan/verify-brand")
+            .send({ brandName: "Dolo 650" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.verified).toBe(false);
+        expect(res.body.medicine.is_counterfeit_alert).toBe(true);
+    });
+
+    it("still returns verified=true for a genuinely safe medicine on cache HIT", async () => {
+        (redisClient.get as jest.Mock).mockResolvedValueOnce(
+            JSON.stringify({ verified: true, medicine: { ...safeMedicine } })
+        );
+
+        const maybeSingle = (supabase.from as jest.Mock)().maybeSingle as jest.Mock;
+        // Live overlay confirms it is still safe.
+        maybeSingle.mockResolvedValueOnce({
+            data: { is_counterfeit_alert: false, is_cdsco_verified: true },
+            error: null,
+        });
+
+        const res = await request(app)
+            .post("/api/v1/scan/verify-brand")
+            .send({ brandName: "Dolo 650" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.verified).toBe(true);
+    });
+
+    it("falls back to cached safety fields when the live overlay read fails", async () => {
+        (redisClient.get as jest.Mock).mockResolvedValueOnce(
+            JSON.stringify({ verified: true, medicine: { ...safeMedicine } })
+        );
+
+        const maybeSingle = (supabase.from as jest.Mock)().maybeSingle as jest.Mock;
+        // Live read errors — route must degrade gracefully (keep cached safe verdict).
+        maybeSingle.mockResolvedValueOnce({ data: null, error: { message: "boom" } });
+
+        const res = await request(app)
+            .post("/api/v1/scan/verify-brand")
+            .send({ brandName: "Dolo 650" });
+
+        expect(res.status).toBe(200);
+        expect(res.body.verified).toBe(true);
+    });
+});


### PR DESCRIPTION
Fixes #4146 (verify-brand manifestation).

POST /api/v1/scan/verify-brand cached the full medicine snapshot (including is_counterfeit_alert, is_cdsco_verified, cdsco_approval_status and the computed verified verdict) for 24h and returned it directly on a cache hit. Unlike /api/verify (batch), it had NO live-safety overlay, so a medicine flagged counterfeit/recalled after a cache entry was written kept being served as verified:true for up to 24h whenever webhook-based invalidation was missed.

Fix:
- Extract SAFETY_OVERLAY_FIELDS + refreshLiveSafety() into shared util apps/api/src/utils/safetyOverlay.ts; verify.ts imports it (behavior unchanged).
- scan.ts verify-brand: on BOTH cache-hit and fresh-DB paths, overlay live safety fields via refreshLiveSafety(supabase, data) and recompute verified with computeVerifiedStatus() from the overlaid fields. Degrades gracefully to cached values if the live read fails (same contract as /api/verify).

Regression tests: apps/api/tests/routes/scan.verify-brand.test.ts (4 cases). The cache-HIT stale-counterfeit case fails on main and passes with the fix; plus DB-lookup, genuine-safe, and live-read-failure guards.

Validation: 4/4 new tests pass; TDD-verified; tsc --noEmit shows no new errors in touched files (remaining tsc errors are the pre-existing wishlist.ts corruption tracked in #4357).

Note: this PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh.

Closes #4146.