### PR TITLE
fix(wishlist): repair corrupted GET list handler with duplicate pagination (#4357)

### DIFF
--- a/apps/api/src/routes/wishlist.ts
+++ b/apps/api/src/routes/wishlist.ts
@@ -260,31 +260,13 @@ router.get(
             return;
         }
 
-        let page = parseInt(req.query.page as string, 10);
-        let limit = parseInt(req.query.limit as string, 10);
-
-        if (isNaN(page) || page <= 0) {
-            page = 1;
-        }
-        if (isNaN(limit) || limit <= 0) {
-            limit = 20;
-        }
-        if (limit > 100) {
-            limit = 100;
-        }
-
-        const from = (page - 1) * limit;
-        const to = from + limit - 1;
+        const rawPage = parseInt(req.query.page as string, 10);
+        const rawLimit = parseInt(req.query.limit as string, 10);
+        const page = isNaN(rawPage) || rawPage < 1 ? 1 : rawPage;
+        const limit = isNaN(rawLimit) || rawLimit < 1 ? 20 : Math.min(rawLimit, 100);
+        const offset = (page - 1) * limit;
 
         try {
-            const rawPage = parseInt(req.query.page as string, 10);
-            const rawLimit = parseInt(req.query.limit as string, 10);
-
-            const page = isNaN(rawPage) || rawPage < 1 ? 1 : rawPage;
-            const limit = isNaN(rawLimit) || rawLimit < 1 ? 20 : Math.min(rawLimit, 100);
-
-            const offset = (page - 1) * limit;
-
             const {
                 data: wishlistItems,
                 error: fetchError,
@@ -295,7 +277,6 @@ router.get(
                 .eq("user_id", req.user.id)
                 .order("created_at", { ascending: false })
                 .range(offset, offset + limit - 1);
-                .range(from, to);
 
             if (fetchError) {
                 next(fetchError);
@@ -303,9 +284,6 @@ router.get(
             }
 
             const totalCount = count ?? 0;
-
-            res.json({
-            const totalCount = count || 0;
             const totalPages = Math.ceil(totalCount / limit);
 
             res.json({
@@ -315,10 +293,6 @@ router.get(
                 count: totalCount,
                 totalPages,
                 items: wishlistItems || [],
-                count: totalCount,
-                page,
-                limit,
-                totalPages: Math.ceil(totalCount / limit),
             });
         } catch (err) {
             next(err);


### PR DESCRIPTION
Closes #4357.

## Problem

The `GET /` (paginated list) handler in `apps/api/src/routes/wishlist.ts` had two revisions of the same pagination logic merged on top of each other. The inner block redeclared `page`/`limit`, an orphaned `.range(from, to);` followed a terminated `.range(offset, ...);` (`TS1128`), and a dangling `res.json({` was followed by the second revision's statements plus a duplicate `res.json` with duplicate object keys (`TS1005`). The result was a **SyntaxError** that:

- broke `tsc --noEmit` for `apps/api` (`TS1128`/`TS1005` at lines 298–323),
- broke runtime import of the wishlist router — and since `app.ts` mounts every route module, the whole Express app failed to start,
- broke the entire Jest suite (any test importing `app` failed to parse).

Verified on `main`: `tsc --noEmit` reports the wishlist.ts errors above; `jest tests/wishlist.test.ts` fails with `SyntaxError: .../wishlist.ts: Unexpected token (298:16)`.

## Fix

Replace the handler body with a single deduplicated implementation (the one proposed in the issue):

- parse `page`/`limit` once with ternary defaults (`page=1`, `limit=20`, cap `100`),
- compute `offset = (page - 1) * limit`,
- run one `.range(offset, offset + limit - 1)` query with `{ count: 'exact' }`,
- emit one `res.json` with the canonical pagination schema (`success`, `page`, `limit`, `count`, `totalPages`, `items`).

The outer `let page/limit` + `from/to` + double-`.range` + double-`res.json` + duplicate object keys are removed. Net: `-31 / +5` lines.

## Validation

- `tsc --noEmit -p apps/api` now reports **zero** `wishlist.ts` errors. (The remaining pre-existing tsc errors are unrelated workspace-package resolution failures for `@sahidawa/shared|validators|types` that exist on `main` too and are outside this issue's scope.)
- **Regression**: the existing `apps/api/tests/wishlist.test.ts` (18 cases covering pagination defaults, page 2, last page, invalid `page`/`limit`, and cap-at-100) **all fail to run on `main`** (`wishlist.ts` fails to parse: `Unexpected token (298:16)`, `Tests: 0 total`) and **all pass with this fix** (`18 passed, 18 total`). TDD-verified by temporarily reverting the source fix.

The open-handle warning in the merge-guest test is pre-existing and unrelated.

Note: this PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh.

Closes #4357.